### PR TITLE
docs: 2026-04-26 セッション振り返りを追加

### DIFF
--- a/docs/working/sessions/2026-04-26.md
+++ b/docs/working/sessions/2026-04-26.md
@@ -1,0 +1,158 @@
+# セッション振り返り
+
+> 実施日: 2026-04-26
+> 対象セッション: v7.2.0 / v7.3.0 後片付け + ドキュメント監査
+
+---
+
+## 1. セッション成果サマリ
+
+### マージ済み PR（5 本）
+
+| PR | 種別 | 内容 | 変更ファイル数 |
+|----|------|------|------------|
+| #66 | feat | TASK-0035 setup-team スキル追加 + TASK-0036 full → high-risk 残存置換 | 13 |
+| #67 | release | PlanGate v7.3.0（CHANGELOG + TASK-0037 handoff + pg-check 連携） | 4 |
+| #68 | chore | TASK-0032/0033 working context を完了状態に更新 | 4 |
+| #69 | chore | plugin v0.5.0 + TASK-0037 handoff 発行 + README 整合 | 4 |
+| #70 | docs | docs/ 配下の full → high-risk 命名統一・skill 一覧更新 | 6 |
+
+**合計**: 5 PR / 31 ファイル変更
+
+### リリース
+
+- **v7.3.0** — setup-team スキル, full → high-risk 完全統一, pg-check × skill-policy-router 連携明示
+
+---
+
+## 2. 計画精度分析
+
+### 想定通りだったこと
+
+- TASK-0035（setup-team スキル追加）: 3 箇所への配置（plugin / .claude / .agents）が計画通り完了
+- TASK-0036（full → high-risk 置換）: plugin/plangate 側 9 ファイルの修正が完了
+- TASK-0037（pg-check GatePolicy 連携）: 3 AC すべて 1 ファイル変更で充足
+
+### 想定外の追加作業（計画外タスク）
+
+| 追加作業 | 発生タイミング | 原因 | 工数感 |
+|---------|-------------|------|------|
+| `.claude/rules/mode-classification.md` の full 残存修正 | PR #66 コミット後に発見 | plugin 版と .claude 版の同期確認が TASK-0036 計画に含まれていなかった | 小 |
+| `.claude/agents/code-optimizer.md` 等の修正漏れ | PR #66 同セッション中に発見 | 対象ファイル一覧の初期調査が不完全（agent ファイルを漏らした） | 小 |
+| TASK-0032/0033 working context の事後更新（PR #68） | PR #63 マージ後に判明 | handoff 発行と current-state 更新を PR マージと同セッションで実施しなかった（2026-04-24 セッションからの積み残し） | 中 |
+| plugin/plangate/README.md のバージョン番号 2 箇所のうち 1 箇所更新漏れ | PR #69 準備中に発見 | ディレクトリ表記内のインラインバージョン番号が changelog と別管理になっていた | 小 |
+| `.claude/skills/README.md` への setup-team 追記漏れ（PR #70） | PR #66 マージ後に発見 | TASK-0035 の受入基準に README 更新が明示されていなかった | 小 |
+| docs/ 配下の full 残存（docs/plangate.md 等）の別 PR 対応（PR #70） | PR #66 〜 #69 完了後に発見 | TASK-0036 の調査スコープが plugin/ と .claude/ に限定されており、docs/ が漏れていた | 中 |
+
+**計画逸脱率**: 計画ステップ数（3 TASK 合計 約 10 ステップ）に対して、想定外タスクが 6 件発生。実質的な作業量は計画の約 1.5〜2 倍。
+
+### Unknowns の的中率
+
+TASK-0035/0036 の事前計画（pbi-input.md）は今セッションで初めて起票されたため、Unknowns の事前記録なし。振り返りから抽出した主なリスクを後掲する。
+
+---
+
+## 3. プロセス上の学び・改善点
+
+### A. 命名統一タスクの「調査スコープ漏れ」パターン
+
+**観察**: `full → high-risk` の置換作業で、plugin/ と .claude/ を調査した後に docs/ の残存が発見され、追加 PR が必要になった。これは TASK-0036 の「変更ファイル数を少なく見積もった」計画精度の問題。
+
+**根本原因**: grep の調査スコープを「変更主体ディレクトリ」に限定し、「参照側ドキュメント」を含めなかった。
+
+**改善アクション（次回 plan 向け）**: 命名統一・リネーム系タスクの計画時は、「対象ディレクトリ一覧」を plan.md の Work Breakdown に明示し、`grep -r "対象文字列" .` でリポジトリ全体を調査してから変更ファイル一覧を確定する。
+
+---
+
+### B. 「mirror ファイル」（plugin 版 ↔ .claude 版）の同期チェック漏れ
+
+**観察**: `plugin/plangate/rules/mode-classification.md` は更新済みだったが、`.claude/rules/mode-classification.md` の同期が漏れていた。同内容を 2 箇所に持つ「mirror ファイル」構造が原因。
+
+**根本原因**: mirror ファイルの存在と対応関係がどこにも記述されていない。
+
+**改善アクション**: plan.md の「Files / Components to Touch」に mirror ファイルを明示するか、リポジトリ内に mirror 関係を記述した index を整備する。短期的には plan 生成時の C-1 チェック項目「mirror ファイルがある場合は両方を記載したか」を追加する。
+
+---
+
+### C. README 内のインラインバージョン番号の管理漏れ
+
+**観察**: `plugin/plangate/README.md` のディレクトリ表記内に `v0.4.0` という記述が 2 箇所あり、片方だけ更新されて不整合が発生した。
+
+**根本原因**: バージョン番号が CHANGELOG + plugin.json + README ディレクトリ表記の 3 箇所に分散しており、リリース時のチェックリストがない。
+
+**改善アクション**: リリース時の V-4 チェック（または V-1 の一部）として「バージョン番号を含む全ファイルのバージョン整合確認」を追加する。
+
+---
+
+### D. handoff.md の発行タイミング（前セッションからの継続課題）
+
+**観察**: TASK-0032/0033 の handoff.md が完了状態になっていなかった（AC の一部が「実装中」のまま）。今セッションで PR #68 として後追い修正した。前回セッション（2026-04-24）でも同じ問題が観察されており、改善が定着していない。
+
+**根本原因**: PR マージ後の「working context 更新」がセッション完了前のチェックリストに入っていない。
+
+**改善アクション**: WF-05（Verify & Handoff）の完了条件に「current-state.md を『完了（Done）』に更新」と「handoff.md の全 AC を PASS に更新」を明示する。セッション終了前に `git status` で未コミット作業確認と同時に「working context が完了状態か」も確認する習慣を確立する。
+
+---
+
+### E. setup-team 追加後の skill 一覧 README 更新漏れ
+
+**観察**: TASK-0035 で `.claude/skills/setup-team/` を追加したが、`.claude/skills/README.md` への記載が漏れ、PR #70 で事後対応となった。
+
+**根本原因**: 「新規スキル追加」のタスク定義に「README への記載」が含まれていなかった。
+
+**改善アクション**: スキル追加タスクの受入基準に「`.claude/skills/README.md` に一行追記されていること」を必須項目として追加する。
+
+---
+
+### スコアカード
+
+| カテゴリ | スコア(/100) | 根拠 |
+|---------|------------|------|
+| 計画精度 | 8/15 | 6 件の想定外タスク発生、調査スコープ漏れが複数 |
+| テスト品質 | 14/15 | 全 AC PASS、markdownlint CI PASS。文書タスクのため自動テスト対象外 |
+| プロセス遵守 | 11/15 | handoff 後追い（前セッションからの継続問題）はあるが Rule 5 は最終的に遵守 |
+| 効率性 | 17/25 | 5 PR に分散（理想は 3 PR 程度に集約可能だった）、追加作業で工数増 |
+| 成果物品質 | 28/30 | 全 handoff 発行完了、TASK-0033 handoff の Agent D 観点漏れを事後修正 |
+| **合計** | **78/100** | |
+
+---
+
+## 4. 次セッションへの申し送り
+
+### 現在地
+
+```yaml
+branch: main
+last_release: v7.3.0
+open_prs: なし
+open_issues: 確認推奨
+working_context_status:
+  TASK-0035: Done（handoff 発行済み）
+  TASK-0036: Done（TASK-0035 handoff に統合）
+  TASK-0037: Done（handoff 発行済み）
+  TASK-0032: Done（working context 完了状態に更新済み）
+  TASK-0033: Done（working context 完了状態に更新済み）
+```
+
+### 優先 V2 候補（今回のセッションで発生した残課題）
+
+| 優先度 | 内容 | 参照 |
+|--------|------|------|
+| 中 | `/pg-think`・`/pg-hunt`・`/pg-verify` への GatePolicy 連携セクション追加 | TASK-0037 handoff § 3 |
+| 中 | worktree 有無の自動検出（Hook 化 PBI） | TASK-0033 handoff § 3 |
+| 低 | codex-multi-agent の broken reference 全体スキャン | TASK-0035 handoff § 3 |
+| 低 | setup-team スキルの受け入れテスト（test-cases.md）作成 | TASK-0035 handoff § 3 |
+
+### 前回セッション（2026-04-24）からの V2 候補（未着手）
+
+| 優先度 | 内容 |
+|--------|------|
+| 高 | `release-manager` Agent 作成 |
+| 高 | Rule 1〜4 違反の CI 自動検出（deterministic hooks） |
+| 中 | v7 ドッグフーディング PBI（実 TASK で WF-01〜05 を一周） |
+
+### 次セッション開始時の推奨アクション
+
+1. `git status` + GitHub Issues でオープン残課題を確認
+2. `docs/working/` 配下の working context が全て完了状態かを確認（前セッションの繰り返しを防ぐ）
+3. 次 PBI を決定する前に V2 候補一覧から優先度と工数を再評価する


### PR DESCRIPTION
## Summary

2026-04-26 セッションの振り返りドキュメントを `docs/working/sessions/2026-04-26.md` に追加。

スコア: **78/100**

主な学び：
- 命名統一タスクは plan 前に `grep -r` で全体スキャンしてから変更ファイル一覧を確定する
- mirror ファイル（plugin と .claude の同名ファイル）の同期チェックを plan.md に明示する
- スキル追加 PBI の AC に「README への追記」を必須項目として加える
- handoff.md の後追い発行を防ぐため WF-05 完了条件を強化する

🤖 Generated with [Claude Code](https://claude.com/claude-code)