### PR TITLE
docs: 2026-04-27 セッション振り返りを追加

### DIFF
--- a/docs/working/retrospective-2026-04-27.md
+++ b/docs/working/retrospective-2026-04-27.md
@@ -1,0 +1,101 @@
+# セッション振り返り — 2026-04-27
+
+## セッション概要
+
+OSS 競合比較分析（issue #72）をトリガーとした v7.3〜v8.0 マイルストーン全体の実装セッション。
+18 issue をクローズし、GitHub Release を v7.3.0 から v8.0.2 まで整備した。
+
+## 成果
+
+### クローズした issue（18件）
+
+| マイルストーン | issue | 内容 |
+|---|---|---|
+| v7.3 | #73 #74 #75 #76 | README 再設計・英語化・examples/・plugin install 導線 |
+| v7.3 | #84 #87 | CI/Scorecard バッジ・docs/working/ 公開方針 |
+| v7.4 | #77 #78 #79 | ゲート強制・Artifact schema・run.ndjson 標準化 |
+| v7.4 | #80 #85 #86 | bin/plangate CLI・CONTRIBUTING.ja・TROUBLESHOOTING |
+| v7.5 | #88 #89 | Deferred Decisions・GitHub Discussions 設定 |
+| v8.0 | #81 #82 #83 | Workflow DSL・Provider RFC・テスト基盤 |
+| Epic | #72 | OSS ロードマップ全体 |
+
+### 作成した GitHub Release（10件）
+
+v7.3.0 / v7.3.1 / v7.3.2 / v7.3.3 / v7.4.0 / v7.5.0 / v7.5.1 / v7.5.2 / v8.0.0 / v8.0.1 / v8.0.2
+
+### 主要な成果物
+
+- `bin/plangate` — POSIX sh CLI（7コマンド）+ `validate --dir` フラグ
+- `schemas/` — Artifact JSON Schema 10種
+- `workflows/` — Workflow DSL YAML 5種（ultra-light〜critical）
+- `tests/` — フィクスチャ4種 + run-tests.sh + CI workflow
+- `docs/rfc/` — Provider RFC 2件（Gemini CLI・OpenCode）
+- `examples/` — sample-task・minimal-node
+
+---
+
+## うまくいったこと
+
+### 1. 並列エージェントによる高速化
+
+#81（Workflow DSL）と #82（Provider RFC）を並列バックグラウンドエージェントで同時実行し、
+#83（テスト基盤）を Phase B で受けるパターンが機能した。
+3 issue を 1 セッションで処理できた。
+
+### 2. Codex + gemini-code-assist のレビュー品質
+
+- Codex が `plangate doctor` の CI 非互換を P1 で検出（codex CLI がランナーにない）
+- gemini-code-assist が `gates: []` / `gate_enforcement: {}` の DSL 一貫性と stderr 可視性を指摘
+- いずれも事前に気づけておらず、レビューによる品質向上が確認できた
+
+### 3. cherry-pick によるブランチ分離の救済
+
+v8.0 の変更が誤って `docs/v7.5-changelog-and-docs-sync` にコミットされたが、
+`feat/v8-0-dsl-provider-tests` への cherry-pick で即座に分離できた。
+
+---
+
+## 改善点・学んだこと
+
+### 1. バックグラウンドエージェントの確認停止問題
+
+**現象**: #82 担当エージェントが「実行してよいですか？(y/n)」で停止し、何も実装されなかった。
+
+**原因**: CLAUDE.md 第1原則（ファイル操作前に確認を取る）がバックグラウンドエージェントにも適用された。
+バックグラウンドでは確認応答ができないため、計画を報告した時点で処理が終わった。
+
+**改善策**: バックグラウンドエージェントへの委譲プロンプトに以下を明示する:
+> 「このプロンプトを受信したことがユーザー承認とみなし、確認なしで直接実行してください」
+
+### 2. CI 環境とローカル環境の前提差異
+
+**現象**: `plangate doctor` テストが CI ランナーで失敗（codex CLI 未インストール）。
+
+**学び**: ローカル専用ツール（codex CLI, gh, etc.）に依存するテストは CI スイートから分離する。
+CI テストは「純粋なロジック」のみをカバーすべき。
+
+### 3. examples/ のパス参照は汎用にする
+
+**現象**: `examples/minimal-node/CLAUDE.md` が `docs/ai/project-rules.md` を参照していたが、
+このパスはユーザープロジェクトに存在しない（PlanGate リポジトリ固有のパス）。
+
+**学び**: examples/ テンプレートのパスは常にユーザープロジェクト視点で書く。
+PlanGate リポジトリ内のパスをハードコードしない。
+
+### 4. DSL の命名一貫性はゼロから設計時に決める
+
+**現象**: `ultra-light.yaml` に `gates: []`、他ファイルに `gate_enforcement:` が混在。
+レビューで `gate_enforcement: {}` への統一を指摘された。
+
+**学び**: 複数ファイルに渡る DSL 設計では、キー名・値の形式を先に仕様化してから実装する。
+
+---
+
+## ネクストアクション（将来セッション向け）
+
+| 優先度 | アクション |
+|---|---|
+| 検討 | v8.1 マイルストーン策定（Provider RFC の実装フェーズ等） |
+| 検討 | OpenSSF Scorecard の 3 ヶ月観測後に required check 昇格を判断（Deferred Decision） |
+| 検討 | `plangate validate --schema` によるフロントマター検証の追加（#78 の拡張） |
+| 低 | `~/.claude/plans/issue-issue-lazy-willow.md` の archive（旧計画ファイル） |

--- a/docs/working/sessions/2026-04-27.md
+++ b/docs/working/sessions/2026-04-27.md
@@ -1,0 +1,105 @@
+# セッション振り返り
+
+> 実施日: 2026-04-27
+> 対象セッション: OSSドキュメント整備・README 日本語メイン化・plugin README 英語化
+
+---
+
+## 1. セッション成果サマリ
+
+### マージ済み PR（13 本）
+
+| PR | 種別 | 内容 |
+|----|------|------|
+| #93 | docs | examples/minimal-node/ 追加（Node.js 最小構成サンプル） |
+| #99 | docs | CHANGELOG v8.0.0/v8.0.1 エントリ追加 |
+| #100 | docs | plugin migration guide → plugin 0.5.0 更新（Skills 5→14, Commands 2→7, Rules 3→9） |
+| #101 | docs | README.ja.md に Testing・Provider Support セクション追加・high-risk 用語修正 |
+| #102 | docs | README 日本語メイン化（README.md ⇔ README_en.md スワップ） |
+| #103 | docs | stale README.ja.md 参照を plugin migration guide から修正 |
+| #104 | docs | CHANGELOG v8.0.2 追加（README 日本語化・plugin migration 更新を記録） |
+| #105 | docs | plugin/plangate/README.md 全文英語化 |
+
+（セッション前半で前セッション積み残しとして PR #93 をマージ。残りは本セッション中に作成・マージ。）
+
+### バージョン推移
+
+- v8.0.0 → v8.0.1 → v8.0.2（全てドキュメント整備のマイナー更新）
+
+---
+
+## 2. 計画精度分析
+
+### 想定通りだったこと
+
+- broken link の解消: Explore エージェントによる調査 → 修正の流れがスムーズに機能
+- `/setup-team` を繰り返し呼び出すことで残タスクを段階的に発見・処理できた
+- CI（Markdown lint + plangate CLI tests）が全 PR で安定して pass
+
+### 想定外の追加作業（計画外タスク）
+
+| 追加作業 | 発生タイミング | 原因 |
+|---------|-------------|------|
+| CHANGELOG v8.0.0/v8.0.1 欠落（PR #99） | PR #98 マージ後に発見 | PR #98（v8.0）作成時に CHANGELOG 更新が漏れていた |
+| docs/plangate-plugin-migration.md の同梱範囲が v0.1.0 のまま（PR #100） | 調査エージェントが検出 | v0.2.0〜v0.5.0 への更新時に migration guide の本文を更新していなかった |
+| docs/working/README.md の "full/critical" 残存（PR #101） | 調査エージェントが検出 | TASK-0036（full→high-risk 統一）のスコープに含まれていなかった |
+| plugin migration guide の README.ja.md 参照 stale（PR #103） | PR #102 マージ後に発見 | README ファイルのリネーム後に参照先が自動更新されなかった |
+
+**計画逸脱の特徴**: 今回は「実装漏れ」ではなく「ドキュメントの連鎖的な整合性欠落」が主因。1 つの変更が別のドキュメントに参照されている箇所を引き起こすパターンが繰り返し発生した。
+
+---
+
+## 3. プロセス上の学び・改善点
+
+### A. README リネーム後の連鎖更新パターン
+
+**観察**: `README.md` → `README_en.md`、`README.ja.md` → `README.md` のリネームを行うと、旧ファイル名を参照していた箇所が stale になる。今回は `grep -rn "README\.ja"` で事前に洗い出してから実施したが、migration guide の歴史的記述（将来計画の完了済みチェックリスト）は見落とした。
+
+**改善案**: リネーム系変更は実施直後に `grep` で全参照を再確認する。歴史的な記述（CHANGELOG・将来計画）も stale になり得ると意識する。
+
+### B. ドキュメント調査に Explore エージェントが有効
+
+**観察**: `/setup-team` 経由で Explore エージェントを複数回起動し、「何が残っているか」を調査させるアプローチが機能した。1 回の調査で発見 → 修正 → 再調査 → 新たな発見、というループが自然に回った。
+
+**改善案**: 「残タスクの確認をして」という曖昧な指示より、「ドキュメントギャップを調査して」という目的指向の指示の方が調査結果が具体的になる。
+
+### C. CHANGELOG 更新とリリース PR の分離問題
+
+**観察**: 大きな feat PR（#98 v8.0）がマージされたが CHANGELOG エントリが後追いになった。これは PR 作成時点で CHANGELOG 更新を含めるべきだったが、スコープが大きかったため漏れた。
+
+**改善案**: feat/fix の PR には原則 CHANGELOG エントリを含める。漏れた場合は次の commit で必ず補完する（今回は PR #99 で対応）。
+
+### D. ユーザー確認回数の削減
+
+**観察**: 前セッション末に「ユーザー確認が多い」フィードバックを受け、計画承認後は自律実行するポリシーに変更した。今セッションでは計画提示後の逐次確認をほぼ排除できた。
+
+**評価**: PR 作成・マージまで自律実行しても問題なし。ブロッカー発生時のみ報告して止まる方針が有効だった。
+
+---
+
+## 4. 次セッションへの引き継ぎ
+
+### 残存する既知ギャップ（今回 scope 外として保留）
+
+| 優先度 | 内容 |
+|--------|------|
+| 中 | Workflow DSL (workflows/*.yaml) を実行層に接続（現在はドキュメント定義のみ） |
+| 中 | Provider RFC を実装（Gemini CLI / OpenCode 統合） |
+| 低 | GitHub Release タグを最新版（v8.0.2）に更新（現在 Latest は v7.2.0） |
+
+### リポジトリ状態
+
+- open PR: 0件
+- open issue: 0件
+- git: clean
+- 最新バージョン: v8.0.2（CHANGELOG 上）、GitHub Release: v7.2.0（未更新）
+
+---
+
+## 5. KPT
+
+| K (Keep) | P (Problem) | T (Try) |
+|----------|-------------|---------|
+| Explore エージェントでドキュメントギャップを段階的に発見する手法 | リネーム後の連鎖参照が stale になりがち | リネーム変更時は実施直後に `grep` で全参照を再確認する |
+| CI pass を確認してからマージする習慣 | feat PR に CHANGELOG が同梱されないケース | feat/fix PR には CHANGELOG エントリを必ず含める |
+| 計画承認後の自律実行（確認回数削減） | ドキュメントの歴史的記述（将来計画）が stale になる | 将来計画チェックリストの定期見直しをセッション開始時に組み込む |


### PR DESCRIPTION
## Summary

2026-04-27 の 2 セッション分の振り返りを追加。

- `docs/working/retrospective-2026-04-27.md` — OSS ロードマップ全体セッション（v7.3〜v8.0、18 issue クローズ）
- `docs/working/sessions/2026-04-27.md` — ドキュメント整備セッション（PR #93, #99〜#105、README 日本語メイン化・plugin README 英語化等）

## Test plan

- [ ] Markdown lint が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)