### PR TITLE
chore(codex): project runtime homeで既存認証を再利用する

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -4,7 +4,7 @@ Codex 固有の設定はこのディレクトリに集約する。
 
 ## 起動方法
 
-このリポジトリの設定を使うには、`./scripts/codex-local.sh ...` を使う。ラッパーが repo 内の runtime home を使い、`.codex/` の設定と `~/.codex` の認証を合成して起動する。
+このリポジトリの設定を使うには、`./scripts/codex-local.sh ...` を使う。ラッパーが repo 内の runtime home を使い、必要なら `~/.codex/auth.json` を `.codex/auth.json` に symlink して、`.codex/` の設定と既存認証を合成して起動する。
 
 ```bash
 ./scripts/codex-local.sh exec --json "確認のみ。1行で返答。"
@@ -20,6 +20,7 @@ Codex 固有の設定はこのディレクトリに集約する。
 ## Auth
 
 - Codex CLI の認証は `~/.codex/auth.json` または `OPENAI_API_KEY` 系の環境変数を使う
+- `./scripts/codex-local.sh` は project-local auth が無い場合のみ `~/.codex/auth.json` を参照する
 - repo 内の `.codex/` には認証情報をコミットしない
 
 ## AI-Dev Workflow

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ node_modules/
 .codex/memories/
 .codex/shell_snapshots/
 .codex/tmp/
+.codex/auth.json
+.codex/models_cache.json
 .codex/skills/.system/
 .codex/version.json
 

--- a/scripts/codex-local.sh
+++ b/scripts/codex-local.sh
@@ -19,5 +19,15 @@ if [ "${1:-}" = "--" ]; then
 fi
 
 cd "$repo_root"
+
+# Keep project-local config/runtime under .codex while reusing the existing
+# user-level auth file when no project-local auth has been provisioned.
+auth_dst="$repo_root/.codex/auth.json"
+auth_src="${CODEX_AUTH_SOURCE:-$HOME/.codex/auth.json}"
+
+if [ ! -e "$auth_dst" ] && [ -f "$auth_src" ]; then
+  ln -s "$auth_src" "$auth_dst"
+fi
+
 export CODEX_HOME="$repo_root/.codex"
 exec codex "$@"


### PR DESCRIPTION
codex-local.sh が CODEX_HOME を repo 内の .codex に固定する構成では、既存の ~/.codex/auth.json を参照できず、Codex の最小実行確認が 401 Unauthorized で失敗していました。

この PR では、project-local auth が無い場合のみ ~/.codex/auth.json を .codex/auth.json として参照するようにし、repo 側の設定を維持したまま既存認証を再利用できるようにしています。あわせて README の説明を実装に合わせ、.gitignore に auth と models cache の runtime 生成物を追加しました。

これにより、./scripts/codex-local.sh exec --json --ephemeral "確認のみ。1行で返答。" が正常終了することを確認しています。