### PR TITLE
docs: 2026-04-24 セッション振り返りを追加

### DIFF
--- a/docs/working/session-retrospective-2026-04-24.md
+++ b/docs/working/session-retrospective-2026-04-24.md
@@ -1,0 +1,84 @@
+# セッション振り返り
+
+> 実施日: 2026-04-24
+> 対象セッション: v7.0.0 後片付け → v7.1.0 リリース + Rule 5 完全適用
+
+---
+
+## 1. セッション成果サマリ
+
+### マージ済み PR（3 本）
+
+| PR | 種別 | 内容 |
+|----|------|------|
+| #48 | docs | README v7 リライト + philosophy.md + GitHub Pages 対応 |
+| #49 | feat | `.agents/skills/` に Claude Code/Codex CLI 共用スキル 18 件追加 |
+| #50 | docs | TASK-0021〜0028 の handoff.md 7 件を一括発行（Rule 5 対応） |
+
+### リリース
+
+- **v7.1.0** — README 刷新 + 共用スキル 18 件 + GitHub Pages + MIT ライセンス
+
+---
+
+## 2. 主な成果
+
+### README の外部向け刷新
+
+v7.0.0 リリース後もREADMEが旧構成のままだった問題を解消。ハーネスエンジニアリング軸への刷新・`docs/philosophy.md`（思想文書）の新設・GitHub Pages エントリーポイントの追加を一括対応した。
+
+### `.agents/skills/` 共用スキル層の確立
+
+Claude Code と Codex CLI の両方から参照できる共用スキル 18 件を `.agents/skills/` に配置。v7 ハイブリッドアーキテクチャの Skill 層（WF-01〜05 対応 10 件 + 汎用 5 件 + Skill 運用 3 件）が揃った。
+
+### Rule 5 の完全適用（handoff.md 一括発行）
+
+v7 で定義した Rule 5「最終成果物は毎回 handoff に集約」が自身の PBI 群（TASK-0021〜0028）で未適用のまま残っていた。今セッションで 7 件を一括発行し、Rule 5 を完全適用した。
+
+---
+
+## 3. プロセスの観察
+
+### うまくいったこと
+
+- **セルフレビューで Copilot 指摘を先取り**: PR 作成前のセルフレビューで `.agents/skills/README.md` の更新漏れを自己検出・修正した
+- **Copilot 指摘への迅速対応**: PR #48（`_config.yml` の無効 include）・PR #49（誤記・重複・パス不整合 4 件）をその場で修正してマージまで完走
+- **並列実行の活用**: handoff.md 7 件の素材収集を 2 エージェント並列で実施し、その後 7 ファイルを同時 Write で作成
+- **残タスクの自己発見**: git status・working context・GitHub Issues を横断確認し、handoff.md の未発行（Rule 5 違反）を自律的に発見
+
+### 改善できること
+
+- **handoff.md の発行タイミング**: 本来は PR マージ直後（WF-05 完了時）に発行すべきだったが、後続セッションで一括対応になった。今後は PR マージと同セッションで発行する
+- **残タスク確認の標準化**: セッション開始時に `git status` + GitHub Issues + working context の 3 点確認を習慣化する
+
+---
+
+## 4. V2 候補（次回以降のアクション）
+
+| 優先度 | 内容 | 理由 |
+|--------|------|------|
+| 高 | `release-manager` Agent 作成 | V-4 担当として TASK-0021 handoff で既知課題に記録済み |
+| 高 | Rule 1〜4 違反の CI 自動検出（deterministic hooks） | 現状 grep 依存、全タスクの V2 候補に共通 |
+| 中 | v7 ドッグフーディング PBI（実 TASK で WF-01〜05 を一周） | アーキテクチャの実用性検証 |
+| 中 | CHANGELOG.md 整備（v3〜v7 統合） | OSS 品質向上 |
+| 低 | 既存 17 Agent の段階的責務ベース移行計画 | 長期的な一本化方針 |
+
+---
+
+## 5. 次回セッション向けコンテキスト
+
+```
+現在地: v7.1.0 リリース済み、全 PBI の handoff.md 発行完了
+main ブランチ: クリーン（未コミット変更なし）
+オープン PR/Issue: なし
+
+次のアクション候補:
+1. release-manager Agent 作成（新規 TASK として PBI 化）
+2. v7 ドッグフーディング（小さな実 PBI で WF-01〜05 を一周）
+3. deterministic hooks 実装（Rule 1〜4 違反の CI 自動検出）
+
+参照先:
+- docs/plangate-v7-hybrid.md — v7 全体像
+- .claude/rules/hybrid-architecture.md — Rule 1〜5 正本
+- docs/working/TASK-0021/handoff.md — v7 既知課題・V2 候補
+```


### PR DESCRIPTION
## Summary

v7.0.0 後片付け → v7.1.0 リリース + Rule 5 完全適用セッションの振り返りを追加。

**主な記録内容**:
- セッション成果（PR #48〜#50、v7.1.0 リリース）
- プロセス観察（うまくいったこと・改善できること）
- V2 候補（次回以降のアクション優先順位）
- 次回セッション向けコンテキスト（現在地・次のアクション・参照先）

🤖 Generated with [Claude Code](https://claude.com/claude-code)