### PR TITLE
chore: plugin v0.5.0 + TASK-0037 handoff（README 整合・broken reference 解消）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ PlanGate の主要リリース履歴。
 
 このファイルは各リリース時点の内容を記録するものであり、この pull request の差分一覧ではない。
 
+## v7.3.1 - 2026-04-26
+
+plugin v0.5.0: setup-team を skill 一覧に追加、broken reference 制約の削除、README バージョン更新。
+
+- `plugin/plangate/README.md` — skill 数 11 → 14、setup-team 追加、既知制約から解消済み broken reference を削除
+- `plugin/plangate/.claude-plugin/plugin.json` — v0.4.0 → v0.5.0、description に Setup Team を追記
+- `docs/working/TASK-0037/handoff.md` — Rule 5 完了資産を発行
+
 ## v7.3.0 - 2026-04-26
 
 モード命名の完全統一、setup-team スキル追加、pg-check × skill-policy-router 連携明示を行ったリリース。

--- a/docs/working/TASK-0037/handoff.md
+++ b/docs/working/TASK-0037/handoff.md
@@ -1,0 +1,65 @@
+# Handoff Package — TASK-0037
+
+> WF-05 Verify & Handoff の必須出力。Rule 5 遵守。
+> 配置: `docs/working/TASK-0037/handoff.md`
+
+## メタ情報
+
+```yaml
+task: TASK-0037
+related_pr: https://github.com/s977043/plangate/pull/67
+author: qa-reviewer (Claude Code)
+issued_at: 2026-04-26
+v1_release: 0b88c23 (PR #67 squash merge → main / v7.3.0)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| `/pg-check` と `skill-policy-router` の連携が明文化されている | PASS | `plugin/plangate/commands/pg-check.md` に `## GatePolicy との連携` セクションを追加。Mode 別の `check` 扱い表を記載 |
+| light 以上で `check` が requiredSkills に含まれることが示されている | PASS | Mode 表で `light: requiredSkills`、`standard 以上: requiredSkills` と明記 |
+| critical finding 時のブロック条件が記述されている | PASS | 「`/pg-check` で critical finding が出た場合は fix なしに次ステップへ進めない」と明記 |
+
+**総合**: `3/3 基準 PASS`
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| なし | — | — | — |
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 |
+|--------|------|----------|
+| 他の `/pg-*` コマンド（think/hunt/verify）にも GatePolicy 連携セクションを追加 | pg-check と同様、skill-policy-router との接続を明示すると一貫性が増す | Low |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| pg-check.md のみ更新 | think/hunt/verify も同時更新 | TASK-0037 のスコープを最小限に限定。他コマンドは V2 候補として残す |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0037 は `pg-check.md` に `## GatePolicy との連携` セクションを追加し、`skill-policy-router` が `check` を `requiredSkills` に含む場合に `/pg-check` が自動要求される仕組みを明文化した。PR #67 (v7.3.0) に含まれてリリース済み。
+
+### 次に手を入れるなら
+
+- `/pg-think`・`/pg-hunt`・`/pg-verify` にも同様の GatePolicy 連携セクションを追加（V2 候補）
+
+### 参照リンク
+
+- PR #67: https://github.com/s977043/plangate/pull/67
+- 対象ファイル: `plugin/plangate/commands/pg-check.md`
+- 連携先: `plugin/plangate/skills/skill-policy-router/SKILL.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP |
+|---------|------|------|-----------|
+| 文書確認（AC 突合） | 3 | 3 | 0 |
+| Markdownlint CI | 1 | 1 | 0 |

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plangate",
-  "version": "0.4.0",
-  "description": "PlanGate — AI coding control OS for Claude Code. Intent/Mode classification, Skill Policy Router, Evidence Ledger, 4-Gate system (Design/TDD/Review/Completion), Context Packager, Subagent Dispatch, Worktree Policy, PR Decision. Commands: /pg-think /pg-hunt /pg-check /pg-verify /pg-tdd.",
+  "version": "0.5.0",
+  "description": "PlanGate — AI coding control OS for Claude Code. Intent/Mode classification, Skill Policy Router, Evidence Ledger, 4-Gate system (Design/TDD/Review/Completion), Context Packager, Subagent Dispatch, Worktree Policy, PR Decision, Setup Team. Commands: /pg-think /pg-hunt /pg-check /pg-verify /pg-tdd.",
   "author": {
     "name": "PlanGate contributors"
   }

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -2,7 +2,7 @@
 
 PlanGate — AI コーディングの開発統制 OS。Intent/Mode 分類、4 Gate システム、エージェント統制層を提供する Claude Code plugin。
 
-- **Version**: 0.4.0
+- **Version**: 0.5.0
 - **Source**: https://github.com/s977043/plangate
 
 ## インストール
@@ -33,12 +33,13 @@ plugin/plangate/
 ├── .claude-plugin/
 │   └── plugin.json         # manifest (v0.4.0)
 ├── agents/                 # 6 agents
-├── skills/                 # 11 skills
+├── skills/                 # 14 skills
 │   ├── brainstorming/
 │   ├── self-review/
 │   ├── subagent-driven-development/
 │   ├── systematic-debugging/
 │   ├── codex-multi-agent/
+│   ├── setup-team/            # TASK-0035 追加
 │   ├── intent-classifier/     # Phase 1 追加
 │   ├── skill-policy-router/   # Phase 1 追加
 │   ├── evidence-ledger/       # Phase 1 追加
@@ -138,7 +139,6 @@ cp plangate/.claude/agents/backend-specialist.md <your-project>/.claude/agents/
 
 ## 既知の制約
 
-- `codex-multi-agent` skill 内に `../setup-team/SKILL.md` への参照あり（legacy 側からの既存 broken reference、plugin も同じ状態）
 - plugin install 後の挙動は Claude Code の内部仕様に依存（詳細は runtime 検証結果を参照）
 - `test-engineer` / `release-manager` agent 未同梱（`.claude/` にも存在しない）
 


### PR DESCRIPTION
## Summary

- **plugin v0.5.0**: setup-team スキルの追加に伴う README・plugin.json の整合更新
- **TASK-0037 handoff**: Rule 5 完了資産を発行
- **CHANGELOG**: v7.3.1 エントリを追加

## 変更内容

### plugin/plangate/README.md
- skill 数 `# 11 skills` → `# 14 skills`（setup-team/design-gate/review-gate が未カウント）
- `setup-team/` を skills 一覧に追加（`# TASK-0035 追加`）
- 既知の制約から解消済みの broken reference 記述を削除（TASK-0035 で setup-team を作成済み）

### plugin/plangate/.claude-plugin/plugin.json
- version `0.4.0` → `0.5.0`
- description に `Setup Team` を追記

### docs/working/TASK-0037/handoff.md
- 3/3 AC PASS の完了資産を発行（Rule 5）

### CHANGELOG
- v7.3.1 エントリを追加

## Test plan

- [ ] Markdownlint CI パス
- [ ] `plugin/plangate/README.md` の skill 数が 14 になっている
- [ ] `plugin/plangate/.claude-plugin/plugin.json` の version が 0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)