### PR TITLE
feat(gate): TASK-0032 5 Gate システム実装（Design/TDD/Review/Completion Gate）

### DIFF
--- a/docs/working/TASK-0032/INDEX.md
+++ b/docs/working/TASK-0032/INDEX.md
@@ -1,0 +1,64 @@
+# INDEX — TASK-0032
+
+## チケット概要
+
+| 項目 | 内容 |
+|------|------|
+| **TASK 番号** | TASK-0032 |
+| **Issue** | [#57](https://github.com/s977043/plangate/issues/57) |
+| **タイトル** | PlanGate 4 Gate システム Phase B — Completion Gate + Mode マトリクス |
+| **ステータス** | In Progress（Phase B 実装中） |
+| **Mode** | high-risk |
+| **作成日** | 2026-04-26 |
+
+## 現在フェーズ
+
+**Phase B: Completion Gate + Mode マトリクス + Working Context 作成中**
+
+- Phase A（design-gate / tdd-gate / review-gate）: 完了済み
+- Phase B: 実装中 → コミット後 C-4 PRレビュー待ち
+
+## 主要ファイル一覧
+
+### Working Context
+
+| ファイル | 役割 | L0 |
+|---------|------|-----|
+| [`INDEX.md`](./INDEX.md) | チケット索引（このファイル） | L0 常読 |
+| [`current-state.md`](./current-state.md) | 現在状態スナップショット | L0 常読 |
+| [`pbi-input.md`](./pbi-input.md) | PBI INPUT PACKAGE | L1 |
+| [`plan.md`](./plan.md) | EXECUTION PLAN | L1 |
+| [`todo.md`](./todo.md) | EXECUTION TODO | L1 |
+| [`test-cases.md`](./test-cases.md) | テストケース定義 | L1 |
+| [`handoff.md`](./handoff.md) | 完了時の引き継ぎパッケージ | WF-05 完了後 |
+
+### 実装ファイル（Phase A: 完了済み）
+
+| ファイル | 概要 |
+|---------|------|
+| `plugin/plangate/rules/design-gate.md` | Design Gate ルール正本 |
+| `plugin/plangate/skills/design-gate/SKILL.md` | Design Gate Skill |
+| `plugin/plangate/commands/pg-tdd.md` | TDD Gate コマンド定義 |
+| `plugin/plangate/rules/review-gate.md` | Review Gate ルール正本 |
+| `plugin/plangate/skills/review-gate/SKILL.md` | Review Gate Skill |
+
+### 実装ファイル（Phase B: 本フェーズ）
+
+| ファイル | 概要 |
+|---------|------|
+| `plugin/plangate/rules/completion-gate.md` | Completion Gate ルール正本（新規） |
+| `plugin/plangate/rules/mode-classification.md` | Gate 適用マトリクス追加（更新） |
+
+## ブランチ構成
+
+| ブランチ | 内容 | 状態 |
+|---------|------|------|
+| `feature/task-0032-gate-system-design` | Phase A: Design Gate | マージ済み |
+| `feature/task-0032-gate-system-tdd-review` | Phase A: TDD + Review Gate | マージ済み |
+| `feature/task-0032-gate-system-completion` | Phase B: Completion Gate + Working Context | 作業中 |
+
+## 関連リンク
+
+- 親 Epic: #53
+- Issue: #57
+- Workflow: `docs/workflows/04_build_and_refine.md`

--- a/docs/working/TASK-0032/current-state.md
+++ b/docs/working/TASK-0032/current-state.md
@@ -1,0 +1,30 @@
+# current-state — TASK-0032
+
+> 最終更新: 2026-04-26
+
+## 現在フェーズ
+
+**Phase B: 実装中 → コミット前**
+
+## 完了済み
+
+- Phase A: design-gate.md / design-gate/SKILL.md / pg-tdd.md / review-gate.md / review-gate/SKILL.md（別ブランチでコミット済み）
+- Phase B: completion-gate.md 作成
+- Phase B: mode-classification.md に Gate 適用マトリクス追加
+- Phase B: Working Context 7 ファイル作成中
+
+## 残タスク
+
+- [ ] todo.md の検証チェックポイント確認
+- [ ] コミット実行
+- [ ] PR 作成
+- [ ] C-4: Human によるPRレビュー
+
+## ブロッカー
+
+なし
+
+## 次のアクション
+
+1. コミット: `feat(gate): TASK-0032 Completion Gate + Mode マトリクス + Working Context (#57)`
+2. PR 作成して C-4 レビューを依頼

--- a/docs/working/TASK-0032/handoff.md
+++ b/docs/working/TASK-0032/handoff.md
@@ -1,0 +1,96 @@
+# Handoff Package — TASK-0032
+
+> WF-05 Verify & Handoff の必須出力。Rule 5 遵守。
+> 配置: `docs/working/TASK-0032/handoff.md`
+
+## メタ情報
+
+```yaml
+task: TASK-0032
+related_issue: https://github.com/s977043/plangate/issues/57
+author: implementation-agent（qa-reviewer 実施前）
+issued_at: 2026-04-26
+v1_release: pending（PR マージ後に更新）
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-1: high-risk 以上で Design Gate なしに実装へ進めない | PASS | `completion-gate.md` 条件 1 に「Mode が high-risk 以上かつ Design Gate を通過していない場合 → BLOCKED」と明記 |
+| AC-2: critical で rollback plan なしに完了できない | PASS | `completion-gate.md` 条件 5 に「critical モードでは rollback plan の存在も必須」、Mode 別適用マトリクスで `critical` 行の Rollback Plan が **必須** |
+| AC-3: TDD 必須モードで failing test evidence がない場合にブロック | PASS | `completion-gate.md` 条件 2 に「Mode が high-risk 以上かつ Evidence Ledger に type:"test" の証拠がない場合 → BLOCKED」「failing test (exitCode=1) の記録が必須」と明記 |
+| AC-4: Review Gate で critical finding がある場合に Completion Gate が失敗する | PASS | `completion-gate.md` 条件 3 に「severity=critical の finding が 1 件以上ある場合 → BLOCKED（全モード）」と明記。`review-gate.md` との参照関係も記述 |
+| AC-5: Evidence Ledger なしに Completion Gate が passed にならない | PASS | `completion-gate.md` 条件 4 に Evidence Ledger の 3 ブロック条件（status failed/unknown、missingEvidence、Ledger 不存在）を明記 |
+| AC-6: 軽微修正では Design/TDD/Review を過剰要求しない | PASS | `mode-classification.md` の Gate 適用マトリクスで `ultra-light` / `light` の Design Gate・TDD Gate・Review Gate が `-`（スキップ）になっている |
+
+**総合**: `6/6 基準 PASS`
+
+**FAIL / WARN の扱い**: 全基準 PASS のため該当なし
+
+> 注: acceptance-tester による正式な V-1 検査は PR マージ前に実施予定。本判定は実装エージェントによる自己確認。
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| Completion Gate の判定が Markdown 定義のみで CI フックが存在しない | minor | accepted（V2 へ） | Yes |
+| `/pg-verify` コマンドの出力形式と completion-gate.md の JSON 形式の同期を手動で維持する必要がある | minor | accepted | Yes |
+
+**Critical 課題の対応**: Critical 課題なし
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue（あれば） |
+|--------|------|----------|-----------------|
+| CI フック自動化（GitHub Actions / pre-commit フック） | V1 は Markdown 定義のみ。機械的な強制は V2 以降で実装 | High | 未発行 |
+| `requiresUserApproval` の三値化（true/false/conditional） | 現在は boolean。`high-risk` では条件付き承認を表現できない | Medium | 未発行 |
+| TypeScript / JSON スキーマ実装 | 現在は Markdown 定義のみ。型安全な Gate Policy 定義は V2 以降 | Medium | 未発行 |
+| Security Gate の追加 | セキュリティ専門の Gate が存在しない。現在は Review Gate の観点 3 として包含 | Low | 未発行 |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| Markdown 定義のみで 4 Gate システムを完成させる | CI フックで機械的にブロック | 工数・複雑度が大きく増加する。V1 は定義を固めることを優先し、自動化は V2 へ先送り |
+| Completion Gate を独立ファイルとして定義 | 既存の evidence-ledger.md に統合 | 単一責務の原則（Rule 3 相当）に従い、独立したルールファイルとして管理することで参照しやすくする |
+| `full` ラベルは使わず `high-risk` に統一 | 並行して `full` / `high-risk` 両方をサポート | TASK-0029 でリネーム済み。二重定義は混乱を招くため廃止 |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0032 は PlanGate 開発統制 OS の Phase 2 として、4 Gate システム（Design Gate / TDD Gate / Review Gate / Completion Gate）を定義した。Phase A（TASK-0032 の前半: 別ブランチで実装済み）で Design Gate・TDD Gate・Review Gate の個別ルールと Skill を定義し、Phase B（本ブランチ）で Completion Gate による統合と Mode 分類マトリクスへの Gate 適用表追加を完了させた。
+
+現在 `feature/task-0032-gate-system-completion` ブランチに 2 つの Phase A ブランチ（`feature/task-0032-gate-system-design` と `feature/task-0032-gate-system-tdd-review`）をマージし、Phase B の 2 ファイル（`completion-gate.md` / `mode-classification.md` 更新）と Working Context 7 ファイルを追加した状態。PR 作成・C-4 レビュー待ち。
+
+### 触れないでほしいファイル
+
+- `plugin/plangate/rules/design-gate.md`: Phase A の成果物。変更すると completion-gate.md との参照整合が崩れる
+- `plugin/plangate/rules/review-gate.md`: Phase A の成果物。Severity 定義と Completion Gate ブロック条件が連携している
+- `plugin/plangate/rules/evidence-ledger.md`: TASK-0030 の成果物。Completion Gate の条件 4 の正本として依存している
+
+### 次に手を入れるなら
+
+- CI フック実装（V2）: `.claude/settings.json` の hooks セクションに completion-gate のチェックを追加
+- `/pg-verify` コマンドの出力形式を `completion-gate.md` の JSON 形式と同期確認
+- `requiresUserApproval` の三値化に対応した GatePolicy 定義の拡張
+
+### 参照リンク
+
+- 親 PBI: [#57](https://github.com/s977043/plangate/issues/57)
+- plan.md: `docs/working/TASK-0032/plan.md`
+- current-state.md: `docs/working/TASK-0032/current-state.md`
+- 関連ルール: `plugin/plangate/rules/completion-gate.md`
+- 関連ルール: `plugin/plangate/rules/mode-classification.md`
+
+## 6. テスト結果サマリ
+
+> acceptance-tester による V-1 受け入れ検査は PR マージ前に実施予定。
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| 文書確認（TC-01〜06） | 6 | 6（実装エージェント自己確認） | 0 | 6/6 AC |
+| markdownlint | 自動（CI） | pending | — | — |
+
+**FAIL / SKIP の詳細**: markdownlint は PR 後の CI で確認予定。文書確認の 6 件は実装エージェントによる自己確認であり、acceptance-tester による正式な検査は別途実施する。

--- a/docs/working/TASK-0032/pbi-input.md
+++ b/docs/working/TASK-0032/pbi-input.md
@@ -1,0 +1,76 @@
+# PBI INPUT PACKAGE — TASK-0032
+
+## メタ情報
+
+```yaml
+task: TASK-0032
+related_issue: https://github.com/s977043/plangate/issues/57
+author: human
+phase: A（PBI INPUT PACKAGE）
+created_at: 2026-04-26
+```
+
+## Context / Why（なぜやるか）
+
+Phase 1（TASK-0029〜0031）完了後、PlanGate を「開発統制 OS」に拡張する Epic #53 の Phase 2 として実施する。
+
+Phase 1 で Intent Classifier / Evidence Ledger / pg コマンド群の基盤が整備された。しかし「AIが完了を主張した = 実際に完了している」という曖昧な状態は依然として残っている。「動くはず」「たぶん通過した」という曖昧な完了主張を排除し、証拠に基づく Gate 通過を強制する仕組みが必要。
+
+4 Gate システム（Design Gate / TDD Gate / Review Gate / Completion Gate）を定義し、Mode 別に適用条件を明確化することで、AIの自己申告に依存しない統制フローを実現する。
+
+## What（Scope）
+
+### In scope
+
+- **Design Gate**: high-risk 以上のモードで設計なしに実装へ進むことを防ぐルール定義
+- **TDD Gate**: failing test evidence を必須とするルール定義（pg-tdd.md + evidence-ledger 連携）
+- **Review Gate**: critical finding を Completion Gate に伝達するルール定義
+- **Completion Gate**: 全 Gate の通過を一元管理する最終チェックポイント定義
+- **Mode 別 Gate マトリクス**: mode-classification.md に Gate 適用表を追加
+- **Working Context**: TASK-0032 一式（pbi-input / plan / todo / test-cases / INDEX / current-state / handoff）
+
+### Out of scope
+
+- CI hook の自動化（GitHub Actions / pre-commit フック実装）
+- TypeScript / JSON スキーマ実装
+- 既存 handoff.md への遡及適用
+- 4 Gate 以外の追加 Gate（例: Performance Gate、Security Gate）
+
+## 受入基準
+
+| AC-ID | 内容 |
+|-------|------|
+| AC-1 | high-risk 以上で Design Gate なしに実装へ進めない（completion-gate.md に明記） |
+| AC-2 | critical で rollback plan なしに完了できない（completion-gate.md に明記） |
+| AC-3 | TDD 必須モードで failing test evidence がない場合にブロックできる（pg-tdd.md + evidence-ledger 連携） |
+| AC-4 | Review Gate で critical finding がある場合に Completion Gate が失敗する（review-gate.md + completion-gate.md 連携） |
+| AC-5 | Evidence Ledger なしに Completion Gate が passed にならない（completion-gate.md に明記） |
+| AC-6 | 軽微修正では Design/TDD/Review を過剰要求しない（mode-classification.md の Gate マトリクスで ultra-light/light は省略） |
+
+## Notes from Refinement
+
+- Phase A（Agent A: Design Gate、Agent B: TDD Gate + Review Gate）は実装済み
+- Phase B（Agent C: Completion Gate + Mode マトリクス統合 + Working Context）が本チケット
+- 4 Gate システムは Markdown 定義のみで V1 完了とする。CI 自動化は V2 以降
+- `mode-classification.md` の「高」ラベルは TASK-0029 で `full` → `high-risk` にリネーム済み
+
+## Estimation Evidence
+
+| 項目 | 見積もり |
+|------|---------|
+| 変更ファイル数 | 8 件 |
+| 受入基準数 | 6 件 |
+| Mode 判定 | high-risk（機能追加、複数ファイル・複数レイヤーの変更） |
+
+### Risks
+
+- `mode-classification.md` 更新時に既存セクションを壊すリスク → セクション追加のみで対応
+- `completion-gate.md` と `evidence-ledger.md` の整合性 → 参照関係を明示して管理
+
+### Unknowns
+
+- `/pg-verify` コマンドの詳細実装は TASK-0031 で確認済み
+
+### Assumptions
+
+- Phase A の 5 ファイル（design-gate.md / design-gate/SKILL.md / pg-tdd.md / review-gate.md / review-gate/SKILL.md）は実装済みで変更不要

--- a/docs/working/TASK-0032/plan.md
+++ b/docs/working/TASK-0032/plan.md
@@ -1,0 +1,97 @@
+# EXECUTION PLAN — TASK-0032
+
+## メタ情報
+
+```yaml
+task: TASK-0032
+related_issue: https://github.com/s977043/plangate/issues/57
+phase: B（EXECUTION PLAN）
+created_at: 2026-04-26
+```
+
+## Goal
+
+4 Gate システム（Design Gate / TDD Gate / Review Gate / Completion Gate）を定義し、Mode 別に適用条件を明確化する。
+「動くはず」「たぶん通過した」という曖昧な完了主張を排除し、証拠に基づく Gate 通過を強制する仕組みを Markdown 定義として完成させる。
+
+## Constraints / Non-goals
+
+**制約**:
+- `mode-classification.md` は既存内容を壊さず、セクション追加のみ行うこと
+- 全ファイルを日本語で作成すること
+- Rule 2 違反（Skill にプロジェクト固有情報を入れる）を避けること
+- Markdown の見出し構造を正しく保つこと（markdownlint CI が走る）
+
+**Non-goals**:
+- CI hook の自動化（GitHub Actions / pre-commit フック実装）
+- TypeScript / JSON スキーマ実装
+- 4 Gate 以外の追加 Gate
+
+## Approach Overview
+
+Phase A（完了済み）: Design Gate / TDD Gate / Review Gate の個別ルール・Skill を定義
+Phase B（本計画）: Completion Gate で全 Gate を統合し、Mode マトリクスを mode-classification.md に追加。Working Context 一式を作成してチケットを完了させる。
+
+## Work Breakdown
+
+### Phase A（完了済み）
+
+| Step | Output | Owner | 状態 |
+|------|--------|-------|------|
+| A-1 | `plugin/plangate/rules/design-gate.md` | Agent A | 完了 |
+| A-2 | `plugin/plangate/skills/design-gate/SKILL.md` | Agent A | 完了 |
+| A-3 | `plugin/plangate/commands/pg-tdd.md` | Agent B | 完了 |
+| A-4 | `plugin/plangate/rules/review-gate.md` | Agent B | 完了 |
+| A-5 | `plugin/plangate/skills/review-gate/SKILL.md` | Agent B | 完了 |
+
+### Phase B（本計画）
+
+| Step | Output | Owner | Risk | チェックポイント |
+|------|--------|-------|------|----------------|
+| B-1 | `plugin/plangate/rules/completion-gate.md` 作成 | Agent C | 低: Phase A との整合性 | 5 ブロック条件が全て記述されているか |
+| B-2 | `plugin/plangate/rules/mode-classification.md` 更新 | Agent C | 低: 既存内容を破壊しない | Gate 適用マトリクスが正しく追加されたか |
+| B-3 | `docs/working/TASK-0032/` 一式作成 | Agent C | 低 | 7 ファイルが全て作成されたか |
+| B-4 | コミット | Agent C | 低 | git log で確認 |
+
+## Files / Components to Touch
+
+| ファイル | 操作 |
+|---------|------|
+| `plugin/plangate/rules/completion-gate.md` | 新規作成 |
+| `plugin/plangate/rules/mode-classification.md` | 更新（Gate 適用マトリクスセクション追加） |
+| `docs/working/TASK-0032/pbi-input.md` | 新規作成 |
+| `docs/working/TASK-0032/plan.md` | 新規作成 |
+| `docs/working/TASK-0032/todo.md` | 新規作成 |
+| `docs/working/TASK-0032/test-cases.md` | 新規作成 |
+| `docs/working/TASK-0032/INDEX.md` | 新規作成 |
+| `docs/working/TASK-0032/current-state.md` | 新規作成 |
+| `docs/working/TASK-0032/handoff.md` | 新規作成 |
+
+## Testing Strategy
+
+- **文書確認テスト**: acceptance-tester が test-cases.md の 6 AC を突合確認
+- **自動化**: markdownlint CI による Markdown 構造チェック
+- **手動確認**: 各 Gate ルールファイルの参照関係が正しいか確認
+
+## Risks & Mitigations
+
+| リスク | 対策 |
+|--------|------|
+| `mode-classification.md` の既存セクションを壊す | セクション追加のみ、既存行は変更しない |
+| `completion-gate.md` と `evidence-ledger.md` の整合性ズレ | 参照パスを明示し、ブロック条件を evidence-ledger.md の正本に合わせる |
+| handoff.md のテスト結果が pending | acceptance-tester 実施前は「pending」と明記し、V1 リリース後に更新 |
+
+## Questions / Unknowns
+
+- なし（Phase A で全ての前提情報が確定済み）
+
+## Mode 判定
+
+**モード**: `high-risk`
+
+**判定根拠**:
+- 変更ファイル数: 9 件 → high-risk（6-15 件）
+- 受入基準数: 6 件 → high-risk（6-10 件）
+- 変更種別: 機能追加（Gate システム完成） → high-risk
+- リスク: 中程度（複数ファイル・複数レイヤーへの変更） → high-risk
+- **最終判定**: `high-risk`

--- a/docs/working/TASK-0032/test-cases.md
+++ b/docs/working/TASK-0032/test-cases.md
@@ -1,0 +1,48 @@
+# テストケース定義 — TASK-0032
+
+## メタ情報
+
+```yaml
+task: TASK-0032
+related_issue: https://github.com/s977043/plangate/issues/57
+phase: B（テストケース定義）
+created_at: 2026-04-26
+```
+
+## 受入基準 → テストケースマッピング
+
+| AC-ID | 受入基準 | テストケース |
+|-------|---------|------------|
+| AC-1 | high-risk 以上で Design Gate なしに実装へ進めない（completion-gate.md に明記） | TC-01 |
+| AC-2 | critical で rollback plan なしに完了できない（completion-gate.md に明記） | TC-02 |
+| AC-3 | TDD 必須モードで failing test evidence がない場合にブロックできる | TC-03 |
+| AC-4 | Review Gate で critical finding がある場合に Completion Gate が失敗する | TC-04 |
+| AC-5 | Evidence Ledger なしに Completion Gate が passed にならない | TC-05 |
+| AC-6 | 軽微修正では Design/TDD/Review を過剰要求しない | TC-06 |
+
+## テストケース一覧
+
+| TC-ID | 対応 AC | 前提条件 | テスト操作 | 期待結果 | 種別 |
+|-------|--------|---------|-----------|---------|------|
+| TC-01 | AC-1 | Mode: high-risk | `completion-gate.md` を参照し「条件 1: Design Gate パス必須（high-risk/critical）」セクションを確認 | `high-risk` 以上で Design Gate が必須（BLOCKED 条件として）明記されている | 文書確認 |
+| TC-02 | AC-2 | Mode: critical | `completion-gate.md` を参照し Mode 別適用マトリクスの `critical` 行と条件 5 を確認 | Rollback Plan が `critical` で **必須** と明記されている | 文書確認 |
+| TC-03 | AC-3 | Mode: high-risk | `completion-gate.md` の条件 2 および `plugin/plangate/commands/pg-tdd.md` の連携記述を確認 | `type: "test"` の証拠が欠落時のブロック条件が明記されている | 文書確認 |
+| TC-04 | AC-4 | Review Gate に critical finding あり | `completion-gate.md` の条件 3 および `plugin/plangate/rules/review-gate.md` の Completion Gate ブロック条件を確認 | `severity=critical` finding → Completion Gate ブロックの連携が両ファイルで整合していることを確認 | 文書確認 |
+| TC-05 | AC-5 | Evidence Ledger 欠落 | `completion-gate.md` の条件 4 を確認 | Evidence Ledger の `status: "passed"` が Completion Gate の必須条件として明記されている | 文書確認 |
+| TC-06 | AC-6 | Mode: ultra-light / light | `plugin/plangate/rules/mode-classification.md` の「## Gate 適用マトリクス」を確認 | `ultra-light` / `light` の Design Gate・TDD Gate が `-`（スキップ）になっている | 文書確認 |
+
+## エッジケース
+
+| ケース | 期待動作 |
+|--------|---------|
+| `standard` モードで Evidence Ledger が存在しない | 条件 4 でブロック（standard では Evidence Ledger 必須） |
+| `ultra-light` モードで Review Gate の critical finding がある | スキップ設定だが、条件 3 により全モードでブロック |
+| `high-risk` モードで major finding のみの場合 | 推奨ブロック（必須ブロックではない）として記述されていること |
+| `critical` モードで major finding のみの場合 | 強制ブロックとして記述されていること |
+
+## 自動化可否
+
+| テストケース | 自動化 | 備考 |
+|------------|--------|------|
+| TC-01〜06 | 手動（文書確認） | Markdown 内容の意味検証は人間が確認。markdownlint による構造チェックは CI で自動化 |
+| エッジケース | 手動（文書確認） | 記述の正確性確認 |

--- a/docs/working/TASK-0032/todo.md
+++ b/docs/working/TASK-0032/todo.md
@@ -1,0 +1,109 @@
+# EXECUTION TODO — TASK-0032
+
+## メタ情報
+
+```yaml
+task: TASK-0032
+related_issue: https://github.com/s977043/plangate/issues/57
+phase: B（EXECUTION TODO）
+created_at: 2026-04-26
+```
+
+## 凡例
+
+- `[x]` = 完了
+- `[ ]` = 未着手 / 作業中
+- `[Agent]` = AIエージェントが実行
+- `[Human]` = 人間が実行
+
+---
+
+## Phase A: Design Gate / TDD Gate / Review Gate（完了済み）
+
+### 準備
+
+- [x] `[Agent]` ブランチ `feature/task-0032-gate-system-design` 作成
+
+### 実装: Agent A（Design Gate）
+
+- [x] `[Agent]` `plugin/plangate/rules/design-gate.md` 作成
+- [x] `[Agent]` `plugin/plangate/skills/design-gate/SKILL.md` 作成
+- [x] `[Agent]` コミット: `feat(gate): TASK-0032 Design Gate 実装 (#57)`
+
+### 実装: Agent B（TDD Gate + Review Gate）
+
+- [x] `[Agent]` `plugin/plangate/commands/pg-tdd.md` 作成
+- [x] `[Agent]` `plugin/plangate/rules/review-gate.md` 作成
+- [x] `[Agent]` `plugin/plangate/skills/review-gate/SKILL.md` 作成
+- [x] `[Agent]` コミット: `feat(gate): TASK-0032 TDD Gate + Review Gate 実装 (#57)`
+
+### 検証: Phase A
+
+- [x] `[Agent]` Phase A の 5 ファイルが揃っていることを確認
+
+---
+
+## Phase B: Completion Gate + Mode マトリクス + Working Context（本フェーズ）
+
+### 準備
+
+- [x] `[Agent]` ブランチ `feature/task-0032-gate-system-completion` 作成
+- [x] `[Agent]` `feature/task-0032-gate-system-design` をマージ
+- [x] `[Agent]` `feature/task-0032-gate-system-tdd-review` をマージ
+
+### 実装: Agent C（Completion Gate）
+
+- [x] `[Agent]` `plugin/plangate/rules/completion-gate.md` 作成
+  - 5 ブロック条件を記述
+  - Mode 別適用マトリクスを記述
+  - PASSED / BLOCKED 出力形式を JSON で記述
+
+### 実装: Agent C（Mode マトリクス統合）
+
+- [x] `[Agent]` `plugin/plangate/rules/mode-classification.md` に「## Gate 適用マトリクス」セクションを追加
+  - 既存内容を変更・削除しないこと
+
+### 実装: Agent C（Working Context）
+
+- [x] `[Agent]` `docs/working/TASK-0032/pbi-input.md` 作成
+- [x] `[Agent]` `docs/working/TASK-0032/plan.md` 作成
+- [x] `[Agent]` `docs/working/TASK-0032/todo.md` 作成（本ファイル）
+- [x] `[Agent]` `docs/working/TASK-0032/test-cases.md` 作成
+- [x] `[Agent]` `docs/working/TASK-0032/INDEX.md` 作成
+- [x] `[Agent]` `docs/working/TASK-0032/current-state.md` 作成
+- [x] `[Agent]` `docs/working/TASK-0032/handoff.md` 作成
+
+### 検証: Phase B 🚩チェックポイント
+
+- [ ] `[Agent]` completion-gate.md の 5 ブロック条件が全て記述されているか確認（AC-1〜5）
+- [ ] `[Agent]` mode-classification.md の Gate マトリクスで ultra-light/light が `-` になっているか確認（AC-6）
+- [ ] `[Agent]` completion-gate.md に「critical で rollback plan 必須」が明記されているか確認（AC-2）
+- [ ] `[Agent]` completion-gate.md に「Evidence Ledger passed が必須条件」が明記されているか確認（AC-5）
+
+### コミット
+
+- [ ] `[Agent]` `git add` して `git commit -m "feat(gate): TASK-0032 Completion Gate + Mode マトリクス + Working Context (#57)"`
+
+---
+
+## Human タスク
+
+### C-3: exec 前ゲート（計画承認）
+
+- [x] `[Human]` plan.md の内容確認・承認（承認済み、本実装の前提）
+
+### C-4: PR レビュー
+
+- [ ] `[Human]` GitHub 上でプルリクエストをレビュー
+- [ ] `[Human]` APPROVE / REQUEST CHANGES / REJECT を判断
+
+---
+
+## 依存関係
+
+| タスク | 依存先 |
+|--------|--------|
+| completion-gate.md 作成 | design-gate.md / review-gate.md / evidence-ledger.md（参照元） |
+| mode-classification.md 更新 | completion-gate.md（Gate 適用マトリクスで参照） |
+| handoff.md 作成 | 全実装ファイルの完成後 |
+| C-4 PRレビュー | Agent C の全タスク完了後 |

--- a/plugin/plangate/commands/pg-tdd.md
+++ b/plugin/plangate/commands/pg-tdd.md
@@ -1,0 +1,78 @@
+# /pg-tdd
+
+TDD サイクル（Red → Green → Refactor）を実行し、各ステップの証拠を Evidence Ledger に記録する。
+
+## 目的
+
+本番コードを書く前に失敗テストを用意する。証拠なしの「テスト通るはず」宣言を防ぐ。
+
+## Iron Law
+
+`NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST`
+
+failing test の exitCode=1 証拠がない場合、Green フェーズへ進まない。
+
+## 引数
+
+`$ARGUMENTS` に実装したい機能・バグ修正の説明を渡す。
+
+## 実行フロー
+
+### Phase 1: Red（失敗テストを書く）
+
+1. テストケースを記述する（機能の期待動作を定義）
+2. テストを実行し、失敗を確認する（exitCode != 0）
+3. 失敗証拠を Evidence Ledger に記録する:
+   - type: "test"
+   - exitCode: 1（または != 0）
+   - outputExcerpt: 失敗メッセージ
+   - conclusion: "期待通りの失敗 - Red フェーズ完了"
+
+### Phase 2: Green（最小実装でテストを通す）
+
+1. テストを通す最小実装を書く（過剰設計しない）
+2. テストを実行し、成功を確認する（exitCode = 0）
+3. 成功証拠を Evidence Ledger に記録する:
+   - type: "test"
+   - exitCode: 0
+   - outputExcerpt: 成功メッセージ
+   - conclusion: "テスト通過 - Green フェーズ完了"
+
+### Phase 3: Refactor（品質改善）
+
+1. テストを通したまま、コードをリファクタリングする
+2. リファクタリング後のテストを実行し、引き続き成功を確認する
+3. リファクタリング証拠を Evidence Ledger に記録する:
+   - type: "test"
+   - exitCode: 0
+   - outputExcerpt: 成功メッセージ
+   - conclusion: "リファクタリング後もテスト通過 - Refactor フェーズ完了"
+
+## 出力フォーマット
+
+### TDD サイクル記録
+
+| フェーズ | 状態 | コマンド | Exit Code | 結果 |
+|---------|------|--------|---------|------|
+| Red | ✅ 完了 | `<テストコマンド>` | 1 | テスト失敗を確認 |
+| Green | ✅ 完了 | `<テストコマンド>` | 0 | テスト通過を確認 |
+| Refactor | ✅ 完了 | `<テストコマンド>` | 0 | リファクタ後も通過 |
+
+### EvidenceLedger（/pg-verify 形式で出力）
+
+```json
+{
+  "claim": "<実装した機能>の TDD サイクル完了",
+  "status": "passed",
+  "evidence": [
+    { "id": "tdd-red", "type": "test", "exitCode": 1, "conclusion": "Red フェーズ完了" },
+    { "id": "tdd-green", "type": "test", "exitCode": 0, "conclusion": "Green フェーズ完了" },
+    { "id": "tdd-refactor", "type": "test", "exitCode": 0, "conclusion": "Refactor フェーズ完了" }
+  ]
+}
+```
+
+## GatePolicy との連携
+
+`requiresFailingTestFirst: true` のモード（high-risk / critical）では、
+Red フェーズの証拠（exitCode=1 の EvidenceItem）なしに Green フェーズへ進めない。

--- a/plugin/plangate/rules/completion-gate.md
+++ b/plugin/plangate/rules/completion-gate.md
@@ -1,0 +1,123 @@
+# Completion Gate ルール（正本）
+
+> 正本。Completion Gate の定義・ブロック条件・判定フローはこのファイルのみで管理する。
+> 参照元: `design-gate.md`、`review-gate.md`、`evidence-ledger.md`、`/pg-verify` コマンド
+
+## 目的
+
+全 Gate の通過を一元管理する最終チェックポイント。
+5 つのブロック条件がすべて満たされた時のみ「completion-gate: PASSED」とする。
+
+「動くはず」「たぶん通過した」という曖昧な完了主張を排除し、証拠に基づく Gate 通過を強制する。
+
+## 5 つのブロック条件（必須）
+
+### 条件 1: Design Gate パス必須（high-risk/critical）
+
+- Mode が `high-risk` 以上かつ Design Gate を通過していない場合 → **BLOCKED**
+- 具体的なブロック事由:
+  - `docs/working/TASK-XXXX/design.md` が存在しない
+  - `design.md` の 8 項目のいずれかが未記入
+  - Mode が `critical` で人間の明示的承認が記録されていない
+- 参照: `plugin/plangate/rules/design-gate.md`
+
+### 条件 2: TDD 証拠必須（high-risk/critical）
+
+- Mode が `high-risk` 以上かつ Evidence Ledger に `type: "test"` の証拠がない場合 → **BLOCKED**
+- failing test（exitCode=1）の記録が必須（`requiresFailingTestFirst` フラグ対応）
+- 参照: `plugin/plangate/rules/evidence-ledger.md`、`plugin/plangate/commands/pg-tdd.md`
+
+### 条件 3: Review Gate パス必須
+
+- `severity=critical` の finding が 1 件以上ある場合 → **BLOCKED**（全モード）
+- Mode が `critical` で `severity=major` の finding が 1 件以上ある場合 → **BLOCKED**
+- 参照: `plugin/plangate/rules/review-gate.md`
+
+### 条件 4: Evidence Ledger passed 必須
+
+- `/pg verify` の出力で `status: "passed"` でない場合 → **BLOCKED**
+- 必須証拠（claim に対応する evidence）が欠落している場合 → **BLOCKED**
+- `EvidenceLedger` 自体が存在しない場合（V-1 受け入れ検査フェーズ以降）→ **BLOCKED**
+- 参照: `plugin/plangate/rules/evidence-ledger.md`
+
+### 条件 5: 人間承認記録必須（high-risk/critical）
+
+- Mode が `high-risk` 以上かつ人間承認の記録が `docs/working/TASK-XXXX/status.md` に存在しない場合 → **BLOCKED**
+- `critical` モードでは `rollback plan` の存在も必須
+- 参照: `plugin/plangate/rules/design-gate.md`（critical 承認要件）
+
+## Mode 別適用マトリクス
+
+| 条件 | ultra-light | light | standard | high-risk | critical |
+|------|------------|-------|----------|-----------|----------|
+| Design Gate | スキップ | スキップ | スキップ | **必須** | **必須** |
+| TDD 証拠 | スキップ | 推奨 | 推奨 | **必須** | **必須** |
+| Review Gate | スキップ | スキップ | critical のみブロック | critical+major 推奨 | critical+major ブロック |
+| Evidence Ledger | スキップ | 推奨 | **必須** | **必須** | **必須** |
+| 人間承認 | 不要 | 不要 | 不要 | **必須** | **必須（明示的）** |
+| Rollback Plan | 不要 | 不要 | 不要 | 推奨 | **必須** |
+
+> Mode 定義は `plugin/plangate/rules/mode-classification.md` を参照。
+
+## Completion Gate の実行フロー
+
+`/pg verify` コマンドが Completion Gate の最終確認ステップとして使用される。
+
+```text
+/pg verify
+  → EvidenceLedger JSON を出力
+  → 5 条件チェック（Design Gate / TDD / Review Gate / Evidence Ledger / 人間承認）
+  → PASSED / BLOCKED 判定
+```
+
+## PASSED 判定の出力形式
+
+```json
+{
+  "completionGate": {
+    "status": "PASSED",
+    "checkedAt": "ISO8601",
+    "mode": "high-risk",
+    "checks": {
+      "designGate": "passed",
+      "tddEvidence": "passed",
+      "reviewGate": "passed",
+      "evidenceLedger": "passed",
+      "humanApproval": "passed",
+      "rollbackPlan": "n/a"
+    }
+  }
+}
+```
+
+## BLOCKED 判定の出力形式
+
+```json
+{
+  "completionGate": {
+    "status": "BLOCKED",
+    "checkedAt": "ISO8601",
+    "mode": "high-risk",
+    "checks": {
+      "designGate": "passed",
+      "tddEvidence": "BLOCKED - no type:test evidence found",
+      "reviewGate": "passed",
+      "evidenceLedger": "passed",
+      "humanApproval": "passed",
+      "rollbackPlan": "n/a"
+    },
+    "blockedBy": ["tddEvidence"]
+  }
+}
+```
+
+## 関連
+
+- Rule: `plugin/plangate/rules/design-gate.md`
+- Rule: `plugin/plangate/rules/review-gate.md`
+- Rule: `plugin/plangate/rules/evidence-ledger.md`
+- Rule: `plugin/plangate/rules/mode-classification.md`（Mode 定義・GatePolicy）
+- Command: `plugin/plangate/commands/pg-verify.md`（実行検証フロー）
+- Skill: `review-gate`（Review Gate 実施手順）
+- Skill: `design-gate`（Design Artifact 生成手順）
+- Iron Law: `NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE`

--- a/plugin/plangate/rules/design-gate.md
+++ b/plugin/plangate/rules/design-gate.md
@@ -1,0 +1,71 @@
+# Design Gate ルール（正本）
+
+> 正本。Design Gate の定義・適用条件はこのファイルのみで管理する。
+> 参照元: `design-gate` Skill、`/pg-think` コマンド、`completion-gate.md`
+
+## 目的
+
+high-risk 以上のモードで「設計なしに実装へ進む」ことを防ぐ。
+設計の意思決定を明文化し、実装着手前に関係者が合意した状態を作る。
+
+## Design Artifact 必須 8 項目
+
+high-risk / critical モードで実装開始前に揃っていなければならない。
+
+| 番号 | 項目 | 内容 |
+|------|------|------|
+| 1 | **問題定義** | 何が問題か（現状・課題・背景） |
+| 2 | **目的** | なぜ解決するか（ゴール・期待効果） |
+| 3 | **非目的** | スコープ外の明示（今回対応しないこと） |
+| 4 | **仕様** | 何を作るか（具体的な機能要件・動作仕様） |
+| 5 | **代替案** | 検討した他のアプローチ（最低 2 案） |
+| 6 | **採用案** | 選んだアプローチと選択理由 |
+| 7 | **リスク** | 実装・運用上のリスク（影響度・対策付き） |
+| 8 | **テスト方針** | どう検証するか（テスト種別・カバー範囲） |
+
+## 適用条件（Mode 別）
+
+| Mode | Design Artifact | 人間承認 |
+|------|----------------|---------|
+| `ultra-light` | 省略可 | 不要 |
+| `light` | 省略可 | 不要 |
+| `standard` | 省略可 | 不要 |
+| `high-risk` | **必須**（8 項目全て） | 推奨 |
+| `critical` | **必須**（8 項目全て） | **必須**（explicit） |
+
+> Mode 定義は `plugin/plangate/rules/mode-classification.md` を参照。
+
+## ブロック条件
+
+以下のいずれかに該当する場合、`/pg-verify` および Completion Gate への移行を **ブロック** する:
+
+1. Mode が `high-risk` 以上で `docs/working/TASK-XXXX/design.md` が存在しない
+2. `design.md` が存在するが 8 項目のいずれかが未記入（空・プレースホルダーのまま）
+3. Mode が `critical` で人間の明示的承認が記録されていない
+
+## /pg-think との連携
+
+`/pg-think` の出力（Problem Restatement / Assumptions / Options / Recommended Approach / Risks）を
+Design Artifact のドラフトとして使用できる。
+
+実行フロー:
+1. `/pg-think` を実行して論点を整理する
+2. `/pg-think` の出力を `design-gate` Skill の 8 項目にマッピングする
+3. `docs/working/TASK-XXXX/design.md` に保存する
+
+## 保存先
+
+```text
+docs/working/TASK-XXXX/design.md
+```
+
+テンプレート: `docs/working/templates/design.md`（存在する場合は参照して形式を合わせる）
+
+## 関連
+
+- Rule: `plugin/plangate/rules/mode-classification.md`（Mode 定義・GatePolicy）
+- Rule: `completion-gate.md`（Completion Gate との連携・ブロック条件の発動）
+- Skill: `plugin/plangate/skills/design-gate/SKILL.md`（Design Artifact 生成手順）
+- Skill: `plugin/plangate/skills/skill-policy-router/SKILL.md`（requiresUserApproval との連携）
+- Command: `plugin/plangate/commands/pg-think.md`（論点整理の初段）
+- Template: `docs/working/templates/design.md`（Design Artifact の保存形式）

--- a/plugin/plangate/rules/mode-classification.md
+++ b/plugin/plangate/rules/mode-classification.md
@@ -95,6 +95,28 @@
 - **最終判定**: {モード}（{オーバーライドの場合はその理由}）
 ```
 
+## Gate 適用マトリクス
+
+各モードで適用する Gate を定義する。○ = 必須、△ = 推奨/任意、- = スキップ。
+
+| Gate | ultra-light | light | standard | high-risk | critical |
+|------|------------|-------|----------|-----------|----------|
+| **Design Gate** | - | - | - | ○ | ○ |
+| **TDD Gate** | - | △ | △ | ○ | ○ |
+| **Review Gate** | - | - | △（/pg-check 推奨） | ○ | ○ |
+| **Completion Gate** | - | △ | ○ | ○ | ○ |
+
+### Gate 詳細
+
+| Gate | ルール正本 | Skill | コマンド |
+|------|-----------|-------|---------|
+| Design Gate | `plugin/plangate/rules/design-gate.md` | `design-gate` | `/pg-think`（初段） |
+| TDD Gate | `plugin/plangate/commands/pg-tdd.md` | — | `/pg-tdd` |
+| Review Gate | `plugin/plangate/rules/review-gate.md` | `review-gate` | `/pg-check` |
+| Completion Gate | `plugin/plangate/rules/completion-gate.md` | — | `/pg-verify` |
+
+> 各 Gate の詳細条件は各ルールファイルを参照。Completion Gate が全 Gate の通過を一元管理する。
+
 ## 調整ガイド
 
 このファイルの判定基準を調整する際のルール:

--- a/plugin/plangate/rules/mode-classification.md
+++ b/plugin/plangate/rules/mode-classification.md
@@ -102,7 +102,7 @@
 | Gate | ultra-light | light | standard | high-risk | critical |
 |------|------------|-------|----------|-----------|----------|
 | **Design Gate** | - | - | - | ○ | ○ |
-| **TDD Gate** | - | △ | △ | ○ | ○ |
+| **TDD Gate** | - | - | △ | ○ | ○ |
 | **Review Gate** | - | - | △（/pg-check 推奨） | ○ | ○ |
 | **Completion Gate** | - | △ | ○ | ○ | ○ |
 

--- a/plugin/plangate/rules/review-gate.md
+++ b/plugin/plangate/rules/review-gate.md
@@ -1,0 +1,70 @@
+# Review Gate ルール（正本）
+
+> 正本。Review Gate の定義・観点・Completion Gate ブロック条件はこのファイルのみで管理する。
+> 参照元: `review-gate` Skill、`/pg-check` コマンド、`completion-gate.md`
+
+## 目的
+
+実装後に仕様・品質・安全性を確認し、critical finding を Completion Gate に伝達する。
+「動くはず」「たぶん大丈夫」を排除し、証拠に基づく品質確認を強制する。
+
+## Review 6 観点
+
+| # | 観点 | チェック内容 |
+|---|------|------------|
+| 1 | **仕様準拠** | 受入基準・設計書との一致。test-cases.md の期待動作と実装の対応 |
+| 2 | **コード品質** | 可読性・命名の適切さ・構造の明確さ。複雑度・重複の有無 |
+| 3 | **セキュリティ** | 入力バリデーション・認証・認可・機密情報の扱い。インジェクション対策 |
+| 4 | **パフォーマンス** | N+1 クエリ・ループ内 I/O・不要データ取得。リソース効率 |
+| 5 | **テスト不足** | カバレッジ・エッジケース。重要パスの未テスト箇所 |
+| 6 | **破壊的変更** | 後方互換性・API 変更・スキーマ変更。既存機能への影響 |
+
+## Severity 定義（/pg-check と統一）
+
+| Severity | 定義 | 例 | Completion Gate 影響 |
+|----------|------|---|---------------------|
+| **critical** | 本番障害・データ不整合・脆弱性 | SQLインジェクション、認可チェック漏れ、データ損失 | ブロック（必須） |
+| **major** | ロジック誤り・テスト不足・設計違反 | N+1クエリ、レイヤー間依存違反、重要パス未テスト | ブロック（Mode依存） |
+| **minor** | 改善提案・命名・コードスタイル | 変数名改善、early return提案、ドキュメント不備 | 影響なし |
+| **info** | FYI・将来課題・好みの問題 | 類似パターンの紹介、リファクター候補、補足情報 | 影響なし |
+
+## Completion Gate ブロック条件
+
+`severity=critical` の finding が 1 件以上ある場合、Completion Gate をブロックする。
+
+### Mode 別ブロック基準
+
+| Mode | critical | major | 判定 |
+|------|----------|-------|------|
+| ultra-light | ブロック | 影響なし | critical のみブロック |
+| light | ブロック | 影響なし | critical のみブロック |
+| standard | ブロック | 影響なし | critical のみブロック |
+| high-risk | ブロック | 推奨ブロック | major があれば人間確認を強く推奨 |
+| critical | ブロック | 強制ブロック | critical + major どちらもブロック |
+
+## 適用条件（Mode 別）
+
+| Mode | Review Gate | 実施方法 |
+|------|-------------|---------|
+| ultra-light | 省略可 | — |
+| light | 省略可 | — |
+| standard | 推奨 | `/pg-check` を実行 |
+| high-risk | 必須 | `/pg-check` + 6 観点チェック |
+| critical | 必須 | `/pg-check` + 6 観点チェック + multi-agent review 推奨 |
+
+## `/pg-check` との連携
+
+`/pg-check` の出力（Findings テーブル）を Review Gate の入力として使用する。
+
+1. `/pg-check` を実行して severity 付き finding を収集する
+2. finding を 6 観点に分類する
+3. critical finding の有無を判定する
+4. Completion Gate へ結果を伝達する
+
+## 関連
+
+- Command: `/pg-check`（差分レビュー・finding 収集）
+- Skill: `review-gate`（Review Gate 実施手順）
+- Rule: `evidence-ledger.md`（Completion Gate 条件の正本）
+- Rule: `review-principles.md`（レビューの姿勢・禁止事項）
+- Iron Law: `NO MERGE WITHOUT TWO-STAGE REVIEW`

--- a/plugin/plangate/skills/design-gate/SKILL.md
+++ b/plugin/plangate/skills/design-gate/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: design-gate
+description: "Design Gate を実施し、設計書（Design Artifact）を生成・評価する。Use when: high-risk 以上のタスクで実装前に設計を整理したい時。「設計書を作りたい」「Design Gate を通したい」「実装前に設計レビューをしたい」。"
+---
+
+# Design Gate
+
+high-risk 以上のタスクで実装前に設計書（Design Artifact）を生成・評価する。
+
+## Iron Law
+
+`NO CODE WITHOUT APPROVED DESIGN FIRST`
+
+high-risk 以上のモードでは、Design Artifact の 8 項目が揃い承認されるまで実装を開始しない。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「シンプルだから設計不要」 | シンプルなほど設計は速い。10 分の設計が数時間の手戻りを防ぐ |
+| 「急いでいるから省略」 | 設計なしの実装は後で手戻りになる。急ぐほど設計が必要 |
+| 「前に似たことをやった」 | コードベースは変化する。前回の前提が今回も成立するとは限らない |
+| 「PoC だから後で直す」 | PoC は往々にして本番コードになる。設計の借金は複利で増える |
+
+## Design Artifact 8 項目の入力フォーム
+
+以下の質問にすべて答えることで Design Artifact が完成する。
+
+### 1. 問題定義
+
+**質問**: 何が問題か？
+
+- 現状はどうなっているか
+- どのような課題・不便が発生しているか
+- なぜ今対応が必要か（背景・トリガー）
+
+### 2. 目的
+
+**質問**: なぜ解決するか？
+
+- このタスクで達成したいゴールは何か
+- 解決後にどのような状態になっていてほしいか（期待効果）
+
+### 3. 非目的
+
+**質問**: 今回対応しないことは？
+
+- スコープ外として明示的に除外するもの
+- 「やらない」と決めた理由
+
+### 4. 仕様
+
+**質問**: 何を作るか？（具体的な機能要件）
+
+- 実装する機能・コンポーネントを列挙する
+- 入力・処理・出力を明示する
+- 受入基準（Acceptance Criteria）を記述する
+
+### 5. 代替案
+
+**質問**: 他に検討したアプローチは？（最低 2 案）
+
+| 案 | 概要 | メリット | デメリット |
+|---|------|--------|---------|
+| 案 1 | ... | ... | ... |
+| 案 2 | ... | ... | ... |
+
+### 6. 採用案
+
+**質問**: 選んだアプローチと選択理由は？
+
+- 採用するアプローチを明示する
+- 代替案と比較した場合の優位点を述べる
+- トレードオフを認識した上で選択した旨を記述する
+
+### 7. リスク
+
+**質問**: 実装・運用上のリスクは？（影響度・対策付き）
+
+| リスク | 影響度 | 発生確率 | 対策 |
+|-------|-------|---------|------|
+| リスク 1 | High / Medium / Low | High / Medium / Low | ... |
+| リスク 2 | ... | ... | ... |
+
+### 8. テスト方針
+
+**質問**: どう検証するか？
+
+| レイヤー | テスト種別 | カバー範囲 |
+|---------|----------|----------|
+| Unit | Unit | ... |
+| Integration | Integration | ... |
+| E2E | E2E | ... |
+
+## 手順
+
+1. `/pg-think` を実行して論点整理を行う（Problem Restatement / Assumptions / Options / Recommended Approach / Risks）
+2. `/pg-think` の出力を元に 8 項目を補完する
+   - Problem Restatement → 問題定義・目的
+   - Assumptions → 非目的（スコープ外の前提）
+   - Options → 代替案
+   - Recommended Approach → 採用案
+   - Risks → リスク
+3. 設計書を `docs/working/TASK-XXXX/design.md` に保存する（`docs/working/templates/design.md` を参照）
+4. **high-risk の場合**: チームへレビュー依頼（推奨）
+5. **critical の場合**: 人間の明示的承認を待つ（必須）。承認前に実装を開始しない
+
+## Mode 別の扱い
+
+| Mode | Design Gate | 承認要件 |
+|------|------------|---------|
+| `ultra-light` | スキップ可 | 不要 |
+| `light` | スキップ可 | 不要 |
+| `standard` | スキップ可 | 不要 |
+| `high-risk` | **必須** | 推奨（承認記録を design.md に残す） |
+| `critical` | **必須** | **必須**（承認なしに実装開始不可） |
+
+## 出力フォーマット
+
+設計書は `docs/working/TASK-XXXX/design.md` に保存する。
+テンプレート `docs/working/templates/design.md` の形式に従い、8 項目を Markdown で記述する。
+
+```markdown
+## メタ情報
+
+task: TASK-XXXX
+related_issue: <issue URL>
+author: <担当者>
+updated: YYYY-MM-DD
+approved_by: <承認者>（high-risk 以上で記入）
+approved_at: YYYY-MM-DD（high-risk 以上で記入）
+
+## 1. 問題定義
+<記述>
+
+## 2. 目的
+<記述>
+
+## 3. 非目的
+<記述>
+
+## 4. 仕様
+<記述>
+
+## 5. 代替案
+<代替案テーブル>
+
+## 6. 採用案
+<記述>
+
+## 7. リスク
+<リスクテーブル>
+
+## 8. テスト方針
+<テストテーブル>
+```
+
+## 関連
+
+- Rule: `plugin/plangate/rules/design-gate.md`（適用条件・ブロック条件の正本）
+- Command: `plugin/plangate/commands/pg-think.md`（論点整理の初段）
+- Template: `docs/working/templates/design.md`（design.md の保存形式）
+- Skill: `plugin/plangate/skills/skill-policy-router/SKILL.md`（GatePolicy との連携）

--- a/plugin/plangate/skills/review-gate/SKILL.md
+++ b/plugin/plangate/skills/review-gate/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: review-gate
+description: "Review Gate を実施し、実装の仕様準拠・品質・セキュリティを 6 観点でレビューする。Use when: 実装完了後にレビューをしたい時。「Review Gate を通したい」「コードレビューをして」「実装の品質確認をしたい」「severity を確認したい」。"
+---
+
+# Review Gate
+
+実装後に 6 観点でレビューを行い、critical finding を Completion Gate に伝達する。
+
+## Iron Law
+
+`NO MERGE WITHOUT TWO-STAGE REVIEW`
+
+severity=critical の finding がある場合、fix なしに Completion Gate を通過させない。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「テストが通ったからレビュー不要」 | テスト通過はロジック正確性の一部に過ぎない。セキュリティ・仕様準拠は別途確認が必要 |
+| 「小さな変更だから critical は出ない」 | 規模に関わらず 6 観点でチェックせよ。1 行の変更でも脆弱性は混入する |
+| 「外部レビューを受けたから大丈夫」 | review type の EvidenceItem として記録せよ。記録なき承認は存在しない |
+
+## 手順
+
+### ステップ 1: `/pg-check` を実行して finding を収集する
+
+```bash
+# 差分レビューを実行して severity 付き finding を取得する
+/pg-check <対象ブランチ or PR番号>
+```
+
+### ステップ 2: 6 観点で finding を分類・severity を付与する
+
+`/pg-check` の Findings を以下の 6 観点に分類する:
+
+| # | 観点 | チェック内容 |
+|---|------|------------|
+| 1 | **仕様準拠** | 受入基準・設計書との一致 |
+| 2 | **コード品質** | 可読性・命名・構造の明確さ |
+| 3 | **セキュリティ** | 入力バリデーション・認証・認可・機密情報 |
+| 4 | **パフォーマンス** | N+1 クエリ・ループ内 I/O・不要データ取得 |
+| 5 | **テスト不足** | カバレッジ・エッジケース・重要パスの未テスト |
+| 6 | **破壊的変更** | 後方互換性・API 変更・スキーマ変更 |
+
+### ステップ 3: critical finding の有無を判定する
+
+- `severity=critical` が 1 件以上 → Completion Gate をブロック
+- `severity=major` が 1 件以上（high-risk / critical Mode）→ 推奨または強制ブロック
+- それ以外 → PASS
+
+### ステップ 4: Review Gate レポートを出力する
+
+以下のフォーマットで出力する（「出力フォーマット」セクション参照）。
+
+### ステップ 5: critical finding がある場合は Completion Gate ブロック通知を出力する
+
+```
+[REVIEW GATE] BLOCKED
+reason: severity=critical の finding が <N> 件あります。fix 後に再レビューが必要です。
+```
+
+## 出力フォーマット
+
+### Review Gate レポート
+
+#### Findings（6 観点）
+
+| 観点 | Finding | Severity | 対応 |
+|-----|---------|---------|------|
+| 仕様準拠 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| コード品質 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| セキュリティ | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| パフォーマンス | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| テスト不足 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| 破壊的変更 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+
+#### 総合判定
+
+```
+**総合判定**: PASS / BLOCK（critical: N件, major: N件）
+
+→ Completion Gate: PASS / BLOCKED
+```
+
+#### EvidenceItem（Evidence Ledger への記録）
+
+```json
+{
+  "id": "review-gate-001",
+  "type": "review",
+  "reviewer": "review-gate skill",
+  "outputExcerpt": "critical: 0件, major: N件",
+  "conclusion": "Review Gate PASS / BLOCKED"
+}
+```
+
+## 関連
+
+- Rule: `review-gate.md`（正本 - ブロック条件・Mode 別適用条件）
+- Command: `/pg-check`（差分レビュー・finding 収集）
+- Skill: `evidence-ledger`（EvidenceItem 記録手順）
+- Rule: `review-principles.md`（レビューの姿勢・禁止事項・False-positive ガード）


### PR DESCRIPTION
## Summary

Epic #53 Phase 2: PlanGate に 4 つの Gate を追加し、「証拠に基づく完了主張」を強制する。

- **Design Gate** (`plugin/plangate/rules/design-gate.md`, `skills/design-gate/SKILL.md`): high-risk 以上で Design Artifact 8 項目必須
- **TDD Gate** (`plugin/plangate/commands/pg-tdd.md`): Red→Green→Refactor と Evidence Ledger 連携
- **Review Gate** (`plugin/plangate/rules/review-gate.md`, `skills/review-gate/SKILL.md`): 6 観点チェック、critical finding → Completion Gate ブロック
- **Completion Gate** (`plugin/plangate/rules/completion-gate.md`): 全 Gate の通過を一元管理する 5 条件チェックポイント
- **Mode 別 Gate マトリクス** (`mode-classification.md` 更新): ultra-light から critical まで Gate 適用条件を定義

Closes #57

## 受入基準 6 件

1. high-risk 以上で Design Gate なしに実装へ進めない（completion-gate.md に明記）
2. critical で rollback plan なしに完了できない（completion-gate.md に明記）
3. TDD 必須モードで failing test evidence がない場合にブロックできる
4. Review Gate で critical finding がある場合に Completion Gate が失敗する
5. Evidence Ledger なしに Completion Gate が passed にならない
6. 軽微修正では Design/TDD/Review を過剰要求しない（ultra-light/light は省略）

## Test plan

- [ ] acceptance-tester で TC-01〜06 を突合（6/6 PASS を確認）
- [ ] `mode-classification.md` の Gate マトリクスが ultra-light〜critical まで正確に定義されているか確認
- [ ] `completion-gate.md` の 5 ブロック条件が全 Gate ルールを参照しているか確認
- [ ] Markdownlint CI パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)