### PR TITLE
docs(handoff): TASK-0021〜0028 の handoff.md を一括発行（Rule 5 対応）

### DIFF
--- a/docs/working/TASK-0021/handoff.md
+++ b/docs/working/TASK-0021/handoff.md
@@ -1,0 +1,98 @@
+# Handoff Package
+
+```yaml
+task: TASK-0021
+related_issue: https://github.com/s977043/plangate/issues/22
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| Workflow 5 phase（WF-01〜WF-05）定義 | PASS | docs/workflows/ 配下に全 5 ファイル + README（TASK-0022） |
+| Skill 10 個（.claude/skills/ 配下） | PASS | context-load 〜 known-issues-log 全 10 件（TASK-0024） |
+| Agent 5 体（責務ベース） | PASS | requirements-analyst / solution-architect / implementation-agent / qa-reviewer / orchestrator（TASK-0025） |
+| Solution Design phase（WF-03）独立 + design.md テンプレ | PASS | docs/working/templates/design.md 7 要素（TASK-0026） |
+| Verify & Handoff phase（WF-05）標準化 + handoff.md 必須化 | PASS | docs/working/templates/handoff.md 6 要素（TASK-0027） |
+| Rule 1〜5 の明文化 | PASS | .claude/rules/hybrid-architecture.md（TASK-0028） |
+| CLAUDE.md / Skill / Hook 境界ルール明文化 | PASS | hybrid-architecture.md「境界ルール」セクション（TASK-0028） |
+| v5/v6 との整合 | PASS | v5 整合済み、v6 roadmap に v7 導線追加（TASK-0028） |
+| 実行シーケンス文書化 | PASS | docs/workflows/execution-sequence.md（Mermaid 図付き）（TASK-0025） |
+
+**総合**: 9/9 基準 PASS
+
+**ホリスティックレビュー結果（3 エージェント並列）**:
+- Codex 全体品質: CONDITIONAL（V-4 担当 release-manager Agent 未実装、legacy workflow-conductor との使い分け不明確）
+- 一貫性: WARN（major 3 件 / minor 4 件、追補で解消可能）
+- Rule 遵守スコア: 34/35（97.1%）
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | `release-manager` Agent 未実装：V-4 担当として記載しているが実体なし | high | 専任 Agent 作成が必要（現状は workflow-conductor で代替） |
+| 2 | legacy `workflow-conductor` と v7 `orchestrator` の使い分けルール不明確 | medium | 並行運用ガイドを plangate-v7-hybrid.md に追補 |
+| 3 | Rule 1〜4 の CI 自動検出：grep 依存で自動化されていない | medium | deterministic hooks 化（V2 最重要） |
+| 4 | v6 roadmap の v7 整合：既存ユーザーが迷う可能性 | low | v6 note 追加済み、移行ガイドで対応 |
+| 5 | 新規参入者の初回実行コスト：クロスリファレンスが多い | low | チュートリアル整備（V2 候補） |
+
+## 3. V2 候補
+
+| 優先度 | 候補 | 理由 |
+|--------|------|------|
+| 高 | `release-manager` Agent 作成 | V-4 に実担当 Agent が必要 |
+| 高 | deterministic hooks 実装（Rule 1〜4 違反検出） | CI 組込みで自動化、再発防止 |
+| 中 | v7 入門チュートリアル（ドッグフーディング PBI で一周） | 実用性検証と新規参入者支援 |
+| 中 | CHANGELOG.md 整備（v3〜v7 統合） | OSS 品質向上 |
+| 低 | 既存 17 Agent の段階的責務ベース移行計画 | 長期的な一本化方針 |
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| v5/v6 を破壊せず v7 を opt-in 拡張で追加 | 全面書き換え | 既存ユーザーへの影響最小化、並行運用の安定性 |
+| orchestrator は既存採用（workflow-conductor と一致） | 新規作成 | 重複回避、既存機能保持 |
+| deterministic hooks は V2 に先送り | TASK-0021 内で実装 | スコープ明確化、設計原則の文書化を優先 |
+| release-manager は V2 候補（現状は workflow-conductor で代替） | V-4 担当 Agent を本 TASK で作成 | 本 TASK の目的はアーキテクチャ定義であり Agent 作成は次フェーズ |
+| Codex C-2 / V-3 を CONDITIONAL として対応後 APPROVE | REJECT して計画から再実施 | PlanGate のゲート思想「CONDITIONAL は修正前提の暫定承認」を自ら実証 |
+
+## 5. 引き継ぎ文書
+
+TASK-0021 は PlanGate の大規模進化点 **v7 ハイブリッドアーキテクチャ（Governance × Modularity）**を確立した親 PBI。
+
+統制層（PlanGate の GATE / STATUS / APPROVAL / ARTIFACT）はそのままに、実行層として Workflow（5 phase）/ Skill（10 個）/ Agent（5 体）の 3 層構造を導入した。
+
+**アーキテクチャ上の到達点**:
+- Workflow は「順序と完了条件のみ」に責務を絞り、実装ノウハウを持たない（Rule 1）
+- Skill は「再利用単位」として案件固有情報なしで整備（Rule 2）
+- Agent は「責務のみ」でツール固有・案件固有仕様を持たない（Rule 3）
+- 案件固有情報は CLAUDE.md に集約（Rule 4）
+- 全 PBI で handoff.md を必須出力（Rule 5）
+
+**次のステップ**:
+1. `release-manager` Agent を新規作成（V2 高優先度）
+2. Rule 1〜4 違反の CI 自動検出（deterministic hooks 実装）
+3. 実際の PBI でドッグフーディング（WF-01〜WF-05 を一周）
+
+**参照先**:
+- `docs/plangate-v7-hybrid.md` — 全体像
+- `.claude/rules/hybrid-architecture.md` — Rule 1〜5 の正本
+- `docs/workflows/README.md` — WF-01〜WF-05 の対応表
+- `docs/working/TASK-0021/retrospective.md` — セッション振り返り
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| サブタスク TASK-0022 | PASS | PR #35 MERGED / V-1〜V-3 全 PASS |
+| サブタスク TASK-0024 | PASS | PR #36 MERGED |
+| サブタスク TASK-0025 | PASS | PR #37 MERGED |
+| サブタスク TASK-0026 | PASS | PR #38 MERGED |
+| サブタスク TASK-0027 | PASS | PR #39 MERGED |
+| サブタスク TASK-0028 | PASS | PR #40 MERGED |
+| ホリスティックレビュー（3 エージェント並列） | CONDITIONAL | 5 件指摘 → 全対応 / PR #43 でマージ済み |
+| v7.0.0 リリース | 完了 | PR #44 MERGED、タグ v7.0.0 |
+| v7 参照伝播 | 完了 | PR #45〜#47 MERGED |

--- a/docs/working/TASK-0022/handoff.md
+++ b/docs/working/TASK-0022/handoff.md
@@ -1,0 +1,69 @@
+# Handoff Package
+
+```yaml
+task: TASK-0022
+related_issue: https://github.com/s977043/plangate/issues/23
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #35
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| 5 phase 定義ファイル（WF-01〜WF-05）が存在 | PASS | docs/workflows/ 配下に 5 ファイル作成確認済み |
+| 各ファイルに必須 6 項目（目的/入力/完了条件/呼び出しSkill/主担当Agent/次phase引き継ぎ） | PASS | V-1 TC-1〜TC-7 全 PASS |
+| Rule 1 準拠（順序と完了条件のみ、実装ノウハウなし） | PASS | Layer 1 機械検証 + Layer 2 ルーブリック CLEAN |
+| docs/workflows/README.md に PlanGate 既存フェーズとの対応表を含める | PASS | A〜V-4 全フェーズ対応表掲載 |
+| 実行シーケンス記載 | PASS | orchestrator → requirements-analyst → ... → orchestrator の連鎖を明記 |
+| 既存 docs/plangate.md 等との矛盾なし | PASS | 整合確認済み（V-3 V3-02 対応で workflow-conductor ベースに修正） |
+| markdown lint 通過 | PASS | L-0 lint 0 error |
+
+**総合**: 7/7 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | Rule 1 違反の自動検出：禁止単語チェックが grep 依存で強度不足 | medium | deterministic hooks 化が必要（TASK-0021 V2 候補と連動） |
+| 2 | 「完了条件」と「手順」のグレーゾーン：Phase 定義で両者が混在しやすい | low | 実運用で発見次第 `.claude/rules/` に追補 |
+
+## 3. V2 候補
+
+- **deterministic hooks 化**: Rule 1 違反の自動検出を git hook / CI で常時実行
+- **Workflow 定義のバージョニング**: WF-01〜WF-05 の破壊的変更を追跡する仕組み
+- **phase 間引き継ぎ検証**: 次 phase の入力を満たしているかを自動チェック
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| docs/workflows/ に新規ファイルとして追加 | 既存 docs/plangate.md を書き換える | 非破壊的拡張で既存ユーザーへの影響を最小化 |
+| モード full（standard から再分類） | standard のまま維持 | C-2 EX-01 指摘対応：Workflow 5 phase 定義は複数ファイル・複数レイヤーに波及するため |
+| todo 粒度を docs 作成の特性として例外許容 | 2-5 分原則を厳守して粒度を細かく設定 | docs 作成タスクは連続する編集作業であり、粒度を細かくすると不自然 |
+
+## 5. 引き継ぎ文書
+
+TASK-0022 は PlanGate v7 ハイブリッドアーキテクチャの **実行層骨格**（Workflow 5 phase）を確立したタスク。
+
+`docs/workflows/` に WF-01〜WF-05 の定義ファイルを新設し、PlanGate 既存フェーズ（A〜V-4）との対応表・実行シーケンスを README に集約した。
+
+**後続タスクへの影響**:
+- TASK-0024（Skill 10 個）・TASK-0025（Agent 5 体）は本タスクの Workflow 定義を骨格として参照
+- docs/workflows/skill-mapping.md（TASK-0024 成果物）が各 Skill の呼び出し phase を規定
+- docs/workflows/execution-sequence.md（TASK-0025 成果物）が Agent の実行順序を規定
+
+**参照先**:
+- `docs/workflows/README.md` — Workflow 全体像と対応表
+- `.claude/rules/hybrid-architecture.md` — Rule 1 の正本
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| L-0 markdown lint | PASS | 0 error |
+| V-1 受け入れ検査 | PASS | TC-1〜TC-7 / E1〜E4 全 PASS |
+| V-2 コード最適化 | PASS | evidence/v2-code-optimization.md 参照 |
+| V-3 外部モデルレビュー（Codex） | PASS（4件対応） | V3-01〜V3-04 全対応 APPROVE 相当 |
+| V-4 リリース前チェック | スキップ | full モード（criticalのみ） |

--- a/docs/working/TASK-0024/handoff.md
+++ b/docs/working/TASK-0024/handoff.md
@@ -1,0 +1,67 @@
+# Handoff Package
+
+```yaml
+task: TASK-0024
+related_issue: https://github.com/s977043/plangate/issues/24
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #36
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| 10 個の Skill が `.claude/skills/` に配置 | PASS | context-load 〜 known-issues-log 全 10 件確認済み |
+| 各 Skill に入力/出力/想定 phase/カテゴリが定義 | PASS | 全 SKILL.md に記載、Codex C-2 スコア 78/100 |
+| Rule 2 遵守（再利用単位限定、案件固有情報なし） | PASS | evidence/rule2-check.md Layer 1 CLEAN / Layer 2 全 10 件再利用可能 |
+| 4 カテゴリ分類（Scan/Check/Design/Build/Review） | PASS | docs/workflows/skill-mapping.md で確認 |
+| 既存 8 件との重複解消 or 共存理由明記 | PASS | evidence/skill-comparison.md で比較表作成、全 10 件が新規名 |
+| WF-01〜WF-05 との phase マッピング表 | PASS | docs/workflows/skill-mapping.md 作成済み |
+
+**総合**: 6/6 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | Skill 定義が案件固有情報を含みやすい：レビュー時の確認負荷が高い | low | rule2-check を CI 自動化することで解消可能 |
+| 2 | 既存 8 Skill との粒度不整合：既存 Skill が古い構造のまま残っている | low | 既存 Skill のリファクタリングは別タスクで対応 |
+
+## 3. V2 候補
+
+- **既存 8 Skill の構造統一**: 新規 10 Skill の SKILL.md 構造に既存スキルを揃えるリファクタリング
+- **Skill の plugin 同梱化**: v7 対応 Skill を plugin/plangate/ に同梱
+- **Rule 2 違反の CI 自動検出**: grep によるプロジェクト固有キーワード検出をパイプラインに組み込む
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| 既存 8 Skill はそのまま維持 | 既存 Skill の構造を一括リファクタリング | スコープ明確化、本 TASK は新規 10 件の整備のみ |
+| Skill テンプレートを既存 SKILL.md 形式に統一 | 新規テンプレートを策定 | 既存との一貫性を優先、変更差分を最小化 |
+| モード full（standard から再分類） | standard のまま維持 | C-2 指摘対応で変更ファイル数が full 基準を超えたため |
+
+## 5. 引き継ぎ文書
+
+TASK-0024 は PlanGate v7 ハイブリッドアーキテクチャの **再利用可能 Skill 層**を確立したタスク。
+
+`.claude/skills/` に 10 個の Skill を新設し、WF-01〜WF-05 各 phase での呼び出し先を `docs/workflows/skill-mapping.md` に集約した。
+
+**後続タスクへの影響**:
+- Skill の呼び出し方は各 Workflow 定義ファイル（TASK-0022）の「呼び出す Skill」セクションに記載
+- acceptance-review / known-issues-log は WF-05（TASK-0027）で必須呼び出し先として定義
+
+**参照先**:
+- `docs/workflows/skill-mapping.md` — WF-01〜WF-05 × Skill のマッピング表
+- `.claude/skills/<name>/SKILL.md` — 各 Skill の入力・出力・想定 phase
+- `evidence/skill-comparison.md` — 既存 8 件との比較
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| C-2 外部 AI レビュー（Codex） | PASS（major 2 / minor 2 全対応） | スコア 78/100 → 全対応 APPROVE 相当 |
+| Rule 2 遵守チェック | PASS | evidence/rule2-check.md Layer 1 CLEAN |
+| 受入基準確認 | PASS | 6/6 基準 PASS |
+| V-4 リリース前チェック | スキップ | full モード（critical のみ） |

--- a/docs/working/TASK-0025/handoff.md
+++ b/docs/working/TASK-0025/handoff.md
@@ -1,0 +1,67 @@
+# Handoff Package
+
+```yaml
+task: TASK-0025
+related_issue: https://github.com/s977043/plangate/issues/25
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #37
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| 5 体の Agent が `.claude/agents/` に新規配置 | PASS | 新規 4 体作成 + 既存 orchestrator 採用（計 5 体） |
+| 各 Agent に責務/委譲関係/allowed-tools/呼び出す Skill が定義 | PASS | 全 agent.md に記載確認済み |
+| Rule 3 遵守（責務のみ、ツール固有・案件固有なし） | PASS | Codex C-2 major 3 件全対応済み |
+| 既存 18 agents との責務マッピング表 | PASS | evidence/existing-agents-inventory.md 作成済み |
+| 実行シーケンスが動作可能な形で文書化 | PASS | docs/workflows/execution-sequence.md（Mermaid 図含む） |
+
+**総合**: 5/5 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | Rule 3 違反の検出：ツール固有・案件固有情報の混入チェックが手動 | medium | CI 自動化が望ましい |
+| 2 | 既存 Agent との責務重複：マッピング表で明示しているが将来的な整理が必要 | low | 段階的移行計画（next phase）で対応 |
+| 3 | allowed-tools の具体リスト：実運用で調整余地あり | low | 実際の TASK 実行後に実績ベースで更新 |
+
+## 3. V2 候補
+
+- **既存 17 Agent の段階的責務ベース移行**: 責務ベース 5 体への集約ロードマップ策定
+- **Rule 3 違反の CI 自動検出**: 特定プロジェクト名・ツール固有ワード検出パイプライン化
+- **Agent 間通信ログ**: 委譲・引き継ぎの追跡ログ構造化
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| orchestrator は既存採用（workflow-conductor と責務一致） | 新規作成 | 既存機能維持、重複作成のリスク回避 |
+| 既存 17 Agent は維持、新規 4 体を追加で共存 | 既存 17 体を削除して 5 体に移行 | 段階的な移行、既存実行環境との互換性維持 |
+| Mermaid 図を execution-sequence.md に追加 | テキストのみの実行シーケンス | 視覚的な理解容易性を優先 |
+
+## 5. 引き継ぎ文書
+
+TASK-0025 は PlanGate v7 ハイブリッドアーキテクチャの **責務ベース Agent 層**を確立したタスク。
+
+新規 4 体（requirements-analyst / solution-architect / implementation-agent / qa-reviewer）+ 既存 orchestrator を採用し、WF-01〜WF-05 の実行シーケンスを `docs/workflows/execution-sequence.md` に文書化した。
+
+**後続タスクへの影響**:
+- 各 Workflow phase の「主担当 Agent」欄はこの 5 体を参照
+- qa-reviewer は WF-05（TASK-0027）の acceptance-review / known-issues-log を主担当
+
+**参照先**:
+- `docs/workflows/execution-sequence.md` — Agent 実行シーケンス（Mermaid 図）
+- `.claude/agents/requirements-analyst.md` 〜 `qa-reviewer.md` — 各 Agent の責務定義
+- `evidence/existing-agents-inventory.md` — 既存 18 agents との責務マッピング
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| C-3 Gate | APPROVED | Codex C-2 major 3 件全対応済、2026-04-20 |
+| Rule 3 遵守チェック | PASS | セルフレビューにて確認 |
+| 受入基準確認 | PASS | 5/5 基準 PASS |
+| V-4 リリース前チェック | スキップ | standard モード |

--- a/docs/working/TASK-0026/handoff.md
+++ b/docs/working/TASK-0026/handoff.md
@@ -1,0 +1,67 @@
+# Handoff Package
+
+```yaml
+task: TASK-0026
+related_issue: https://github.com/s977043/plangate/issues/26
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #38
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| WF-03 が独立 phase として深化 | PASS | docs/workflows/03_solution_design.md 更新済み |
+| 設計 artifact テンプレート（design.md）作成（7 要素構造） | PASS | docs/working/templates/design.md 作成済み |
+| solution-architect Agent 出力フォーマットと一致 | PASS | TASK-0025 完了後に整合確認済み |
+| plan.md との役割分担明示 | PASS | テンプレート冒頭に役割分担表を掲載 |
+| PlanGate フロー（A→D）における WF-03 挿入位置の図示 | PASS | docs/workflows/plangate-insertion-map.md（Mermaid）作成済み |
+| サンプル design.md が 1 件作成 | PASS | TASK-0023 を題材にサンプル作成済み |
+
+**総合**: 6/6 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | plan.md と design.md の境界が曖昧で二重管理リスク | medium | 実運用での発見次第 working-context.md に注意書き追加 |
+| 2 | design.md の最適な section 粒度：プロジェクト規模による差異が大きい | low | 実運用データを蓄積してから粒度ガイドを更新 |
+| 3 | サンプル design.md が具体的すぎて再利用困難 | low | テンプレートとサンプルを分離する構成で対応可能 |
+
+## 3. V2 候補
+
+- **design.md の lint 検証**: 7 要素の必須セクション存在チェックを自動化
+- **plan.md/design.md 境界検出**: 「実装ノウハウ」が plan.md に混入していないか自動チェック
+- **design.md の実績サンプル集**: 複数 PBI のサンプルを `docs/working/templates/examples/` に蓄積
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| plan.md は変更なし、design.md を新設 | plan.md を design.md に統合 | 既存ワークフローとの後方互換性維持 |
+| サンプルを TASK-0023 題材で 1 件作成 | 汎用的なサンプルを複数作成 | スコープ明確化、実際の TASK での検証を優先 |
+| モード light | standard | 変更ファイル数が light 基準内に収まったため |
+
+## 5. 引き継ぎ文書
+
+TASK-0026 は PlanGate v7 の **Solution Design phase（WF-03）独立化**を担ったタスク。
+
+`docs/working/templates/design.md`（7 要素：モジュール境界・データフロー・状態管理・エラーパス・テスト観点・依存制約・技術的妥協点）を新設し、solution-architect Agent の出力フォーマットとして標準化した。
+
+**後続タスクへの影響**:
+- WF-04（Build & Refine）の入力は本タスクで定義した design.md 形式
+- feature-implement Skill（TASK-0024）は design artifact を入力として受け取る
+
+**参照先**:
+- `docs/working/templates/design.md` — design artifact テンプレート（7 要素）
+- `docs/workflows/03_solution_design.md` — WF-03 の phase 定義
+- `docs/workflows/plangate-insertion-map.md` — PlanGate × WF の挿入位置図
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| C-3 Gate | APPROVED | Codex C-2 CONDITIONAL → 全対応済み、2026-04-20 |
+| 受入基準確認 | PASS | 6/6 基準 PASS |
+| V-4 リリース前チェック | スキップ | light モード |

--- a/docs/working/TASK-0027/handoff.md
+++ b/docs/working/TASK-0027/handoff.md
@@ -1,0 +1,67 @@
+# Handoff Package
+
+```yaml
+task: TASK-0027
+related_issue: https://github.com/s977043/plangate/issues/27
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #39
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| WF-05 が標準 phase として深化 | PASS | docs/workflows/05_verify_and_handoff.md 更新済み |
+| handoff package テンプレート（6 要素）作成 | PASS | docs/working/templates/handoff.md 作成済み |
+| status.md / current-state.md との役割分担明示 | PASS | テンプレート冒頭の役割分担表に記載 |
+| acceptance-review / known-issues-log Skill 連携定義 | PASS | WF-05 定義ファイルに Skill 呼び出し順序を記載 |
+| 全 PBI で handoff 必須ルールが .claude/rules/working-context.md に記載 | PASS | handoff 節追加済み、全 PBI 必須として明記 |
+| V-1 受け入れ検査との関係明示 | PASS | WF-05 内で V-1 後・C-4 前の発行タイミングを明記 |
+
+**総合**: 6/6 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | handoff.md と status.md の二重管理リスク：役割が重複して感じられる | medium | 役割分担表を冒頭に置くことで緩和、実運用で判断 |
+| 2 | 全 PBI 必須化によるオーバーヘッド：light モードでも同じ 6 要素 | low | テンプレートに簡易版を準備（light モード以下は「該当なし」明記で可） |
+| 3 | acceptance-review / known-issues-log が TASK-0024 完了前は参照不可 | 解消済み | TASK-0024 完了後に整合確認済み |
+
+## 3. V2 候補
+
+- **handoff.md 生成の自動化**: V-1 PASS 後に acceptance-review / known-issues-log Skill の出力を自動集約
+- **handoff.md の lint**: 6 要素の必須セクション存在チェックを CI に組み込む
+- **handoff.md の公開範囲制御**: GitHub Pages での working/ 除外設定と連動
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| handoff.md を status.md に追記ではなく独立ファイルとして新設 | status.md に handoff セクションを追加 | 役割の明確分離（進行中 vs 完了資産）、参照のしやすさ |
+| handoff.md ファイル名を固定（日付サフィックスなし） | handoff-YYYYMMDD.md 形式 | バージョン管理は git 履歴で追跡、ファイル名は常に handoff.md で固定 |
+| モード light | standard | 変更ファイル数が light 基準内、リスクも低い |
+
+## 5. 引き継ぎ文書
+
+TASK-0027 は PlanGate v7 の **Verify & Handoff 標準化（WF-05）**を担ったタスク。
+
+`docs/working/templates/handoff.md`（6 要素）を新設し、全 PBI で handoff.md を必須出力とするルールを `.claude/rules/working-context.md` に明文化した。
+
+**後続タスクへの影響**:
+- 全ての TASK（TASK-0022〜0028 含む）で handoff.md を発行することが義務付けられた（本タスクの成果物がその根拠）
+- 本 handoff.md 自体が Rule 5 の実証でもある
+
+**参照先**:
+- `docs/working/templates/handoff.md` — handoff テンプレート（6 要素）
+- `docs/workflows/05_verify_and_handoff.md` — WF-05 の phase 定義
+- `.claude/rules/working-context.md` — handoff 必須ルール（handoff 節）
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| C-3 Gate | APPROVED | Codex C-2 major 3 件 / minor 1 件全対応済み、2026-04-20 |
+| 受入基準確認 | PASS | 6/6 基準 PASS |
+| V-4 リリース前チェック | スキップ | light モード |

--- a/docs/working/TASK-0028/handoff.md
+++ b/docs/working/TASK-0028/handoff.md
@@ -1,0 +1,66 @@
+# Handoff Package
+
+```yaml
+task: TASK-0028
+related_issue: https://github.com/s977043/plangate/issues/28
+author: orchestrator
+issued_at: 2026-04-24
+v1_release: v7.0.0 / PR #40
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 |
+|---------|------|------|
+| docs/plangate-v7-hybrid.md が作成 | PASS | 全体像統合ドキュメントとして作成済み |
+| Rule 1〜5 が明記 | PASS | .claude/rules/hybrid-architecture.md に正本として明記 |
+| CLAUDE.md / Skill / Hook の境界ルールが明記 | PASS | hybrid-architecture.md「境界ルール」セクションに記載 |
+| ガバナンス層と実行層の接続表が含まれる | PASS | plangate-v7-hybrid.md および hybrid-architecture.md に接続表掲載 |
+| 既存 v5/v6 との整合（差分・位置付け）が明記 | PASS | v5 は整合済み、v6 roadmap に v7 導線 note 追加済み |
+| .claude/rules/ の該当ファイルが更新 or 新規追加 | PASS | hybrid-architecture.md 新規作成 |
+
+**総合**: 6/6 基準 PASS
+
+## 2. 既知課題一覧
+
+| # | 課題 | 優先度 | V2 移行理由 |
+|---|------|--------|------------|
+| 1 | Rule 1〜4 の自動違反検出：現状は grep 依存で CI 未組込み | medium | deterministic hooks 化が V2 の最重要課題 |
+| 2 | v6 roadmap の v7 整合：既存ユーザーが v6 → v7 移行時に迷う可能性 | low | v6 roadmap に note を追加済み、詳細は plangate-plugin-migration.md で対応 |
+
+## 3. V2 候補
+
+- **Rule 1〜4 の CI 自動検出**: 各 Rule の違反パターンを CI パイプラインで常時チェック
+- **v7 入門ガイド**: 新規参入者向けの「v7 を最初から使う」チュートリアルを作成
+- **CHANGELOG.md 整備**: v3〜v7 の変更履歴を統合（OSS 品質向上）
+
+## 4. 妥協点
+
+| 選択した方針 | 選ばなかった選択肢 | 理由 |
+|------------|----------------|------|
+| Rule 1〜5 の正本を .claude/rules/hybrid-architecture.md に分離 | CLAUDE.md に埋め込む | Rule 4「案件固有情報は CLAUDE.md に寄せる」との整合性、他プロジェクトでも参照可能な汎用形式 |
+| 既存 v5/v6 は破壊せず v7 を opt-in として追加 | 全面書き換え | 既存ユーザーへの影響最小化、段階的な移行を可能にする |
+| deterministic hooks の実装は V2 に先送り | TASK-0028 内で hooks を実装 | スコープ明確化。設計原則の文書化が本 TASK の責務 |
+
+## 5. 引き継ぎ文書
+
+TASK-0028 は PlanGate v7 ハイブリッドアーキテクチャの **Rule 1〜5 とガバナンス層・実行層の統合ルール**を確立したタスク。
+
+`docs/plangate-v7-hybrid.md`（全体像）と `.claude/rules/hybrid-architecture.md`（Rule 1〜5 正本）を新設し、CLAUDE.md / Skill / Hook の強制力軸での境界を明文化した。
+
+**後続タスクへの影響**:
+- Rule 1〜5 は全 v7 サブタスク（TASK-0022〜0027）の設計原則として機能
+- 新規 Skill / Agent / Workflow を追加する際の判断基準として参照
+
+**参照先**:
+- `.claude/rules/hybrid-architecture.md` — Rule 1〜5 の正本（使い分けの判断基準）
+- `docs/plangate-v7-hybrid.md` — ハイブリッドアーキテクチャの全体像
+- `CLAUDE.md` — 案件固有情報の集約先
+
+## 6. テスト結果サマリ
+
+| 検証ステップ | 結果 | 詳細 |
+|------------|------|------|
+| C-3 Gate | APPROVED | Codex C-2 major 3 件 / minor 1 件全対応済み、2026-04-20 |
+| 受入基準確認 | PASS | 6/6 基準 PASS |
+| V-4 リリース前チェック | スキップ | light モード |


### PR DESCRIPTION
## Summary

v7 ハイブリッドアーキテクチャ **Rule 5「最終成果物は毎回 handoff に集約」** に従い、マージ済み全 PBI の handoff.md を一括作成。

| タスク | 内容 | 受入基準 |
|--------|------|---------|
| TASK-0021 | v7 ハイブリッドアーキテクチャ（親 PBI） | 9/9 PASS |
| TASK-0022 | Workflow 5 phase 定義 | 7/7 PASS |
| TASK-0024 | 再利用可能 Skill 10 個 | 6/6 PASS |
| TASK-0025 | 責務ベース Agent 5 体 | 5/5 PASS |
| TASK-0026 | Solution Design 独立化（WF-03） | 6/6 PASS |
| TASK-0027 | Verify & Handoff 標準化（WF-05） | 6/6 PASS |
| TASK-0028 | Rule 1〜5 統合ルール | 6/6 PASS |

各 handoff.md に必須 6 要素（要件適合確認・既知課題・V2候補・妥協点・引き継ぎ文書・テスト結果）を記載。

## Test plan

- [ ] 各 handoff.md に 6 要素のセクションが存在すること
- [ ] `docs/working/templates/handoff.md` のテンプレート構造に準拠していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)