### PR TITLE
docs: v7.4 — CONTRIBUTING.ja, TROUBLESHOOTING, JSON schemas, gate enforcement spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping improve this project.
+Thanks for helping improve PlanGate.
 
 ## Workflow
 
@@ -16,3 +16,72 @@ Thanks for helping improve this project.
 - Update documentation when behavior or usage changes.
 - Avoid committing secrets, local credentials, or generated build artifacts.
 - Call out security or compatibility tradeoffs in the pull request.
+
+---
+
+## 日本語による貢献ガイド
+
+PlanGate は日本語での貢献を歓迎しています。
+
+### PlanGate の貢献フロー
+
+PlanGate 自身のワークフローに従って貢献を進めてください。
+
+```text
+1. Issue を開く（意図を共有する）
+2. pbi-input.md を作成する（What / Why / 受入基準を記述）
+3. /ai-dev-workflow plan で plan / todo / test-cases を生成する
+4. C-3 ゲート: plan.md を人間がレビューし APPROVE / CONDITIONAL / REJECT を判断する
+5. /ai-dev-workflow exec で実装・テスト・PR 作成まで自動実行する
+6. C-4 ゲート: GitHub PR を人間がレビューしてマージする
+```
+
+`good first issue` ラベルがついた Issue は、初めて貢献する方に適した範囲・難易度のタスクです。まずはそこから始めることを推奨します。
+
+### 開発環境のセットアップ
+
+PlanGate は Claude Code と Codex CLI を前提にしています。
+
+#### Option A — Plugin として利用する（推奨）
+
+```bash
+git clone https://github.com/s977043/plangate.git
+# Claude Code 公式のプラグイン登録手順に従う
+# 参照: plugin/plangate/README.md
+```
+
+#### Option B — `.claude/` を直接配置する
+
+```bash
+git clone https://github.com/s977043/plangate.git
+cp -r plangate/.claude/ your-project/.claude/
+```
+
+どちらか一方を選択してください。両方を適用すると競合が発生します。
+
+### コミットメッセージ規約
+
+Conventional Commits に従います。
+
+| プレフィックス | 用途 |
+| --- | --- |
+| `feat:` | 新機能追加 |
+| `fix:` | バグ修正 |
+| `docs:` | ドキュメントのみの変更 |
+| `chore:` | ビルド・設定・依存関係の変更 |
+| `refactor:` | リファクタリング（機能変更なし） |
+| `test:` | テスト追加・修正 |
+
+例: `feat: add gate enforcement spec (c3.json + plan_hash)`
+
+### 新規 provider の追加
+
+AI エージェントツールの新しい provider（例: Gemini CLI）を追加する場合は、Issue #82 のトラッキング issue を参照し、そこに追記してください。実装手順は決まり次第 `docs/` に追加されます。
+
+### CI について
+
+PR には `Markdown lint` の必須チェックがあります。ローカルで確認するには:
+
+```bash
+npx markdownlint-cli2 "**/*.md" --ignore node_modules
+```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,124 @@
+# Troubleshooting
+
+A diagnostic guide for common issues when installing and using PlanGate.
+
+---
+
+## Installation
+
+### `.claude/` と plugin を二重インストールしてしまった
+
+**症状**: コマンドが二重に実行される、または挙動が予期しない。
+
+**原因**: Option A（plugin）と Option B（`.claude/` 直接配置）を両方適用している。
+
+**対処**:
+
+1. どちらを使うか決める（plugin 推奨）。
+2. Option B を削除する場合: `rm -rf your-project/.claude/` で手動削除する。
+3. Option A を削除する場合: Claude Code のプラグイン削除コマンドで plugin を登録解除する。
+
+参照: [README.md — Plugin vs .claude/](README.md#plugin-vs-claude--which-to-use)
+
+### plugin が反映されない・コマンドが認識されない
+
+**症状**: `/working-context` や `/ai-dev-workflow` を実行しても "Unknown command" になる。
+
+**確認手順**:
+
+1. `plugin/plangate/README.md` の手順通りに plugin が登録されているか確認する。
+2. Claude Code を再起動してから再度試す。
+3. `.claude/commands/` を直接配置する Option B に切り替えることも検討する。
+
+### plugin を更新しても変更が反映されない
+
+**症状**: `git pull` 後も古い挙動になる。
+
+**対処**:
+
+1. Claude Code を完全に終了・再起動する。
+2. それでも解決しない場合は、plugin を一度登録解除し、再登録する。
+
+---
+
+## Workflow
+
+### `/working-context TASK-XXXX` が動かない
+
+**症状**: コマンドを実行しても応答がない、またはエラーになる。
+
+**確認手順**:
+
+1. `docs/working/TASK-XXXX/` ディレクトリが存在するか確認する。
+   存在しない場合、先にチケットディレクトリと `pbi-input.md` を作成する。
+2. plugin または `.claude/commands/` が正しく配置されているか確認する（上記参照）。
+
+### `/ai-dev-workflow plan` でエラーになる
+
+**症状**: plan 生成時にエラーが出て途中で止まる。
+
+**確認手順**:
+
+1. `docs/working/TASK-XXXX/pbi-input.md` が存在し、Why / What / 受入基準のセクションが埋まっているか確認する。
+2. Claude Code のモデルが利用可能な状態か確認する（API 障害等）。
+3. それでも解決しない場合は Issue を開いてください。
+
+---
+
+## Gate
+
+### C-3 承認なしで exec が走ってしまった場合の確認方法
+
+**確認手順**:
+
+1. `docs/working/TASK-XXXX/plan.md` の `status` frontmatter を確認する。`approved` になっているか。
+2. `docs/working/TASK-XXXX/approvals/c3.json` が存在し、`"c3_status": "APPROVED"` になっているか。
+3. exec 前に承認が取れていない場合、実装済みコードをレビューし、C-4 ゲートで対処する。
+
+将来的に `approvals/c3.json` の存在チェックが exec フック（`pre-exec`）として自動化される予定です（Issue #77）。
+
+---
+
+## Environment
+
+### Claude Code と Codex CLI の両方が必要なケースの確認
+
+PlanGate は **Claude Code のみ**でも利用可能です。Codex CLI は以下のケースで追加価値を提供します。
+
+| ユースケース | Claude Code | Codex CLI |
+| --- | --- | --- |
+| plan / exec / PR | 必須 | 不要 |
+| 外部レビュー（C-2 / V-3） | 不要 | 推奨 |
+| 並列マルチエージェント実行 | 可 | 可 |
+
+Codex CLI のセットアップ: <https://github.com/openai/codex>
+
+---
+
+## CI
+
+### Markdown lint が失敗する場合の対処
+
+**症状**: PR の CI チェック `Markdown lint` が失敗する。
+
+**ローカルで確認する**:
+
+```bash
+npx markdownlint-cli2 "**/*.md" --ignore node_modules
+```
+
+**よくある原因と修正**:
+
+| エラーコード | 原因 | 修正 |
+| --- | --- | --- |
+| MD013 | 行が長すぎる | `.markdownlint-cli2.jsonc` で `MD013: false` を確認（プロジェクト設定で無効化済み） |
+| MD041 | ファイルの先頭が H1 でない | ファイルの先頭に `# タイトル` を追加する |
+| MD022 | 見出しの前後に空行がない | 見出しの前後に空行を入れる |
+| MD032 | リストの前後に空行がない | リストの前後に空行を入れる |
+
+---
+
+## Getting More Help
+
+解決しない場合は [GitHub Issues](https://github.com/s977043/plangate/issues) を開いてください。
+質問・相談は [GitHub Discussions](https://github.com/s977043/plangate/discussions) へ。

--- a/docs/working/templates/handoff.md
+++ b/docs/working/templates/handoff.md
@@ -1,3 +1,13 @@
+---
+task_id: TASK-XXXX
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: YYYY-MM-DD
+author: qa-reviewer
+v1_release: ""
+---
+
 # Handoff Package テンプレート
 
 > WF-05 Verify & Handoff の**毎回必須出力**。`qa-reviewer` / `orchestrator` が発行。

--- a/docs/working/templates/review-external.md
+++ b/docs/working/templates/review-external.md
@@ -1,3 +1,13 @@
+---
+task_id: TASK-XXXX
+artifact_type: review-external
+schema_version: 1
+status: draft
+verdict: PASS
+reviewer_tool: codex
+created_by: orchestrator
+---
+
 # TASK-XXXX 外部AIレビュー結果（C-2）
 
 > レビュー日: YYYY-MM-DD

--- a/docs/working/templates/review-self.md
+++ b/docs/working/templates/review-self.md
@@ -1,3 +1,12 @@
+---
+task_id: TASK-XXXX
+artifact_type: review-self
+schema_version: 1
+status: draft
+verdict: PASS
+created_by: orchestrator
+---
+
 # TASK-XXXX セルフレビュー結果（C-1）
 
 > レビュー日: YYYY-MM-DD

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,86 @@
+# PlanGate Schemas
+
+JSON Schema definitions for PlanGate artifacts and execution records.
+
+## Artifact Schemas (frontmatter)
+
+All PlanGate markdown artifacts carry a YAML frontmatter block that is validated against these schemas.
+
+| Schema | Artifact file | Description |
+| --- | --- | --- |
+| `pbi-input.schema.json` | `pbi-input.md` | PBI Input Package |
+| `plan.schema.json` | `plan.md` | Execution Plan |
+| `todo.schema.json` | `todo.md` | Execution TODO |
+| `test-cases.schema.json` | `test-cases.md` | Test Cases |
+| `review-self.schema.json` | `review-self.md` | C-1 Self Review |
+| `review-external.schema.json` | `review-external.md` | C-2 External Review |
+| `handoff.schema.json` | `handoff.md` | WF-05 Handoff Package |
+
+### Frontmatter Standard
+
+```yaml
+---
+task_id: TASK-0001
+artifact_type: plan        # see artifact_type values in each schema
+schema_version: 1
+status: draft              # draft | approved | final
+created_by: spec-writer
+source_pbi_hash: sha256:<64-char-hex>
+---
+```
+
+## Gate Approval Schemas
+
+Machine-readable approval records written to `docs/working/TASK-XXXX/approvals/`.
+
+| Schema | File | Description |
+| --- | --- | --- |
+| `c3-approval.schema.json` | `approvals/c3.json` | C-3 gate approval record |
+| `c4-approval.schema.json` | `approvals/c4.json` | C-4 gate approval record |
+| `status.schema.json` | `status.json` | Task state snapshot |
+
+### c3.json example
+
+```json
+{
+  "task_id": "TASK-0001",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "human",
+  "approved_at": "2026-04-26T10:00:00+09:00",
+  "plan_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```
+
+### exec pre-check (gate enforcement)
+
+Before `exec` begins, the following are verified:
+
+1. `plan.md`, `todo.md`, `test-cases.md`, `review-self.md` exist
+2. `approvals/c3.json` exists and `c3_status === "APPROVED"`
+3. Current `sha256(plan.md)` matches `plan_hash` in `c3.json` (detects post-approval modification)
+4. For `high-risk` or `critical` mode: `review-external.md` must also exist
+
+## Execution Log Schema
+
+| Schema | File | Description |
+| --- | --- | --- |
+| `run-event.schema.json` | `run.ndjson` | Single event line in the NDJSON execution log |
+
+### run.ndjson format
+
+Each line is a JSON object conforming to `run-event.schema.json`.
+
+```jsonl
+{"ts":"2026-04-26T10:00:00+09:00","task_id":"TASK-0001","phase":"B","event":"plan_generated","agent":"spec-writer"}
+{"ts":"2026-04-26T10:30:00+09:00","task_id":"TASK-0001","phase":"C-3","event":"approved","by":"human","plan_hash":"sha256:e3b0c4..."}
+{"ts":"2026-04-26T11:00:00+09:00","task_id":"TASK-0001","phase":"D","event":"exec_started","agent":"implementer"}
+{"ts":"2026-04-26T11:05:00+09:00","task_id":"TASK-0001","phase":"D","event":"task_completed","task_ref":"T-01","agent":"implementer"}
+{"ts":"2026-04-26T11:30:00+09:00","task_id":"TASK-0001","phase":"V-1","event":"acceptance_passed","agent":"acceptance-tester"}
+{"ts":"2026-04-26T11:35:00+09:00","task_id":"TASK-0001","phase":"PR","event":"pr_created","pr_number":42,"agent":"orchestrator"}
+```
+
+## Schema Version Policy
+
+- `schema_version` starts at `1` and increments on breaking changes.
+- Non-breaking additions (new optional fields) do not require a version bump.

--- a/schemas/c3-approval.schema.json
+++ b/schemas/c3-approval.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/c3-approval.schema.json",
+  "title": "C-3 Approval Record",
+  "description": "Machine-readable C-3 gate approval record (approvals/c3.json)",
+  "type": "object",
+  "required": ["task_id", "phase", "c3_status", "approved_by", "approved_at", "plan_hash"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "phase": {
+      "type": "string",
+      "const": "C-3"
+    },
+    "c3_status": {
+      "type": "string",
+      "enum": ["APPROVED", "CONDITIONAL", "REJECTED"]
+    },
+    "approved_by": {
+      "type": "string",
+      "description": "Identifier of the approver (typically 'human')"
+    },
+    "approved_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the approval"
+    },
+    "plan_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "SHA-256 of plan.md at approval time; used to detect post-approval modification"
+    },
+    "conditions": {
+      "type": "string",
+      "description": "Required when c3_status is CONDITIONAL — describes required changes before exec"
+    },
+    "rejection_reason": {
+      "type": "string",
+      "description": "Required when c3_status is REJECTED"
+    }
+  },
+  "if": {
+    "properties": { "c3_status": { "const": "CONDITIONAL" } }
+  },
+  "then": {
+    "required": ["conditions"]
+  },
+  "additionalProperties": false
+}

--- a/schemas/c3-approval.schema.json
+++ b/schemas/c3-approval.schema.json
@@ -41,11 +41,25 @@
       "description": "Required when c3_status is REJECTED"
     }
   },
-  "if": {
-    "properties": { "c3_status": { "const": "CONDITIONAL" } }
-  },
-  "then": {
-    "required": ["conditions"]
-  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "c3_status": { "const": "CONDITIONAL" } },
+        "required": ["c3_status"]
+      },
+      "then": {
+        "required": ["conditions"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "c3_status": { "const": "REJECTED" } },
+        "required": ["c3_status"]
+      },
+      "then": {
+        "required": ["rejection_reason"]
+      }
+    }
+  ],
   "additionalProperties": false
 }

--- a/schemas/c4-approval.schema.json
+++ b/schemas/c4-approval.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/c4-approval.schema.json",
+  "title": "C-4 Approval Record",
+  "description": "Machine-readable C-4 gate approval record (approvals/c4.json)",
+  "type": "object",
+  "required": ["task_id", "phase", "c4_status", "approved_by", "approved_at"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "phase": {
+      "type": "string",
+      "const": "C-4"
+    },
+    "c4_status": {
+      "type": "string",
+      "enum": ["APPROVED", "REQUEST_CHANGES", "REJECTED"]
+    },
+    "approved_by": {
+      "type": "string"
+    },
+    "approved_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "pr_number": {
+      "type": "integer",
+      "description": "GitHub PR number reviewed at C-4"
+    },
+    "pr_sha": {
+      "type": "string",
+      "description": "HEAD commit SHA of the merged PR"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/handoff.schema.json
+++ b/schemas/handoff.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/handoff.schema.json",
+  "title": "Handoff Package",
+  "description": "PlanGate WF-05 handoff artifact (handoff.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "handoff"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "final"
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601 date when handoff was issued"
+    },
+    "author": {
+      "type": "string",
+      "description": "Agent or person who issued the handoff"
+    },
+    "v1_release": {
+      "type": "string",
+      "description": "Commit SHA or tag of the v1 release"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/pbi-input.schema.json
+++ b/schemas/pbi-input.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/pbi-input.schema.json",
+  "title": "PBI Input Package",
+  "description": "PlanGate PBI INPUT PACKAGE artifact (pbi-input.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$",
+      "description": "Task identifier, e.g. TASK-0001"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "pbi-input"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "created_by": {
+      "type": "string"
+    },
+    "source_pbi_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/plan.schema.json",
+  "title": "Execution Plan",
+  "description": "PlanGate EXECUTION PLAN artifact (plan.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "plan"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["ultra-light", "light", "standard", "high-risk", "critical"]
+    },
+    "created_by": {
+      "type": "string"
+    },
+    "source_pbi_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/review-external.schema.json
+++ b/schemas/review-external.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/review-external.schema.json",
+  "title": "External Review Result",
+  "description": "PlanGate C-2 external review artifact (review-external.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "review-external"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "reviewer_tool": {
+      "type": "string",
+      "description": "External AI tool used for review, e.g. codex, gemini"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["PASS", "WARN", "FAIL"]
+    },
+    "created_by": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/review-self.schema.json
+++ b/schemas/review-self.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/review-self.schema.json",
+  "title": "Self Review Result",
+  "description": "PlanGate C-1 self-review artifact (review-self.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "review-self"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["PASS", "WARN", "FAIL"],
+      "description": "Overall C-1 verdict"
+    },
+    "created_by": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/run-event.schema.json
+++ b/schemas/run-event.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/run-event.schema.json",
+  "title": "Run Event",
+  "description": "Single NDJSON event in run.ndjson execution log",
+  "type": "object",
+  "required": ["ts", "task_id", "phase", "event"],
+  "properties": {
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the event"
+    },
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["A", "B", "C-1", "C-2", "C-3", "D", "L-0", "V-1", "V-2", "V-3", "V-4", "PR", "C-4"],
+      "description": "PlanGate workflow phase in which the event occurred"
+    },
+    "event": {
+      "type": "string",
+      "enum": [
+        "plan_generated",
+        "todo_generated",
+        "test_cases_generated",
+        "review_self_completed",
+        "review_external_completed",
+        "approved",
+        "conditional_approved",
+        "rejected",
+        "exec_started",
+        "task_completed",
+        "task_failed",
+        "lint_passed",
+        "lint_failed",
+        "acceptance_passed",
+        "acceptance_failed",
+        "optimization_completed",
+        "pr_created",
+        "pr_merged",
+        "session_started",
+        "session_ended"
+      ]
+    },
+    "agent": {
+      "type": "string",
+      "description": "Agent or tool that produced the event"
+    },
+    "by": {
+      "type": "string",
+      "description": "Human or agent identifier (used for gate events)"
+    },
+    "plan_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "plan.md hash at the time of a gate event"
+    },
+    "task_ref": {
+      "type": "string",
+      "description": "Task identifier from todo.md, e.g. T-01"
+    },
+    "case_id": {
+      "type": "string",
+      "description": "Acceptance criteria or test case ID, e.g. AC-003"
+    },
+    "detail": {
+      "type": "string",
+      "description": "Human-readable detail or error message"
+    },
+    "pr_number": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/status.schema.json
+++ b/schemas/status.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/status.schema.json",
+  "title": "Task Status",
+  "description": "Machine-readable task state snapshot (status.json)",
+  "type": "object",
+  "required": ["task_id", "schema_version", "phase", "mode", "updated_at"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["A", "B", "C-1", "C-2", "C-3", "D", "L-0", "V-1", "V-2", "V-3", "V-4", "PR", "C-4", "Done"],
+      "description": "Current PlanGate workflow phase"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["ultra-light", "light", "standard", "high-risk", "critical"]
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "artifacts": {
+      "type": "object",
+      "description": "Presence of required artifact files",
+      "properties": {
+        "pbi_input": { "type": "boolean" },
+        "plan": { "type": "boolean" },
+        "todo": { "type": "boolean" },
+        "test_cases": { "type": "boolean" },
+        "review_self": { "type": "boolean" },
+        "review_external": { "type": "boolean" },
+        "handoff": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "gates": {
+      "type": "object",
+      "properties": {
+        "c3": {
+          "type": "string",
+          "enum": ["pending", "APPROVED", "CONDITIONAL", "REJECTED"]
+        },
+        "c4": {
+          "type": "string",
+          "enum": ["pending", "APPROVED", "REQUEST_CHANGES", "REJECTED"]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/test-cases.schema.json
+++ b/schemas/test-cases.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/test-cases.schema.json",
+  "title": "Test Cases",
+  "description": "PlanGate TEST CASES artifact (test-cases.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "test-cases"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "created_by": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/todo.schema.json
+++ b/schemas/todo.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/todo.schema.json",
+  "title": "Execution TODO",
+  "description": "PlanGate EXECUTION TODO artifact (todo.md frontmatter)",
+  "type": "object",
+  "required": ["task_id", "artifact_type", "schema_version"],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$"
+    },
+    "artifact_type": {
+      "type": "string",
+      "const": "todo"
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "approved", "final"],
+      "default": "draft"
+    },
+    "created_by": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

v7.4 milestone: OSS credibility and specification completeness improvements.

- **#85** `CONTRIBUTING.md`: Added Japanese contribution guide with PlanGate-native workflow (issue → C-3 → exec → PR), setup options (plugin vs `.claude/`), commit conventions, and CI instructions
- **#86** `TROUBLESHOOTING.md`: New file covering installation, workflow, gate, environment, and CI issues
- **#77** Gate enforcement spec: `schemas/c3-approval.schema.json`, `c4-approval.schema.json`, `status.schema.json` define the machine-readable approval trail; `schemas/README.md` documents the exec pre-check algorithm
- **#78** Artifact JSON schemas: 7 schemas (`pbi-input`, `plan`, `todo`, `test-cases`, `review-self`, `review-external`, `handoff`) + frontmatter added to templates
- **#79** `run.ndjson` spec: `schemas/run-event.schema.json` defines the NDJSON execution log format with typed event kinds

## Changes

| File | Change |
| --- | --- |
| `CONTRIBUTING.md` | Enhanced with Japanese section |
| `TROUBLESHOOTING.md` | New |
| `schemas/*.schema.json` (×10) | New |
| `schemas/README.md` | New |
| `docs/working/templates/handoff.md` | Frontmatter added |
| `docs/working/templates/review-self.md` | Frontmatter added |
| `docs/working/templates/review-external.md` | Frontmatter added |

## Test plan

- [x] `npx markdownlint-cli2 CONTRIBUTING.md` → 0 errors
- [x] Full CI lint target (18 files) → 0 errors
- [ ] CI check passes on PR

Closes #77
Closes #78
Closes #79
Closes #85
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)