### PR TITLE
release: PlanGate v7.0.0 (ハイブリッドアーキテクチャ)

### DIFF
--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "PlanGate workflow for Claude Code: AI-driven development with TDD, multi-phase review gates (C-1/C-2/C-3/C-4), and 5-stage mode classification (ultra-light/light/standard/full/critical).",
   "author": {
     "name": "PlanGate contributors"

--- a/release-notes/v7.0.0.md
+++ b/release-notes/v7.0.0.md
@@ -1,0 +1,131 @@
+# PlanGate v7.0.0
+
+AI駆動開発ワークフロー PlanGate の v7 メジャーリリース。
+**Governance × Modularity =「強固な運用 × 柔軟な実行」** を実現するため、v5/v6 の統制層を維持しつつ、実行層を **Workflow / Skill / Agent** の 3 層ハイブリッドアーキテクチャで再構築しました。
+
+親 Issue: [#22](https://github.com/s977043/plangate/issues/22)
+
+## コンセプト
+
+PlanGate v5/v6 は「止める・承認する・状態を保存する」統制が強い一方、観点が `plan.md` に埋め込まれやすく、再利用性と拡張性に改善余地がありました。v7 は **統制層（PlanGate）を外殻**、**実行層（Workflow/Skill/Agent）を内核**として組み合わせることで、統制の強さを保ったまま実行をスケールさせます。
+
+![PlanGate ハイブリッドアーキテクチャ](https://github.com/s977043/plangate/blob/main/docs/assets/plangate-hybrid-architecture.png?raw=true)
+
+## 主な変更
+
+### 新規追加
+
+#### Workflow 層（WF-01〜WF-05）
+
+`docs/workflows/` 配下に 5 phase の定義ファイルと目次・対応表を新設。各 phase は **Rule 1 準拠**（順序と完了条件のみ、実装ノウハウなし）。
+
+| Phase | 目的 |
+|---|---|
+| **WF-01** Context Bootstrap | 前提・制約・品質基準の読み込み |
+| **WF-02** Requirement Expansion | 曖昧な要求から仕様の抜け漏れを洗い出す |
+| **WF-03** Solution Design | 仕様を実装可能な構造へ落とす |
+| **WF-04** Build & Refine | 設計に従って最小単位で実装 |
+| **WF-05** Verify & Handoff | 品質確認と handoff 完成 |
+
+関連ファイル: `docs/workflows/README.md`, `01_*.md`〜`05_*.md`, `skill-mapping.md`, `execution-sequence.md`, `plangate-insertion-map.md`
+
+#### Skill 層（10 個）
+
+`.claude/skills/` に **再利用可能 Skill** を 10 個新設。Rule 2 準拠（再利用単位限定、案件固有情報なし）。
+
+| カテゴリ | Skill |
+|---|---|
+| Scan | `context-load` / `requirement-gap-scan` |
+| Check | `nonfunctional-check` / `edgecase-enumeration` / `risk-assessment` |
+| Design | `acceptance-criteria-build` / `architecture-sketch` |
+| Build | `feature-implement` |
+| Review | `acceptance-review` / `known-issues-log` |
+
+#### Agent 層（5 体）
+
+`.claude/agents/` に **責務ベース Agent** を 5 体新設（`orchestrator` は既存を PlanGate hybrid 用に再定義）。Rule 3 準拠（責務のみ、ツール固有/案件固有なし）。
+
+- `orchestrator` — 実行層総責任者（phase 遷移 / 委譲 / 完了判定 / handoff 発行）
+- `requirements-analyst` — 初期要求 → 仕様変換
+- `solution-architect` — 仕様 → 実装可能な構造への落とし込み
+- `implementation-agent` — design artifact に基づく最小単位実装
+- `qa-reviewer` — WF-02 締め + WF-05 受け入れレビュー
+
+#### artifact テンプレート
+
+- `docs/working/templates/design.md` — Solution Design 成果物（7 要素）
+- `docs/working/templates/handoff.md` — Verify & Handoff 完了資産（6 要素、**全 PBI 必須化 / Rule 5**）
+
+#### 統合ルール（Rule 1〜5）
+
+- `docs/plangate-v7-hybrid.md` — v7 ハイブリッドアーキテクチャ全体像
+- `.claude/rules/hybrid-architecture.md` — Rule 1〜5 + CLAUDE.md/Skill/Hook 境界ルール
+
+#### PlanGate 対応表
+
+`docs/workflows/README.md` に既存 PlanGate フェーズ（A/B/C-1〜V-4/PR作成/C-4）と WF-01〜WF-05 の対応表を収録。統制層（PlanGate）と実行層（Workflow）の境界が読み取れます。
+
+### 逆輸入改善点の達成
+
+親 PBI で合意された優先順位付き 4 改善点を全て実装:
+
+1. ✅ **review 観点の Skill 化** — 10 Skill が再利用資産として独立
+2. ✅ **solution-architect を独立フェーズ化** — WF-03 で設計抜けを解消
+3. ✅ **Verify & Handoff を標準 phase 化** — handoff.md が全 PBI 必須出力に
+4. ✅ **責務ベース subagent** — 5 Agent 構成（requirements / design / implement / verify / orchestrate）
+
+### 破壊的変更（Breaking Changes）
+
+#### `.claude/agents/orchestrator.md` の意味変更
+
+- **旧**: 汎用マルチエージェント調整エージェント
+- **新**: PlanGate v7 実行層の総責任者 + 汎用マルチエージェント調整（統合版）
+
+既存の汎用マルチエージェント調整機能は維持されていますが、PlanGate hybrid の phase 遷移制御が追加されています。
+
+### 非破壊的な変更
+
+- v5/v6 の既存フェーズ（A / B / C-1〜V-4 / PR作成 / C-4）は一切変更されていません
+- v5/v6 のエージェント（18 体）は引き続き利用可能です
+- 既存プロジェクトは v5/v6 運用を継続しつつ、段階的に v7 要素を **opt-in** できます
+
+## 変更統計
+
+- **サブ Issue**: 6 件（#23-#28）全て CLOSED
+- **マージ済み PR**: #35 / #36 / #37 / #38 / #39 / #40 / #41 / #43
+- **新規ファイル**: 22 個
+  - Workflow: 9（目次 + 5 phase + skill-mapping + execution-sequence + plangate-insertion-map）
+  - Skill: 10
+  - Agent: 4（orchestrator は更新）
+  - Template: 2
+  - Rule: 2（v7-hybrid + hybrid-architecture）
+- **更新ファイル**: 6（v5/v6 ドキュメントへの v7 導線、CLAUDE.md、既存 orchestrator）
+
+## アップグレードガイド
+
+### v6 → v7
+
+1. **v5/v6 のまま運用を続ける場合**: 何もする必要はありません。v7 は **opt-in** です。
+2. **v7 を試す場合**: `docs/plangate-v7-hybrid.md` を読み、小さな PBI で WF-01〜WF-05 の流れを試走してください。
+3. **v7 にフル移行する場合**: `docs/workflows/README.md` の PlanGate 対応表で、既存フェーズと WF との対応を確認しながら段階的に移行。
+
+### 既存プロジェクトへの影響
+
+- `orchestrator` agent を直接呼び出している場合、新しい責務に沿って動作します。汎用マルチエージェント調整機能は維持されているため、既存ユースケースは継続可能。
+- `.claude/agents/` 配下の既存 17 体（workflow-conductor / spec-writer / implementer / 他）は **そのまま利用可能**。
+- `docs/plangate.md`（v5）と `docs/plangate-v6-roadmap.md`（v6）の冒頭に v7 への導線が追加されました。
+
+## 次フェーズ候補（本リリーススコープ外）
+
+- 各 Agent / Skill の runtime 検証（実 PBI でドッグフーディング）
+- Codex CLI 側への同期（plugin 化は TASK-0016 で対応済）
+- deterministic hooks の実装（v6 P1 / hybrid-architecture.md で基盤記述のみ）
+
+## 関連ドキュメント
+
+- v7 全体像: [docs/plangate-v7-hybrid.md](../docs/plangate-v7-hybrid.md)
+- Rule 1〜5 + 境界ルール: [.claude/rules/hybrid-architecture.md](../.claude/rules/hybrid-architecture.md)
+- Workflow 目次: [docs/workflows/README.md](../docs/workflows/README.md)
+- Skill マッピング: [docs/workflows/skill-mapping.md](../docs/workflows/skill-mapping.md)
+- 実行シーケンス: [docs/workflows/execution-sequence.md](../docs/workflows/execution-sequence.md)
+- 親 PBI: [docs/working/TASK-0021/pbi-input.md](../docs/working/TASK-0021/pbi-input.md)


### PR DESCRIPTION
## Summary

PlanGate v7.0.0 リリース準備。TASK-0021 シリーズで実装された **Governance × Modularity =「強固な運用 × 柔軟な実行」** ハイブリッドアーキテクチャを正式リリース。

## 変更内容

- `release-notes/v7.0.0.md` 新規作成（全体像 + Breaking changes + アップグレードガイド）
- `plugin/plangate/.claude-plugin/plugin.json` バージョン `0.1.0` → `0.2.0`

## 主要な成果物（本 PR 単体ではなく v7.0.0 全体）

- Workflow 5 phase（`docs/workflows/`）
- Skill 10 個（`.claude/skills/`）
- Agent 5 体（`.claude/agents/`）
- artifact テンプレート 2（design / handoff）
- Rule 1〜5 統合ルール（`docs/plangate-v7-hybrid.md` + `.claude/rules/hybrid-architecture.md`）

## リリース後の作業（本 PR マージ直後）

1. `v7.0.0` タグ作成（main ベース）
2. GitHub Release 公開（`--latest` 指定 / `release-notes/v7.0.0.md` を notes に指定）
3. 親 Issue #22 に Release URL を追記

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)