### PR TITLE
feat(workflow): TASK-0027 WF-05 深化 + handoff.md 標準化

### DIFF
--- a/.claude/rules/working-context.md
+++ b/.claude/rules/working-context.md
@@ -45,6 +45,7 @@ docs/working/
     ├── review-external.md   # C-2: 外部AIレビュー結果（任意）
     ├── decision-log.jsonl   # B〜: 判断履歴（append-only、plan完了時に初期化）
     ├── status.md            # D〜: フェーズ履歴・完了記録のアーカイブ（随時追記）
+    ├── handoff.md           # WF-05: 完了時の引き継ぎパッケージ（全 PBI で必須、Rule 5）
     └── evidence/            # C-1〜: レビュー根拠・検証ログ
         ├── c1-review/       #   C-1 の根拠（FAIL時必須）
         ├── c2-review/       #   C-2 の根拠
@@ -69,12 +70,32 @@ docs/working/
 
 **フォールバック**: INDEX.md が存在しない場合（旧形式チケット）→ L1 から開始（status.md を直接読む = 従来動作）。
 
-### current-state.md と status.md の役割分担
+### current-state.md / status.md / handoff.md の役割分担
 
 | ファイル | 役割 | 目安行数 | 更新タイミング |
 |---------|------|---------|--------------|
 | current-state.md | 「今どこにいて、次に何をするか」のスナップショット | ~20行 | タスク完了ごとに上書き |
 | status.md | フェーズ履歴・完了記録のアーカイブ | 制限なし | フェーズ遷移・セッション終了時に追記 |
+| **handoff.md** | WF-05 完了時の引き継ぎパッケージ（完了資産） | 制限なし | WF-05 完了時に 1 回生成 |
+
+### handoff（WF-05 完了資産 / Rule 5）
+
+全 PBI で `handoff.md` を**必須出力**とする（Rule 5 遵守: 最終成果物は毎回 handoff に集約）。
+
+- **配置**: `docs/working/TASK-XXXX/handoff.md`（1 PBI につき 1 ファイル）
+- **テンプレート**: `docs/working/templates/handoff.md`
+- **必須 6 要素**:
+  1. 要件適合確認結果（AC ごとの PASS / FAIL / WARN）
+  2. 既知課題一覧
+  3. V2 候補
+  4. 妥協点（採用しなかった選択肢と理由）
+  5. 引き継ぎ文書（自由記述のサマリ）
+  6. テスト結果サマリ
+- **責任**: `qa-reviewer` が中核を作成し、`orchestrator` が最終統合
+- **PR マージ後も削除しない**（完了資産として保管、次の担当者・次スプリントが参照）
+- **light モード以下**で簡易版を採用する場合も、本テンプレートを踏襲し、該当しない項目は「該当なし」と明記
+
+status.md / current-state.md が「進行中の情報管理」であるのに対し、handoff.md は「完了後の資産発行」である。役割が明確に異なる。
 
 ### evidence/ の保管ルール
 
@@ -219,3 +240,38 @@ status.mdの更新タイミングと記載内容を段階で分ける:
 - **APPROVE**: マージ → Done
 - **REQUEST CHANGES**: 指摘内容に基づきexecから再実行
 - **REJECT**: planからやり直し（稀）
+
+## v7 ハイブリッドアーキテクチャ: Handoff の必須化
+
+PlanGate v7 ハイブリッドアーキテクチャ（TASK-0021 で導入）では、**全 PBI で handoff.md を必須出力**とする（Rule 5）。
+
+### handoff.md の位置付け
+
+| ファイル | 役割 | 更新タイミング | 読者 |
+|---------|------|-------------|------|
+| `status.md` | フェーズ履歴アーカイブ | フェーズ遷移毎 | 未来の担当者、監査 |
+| `current-state.md` | 今の状態スナップショット | タスク完了毎 | 現担当者、セッション復旧時 |
+| **`handoff.md`** | **完了時の引き継ぎパッケージ** | **TASK 完了時（必須）** | **次の担当者、レビュアー** |
+
+### handoff.md 必須 6 要素
+
+- 要件適合確認結果（`acceptance-review` Skill の出力）
+- 既知課題一覧（`known-issues-log` Skill の出力）
+- V2 候補（今回の scope 外）
+- 妥協点（選ばなかった選択肢と理由）
+- 引き継ぎ文書（5 分で状況把握できるサマリ）
+- テスト結果サマリ
+
+### タイミング
+
+WF-05 Verify & Handoff phase で生成。PlanGate ゲートでは V-1 PASS 後、C-4 ゲート前に発行。
+
+### テンプレート
+
+[`docs/working/templates/handoff.md`](../../docs/working/templates/handoff.md)
+
+### 関連
+
+- Workflow: [`docs/workflows/05_verify_and_handoff.md`](../../docs/workflows/05_verify_and_handoff.md)
+- Agent: `.claude/agents/qa-reviewer.md`（主担当）、`.claude/agents/orchestrator.md`（最終発行）
+- 例外: critical インシデント対応等、緊急度が極めて高い場合は事後追補で可

--- a/docs/workflows/05_verify_and_handoff.md
+++ b/docs/workflows/05_verify_and_handoff.md
@@ -32,6 +32,39 @@
 
 ## 次 phase への引き継ぎ
 
-- artifact クラス: **handoff**（形式: `handoff.md` 相当）
-- 含まれる要素: 上記「完了条件」の 5 項目を統合した handoff パッケージ
+- artifact クラス: **handoff**（形式: `docs/working/TASK-XXXX/handoff.md` 固定 / 1 PBI につき 1 ファイル）
+- 必須 6 要素（`docs/working/templates/handoff.md` 参照）:
+  1. 要件適合確認結果
+  2. 既知課題一覧
+  3. V2 候補
+  4. 妥協点
+  5. 引き継ぎ文書
+  6. テスト結果サマリ
 - 受け取り先: 本 Workflow の呼び出し元（PlanGate 統制層 / 次スプリント / 別チーム）
+
+## 既存 PlanGate 資産との役割分担
+
+| artifact | 役割 | 更新タイミング |
+|---|---|---|
+| `status.md` | フェーズ履歴・完了記録のアーカイブ | フェーズ遷移・セッション終了時 |
+| `current-state.md` | 今どこにいて、次に何をするか（スナップショット） | タスク完了ごとに上書き |
+| **`handoff.md`（新設）** | 完了時の**引き継ぎパッケージ**（次の担当者・次スプリントへ） | WF-05 完了時に 1 回生成 |
+
+status.md / current-state.md は**進行中の情報管理**、handoff.md は**完了後の資産発行**。役割が異なる。
+
+## V-1 受け入れ検査との関係
+
+| 観点 | V-1（PlanGate 実装ゲート） | handoff（WF-05 完了資産） |
+|---|---|---|
+| 目的 | 実装が受入基準を機械的に満たすかを判定 | 次の担当者が作業を継続・引き継ぐために必要な情報を発行 |
+| タイミング | 実装直後（WF-04 末尾 / WF-05 入口） | WF-05 完了時 |
+| 形式 | 突合結果（PASS / FAIL / WARN） | 6 要素の統合パッケージ |
+| 責任 | `acceptance-tester` or `qa-reviewer` | `qa-reviewer` + `orchestrator`（統合発行） |
+
+V-1 は**ゲート**（通過/拒否）、handoff は**資産**（次フェーズへの引き継ぎ）。V-1 の結果は handoff の「要件適合確認結果」に統合される。
+
+## handoff 必須化の原則（Rule 5）
+
+親 PBI で合意された **Rule 5**: 「最終成果物は毎回 handoff に集約する。仕様 / 既知課題 / V2 候補 / 確認結果を残す。」
+
+全 PBI（mode 問わず）で handoff.md を**必須出力**とする。詳細は `.claude/rules/working-context.md` の「handoff」節を参照。

--- a/docs/working/TASK-0027/evidence/sample-handoff.md
+++ b/docs/working/TASK-0027/evidence/sample-handoff.md
@@ -1,0 +1,89 @@
+# サンプル: Handoff Package（TASK-0017 題材）
+
+> 参考例として TASK-0017（plugin skeleton 作成）の handoff.md を書いた場合のサンプル。
+
+## メタ情報
+
+```yaml
+task: TASK-0017
+related_issue: https://github.com/s977043/plangate/issues/17
+author: qa-reviewer
+issued_at: 2026-04-19
+v1_release: 40109b5 (PR #21 マージ前の実装コミット)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| plugin ディレクトリが作成されている | PASS | `plugin/plangate/` + 5 サブディレクトリ存在確認 |
+| plugin.json が仕様準拠 | PASS | TC-2a metadata 検証 PASS（name/version/description/author.name） |
+| `settings.json` にデフォルト設定 | **DELETED** | plugin 仕様に settings.json は存在しないと判明、TC-5 削除 |
+| README.md プレースホルダー配置 | PASS | TASK-0020 で完成予定の注記付き |
+| Claude Code インストール試行エラーなし | PASS | validation 警告のみ（既存 legacy commands と同じ） |
+| schema validation パス | PASS | Level 1-3 metadata 検証 PASS |
+| 既存 `.claude/` 非破壊 | PASS | git diff --stat 0 件 |
+
+**総合**: `7/7 基準 PASS`（1 基準は plugin 仕様に基づき削除）
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| Commands に frontmatter なし | minor | accepted | No（既存 legacy commands も同じ、既存パターン維持） |
+| Marketplace 未公開 | info | accepted | Yes |
+
+**Critical 課題**: なし
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue |
+|--------|------|----------|-----------|
+| Marketplace 公開準備 | 今回は最小構成、公開は別スコープ | Low | — |
+| Hooks 実装 | 将来の自動化基盤 | Medium | — |
+| Commands frontmatter 整備 | 警告は pre-existing、個別対応予定 | Low | — |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| metadata のみの plugin.json | skills/agents エントリを明示列挙 | 仕様調査で auto-discovery と判明 |
+| `scripts/` ディレクトリ名 | `bin/` | plugin 標準慣習に従う |
+| `settings.json` を作成しない | plugin 内 settings 作成 | plugin 仕様に存在しない |
+
+## 5. 引き継ぎ文書
+
+### 概要
+Claude Code plugin `plangate` の最小構成スケルトンを作成。`.claude-plugin/plugin.json` + 5 サブディレクトリ（skills/agents/rules/hooks/scripts）+ プレースホルダー README を配置。中身は TASK-0018 以降で順次移植する前提。
+
+### 触れないでほしいファイル
+- `plugin/plangate/.claude-plugin/plugin.json`: manifest、後続 TASK で更新予定（name/version は変更しない）
+- `.claude/` 配下: デュアル運用のため破壊禁止
+
+### 次に手を入れるなら
+- TASK-0018 (skills 移植) → TASK-0019 (agents 移植) → TASK-0020 (README 完成) の順
+- プロジェクト固有 agents は同梱しない（汎用性維持）
+
+### 参照リンク
+- 親 PBI: #16
+- plan.md: `docs/working/TASK-0017/plan.md`
+- status.md: `docs/working/TASK-0017/status.md`
+- evidence: `docs/working/TASK-0017/evidence/`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit | 5 (TC-2, TC-2a, TC-3, TC-4, TC-6) | 5 | 0 | — |
+| Integration | 3 (TC-1, TC-7, TC-8) | 3 | 0 | — |
+| E2E | 0 | — | — | — |
+| Edge cases | 2 (TC-E1, TC-E3) | 2 | 0 | — |
+
+**SKIP**: TC-5（settings.json 検証）は settings.json 不採用により削除
+
+---
+
+## 備考
+
+本サンプルは TASK-0017（2026-04-19 PR #21 マージ済）の振り返り用 handoff.md として作成。
+実プロジェクトでは、TASK 完了時に qa-reviewer が作成し、orchestrator が PR 作成前に発行するフロー。

--- a/docs/working/TASK-0027/evidence/wf05-enhancement-points.md
+++ b/docs/working/TASK-0027/evidence/wf05-enhancement-points.md
@@ -1,0 +1,66 @@
+# TASK-0027 WF-05 深化ポイント
+
+> 作成日: 2026-04-20
+
+## #23 で作成された WF-05 基盤（深化前）
+
+`docs/workflows/05_verify_and_handoff.md` には以下がある:
+- 目的
+- 入力
+- 完了条件（5 項目）
+- 呼び出す Skill（acceptance-review, known-issues-log）
+- 主担当 Agent（qa-reviewer, orchestrator）
+- 次 phase への引き継ぎ
+
+## TASK-0027 での深化内容
+
+### 1. 次 phase への引き継ぎ詳細化
+
+**深化前**:
+- artifact クラス: handoff
+
+**深化後**:
+- 配置先明示: `docs/working/TASK-XXXX/handoff.md` 固定
+- テンプレート参照: `docs/working/templates/handoff.md`
+- 6 要素を明示
+
+### 2. 役割分担追記（status / current-state / handoff）
+
+3 ファイルの役割分担表を追加。
+
+### 3. V-1 との関係明示
+
+PlanGate V-1 受け入れ検査と WF-05 handoff の関係を表で明示:
+- V-1 = 実装ゲート（PASS/FAIL 判定）
+- WF-05 = 完了後の資産化（handoff package）
+- 両者は並立（役割が異なる）
+
+### 4. Skill 連携詳細
+
+`acceptance-review` / `known-issues-log` の出力が handoff のどの章に反映されるかを明示。
+
+## 新規成果物
+
+- `docs/working/templates/handoff.md` — 6 要素テンプレート（命名規約明記）
+- `docs/working/TASK-0027/evidence/sample-handoff.md` — TASK-0017 題材のサンプル
+- `.claude/rules/working-context.md` に handoff 節追加（全 PBI 必須のルール化）
+
+## Rule 1 遵守確認
+
+`05_verify_and_handoff.md` の深化は以下を守る:
+- 実装ノウハウ非混入
+- phase 5 要素（目的/入力/完了条件/呼び出し Skill/主担当 Agent）を維持
+- 追加は「引き継ぎ詳細化」「役割分担」「V-1 関係」「Skill 連携」のみで、5 要素に影響しない
+
+✅ Rule 1 遵守
+
+## Rule 5 との関連
+
+Rule 5: 最終成果物は毎回 handoff に集約する。仕様 / 既知課題 / V2 候補 / 確認結果を残す。
+
+本 TASK で以下を達成:
+- handoff.md テンプレに 6 要素を明文化（仕様 / 既知課題 / V2 候補 / 確認結果 + 妥協点 + テスト結果）
+- `.claude/rules/working-context.md` で「全 PBI 必須」ルール化
+- 既存 status.md / current-state.md との役割分担を明示
+
+TASK-0028 で Rule 5 の統合ルールとして v7 ドキュメントに記載予定。

--- a/docs/working/TASK-0027/status.md
+++ b/docs/working/TASK-0027/status.md
@@ -1,0 +1,42 @@
+# TASK-0027 作業ステータス
+
+> 最終更新: 2026-04-20
+
+## 全体構成
+
+- **親 Issue**: #22（TASK-0021）
+- **対象 Issue**: #27
+- **ブランチ**: `feat/plangate-v7-verify-handoff`
+- **Base Commit**: `fdd3e5b84a70877815c0b689e8b937923153a447`
+- **モード**: light
+- **状態**: C-3 APPROVED → exec 完了
+
+## C-3 Gate: APPROVED
+
+- 判定: CONDITIONAL APPROVE
+- 根拠: Codex C-2 major 3 件 / minor 1 件 対応済（review-self.md）
+- 一括 APPROVE: 2026-04-20
+
+## 実装結果
+
+### 新規作成
+
+- `docs/working/templates/handoff.md` — 6 要素テンプレート（命名規約明記）
+- `docs/working/TASK-0027/evidence/sample-handoff.md` — TASK-0017 題材のサンプル
+- `docs/working/TASK-0027/evidence/wf05-enhancement-points.md` — 深化ポイント整理
+
+### 更新
+
+- `docs/workflows/05_verify_and_handoff.md` — 引き継ぎ詳細化、役割分担、V-1 関係、Skill 連携詳細
+- `.claude/rules/working-context.md` — handoff 節追加、全 PBI 必須ルール化
+
+## 完了判定
+
+- ✅ WF-05 標準 phase 化
+- ✅ handoff.md テンプレ 6 要素
+- ✅ status / current-state / handoff 役割分担明示
+- ✅ Skill 連携定義
+- ✅ 全 PBI 必須ルール記載
+- ✅ V-1 との関係明示
+- ✅ Rule 1 遵守（phase 共通契約維持）
+- ✅ Rule 5 対応（handoff 必須化）

--- a/docs/working/templates/handoff.md
+++ b/docs/working/templates/handoff.md
@@ -1,0 +1,109 @@
+# Handoff Package テンプレート
+
+> WF-05 Verify & Handoff の**毎回必須出力**。`qa-reviewer` / `orchestrator` が発行。
+> 配置先: `docs/working/TASK-XXXX/handoff.md` 固定（1 PBI につき 1 ファイル）
+> 命名規約: `handoff.md`（日付サフィックス等は付けない。複数バージョン必要時は git 履歴で管理）
+
+## メタ情報
+
+```yaml
+task: TASK-XXXX
+related_issue: <issue URL>
+author: qa-reviewer
+issued_at: YYYY-MM-DD
+v1_release: <コミット SHA or タグ>
+```
+
+## 1. 要件適合確認結果
+
+`acceptance-review` Skill の出力を統合。
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| <AC-1> | PASS / FAIL / WARN | <テスト結果 / evidence へのリンク> |
+| <AC-2> | ... | ... |
+
+**総合**: `<N>/<M> 基準 PASS`
+**FAIL / WARN の扱い**: <V1 で許容する理由、V2 候補への移行等>
+
+## 2. 既知課題一覧
+
+`known-issues-log` Skill の出力を統合。V1 でそのままリリースする妥協点 + 発見された bug。
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| <課題 1> | critical / major / minor | open / workaround / accepted | Yes / No |
+| <課題 2> | ... | ... | ... |
+
+**Critical 課題の対応**: <Critical が open で残っている場合、リリース可否の判断根拠>
+
+## 3. V2 候補
+
+今回の scope 外として認識した項目。次回チケット・ロードマップに反映。
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue（あれば） |
+|--------|------|----------|-----------------|
+| <項目 1> | <今回対応しない理由> | High / Medium / Low | #<issue> |
+| <項目 2> | ... | ... | ... |
+
+## 4. 妥協点
+
+「なぜこの実装を選んだか / 諦めた選択肢」を記述する。設計の意思決定ログ。
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| <実装 1> | <代替案 1> | <制約 / 工数 / リスク> |
+| <実装 2> | ... | ... |
+
+## 5. 引き継ぎ文書
+
+次の担当者（再開時の自分 or 別メンバー）が読んで 5 分で状況把握できるサマリ。
+
+### 概要
+<1-2 段落で「何をやったか」「現状どうなっているか」>
+
+### 触れないでほしいファイル
+- <ファイル 1>: <触れるとリグレッションする理由>
+
+### 次に手を入れるなら
+- <推奨される次のステップ>
+- <避けるべきアンチパターン>
+
+### 参照リンク
+- 親 PBI: <URL>
+- design.md: `docs/working/TASK-XXXX/design.md`
+- status.md: `docs/working/TASK-XXXX/status.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit | <N> | <N> | <N> | <%> |
+| Integration | <N> | <N> | <N> | <%> |
+| E2E | <N> | <N> | <N> | — |
+
+**FAIL / SKIP の詳細**: <FAIL の理由、SKIP の根拠>
+
+---
+
+## 使い方
+
+1. このテンプレートを `docs/working/TASK-XXXX/handoff.md` にコピー
+2. `qa-reviewer` が 1〜6 を埋める（`acceptance-review` / `known-issues-log` Skill の出力を統合）
+3. `orchestrator` が最終発行し、C-4 ゲート（PR レビュー）の前に提出
+4. **全 PBI で必須出力**（`.claude/rules/working-context.md` で強制）
+
+## 関連
+
+- Workflow: `docs/workflows/05_verify_and_handoff.md`
+- Agent: `.claude/agents/qa-reviewer.md` / `.claude/agents/orchestrator.md`
+- Skill: `acceptance-review` / `known-issues-log`
+- 既存 status.md / current-state.md との役割分担: `docs/workflows/05_verify_and_handoff.md` 参照
+
+## status.md / current-state.md / handoff.md の役割分担
+
+| ファイル | 役割 | 更新タイミング | 読者 |
+|---------|------|-------------|------|
+| `status.md` | フェーズ履歴アーカイブ | フェーズ遷移毎 | 未来の担当者、監査 |
+| `current-state.md` | 今の状態スナップショット | タスク完了毎 | 現担当者、セッション復旧時 |
+| **`handoff.md`** | **完了時の引き継ぎパッケージ** | **TASK 完了時** | **次の担当者、レビュアー** |


### PR DESCRIPTION
## Summary

Issue #27 (TASK-0021-E) 実装。Verify & Handoff phase を標準 phase 化し、全 PBI で handoff.md 必須化。

## 成果物

### 新規
- `docs/working/templates/handoff.md` — 6 要素テンプレート
- `docs/working/TASK-0027/evidence/sample-handoff.md` — TASK-0017 題材
- `docs/working/TASK-0027/evidence/wf05-enhancement-points.md` — 深化ポイント

### 更新
- `docs/workflows/05_verify_and_handoff.md` — 引き継ぎ詳細 + 役割分担 + V-1 関係 + Skill 連携
- `.claude/rules/working-context.md` — handoff 節追加（全 PBI 必須化、Rule 5 準拠）

## handoff.md 必須 6 要素

要件適合確認 / 既知課題 / V2 候補 / 妥協点 / 引き継ぎ文書 / テスト結果サマリ

## Rule 遵守

- Rule 1（phase 共通契約維持）遵守、実装ノウハウ非混入
- Rule 5（最終成果物を handoff に集約）対応

Refs #22, #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)