### PR TITLE
[codex] Fix Scorecard workflow results output

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,4 +36,18 @@ jobs:
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
+          results_file: results.sarif
+          results_format: sarif
           publish_results: true
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload Scorecard SARIF
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Fix the post-merge OpenSSF Scorecard workflow failure from PR #14.
- Configure the required Scorecard outputs: `results_file` and `results_format`.
- Upload the generated SARIF as a short-lived Actions artifact and to GitHub code scanning.
- Keep all newly added action references pinned to 40-character commit SHAs.

## Root cause

The merged Scorecard workflow set `publish_results: true` but did not provide the required `results_file` / `results_format` inputs. The failed run logged: `validating options: results path is empty`.

## Validation

- Parsed `.github/workflows/scorecard.yml` with Python/PyYAML.
- Ran `actionlint 1.7.12` against workflows.
- Verified all workflow `uses:` references are pinned to 40-character commit SHAs.
