### PR TITLE
docs: READMEの解説記事URLをnote公開URLに差し替え

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ## 解説記事
 
-<!-- TODO: note公開後にURLを差し替え -->
-- [AIコーディングの暴走を「仕組み」で止める — PlanGateという開発フロー](https://note.com/xxx)（note）
+- [AIコーディングの暴走を「仕組み」で止める — PlanGateという開発フロー](https://note.com/mine_unilabo/n/n3aae6b5467b9)（note）
 
 ## 概要
 


### PR DESCRIPTION
## Summary
- READMEの解説記事セクションにあったプレースホルダーURL（`https://note.com/xxx`）を公開済みのnote記事URLに差し替え
- TODOコメント（`<!-- TODO: note公開後にURLを差し替え -->`）を削除

## Test plan
- [ ] README.mdのリンクが正しく表示されること
- [ ] リンク先が正しいnote記事に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)