### PR TITLE
docs(CLAUDE): v7 ハイブリッドアーキテクチャへの参照を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@
 | スキル一覧 | `.claude/skills/README.md` |
 | 共有スキル | `.agents/skills/`（Claude Code・Codex CLI共用） |
 | 運用ルール | `.claude/rules/` |
-| PlanGateワークフロー | `docs/plangate.md` |
+| PlanGateワークフロー（v5 現行） | `docs/plangate.md` |
+| PlanGate v7 ハイブリッド | `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md` |
+| Workflow 定義（WF-01〜WF-05） | `docs/workflows/README.md` |
 | 役割分担 | `docs/ai/tool-roles.md` |
 
 ## 迷ったらの判断基準


### PR DESCRIPTION
## Summary

TASK-0021（親 #22）完了に伴い、CLAUDE.md の「Claude Code固有の参照先」表に v7 ハイブリッドアーキテクチャ関連の参照を追加。

## 変更内容

- PlanGate v7 ハイブリッド → `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md`
- Workflow 定義（WF-01〜WF-05） → `docs/workflows/README.md`
- 既存の「PlanGateワークフロー」行に「v5 現行」を明記（v5/v7 の位置関係を明確化）

## 補完関係

- v5 = 現行（ゲート型ワークフロー、`docs/plangate.md`）
- v7 = v5 の統制層を維持しつつ実行層を Workflow/Skill/Agent 3 層で再構築

v5 を置換せず、内側で拡張する設計。

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)