### PR TITLE
release: PlanGate v7.3.0（setup-team スキル, high-risk 統一, pg-check 連携）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ PlanGate の主要リリース履歴。
 
 このファイルは各リリース時点の内容を記録するものであり、この pull request の差分一覧ではない。
 
+## v7.3.0 - 2026-04-26
+
+モード命名の完全統一、setup-team スキル追加、pg-check × skill-policy-router 連携明示を行ったリリース。
+
+### setup-team スキル追加（TASK-0035）
+
+- `plugin/plangate/skills/setup-team/` — タスク規模・モードに応じたマルチエージェントチーム設計スキルを追加
+- `.claude/skills/setup-team/` / `.agents/skills/setup-team/` にも同一ファイルを配置
+- `skills/codex-multi-agent/SKILL.md` の broken reference（`../setup-team/SKILL.md`）を解消
+
+### full → high-risk モード命名完全統一（TASK-0036）
+
+- `plugin/plangate/agents/workflow-conductor.md` — 5 箇所置換（フェーズ表、判定ロジック、status.md テンプレート、V-2 記述）
+- `plugin/plangate/agents/code-optimizer.md` — frontmatter description + When You Should Be Used
+- `plugin/plangate/rules/working-context.md` — V-2 記述・plan.md テンプレート・status.md テンプレート
+- `plugin/plangate/commands/ai-dev-workflow.md` — Mode判定テンプレート
+- `.claude/` 側の対応ファイル（agents/workflow-conductor.md, agents/code-optimizer.md, agents/README.md, rules/mode-classification.md, rules/working-context.md, commands/ai-dev-workflow.md）も同様に更新
+
+### pg-check × skill-policy-router 連携明示（TASK-0037）
+
+- `plugin/plangate/commands/pg-check.md` — GatePolicy との連携セクションを追加
+- `skill-policy-router` が `check` を requiredSkills に含む場合に `/pg-check` が自動要求される旨を明記
+
 ## v7.2.0 - 2026-04-26
 
 Epic [#53](https://github.com/s977043/plangate/issues/53)「PlanGate を AI コーディングの開発統制 OS へ拡張する」の Phase 1〜3 を完了したリリース。

--- a/docs/working/TASK-0035/handoff.md
+++ b/docs/working/TASK-0035/handoff.md
@@ -1,0 +1,85 @@
+# Handoff Package — TASK-0035 / TASK-0036
+
+> TASK-0035（setup-team スキル追加）と TASK-0036（full → high-risk 残存置換）を統合した handoff。
+> PR #66 でまとめてリリース済み。
+
+## メタ情報
+
+```yaml
+task: TASK-0035 / TASK-0036
+related_pr: https://github.com/s977043/plangate/pull/66
+author: qa-reviewer (Claude Code)
+issued_at: 2026-04-26
+v1_release: c7aa327 (PR #66 squash merge)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| TASK-0035: setup-team SKILL.md が plugin/plangate/skills に存在する | PASS | `plugin/plangate/skills/setup-team/SKILL.md` 作成済み |
+| TASK-0035: .claude/skills に存在する | PASS | `.claude/skills/setup-team/SKILL.md` 作成済み |
+| TASK-0035: .agents/skills に存在する | PASS | `.agents/skills/setup-team/SKILL.md` 作成済み |
+| TASK-0035: codex-multi-agent の broken reference が解消される | PASS | 参照先ファイルが存在するようになった |
+| TASK-0036: plugin/plangate 側の full → high-risk 置換完了 | PASS | 9 ファイルすべて修正済み（code-optimizer 含む） |
+| TASK-0036: .claude/ 側の full → high-risk 置換完了 | PASS | mode-classification.md 含む全ファイル修正済み |
+| TASK-0036: Markdownlint CI パス | PASS | PR #66 CI 確認済み |
+
+**総合**: `7/7 基準 PASS`
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| TASK-0037: pg-check × skill-policy-router 連携明示が未完（本タスク時点） | minor | → TASK-0037 で対応済み | No |
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 |
+|--------|------|----------|
+| setup-team スキルの受け入れテスト（test-cases.md）作成 | 今回は文書のみ、検証スキップ | Low |
+| codex-multi-agent の broken reference を全体スキャンして他にないか確認 | 今回は既知の1件のみ対応 | Low |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| TASK-0035/0036 を同一 PR (#66) でまとめてリリース | 別々の PR で分割リリース | 変更規模が小さく分割コストが高いため統合 |
+| .agents/skills/setup-team/ に同一ファイルをコピー | .agents/skills からの symlink | symlink は git 管理が複雑になるためコピーで統一 |
+| full → high-risk の注記なし置換 | 「full は非推奨 (deprecated: high-risk を使用)」コメント追加 | plugin 版 mode-classification.md には既に注記があり重複になるため省略 |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0035 では、`/setup-team` コマンド呼び出し時に参照されるスキルファイルが存在しなかった問題を解決した。
+`plugin/plangate/skills/setup-team/SKILL.md` を新規作成し、`.claude/skills/` および `.agents/skills/` にも配置することで、
+`codex-multi-agent/SKILL.md` の broken reference も解消した。
+
+TASK-0036 では、`full` モードラベルを `high-risk` に統一するための残存置換を実施した。
+`plugin/plangate/rules/mode-classification.md` は Phase 1 (TASK-0029) で既に更新済みだったが、
+`workflow-conductor.md`・`working-context.md`・`ai-dev-workflow.md`・`code-optimizer.md` など
+参照側のファイルが未更新のままだった。全9ファイルを修正してリポジトリ全体で `full` モード表記を撲滅した。
+
+### 触れないでほしいファイル
+
+- `plugin/plangate/rules/mode-classification.md`: full → high-risk の正本。既に更新済みのため再変更不要
+
+### 次に手を入れるなら
+
+- v7.3.0 リリース（CHANGELOG 更新 + git タグ）
+- setup-team スキルを実際に呼び出してみて動作確認
+
+### 参照リンク
+
+- PR #66: https://github.com/s977043/plangate/pull/66
+- plugin README: `plugin/plangate/README.md`
+- setup-team SKILL: `plugin/plangate/skills/setup-team/SKILL.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP |
+|---------|------|------|-----------|
+| Markdownlint CI | 1 | 1 | 0 |
+| 文書確認（TASK-0035 受入基準） | 3 | 3 | 0 |
+| 文書確認（TASK-0036 受入基準） | 4 | 4 | 0 |

--- a/docs/working/TASK-0036/handoff.md
+++ b/docs/working/TASK-0036/handoff.md
@@ -1,0 +1,4 @@
+# Handoff — TASK-0036
+
+> TASK-0036 は TASK-0035 と同一 PR (#66) でリリース。
+> 統合 handoff は `docs/working/TASK-0035/handoff.md` を参照。

--- a/plugin/plangate/commands/pg-check.md
+++ b/plugin/plangate/commands/pg-check.md
@@ -16,6 +16,18 @@ severity=critical の finding がある場合、fix なしに完了しない。
 
 `$ARGUMENTS` にレビュー対象（PR 番号またはブランチ名）を渡す。省略時は現在のブランチの差分。
 
+## GatePolicy との連携
+
+`skill-policy-router` が `check` を `requiredSkills` に含む場合、このコマンドが自動的に要求される。
+
+| Mode | check の扱い |
+|------|-------------|
+| ultra-light | optionalSkills（任意） |
+| light | requiredSkills（必須） |
+| standard 以上 | requiredSkills（必須） |
+
+GatePolicy が `{ "requiredSkills": ["check", ...] }` を返した場合、ワークフローは `/pg-check` の実行を求める。`/pg-check` で critical finding が出た場合は fix なしに次ステップへ進めない。
+
 ## 実行フロー
 
 1. **Diff Summary**: 変更差分の概要を把握する（`git diff --stat`）


### PR DESCRIPTION
## Summary

- **TASK-0035/0036** は PR #66 でマージ済み（このPRには後処理のみ含む）
- **TASK-0037**: `pg-check.md` に GatePolicy との連携セクションを追加
- **handoff.md**: TASK-0035/0036 の Rule 5 成果物を発行
- **CHANGELOG**: v7.3.0 エントリを追加

## 変更内容

### TASK-0037: pg-check × skill-policy-router 連携明示
- `plugin/plangate/commands/pg-check.md` に `## GatePolicy との連携` セクション追加
- `skill-policy-router` が `check` を requiredSkills に含む場合に `/pg-check` が自動要求される旨を Mode 表で明記

### handoff.md（Rule 5）
- `docs/working/TASK-0035/handoff.md` — 7/7 基準 PASS の統合 handoff
- `docs/working/TASK-0036/handoff.md` — TASK-0035 handoff への参照

### CHANGELOG
- v7.3.0 エントリ追加（setup-team スキル / high-risk 統一 / pg-check 連携）

## Test plan

- [ ] Markdownlint CI パス
- [ ] `plugin/plangate/commands/pg-check.md` に GatePolicy 連携セクションが存在する
- [ ] `docs/working/TASK-0035/handoff.md` が存在し 6 要素を含む
- [ ] CHANGELOG に v7.3.0 が記載されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)