### PR TITLE
docs: v7.3 onboarding — English README, examples/, plugin install guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ PlanGate の主要リリース履歴。
 
 このファイルは各リリース時点の内容を記録するものであり、この pull request の差分一覧ではない。
 
+## v7.3.2 - 2026-04-26
+
+docs: v7.3 onboarding — English README, examples/, plugin install guide (#73 #74 #75 #76)
+
+### Added
+
+- `README.md` — English primary README: 30s/2min/10min structure, plugin install at top, dedup warning
+- `README.ja.md` — Japanese version (restructured from previous `README.md`)
+- `examples/` — Worked example of PlanGate artifacts (Node.js user registration scenario)
+
 ## v7.3.1 - 2026-04-26
 
 plugin v0.5.0: setup-team を skill 一覧に追加、broken reference 制約の削除、README バージョン更新。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,178 @@
+# PlanGate
+
+> 「承認なし、コードなし」― AI コーディングエージェントのためのゲート型ワークフロー
+
+[![GitHub release](https://img.shields.io/github/v/release/s977043/plangate)](https://github.com/s977043/plangate/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![English](https://img.shields.io/badge/lang-English-blue)](README.md)
+
+PlanGate は、AI コーディングエージェントのためのガバナンス優先ワークフローハーネスです。
+人間が承認した計画・タスク・受入テストが揃うまで、AI にプロダクションコードを書かせません。
+
+一般的なエージェントフレームワークが「自律性」を重視するのに対し、PlanGate は **承認境界・監査可能性・スクラム親和性** を重視します。
+
+![PlanGate overview](docs/assets/harness-plangate-readme-dark-v2.png)
+
+## インストール
+
+### Option A: clone + plugin 登録（推奨）
+
+```bash
+git clone https://github.com/s977043/plangate.git
+cd plangate
+```
+
+その後、[Claude Code plugin 登録手順](plugin/plangate/README.md) に従うか、`.claude/` をプロジェクトにコピーしてください。
+
+### Option B: `.claude/` を直接コピー
+
+```bash
+git clone https://github.com/s977043/plangate.git
+cp -r plangate/.claude/ your-project/.claude/
+```
+
+> [!WARNING]
+> **同じプロジェクトで両方の方法を使わないでください。**
+> plugin のインストールと `.claude/` のコピーを併用すると、Skill・コマンドの重複解決が起きます。
+> どちらか一方を選択してください。詳細は [plugin 移行ガイド](docs/plangate-plugin-migration.md) を参照してください。
+
+## 仕組み
+
+PlanGate は AI 実装の前後に 2 つの人間承認ゲートを設けます。
+
+| ゲート | タイミング | 判断 |
+| --- | --- | --- |
+| **C-3** | 計画レビュー後、実装前 | APPROVE / CONDITIONAL / REJECT |
+| **C-4** | AI 実装後、GitHub PR 上 | APPROVE / REQUEST CHANGES |
+
+```text
+人間が PBI を書く → AI が計画を生成 → [C-3: 人間が承認]
+→ AI が実装（TDD）→ 自動検証（L-0, V-1…V-4）
+→ PR 作成 → [C-4: 人間が GitHub でレビュー] → マージ
+```
+
+| 中核アイデア | 内容 |
+| --- | --- |
+| 計画先行 | PBI から plan / todo / test-cases を作り、承認前の実装を禁止する |
+| ゲート制御 | C-3（計画承認）と C-4（PR レビュー）で人間の判断点を固定する |
+| 検証内蔵 | L-0 / V-1〜V-4 により、実装後の検証をワークフローに組み込む |
+| 状態の永続化 | `docs/working/TASK-XXXX/` に計画、レビュー、検証、handoff を残す |
+| 実行層の分離 | v7 では Workflow / Skill / Agent を分け、再利用性と拡張性を高める |
+
+## クイックスタート
+
+```bash
+# 1. 作業コンテキスト作成
+/working-context TASK-XXXX
+
+# 2. Plan + ToDo + Test Cases 生成、セルフレビュー
+/ai-dev-workflow TASK-XXXX plan
+
+# 3. [C-3 ゲート] 人間がレビュー後、実行
+/ai-dev-workflow TASK-XXXX exec
+```
+
+詳細: [docs/plangate.md](docs/plangate.md)
+
+## 10 分チュートリアル
+
+### ステップ 1: 作業コンテキストを作成する
+
+```bash
+/working-context TASK-0001
+```
+
+`docs/working/TASK-0001/pbi-input.md` と関連する成果物ファイルが作成されます。
+
+### ステップ 2: PBI INPUT PACKAGE を記入する（人間作業）
+
+`docs/working/TASK-0001/pbi-input.md` を編集します。
+
+- **Why** — ビジネスコンテキスト、解決する問題
+- **What** — スコープの内外
+- **受入基準** — 検証可能・テスト可能な条件
+
+### ステップ 3: 計画を生成する
+
+```bash
+/ai-dev-workflow TASK-0001 plan
+```
+
+AI が `plan.md`、`todo.md`、`test-cases.md`、`review-self.md` を生成します。
+
+### ステップ 4: C-3 ゲート — 人間がレビューして承認する（人間作業）
+
+`docs/working/TASK-0001/plan.md` を読み、判断します。
+
+- **APPROVE** → exec に進む
+- **CONDITIONAL** → 必要な修正を記録して進む
+- **REJECT** → PBI を修正して計画を再生成する
+
+### ステップ 5: 実行する
+
+```bash
+/ai-dev-workflow TASK-0001 exec
+```
+
+AI が TDD で実装し、lint 修正（L-0）、受け入れ検査（V-1）、外部レビュー（V-3）を実行して PR を作成します。
+
+### ステップ 6: C-4 ゲート — GitHub で PR レビューする（人間作業）
+
+GitHub 上で PR をレビューし、準備ができたらマージします。完了です。
+
+全成果物ファイルの完成例は `examples/sample-task/` を参照してください。
+
+## Plugin vs `.claude/` の違い
+
+| | Plugin（plugin 登録経由） | `.claude/` コピー |
+| --- | --- | --- |
+| **用途** | 複数プロジェクトのベースレイヤー | 単一プロジェクトまたは完全カスタマイズ |
+| **更新** | 再 clone と再登録 | 手動 `git pull` |
+| **カスタマイズ** | プロジェクトの `.claude/` が plugin を上書き | 直接編集 |
+| **競合リスク** | 低い（スキル・コマンドが名前空間で管理） | なし |
+
+技術的には両方の共存も可能です。Plugin がベースを提供し、プロジェクトの `.claude/` が上書きします。
+登録手順は [plugin/plangate/README.md](plugin/plangate/README.md) を参照してください。
+
+## リポジトリ構成
+
+```text
+/docs                    — ナレッジ・ワークフロードキュメント
+  /ai                    — 共通ルール・役割分担
+  /workflows             — v7 Workflow 定義（WF-01〜WF-05）
+  /working               — チケット単位の作業コンテキスト（TASK-XXXX/）
+/.claude                 — Claude Code 設定
+/.codex                  — Codex CLI 設定
+/plugin/plangate         — Claude Code plugin パッケージ
+/scripts                 — ヘルパースクリプト
+/examples                — PlanGate 成果物の完成例
+```
+
+## Claude Code + Codex CLI
+
+PlanGate は Claude Code と Codex CLI の併用を前提にしています。共通ルールは [docs/ai/project-rules.md](docs/ai/project-rules.md) に一元化し、ツール固有の入口ファイルは薄く保ちます。
+
+| ツール | 入口ファイル | 固有設定 |
+| --- | --- | --- |
+| Claude Code | [CLAUDE.md](CLAUDE.md) | `.claude/` |
+| Codex CLI | [AGENTS.md](AGENTS.md) | `.codex/` |
+| 共通 | [docs/ai/project-rules.md](docs/ai/project-rules.md) | `docs/`、`scripts/` |
+
+役割分担の詳細: [docs/ai/tool-roles.md](docs/ai/tool-roles.md)
+
+## Read Next
+
+| ドキュメント | 内容 |
+| --- | --- |
+| [docs/philosophy.md](docs/philosophy.md) | 思想、問題設定、ハーネスエンジニアリング上の位置づけ |
+| [docs/index.md](docs/index.md) | GitHub Pages 用の公開ドキュメント入口 |
+| [docs/plangate.md](docs/plangate.md) | PlanGate ガイド、運用手順、フェーズ説明 |
+| [docs/plangate-v7-hybrid.md](docs/plangate-v7-hybrid.md) | v7 ハイブリッドアーキテクチャ |
+| [docs/workflows/README.md](docs/workflows/README.md) | WF-01〜WF-05 の Workflow 定義 |
+| [docs/plangate-plugin-migration.md](docs/plangate-plugin-migration.md) | Claude Code plugin としての利用・移行 |
+| [docs/oss-governance.md](docs/oss-governance.md) | OSS 公開設定・運用判断 |
+| [CHANGELOG.md](CHANGELOG.md) | 主要リリース履歴 |
+
+## ライセンス
+
+MIT — [LICENSE](LICENSE) を参照

--- a/README.md
+++ b/README.md
@@ -1,104 +1,182 @@
 # PlanGate
 
-PlanGate は、AI コーディングエージェントをプロダクション開発で扱うためのゲート型ワークフローです。
+> "No approval, no code." — A gate-driven workflow for AI coding agents.
 
-「計画を承認しないと AI は 1 行もコードを書けない」という関所モデルを中核に、PBI から計画、承認、実装、検証、handoff までを構造化します。
+[![GitHub release](https://img.shields.io/github/v/release/s977043/plangate)](https://github.com/s977043/plangate/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![日本語](https://img.shields.io/badge/lang-%E6%97%A5%E6%9C%AC%E8%AA%9E-blue)](README.ja.md)
 
-![Harness Engineering と PlanGate の関係](docs/assets/harness-plangate-readme-dark-v2.png)
+PlanGate is a governance-first workflow harness for AI coding agents.
+It prevents AI agents from writing production code until a human-approved plan, task list, and acceptance test set exist.
 
-## 何を目指すか
+Unlike agent frameworks that focus on autonomy, PlanGate focuses on **approval boundaries, auditability, and Scrum-friendly delivery**.
 
-PlanGate は、AI エージェントを単体の便利な実装者としてではなく、承認境界・成果物・検証手順を持つ開発ハーネスの中で動かすことを目指します。
+![PlanGate overview](docs/assets/harness-plangate-readme-dark-v2.png)
 
-一般的なハーネスエンジニアリングが「AI を安全に動かす外枠」を整えるものだとすれば、PlanGate はその外枠の中で次を具体化します。
+## Install
 
-- 計画が承認されるまで実装を始めない
-- 承認・差し戻し・再実行の境界を明確にする
-- 実装前に計画、タスク、テスト観点を成果物として残す
-- 実装後に受け入れ検査、レビュー、handoff を残す
-- 判断基準とコンテキストを個人の記憶ではなくファイルに固定する
-
-## 向き合う課題
-
-AI コーディングは速い一方で、運用の外枠が弱いと次の問題が起きやすくなります。
-
-- AI 実装が計画より先行しやすい
-- 承認や責任境界が曖昧になりやすい
-- 検証が後付けになり、品質保証が不安定になりやすい
-- コンテキストや評価基準がセッションや個人に依存しやすい
-- 完了判断の根拠が PR や会話ログに散らばりやすい
-
-PlanGate はこれらを注意力ではなく、ワークフロー、ゲート、成果物、再利用可能な Skill / Agent の分離によって抑えます。
-
-詳細な思想と問題設定は [docs/philosophy.md](docs/philosophy.md) を参照してください。
-
-## 中核アイデア
-
-| アイデア | 内容 |
-| --- | --- |
-| 計画先行 | PBI から plan / todo / test-cases を作り、承認前の実装を禁止する |
-| ゲート制御 | C-3（計画承認）と C-4（PR レビュー）で人間の判断点を固定する |
-| 検証内蔵 | L-0 / V-1〜V-4 により、実装後の検証をワークフローに組み込む |
-| 状態の永続化 | `docs/working/TASK-XXXX/` に計画、レビュー、検証、handoff を残す |
-| 実行層の分離 | v7 では Workflow / Skill / Agent を分け、再利用性と拡張性を高める |
-
-## クイックスタート
-
-詳細: [docs/plangate.md](docs/plangate.md)
+### Option A: Clone and symlink (recommended)
 
 ```bash
-# 1. 作業コンテキスト作成
+git clone https://github.com/s977043/plangate.git
+cd plangate
+```
+
+Then follow [Claude Code plugin registration instructions](plugin/plangate/README.md) or copy `.claude/` into your project.
+
+### Option B: Copy `.claude/` directly
+
+```bash
+git clone https://github.com/s977043/plangate.git
+cp -r plangate/.claude/ your-project/.claude/
+```
+
+> [!WARNING]
+> **Do not use both methods in the same project.**
+> Installing the plugin AND copying `.claude/` causes duplicate skill/command resolution.
+> Choose one method. See [plugin migration guide](docs/plangate-plugin-migration.md) for details.
+
+## How It Works
+
+PlanGate enforces two human-approval gates before and after AI implementation:
+
+| Gate | When | Decision |
+| --- | --- | --- |
+| **C-3** | After plan review, before implementation | APPROVE / CONDITIONAL / REJECT |
+| **C-4** | After AI implements, on GitHub PR | APPROVE / REQUEST CHANGES |
+
+```text
+Human writes PBI → AI generates plan → [C-3: Human approves]
+→ AI implements (TDD) → Auto-verify (L-0, V-1…V-4)
+→ PR created → [C-4: Human reviews on GitHub] → Merge
+```
+
+| Concept | Description |
+| --- | --- |
+| Plan-first | PBI → plan / todo / test-cases before any code |
+| Gate control | C-3 (plan approval) and C-4 (PR review) fix human decision points |
+| Built-in verification | L-0 lint fix, V-1 acceptance check, V-3 external review |
+| Persistent artifacts | `docs/working/TASK-XXXX/` keeps plan, review, tests, handoff |
+| Separated execution layer | v7: Workflow / Skill / Agent separated for reusability |
+
+## Quick Start
+
+```bash
+# 1. Create working context
 /working-context TASK-XXXX
 
-# 2. Plan + ToDo + Test Cases 生成、セルフレビュー、外部 AI レビュー
+# 2. Generate plan + todo + test cases + self-review
 /ai-dev-workflow TASK-XXXX plan
 
-# 3. 人間レビュー（PlanGate ゲート）後、Agent 実行
+# 3. [C-3 Gate] Human reviews plan, then execute
 /ai-dev-workflow TASK-XXXX exec
 ```
 
-## リポジトリ構成
+Details: [docs/plangate.md](docs/plangate.md)
+
+## 10-Minute Tutorial
+
+### Step 1: Create working context
+
+```bash
+/working-context TASK-0001
+```
+
+Creates `docs/working/TASK-0001/pbi-input.md` and related artifact files.
+
+### Step 2: Fill in PBI INPUT PACKAGE (human)
+
+Edit `docs/working/TASK-0001/pbi-input.md`:
+
+- **Why** — business context, problem being solved
+- **What** — scope in / out
+- **Acceptance criteria** — verifiable, testable conditions
+
+### Step 3: Generate plan
+
+```bash
+/ai-dev-workflow TASK-0001 plan
+```
+
+AI produces: `plan.md`, `todo.md`, `test-cases.md`, `review-self.md`
+
+### Step 4: C-3 Gate — Human reviews and approves (human)
+
+Read `docs/working/TASK-0001/plan.md` and decide:
+
+- **APPROVE** → proceed to exec
+- **CONDITIONAL** → note required fixes, proceed
+- **REJECT** → revise PBI and regenerate plan
+
+### Step 5: Execute
+
+```bash
+/ai-dev-workflow TASK-0001 exec
+```
+
+AI implements with TDD, runs lint fix (L-0), acceptance check (V-1), external review (V-3), and creates a PR.
+
+### Step 6: C-4 Gate — PR review on GitHub (human)
+
+Review the PR on GitHub and merge when ready. Done.
+
+See `examples/sample-task/` for a complete worked example of all artifact files.
+
+## Plugin vs `.claude/` — Which to use?
+
+| | Plugin (via plugin registration) | `.claude/` copy |
+| --- | --- | --- |
+| **Use case** | Base layer for multiple projects | Single project or full customization |
+| **Update** | Re-clone and re-register | Manual `git pull` |
+| **Customization** | Project `.claude/` overrides plugin | Edit directly |
+| **Conflict risk** | Low (namespaced skills/commands) | None |
+
+Both can technically coexist. Plugin provides the base, project `.claude/` overrides.
+See [plugin/plangate/README.md](plugin/plangate/README.md) for registration instructions.
+
+## Repository Layout
 
 ```text
-/docs                    - ナレッジ・ガイドドキュメント
-  /ai                    - 共通ルール・役割分担
-  /workflows             - v7 Workflow 定義
-  /working               - チケット単位の作業コンテキスト
-/.claude                 - Claude Code 固有の設定
-/.codex                  - Codex CLI 固有の設定
-/plugin/plangate         - Claude Code plugin 配布パッケージ
-/scripts                 - 起動スクリプト
+/docs                    — Knowledge and workflow documentation
+  /ai                    — Shared rules and role definitions
+  /workflows             — v7 Workflow definitions (WF-01 to WF-05)
+  /working               — Per-ticket working context (TASK-XXXX/)
+/.claude                 — Claude Code configuration
+/.codex                  — Codex CLI configuration
+/plugin/plangate         — Claude Code plugin package
+/scripts                 — Helper scripts
+/examples                — Worked examples of PlanGate artifacts
 ```
 
 ## Claude Code + Codex CLI
 
-PlanGate は Claude Code と Codex CLI の併用を前提にしています。共通ルールは [docs/ai/project-rules.md](docs/ai/project-rules.md) に一元化し、ツール固有の入口ファイルは薄く保ちます。
+PlanGate is designed for use with both Claude Code and Codex CLI. Shared rules are centralized in [docs/ai/project-rules.md](docs/ai/project-rules.md); tool-specific entry files are kept thin.
 
-| ツール | 入口ファイル | 固有設定 |
+| Tool | Entry file | Config |
 | --- | --- | --- |
 | Claude Code | [CLAUDE.md](CLAUDE.md) | `.claude/` |
 | Codex CLI | [AGENTS.md](AGENTS.md) | `.codex/` |
-| 共通 | [docs/ai/project-rules.md](docs/ai/project-rules.md) | `docs/`, `scripts/` |
+| Shared | [docs/ai/project-rules.md](docs/ai/project-rules.md) | `docs/`, `scripts/` |
 
-役割分担の詳細: [docs/ai/tool-roles.md](docs/ai/tool-roles.md)
+Role details: [docs/ai/tool-roles.md](docs/ai/tool-roles.md)
 
 ## Read Next
 
-| ドキュメント | 内容 |
+| Document | Description |
 | --- | --- |
-| [docs/philosophy.md](docs/philosophy.md) | 思想、問題設定、ハーネスエンジニアリング上の位置づけ |
-| [docs/index.md](docs/index.md) | GitHub Pages 用の公開ドキュメント入口 |
-| [docs/plangate.md](docs/plangate.md) | PlanGate ガイド、運用手順、フェーズ説明 |
-| [docs/plangate-v7-hybrid.md](docs/plangate-v7-hybrid.md) | v7 ハイブリッドアーキテクチャ |
-| [docs/workflows/README.md](docs/workflows/README.md) | WF-01〜WF-05 の Workflow 定義 |
-| [docs/plangate-plugin-migration.md](docs/plangate-plugin-migration.md) | Claude Code plugin としての利用・移行 |
-| [docs/oss-governance.md](docs/oss-governance.md) | OSS 公開設定・運用判断 |
-| [CHANGELOG.md](CHANGELOG.md) | 主要リリース履歴 |
+| [docs/philosophy.md](docs/philosophy.md) | Philosophy, problem framing, harness engineering positioning |
+| [docs/index.md](docs/index.md) | GitHub Pages documentation entry point |
+| [docs/plangate.md](docs/plangate.md) | PlanGate guide, operating procedures, phase descriptions |
+| [docs/plangate-v7-hybrid.md](docs/plangate-v7-hybrid.md) | v7 hybrid architecture |
+| [docs/workflows/README.md](docs/workflows/README.md) | WF-01 to WF-05 Workflow definitions |
+| [docs/plangate-plugin-migration.md](docs/plangate-plugin-migration.md) | Using and migrating to Claude Code plugin |
+| [docs/oss-governance.md](docs/oss-governance.md) | OSS publication settings and operational decisions |
+| [CHANGELOG.md](CHANGELOG.md) | Major release history |
 
-## 解説記事
+## Japanese README
 
-- [AIコーディングの暴走を「仕組み」で止める — PlanGateという開発フロー](https://note.com/mine_unilabo/n/n3aae6b5467b9)（note）
+[日本語版 README はこちら → README.ja.md](README.ja.md)
 
-## ライセンス
+## License
 
-[MIT](LICENSE)
+MIT — see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ Unlike agent frameworks that focus on autonomy, PlanGate focuses on **approval b
 
 ## Install
 
-### Option A: Clone and symlink (recommended)
+### Option A: Clone and register plugin (recommended)
 
 ```bash
 git clone https://github.com/s977043/plangate.git
-cd plangate
 ```
 
-Then follow [Claude Code plugin registration instructions](plugin/plangate/README.md) or copy `.claude/` into your project.
+Then follow [Claude Code plugin registration instructions](plugin/plangate/README.md) to register the plugin.
 
 ### Option B: Copy `.claude/` directly
 
@@ -131,8 +130,8 @@ See `examples/sample-task/` for a complete worked example of all artifact files.
 | **Customization** | Project `.claude/` overrides plugin | Edit directly |
 | **Conflict risk** | Low (namespaced skills/commands) | None |
 
-Both can technically coexist. Plugin provides the base, project `.claude/` overrides.
-See [plugin/plangate/README.md](plugin/plangate/README.md) for registration instructions.
+Choose **one** method per project. If you need to customize skills or commands beyond what the plugin offers, use Option B and edit `.claude/` directly.
+See [plugin/plangate/README.md](plugin/plangate/README.md) for plugin registration instructions.
 
 ## Repository Layout
 

--- a/docs/working/sessions/2026-04-26.md
+++ b/docs/working/sessions/2026-04-26.md
@@ -1,0 +1,158 @@
+# セッション振り返り
+
+> 実施日: 2026-04-26
+> 対象セッション: v7.2.0 / v7.3.0 後片付け + ドキュメント監査
+
+---
+
+## 1. セッション成果サマリ
+
+### マージ済み PR（5 本）
+
+| PR | 種別 | 内容 | 変更ファイル数 |
+|----|------|------|------------|
+| #66 | feat | TASK-0035 setup-team スキル追加 + TASK-0036 full → high-risk 残存置換 | 13 |
+| #67 | release | PlanGate v7.3.0（CHANGELOG + TASK-0037 handoff + pg-check 連携） | 4 |
+| #68 | chore | TASK-0032/0033 working context を完了状態に更新 | 4 |
+| #69 | chore | plugin v0.5.0 + TASK-0037 handoff 発行 + README 整合 | 4 |
+| #70 | docs | docs/ 配下の full → high-risk 命名統一・skill 一覧更新 | 6 |
+
+**合計**: 5 PR / 31 ファイル変更
+
+### リリース
+
+- **v7.3.0** — setup-team スキル, full → high-risk 完全統一, pg-check × skill-policy-router 連携明示
+
+---
+
+## 2. 計画精度分析
+
+### 想定通りだったこと
+
+- TASK-0035（setup-team スキル追加）: 3 箇所への配置（plugin / .claude / .agents）が計画通り完了
+- TASK-0036（full → high-risk 置換）: plugin/plangate 側 9 ファイルの修正が完了
+- TASK-0037（pg-check GatePolicy 連携）: 3 AC すべて 1 ファイル変更で充足
+
+### 想定外の追加作業（計画外タスク）
+
+| 追加作業 | 発生タイミング | 原因 | 工数感 |
+|---------|-------------|------|------|
+| `.claude/rules/mode-classification.md` の full 残存修正 | PR #66 コミット後に発見 | plugin 版と .claude 版の同期確認が TASK-0036 計画に含まれていなかった | 小 |
+| `.claude/agents/code-optimizer.md` 等の修正漏れ | PR #66 同セッション中に発見 | 対象ファイル一覧の初期調査が不完全（agent ファイルを漏らした） | 小 |
+| TASK-0032/0033 working context の事後更新（PR #68） | PR #63 マージ後に判明 | handoff 発行と current-state 更新を PR マージと同セッションで実施しなかった（2026-04-24 セッションからの積み残し） | 中 |
+| plugin/plangate/README.md のバージョン番号 2 箇所のうち 1 箇所更新漏れ | PR #69 準備中に発見 | ディレクトリ表記内のインラインバージョン番号が changelog と別管理になっていた | 小 |
+| `.claude/skills/README.md` への setup-team 追記漏れ（PR #70） | PR #66 マージ後に発見 | TASK-0035 の受入基準に README 更新が明示されていなかった | 小 |
+| docs/ 配下の full 残存（docs/plangate.md 等）の別 PR 対応（PR #70） | PR #66 〜 #69 完了後に発見 | TASK-0036 の調査スコープが plugin/ と .claude/ に限定されており、docs/ が漏れていた | 中 |
+
+**計画逸脱率**: 計画ステップ数（3 TASK 合計 約 10 ステップ）に対して、想定外タスクが 6 件発生。実質的な作業量は計画の約 1.5〜2 倍。
+
+### Unknowns の的中率
+
+TASK-0035/0036 の事前計画（pbi-input.md）は今セッションで初めて起票されたため、Unknowns の事前記録なし。振り返りから抽出した主なリスクを後掲する。
+
+---
+
+## 3. プロセス上の学び・改善点
+
+### A. 命名統一タスクの「調査スコープ漏れ」パターン
+
+**観察**: `full → high-risk` の置換作業で、plugin/ と .claude/ を調査した後に docs/ の残存が発見され、追加 PR が必要になった。これは TASK-0036 の「変更ファイル数を少なく見積もった」計画精度の問題。
+
+**根本原因**: grep の調査スコープを「変更主体ディレクトリ」に限定し、「参照側ドキュメント」を含めなかった。
+
+**改善アクション（次回 plan 向け）**: 命名統一・リネーム系タスクの計画時は、「対象ディレクトリ一覧」を plan.md の Work Breakdown に明示し、`grep -r "対象文字列" .` でリポジトリ全体を調査してから変更ファイル一覧を確定する。
+
+---
+
+### B. 「mirror ファイル」（plugin 版 ↔ .claude 版）の同期チェック漏れ
+
+**観察**: `plugin/plangate/rules/mode-classification.md` は更新済みだったが、`.claude/rules/mode-classification.md` の同期が漏れていた。同内容を 2 箇所に持つ「mirror ファイル」構造が原因。
+
+**根本原因**: mirror ファイルの存在と対応関係がどこにも記述されていない。
+
+**改善アクション**: plan.md の「Files / Components to Touch」に mirror ファイルを明示するか、リポジトリ内に mirror 関係を記述した index を整備する。短期的には plan 生成時の C-1 チェック項目「mirror ファイルがある場合は両方を記載したか」を追加する。
+
+---
+
+### C. README 内のインラインバージョン番号の管理漏れ
+
+**観察**: `plugin/plangate/README.md` のディレクトリ表記内に `v0.4.0` という記述が 2 箇所あり、片方だけ更新されて不整合が発生した。
+
+**根本原因**: バージョン番号が CHANGELOG + plugin.json + README ディレクトリ表記の 3 箇所に分散しており、リリース時のチェックリストがない。
+
+**改善アクション**: リリース時の V-4 チェック（または V-1 の一部）として「バージョン番号を含む全ファイルのバージョン整合確認」を追加する。
+
+---
+
+### D. handoff.md の発行タイミング（前セッションからの継続課題）
+
+**観察**: TASK-0032/0033 の handoff.md が完了状態になっていなかった（AC の一部が「実装中」のまま）。今セッションで PR #68 として後追い修正した。前回セッション（2026-04-24）でも同じ問題が観察されており、改善が定着していない。
+
+**根本原因**: PR マージ後の「working context 更新」がセッション完了前のチェックリストに入っていない。
+
+**改善アクション**: WF-05（Verify & Handoff）の完了条件に「current-state.md を『完了（Done）』に更新」と「handoff.md の全 AC を PASS に更新」を明示する。セッション終了前に `git status` で未コミット作業確認と同時に「working context が完了状態か」も確認する習慣を確立する。
+
+---
+
+### E. setup-team 追加後の skill 一覧 README 更新漏れ
+
+**観察**: TASK-0035 で `.claude/skills/setup-team/` を追加したが、`.claude/skills/README.md` への記載が漏れ、PR #70 で事後対応となった。
+
+**根本原因**: 「新規スキル追加」のタスク定義に「README への記載」が含まれていなかった。
+
+**改善アクション**: スキル追加タスクの受入基準に「`.claude/skills/README.md` に一行追記されていること」を必須項目として追加する。
+
+---
+
+### スコアカード
+
+| カテゴリ | スコア(/100) | 根拠 |
+|---------|------------|------|
+| 計画精度 | 8/15 | 6 件の想定外タスク発生、調査スコープ漏れが複数 |
+| テスト品質 | 14/15 | 全 AC PASS、markdownlint CI PASS。文書タスクのため自動テスト対象外 |
+| プロセス遵守 | 11/15 | handoff 後追い（前セッションからの継続問題）はあるが Rule 5 は最終的に遵守 |
+| 効率性 | 17/25 | 5 PR に分散（理想は 3 PR 程度に集約可能だった）、追加作業で工数増 |
+| 成果物品質 | 28/30 | 全 handoff 発行完了、TASK-0033 handoff の Agent D 観点漏れを事後修正 |
+| **合計** | **78/100** | |
+
+---
+
+## 4. 次セッションへの申し送り
+
+### 現在地
+
+```yaml
+branch: main
+last_release: v7.3.0
+open_prs: なし
+open_issues: 確認推奨
+working_context_status:
+  TASK-0035: Done（handoff 発行済み）
+  TASK-0036: Done（TASK-0035 handoff に統合）
+  TASK-0037: Done（handoff 発行済み）
+  TASK-0032: Done（working context 完了状態に更新済み）
+  TASK-0033: Done（working context 完了状態に更新済み）
+```
+
+### 優先 V2 候補（今回のセッションで発生した残課題）
+
+| 優先度 | 内容 | 参照 |
+|--------|------|------|
+| 中 | `/pg-think`・`/pg-hunt`・`/pg-verify` への GatePolicy 連携セクション追加 | TASK-0037 handoff § 3 |
+| 中 | worktree 有無の自動検出（Hook 化 PBI） | TASK-0033 handoff § 3 |
+| 低 | codex-multi-agent の broken reference 全体スキャン | TASK-0035 handoff § 3 |
+| 低 | setup-team スキルの受け入れテスト（test-cases.md）作成 | TASK-0035 handoff § 3 |
+
+### 前回セッション（2026-04-24）からの V2 候補（未着手）
+
+| 優先度 | 内容 |
+|--------|------|
+| 高 | `release-manager` Agent 作成 |
+| 高 | Rule 1〜4 違反の CI 自動検出（deterministic hooks） |
+| 中 | v7 ドッグフーディング PBI（実 TASK で WF-01〜05 を一周） |
+
+### 次セッション開始時の推奨アクション
+
+1. `git status` + GitHub Issues でオープン残課題を確認
+2. `docs/working/` 配下の working context が全て完了状態かを確認（前セッションの繰り返しを防ぐ）
+3. 次 PBI を決定する前に V2 候補一覧から優先度と工数を再評価する

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# PlanGate Examples
+
+A complete worked example showing PlanGate artifacts for a real-world task.
+
+## Scenario
+
+**"Add user registration to a Node.js/Express API"**
+
+`POST /api/users` with email validation, bcrypt password hashing (cost=12), and PostgreSQL storage.
+
+## Files
+
+| File | Phase | Description |
+|------|-------|-------------|
+| `sample-task/pbi-input.md` | A | PBI INPUT PACKAGE (written by human) |
+| `sample-task/plan.md` | B | Execution plan (AI-generated) |
+| `sample-task/todo.md` | B | Task breakdown for agent execution |
+| `sample-task/test-cases.md` | B | Test case definitions |
+| `sample-task/review-self.md` | C-1 | 17-point self-review result |
+| `sample-task/handoff.md` | WF-05 | Handoff package after completion |
+
+## How to Use
+
+1. Read `pbi-input.md` first — this is what the human writes before running PlanGate.
+2. Run `/ai-dev-workflow TASK-XXXX plan` to generate the other files automatically.
+3. Use these files as format references for your own tasks.
+
+## Templates
+
+Blank templates are available in [`docs/working/templates/`](../docs/working/templates/).

--- a/examples/sample-task/handoff.md
+++ b/examples/sample-task/handoff.md
@@ -1,0 +1,102 @@
+# Handoff Package — Add User Registration Endpoint
+
+> WF-05 Verify & Handoff の必須出力。
+> 配置先: `examples/sample-task/handoff.md`
+
+## メタ情報
+
+```yaml
+task: sample-task
+related_issue: N/A (example)
+author: qa-reviewer
+issued_at: 2026-04-26
+v1_release: N/A (example artifact)
+```
+
+---
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-1: 有効body → 201 + { id, email, created_at } | PASS | TC-01: integration test PASS。id・email・created_atの全フィールド存在確認 |
+| AC-2: 重複メール → 409 | PASS | TC-02: DB UNIQUE制約違反をcatchして409を返すことを確認 |
+| AC-3: 不正メールフォーマット → 400 | PASS | TC-03: `isValidEmail`がfalseを返し400レスポンス確認 |
+| AC-4: パスワード7文字以下 → 400 | PASS | TC-04: `isValidPassword`がfalseを返し400レスポンス確認 |
+| AC-5: bcryptハッシュでDB保存 | PASS | TC-05: DBの`password_hash`が`$2b$12$`形式、bcrypt.compareで照合成功 |
+| AC-6: メールlowercase正規化 | PASS | TC-06: `USER@EXAMPLE.COM`入力→DB保存値が`user@example.com`であることを確認 |
+| AC-7: unit + integration tests PASS | PASS | TC-07/TC-08: unit 12/12 PASS。TC-01〜TC-08+TC-E1〜E5: integration 13/13 PASS |
+
+**総合**: `7/7 基準 PASS`
+
+---
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2候補か |
+|------|---------|------|---------|
+| なし | — | — | — |
+
+今回のスコープ内で Critical / Major の課題は発見されなかった。
+
+---
+
+## 3. V2 候補
+
+| V2候補 | 理由 | 推定優先度 | 関連Issue |
+|--------|------|----------|---------|
+| パスワード強度チェック（Zxcvbn等） | 現状は長さのみ。辞書攻撃耐性を高めるためスコアベース検証を追加 | Medium | — |
+| Rate limiting（登録エンドポイント） | 大量リクエストによるDB負荷・アカウント列挙攻撃への対策 | High | — |
+| メール確認フロー（Email verification） | 登録後にメールアドレスの所有権を確認。スパム登録防止 | Medium | — |
+| メールの前後スペーストリミング | 現状はバリデーションで弾く設計。trim後に再検証する方が UX が良い | Low | — |
+
+---
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| bcrypt cost=12（固定値） | 環境変数で設定可能にする | 今回はシンプルさを優先。設定外部化はV2で対応 |
+| DB UNIQUE制約で409を制御 | アプリ側で事前SELECT→INSERT | TOCTOU問題を避けるためDB側で最終制御。パフォーマンスは問題なし |
+| email lowercase正規化のみ | 前後スペーストリム | スペース付きメールはバリデーションで弾く設計を選択。将来trimに変更可能 |
+| OAuth・メール確認は対象外 | 登録と同時にOAuth連携 | PBIスコープを最小化し、確実にAC-1〜AC-7を満たすことを優先 |
+
+---
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+`POST /api/users` エンドポイントの実装が完了した。
+bcrypt cost=12 でのパスワードハッシュ化、メールのlowercase正規化、DB UNIQUE制約を使った重複検出がすべて実装済み。
+unit tests（validators）・integration tests（エンドポイント）ともに全件PASSを確認。
+
+### 触れないでほしいファイル
+
+- `src/services/userService.js`: bcryptのasync/await パターンを変更すると平文保存のリスクがある
+- `src/validators/user.js`: TC-07/TC-08のunit testsが壊れる変更は要注意
+
+### 次に手を入れるなら
+
+- パスワード強度チェック（V2候補）: `src/validators/user.js` の `isValidPassword` を拡張
+- Rate limiting: Expressミドルウェア（express-rate-limit等）を `src/app.js` に追加
+- メール確認フロー: 登録後にJWTトークン付きメールを送信する別PBIとして作成
+
+### 参照リンク
+
+- PBI: `examples/sample-task/pbi-input.md`
+- Plan: `examples/sample-task/plan.md`
+- Test cases: `examples/sample-task/test-cases.md`
+- Templates: `docs/working/templates/`
+
+---
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit (validators) | 12 | 12 | 0 | isValidEmail: 100%, isValidPassword: 100% |
+| Integration (endpoint) | 13 | 13 | 0 | AC-1〜AC-7 + TC-E1〜E5 全件 |
+| **合計** | **25** | **25** | **0** | — |
+
+lint: エラー0件（`npm run lint` PASS）

--- a/examples/sample-task/pbi-input.md
+++ b/examples/sample-task/pbi-input.md
@@ -1,0 +1,70 @@
+---
+task_id: sample-task
+artifact_type: pbi-input
+schema_version: 1
+---
+
+# PBI INPUT PACKAGE — Add User Registration Endpoint
+
+## Context / Why
+
+The application currently has no user registration endpoint.
+New users must be inserted into the database directly by administrators,
+which is not scalable and introduces operational risk.
+This PBI adds a `POST /api/users` endpoint to automate registration
+with proper input validation and secure password storage.
+
+## What — Scope
+
+### In scope
+
+- `POST /api/users` endpoint accepting `{ email, password }` in request body
+- Email format validation (RFC 5322 basic check, lowercase normalization)
+- Password minimum length validation (8 characters)
+- bcrypt password hashing (cost factor: 12)
+- PostgreSQL INSERT into existing `users` table
+- 201 Created response with `{ id, email, created_at }` on success
+- 409 Conflict response when email already exists
+- 400 Bad Request for invalid email format or insufficient password length
+
+### Out of scope
+
+- Email verification flow (separate PBI)
+- Password reset / forgot password
+- OAuth / social login
+- Rate limiting (infrastructure concern)
+- `users` table migration (table already exists)
+
+## Acceptance Criteria
+
+- [ ] AC-1: `POST /api/users` with valid body → 201 Created + `{ id, email, created_at }`
+- [ ] AC-2: Duplicate email → 409 Conflict + `{ error: "Email already registered" }`
+- [ ] AC-3: Invalid email format → 400 Bad Request + `{ error: "Invalid email format" }`
+- [ ] AC-4: Password shorter than 8 characters → 400 Bad Request + `{ error: "Password must be at least 8 characters" }`
+- [ ] AC-5: Password is stored as bcrypt hash (not plaintext) in the database
+- [ ] AC-6: Email is normalized to lowercase before storage
+- [ ] AC-7: Unit tests for validation functions pass; integration tests for the endpoint pass
+
+## Notes from Refinement
+
+- bcrypt cost factor agreed as 12 (security/performance balance)
+- Email normalization: lowercase only; leading/trailing spaces trigger validation rejection
+- Existing `users` table has a UNIQUE constraint on `email` column — use this for 409 detection
+
+## Estimation Evidence
+
+**Risks**
+
+- bcrypt is async; missing `await` could silently store unhashed passwords
+- Race condition on duplicate email: DB UNIQUE constraint is the authoritative guard
+
+**Unknowns**
+
+- Need to verify that existing auth middleware does not intercept `POST /api/users` before registration
+
+**Assumptions**
+
+- PostgreSQL `users` table exists with columns:
+  `id SERIAL PRIMARY KEY, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, created_at TIMESTAMPTZ DEFAULT NOW()`
+- Project uses async/await throughout (no callback-style)
+- Jest is the test runner

--- a/examples/sample-task/plan.md
+++ b/examples/sample-task/plan.md
@@ -1,0 +1,75 @@
+---
+task_id: sample-task
+artifact_type: plan
+schema_version: 1
+status: approved
+---
+
+# EXECUTION PLAN — Add User Registration Endpoint
+
+## Goal
+
+Implement `POST /api/users` endpoint and satisfy all 7 acceptance criteria (AC-1 through AC-7).
+
+## Constraints / Non-goals
+
+- OAuth, email verification, and password reset are out of scope
+- Rate limiting is an infrastructure concern — not in this PBI
+- `users` table migration is not required (table already exists)
+- No changes to existing auth middleware
+
+## Approach Overview
+
+Implement in dependency order: validation functions → service layer → route handler → mount to app → tests.
+bcrypt is used exclusively via async/await to prevent accidental plaintext storage.
+
+## Work Breakdown
+
+| Step | Content | Output | Owner | Risk | Checkpoint |
+|------|---------|--------|-------|------|-----------|
+| Step 1 | Explore existing auth middleware and confirm users table schema | Schema confirmed, no middleware conflict | agent | Low | 🚩 |
+| Step 2 | Implement `src/validators/user.js` | `isValidEmail`, `isValidPassword` functions | agent | Low | 🚩 |
+| Step 3 | Implement `src/services/userService.js` | `createUser` with bcrypt + DB INSERT + 409 detection | agent | Medium (async misuse) | 🚩 |
+| Step 4 | Implement `src/routes/users.js` + mount in `src/app.js` | POST /api/users handler live | agent | Low | 🚩 |
+| Step 5 | Implement unit + integration tests | All AC-7 test suites passing | agent | Low | 🚩 |
+
+## Files / Components to Touch
+
+| Type | File Path | Change |
+|------|-----------|--------|
+| New | `src/validators/user.js` | Email format check, password length check |
+| New | `src/services/userService.js` | bcrypt hash, DB INSERT, duplicate detection |
+| New | `src/routes/users.js` | POST /api/users handler |
+| Modify | `src/app.js` | Mount users router |
+| New | `tests/unit/validators/user.test.js` | Unit tests for validators |
+| New | `tests/integration/routes/users.test.js` | Integration tests for endpoint |
+
+## Testing Strategy
+
+- **Unit**: `isValidEmail` and `isValidPassword` — normal, invalid, boundary inputs
+- **Integration**: All 7 ACs + edge cases TC-E1 through TC-E5 against running test DB
+- **Edge cases**: empty body, missing fields, max-length email, empty string password, SQL injection patterns
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| bcrypt async misuse (missing await) | Enforce async/await + try/catch; never use bcrypt.hashSync in production path |
+| Duplicate email race condition | DB UNIQUE constraint is the final guard; catch constraint violation error for 409 |
+| Auth middleware intercepting registration | Confirm in Step 1 exploration before writing any handler code |
+
+## Questions / Unknowns
+
+- None remaining after Step 1 exploration (schema and middleware confirmed)
+
+## Mode判定
+
+**モード**: `standard`
+
+**判定根拠**:
+
+- 変更ファイル数: 6 → standard
+- 受入基準数: 7 → standard
+- 変更種別: 新機能追加（単一エンドポイント） → standard
+- リスク: 中（bcrypt非同期、重複制御） → standard
+- **最終判定**: standard

--- a/examples/sample-task/review-self.md
+++ b/examples/sample-task/review-self.md
@@ -1,0 +1,114 @@
+---
+task_id: sample-task
+artifact_type: review-self
+schema_version: 1
+---
+
+# sample-task セルフレビュー結果（C-1）
+
+> レビュー日: 2026-04-26
+> 判定: **PASS** — critical=0, major=0, minor=0
+
+## サマリー
+
+| result | 件数 |
+|--------|------|
+| PASS | 17 |
+| WARN | 0 |
+| FAIL | 0 |
+
+---
+
+## Plan チェック（7項目）
+
+### C1-PLAN-01: 受入基準網羅性
+
+- **result**: PASS
+- **finding**: AC-1〜AC-7の全7件がWork Breakdown（Step 2〜5）にマッピングされている。AC-5（bcryptハッシュ）はStep 3、AC-6（lowercase正規化）はStep 2のvalidatorに対応
+
+### C1-PLAN-02: Unknowns処理
+
+- **result**: PASS
+- **finding**: 「authミドルウェアとの衝突確認」がStep 1のチェックポイントとして明記されており、unknownが解決手段付きで計画に組み込まれている
+
+### C1-PLAN-03: スコープ制御
+
+- **result**: PASS
+- **finding**: OAuth・メール確認・rate limiting・migration がNon-goalsに明記されている。スコープクリープの兆候なし
+
+### C1-PLAN-04: テスト戦略
+
+- **result**: PASS
+- **finding**: Unit（validator関数）・Integration（エンドポイント）・Edge cases（TC-E1〜E5）の3層が具体的なファイルパスと対象で定義されている
+
+### C1-PLAN-05: Work Breakdown Output
+
+- **result**: PASS
+- **finding**: Step 1〜5の各ステップに具体的なOutputが記載されている（例: Step 2 → `isValidEmail`, `isValidPassword` 関数）
+
+### C1-PLAN-06: 依存関係
+
+- **result**: PASS
+- **finding**: validator → service → route → app.jsの順序は正しい。テストはT-04（validator）とT-07（route mount）完了後に分岐する設計で矛盾なし
+
+### C1-PLAN-07: 動作検証自動化
+
+- **result**: PASS
+- **finding**: `npm test` でunit + integration全件を自動実行可能。CI連携はinfraスコープ外だが、ローカル自動化は担保されている
+
+---
+
+## ToDo チェック（5項目）
+
+### C1-TODO-08: タスク粒度
+
+- **result**: PASS
+- **finding**: T-01〜T-15の15タスクはそれぞれ1〜2時間程度の粒度。T-05（serviceレイヤー実装）が最も大きいが、bcryptとDB操作をまとめた合理的な単位
+
+### C1-TODO-09: depends_on設定
+
+- **result**: PASS
+- **finding**: 全依存関係がdepends_on付きで明記されており、依存関係グラフが todo.md に記載されている
+
+### C1-TODO-10: チェックポイント設定
+
+- **result**: PASS
+- **finding**: 🚩マークがT-03/T-04/T-05/T-06/T-07/T-08/T-11/T-13の8箇所に設定されており、重要な実装完了ポイントをカバーしている
+
+### C1-TODO-11: Iron Law遵守
+
+- **result**: PASS
+- **finding**: H-01（C-3承認）がexec開始前の必須タスクとして明記されている。H-02（C-4 PRレビュー）も完了条件として記載
+
+### C1-TODO-12: 完了条件
+
+- **result**: PASS
+- **finding**: T-15（handoff.md生成）とH-02（C-4マージ）が最終完了条件として定義されている
+
+---
+
+## TestCases チェック（3項目）
+
+### C1-TEST-13: 受入基準との紐付き
+
+- **result**: PASS
+- **finding**: AC-1〜AC-7の全7件がAC→TCマッピング表でTCと対応付けられている。対応TCが存在しないACはない
+
+### C1-TEST-14: Edge case網羅
+
+- **result**: PASS
+- **finding**: TC-E1（bodyなし）・TC-E2（emailのみ）・TC-E3（最大長email）・TC-E4（空文字password）・TC-E5（SQLインジェクション）の5件を定義。主要な境界値・異常入力パターンをカバー
+
+### C1-TEST-15: 自動化可否
+
+- **result**: PASS
+- **finding**: TC-01〜TC-08・TC-E1〜TC-E5の全13件がunit/integrationとして自動実行可能。手動確認が必要なケースはない
+
+---
+
+## 総合判定
+
+**PASS** — critical=0, major=0, minor=0
+
+planのWork Breakdownとtodo.mdのdepends_on、test-cases.mdのAC→TCマッピングが一貫している。
+エッジケース5件（TC-E1〜E5）を含む全テストが自動化可能であることを確認した。

--- a/examples/sample-task/test-cases.md
+++ b/examples/sample-task/test-cases.md
@@ -1,0 +1,110 @@
+---
+task_id: sample-task
+artifact_type: test-cases
+schema_version: 1
+---
+
+# TEST CASES — Add User Registration Endpoint
+
+## AC → TC マッピング
+
+| Acceptance Criteria | Test Cases |
+|--------------------|-----------|
+| AC-1: 有効body → 201 + { id, email, created_at } | TC-01 |
+| AC-2: 重複メール → 409 | TC-02 |
+| AC-3: 不正メールフォーマット → 400 | TC-03, TC-E3 |
+| AC-4: パスワード7文字以下 → 400 | TC-04, TC-E4 |
+| AC-5: bcryptハッシュでDB保存 | TC-05 |
+| AC-6: メールlowercase正規化 | TC-06 |
+| AC-7: unit tests + integration tests PASS | TC-07, TC-08 |
+| エッジケース | TC-E1〜TC-E5 |
+
+## テストケース一覧
+
+### 正常系
+
+**TC-01: 有効なリクエスト → 201 Created**
+
+- 前提: DBに同一メールが存在しない
+- 入力: `POST /api/users` body = `{ "email": "user@example.com", "password": "password123" }`
+- 期待: HTTP 201, body = `{ "id": <number>, "email": "user@example.com", "created_at": <timestamp> }`
+- 種別: integration
+
+**TC-02: 重複メール → 409 Conflict**
+
+- 前提: `user@example.com` が既にDBに存在する
+- 入力: `POST /api/users` body = `{ "email": "user@example.com", "password": "anotherpass" }`
+- 期待: HTTP 409, body = `{ "error": "Email already registered" }`
+- 種別: integration
+
+### 異常系
+
+**TC-03: 不正メールフォーマット → 400 Bad Request**
+
+- 入力: `{ "email": "not-an-email", "password": "password123" }`
+- 期待: HTTP 400, body = `{ "error": "Invalid email format" }`
+- 種別: integration
+
+**TC-04: パスワード7文字 → 400 Bad Request**
+
+- 入力: `{ "email": "user@example.com", "password": "short1!" }`
+- 期待: HTTP 400, body = `{ "error": "Password must be at least 8 characters" }`
+- 種別: integration
+
+**TC-05: bcryptハッシュ保存確認**
+
+- 入力: 正常登録リクエスト
+- 期待: DBの `password_hash` カラムが `$2b$` で始まるbcrypt形式。平文パスワードと一致しない
+- 種別: integration
+
+**TC-06: メールlowercase正規化**
+
+- 入力: `{ "email": "USER@EXAMPLE.COM", "password": "password123" }`
+- 期待: HTTP 201, DBに `"user@example.com"` として保存
+- 種別: integration
+
+### unit テスト確認
+
+**TC-07: `isValidEmail` unit tests PASS**
+
+- 入力パターン: `"user@example.com"` (valid), `"not-an-email"` (invalid), `""` (invalid), `"a@b.c"` (valid)
+- 期待: 各パターンで `true` / `false` が正しく返る
+- 種別: unit
+
+**TC-08: `isValidPassword` unit tests PASS**
+
+- 入力パターン: `"password123"` (valid, 8+), `"short1!"` (invalid, 7), `""` (invalid)
+- 期待: 各パターンで `true` / `false` が正しく返る
+- 種別: unit
+
+### エッジケース
+
+**TC-E1: bodyなし → 400**
+
+- 入力: `POST /api/users` body = `{}`
+- 期待: HTTP 400
+- 種別: integration
+
+**TC-E2: emailのみ（passwordなし）→ 400**
+
+- 入力: `{ "email": "user@example.com" }`
+- 期待: HTTP 400
+- 種別: integration
+
+**TC-E3: 最大長メール（254文字）→ 201**
+
+- 入力: 254文字の有効メールアドレス
+- 期待: HTTP 201（RFC 5321の上限内）
+- 種別: integration
+
+**TC-E4: 空文字パスワード → 400**
+
+- 入力: `{ "email": "user@example.com", "password": "" }`
+- 期待: HTTP 400
+- 種別: integration
+
+**TC-E5: SQL injectionパターンのメール → 400または安全に処理**
+
+- 入力: `{ "email": "'; DROP TABLE users; --", "password": "password123" }`
+- 期待: HTTP 400（メールバリデーションで弾く）またはパラメタライズドクエリで安全に処理
+- 種別: integration

--- a/examples/sample-task/todo.md
+++ b/examples/sample-task/todo.md
@@ -1,0 +1,68 @@
+---
+task_id: sample-task
+artifact_type: todo
+schema_version: 1
+---
+
+# EXECUTION TODO — Add User Registration Endpoint
+
+## 🤖 Agentタスク
+
+### 準備フェーズ
+
+- [ ] T-01: scope確認・plan.md読み込み (agent)
+- [ ] T-02: `src/app.js` と既存authミドルウェアを探索し、POST /api/users が遮断されないか確認 (agent)
+- [ ] T-03: usersテーブルスキーマ確認（カラム名・制約・型） (agent) 🚩
+
+### 実装フェーズ
+
+- [ ] T-04: `src/validators/user.js` 実装（`isValidEmail`, `isValidPassword`） (agent) 🚩
+  - depends_on: T-03
+- [ ] T-05: `src/services/userService.js` 実装（`hashPassword`, `createUser`, DB INSERT, 409検出） (agent) 🚩
+  - depends_on: T-04
+- [ ] T-06: `src/routes/users.js` 実装（POST /api/users ハンドラ、バリデーション呼び出し、サービス呼び出し） (agent) 🚩
+  - depends_on: T-05
+- [ ] T-07: `src/app.js` にusersルーターをmount (agent)
+  - depends_on: T-06
+- [ ] T-08: セルフレビュー① — 実装の妥当性・bcryptのasync/await使用・エラーレスポンス形式を確認 (agent) 🚩
+  - depends_on: T-07
+
+### テストフェーズ
+
+- [ ] T-09: `tests/unit/validators/user.test.js` 実装（isValidEmail: 正常・異常・境界値、isValidPassword: 正常・短い・空文字） (agent)
+  - depends_on: T-04
+- [ ] T-10: `tests/integration/routes/users.test.js` 実装（TC-01〜TC-08 + TC-E1〜TC-E5） (agent)
+  - depends_on: T-07
+- [ ] T-11: セルフレビュー② — テスト網羅性・AC→TCマッピング・エッジケース確認 (agent) 🚩
+  - depends_on: T-09, T-10
+
+### 検証フェーズ
+
+- [ ] T-12: `npm run lint` 実行・エラー修正 (agent)
+  - depends_on: T-11
+- [ ] T-13: `npm test` 実行・全件PASS確認 (agent) 🚩
+  - depends_on: T-12
+- [ ] T-14: AC-1〜AC-7 を test-cases.md と突合し、全件PASS確認 (agent)
+  - depends_on: T-13
+- [ ] T-15: `handoff.md` 生成 (agent)
+  - depends_on: T-14
+
+## 👤 Humanタスク
+
+- [ ] H-01: **C-3ゲート** — `docs/working/TASK-XXXX/plan.md` を読み、APPROVE / CONDITIONAL / REJECT を判断（exec開始前に必須）(human)
+  - depends_on: plan.md, todo.md, test-cases.md, review-self.md 生成完了
+- [ ] H-02: **C-4ゲート** — GitHub PR をレビュー・マージ（完了後）(human)
+  - depends_on: PR作成完了
+
+## ⚠️ 依存関係
+
+```
+T-01 → T-02 → T-03
+T-03 → T-04 → T-05 → T-06 → T-07 → T-08
+T-04 → T-09
+T-07 → T-10
+T-08, T-09, T-10 → T-11 → T-12 → T-13 → T-14 → T-15
+H-01 must complete before exec starts
+T-15 must complete before PR is created
+H-02 must complete before Done
+```

--- a/examples/sample-task/todo.md
+++ b/examples/sample-task/todo.md
@@ -49,7 +49,7 @@ schema_version: 1
 
 ## 👤 Humanタスク
 
-- [ ] H-01: **C-3ゲート** — `docs/working/TASK-XXXX/plan.md` を読み、APPROVE / CONDITIONAL / REJECT を判断（exec開始前に必須）(human)
+- [ ] H-01: **C-3ゲート** — `examples/sample-task/plan.md` を読み、APPROVE / CONDITIONAL / REJECT を判断（exec開始前に必須）(human)
   - depends_on: plan.md, todo.md, test-cases.md, review-self.md 生成完了
 - [ ] H-02: **C-4ゲート** — GitHub PR をレビュー・マージ（完了後）(human)
   - depends_on: PR作成完了


### PR DESCRIPTION
## Summary

- **README.md** — English primary: 30-second value proposition, `## Install` at top with `[!WARNING]` dedup warning, 10-Minute Tutorial (6 steps), Plugin vs `.claude/` comparison table
- **README.ja.md** — New Japanese version with identical section structure; badge + text link to English version
- **examples/** — Complete worked example for Node.js user registration scenario: pbi-input, plan, todo, test-cases, review-self, handoff (7 files)
- **CHANGELOG.md** — Add v7.3.2 entry

## Motivation

Competitive OSS analysis (issue #72) identified that PlanGate's first-run experience is weaker than superpowers / ECC / OMC. This PR addresses all P0 items for the v7.3 milestone.

## Test plan

- [x] `npx markdownlint-cli2 README.md` — 0 errors
- [x] qa-reviewer AC acceptance check — all 18 criteria PASS
- [x] `docs/working/templates/` unchanged (git status verified)
- [x] `CLAUDE.md` unchanged
- [x] CI (markdown lint job) will run on PR

## Closes

Closes #73
Closes #74
Closes #75
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)