### PR TITLE
docs: 2026-04-27 セッション2振り返り（v8.1.0実装・リリース）

### DIFF
--- a/docs/working/retrospective-2026-04-27.md
+++ b/docs/working/retrospective-2026-04-27.md
@@ -99,3 +99,82 @@ PlanGate リポジトリ内のパスをハードコードしない。
 | 検討 | OpenSSF Scorecard の 3 ヶ月観測後に required check 昇格を判断（Deferred Decision） |
 | 検討 | `plangate validate --schema` によるフロントマター検証の追加（#78 の拡張） |
 | 低 | `~/.claude/plans/issue-issue-lazy-willow.md` の archive（旧計画ファイル） |
+
+---
+
+## セッション 2（継続） — v8.1.0 実装・リリース
+
+### セッション概要
+
+前セッションで策定された v8.1 マイルストーン（Provider RFC 実装フェーズ）を即日実施。
+`bin/plangate` に validate --mode / review / exec の 3 コマンドを追加し、v8.1.0 としてリリースした。
+
+### 成果
+
+#### マージした PR（#99〜#108）
+
+| PR | 内容 |
+|---|---|
+| #99 | CHANGELOG v8.0.0/v8.0.1 補完 |
+| #100 | plugin migration guide を v0.5.0 に更新 |
+| #101 | README.ja.md 同期・full→high-risk 修正 |
+| #102 | README 日本語メイン化（README.md ⇔ README_en.md スワップ） |
+| #103 | plugin migration guide の stale 参照修正 |
+| #104 | CHANGELOG v8.0.2 補完 |
+| #105 | plugin/plangate/README.md 英語化 |
+| #106 | セッション振り返り追加（前セッション分） |
+| #107 | bin/plangate に validate --mode / review / exec 追加（v8.1.0 本体） |
+| #108 | v8.1.0 フォローアップ（CHANGELOG, RFC status, README, doctor） |
+
+#### 主要な成果物
+
+- `bin/plangate validate --mode <mode>` — workflows/*.yaml の gate_enforcement.c3 を動的読み込み
+- `bin/plangate review <TASK>` — Gemini CLI dispatch（PLANGATE_EXTERNAL_REVIEWER=gemini）
+- `bin/plangate exec <TASK>` — C-3 gate 確認 + OpenCode dispatch（PLANGATE_IMPL_AGENT=opencode）
+- `bin/plangate doctor` — Optional Provider CLIs（gemini / opencode）の検出を追加
+- `tests/run-tests.sh` — 4件 → 10件（新規 6 件追加、全件 PASS）
+- GitHub Release v8.1.0（Latest）
+
+### うまくいったこと
+
+#### 1. RFC → 実装の直接接続
+
+前セッションで策定した Provider RFC（Gemini CLI / OpenCode）の仕様がそのまま実装ガイドになった。
+RFC の「Implementation Plan」セクションが実装手順と 1:1 対応しており、設計の品質が実装速度に直結した。
+
+#### 2. POSIX sh 準拠の維持
+
+`bin/plangate` に 3 コマンドを追加しながら bashism を一切使わずに実装できた。
+python3 を呼び出して YAML パースを委譲するパターン（`plangate_yaml_c3_artifacts`）が拡張性を保ちつつシェル依存を回避する良い設計だった。
+
+#### 3. テスト先行設計
+
+validate --mode / review / exec それぞれのテストケースを実装前に設計し、実装後に全件 PASS を確認できた。
+CI（`tests/run-tests.sh`）がリグレッション検知の役割を果たした。
+
+### 改善点・学んだこと
+
+#### 1. grep パターンの精度不足による false positive
+
+**現象**: AC-4-2 の受け入れ検査で `grep -n '\[\['` が bash 拡張構文の検出を意図していたが、
+`sed` パターン内の `[[:space:]]` にもマッチして false positive FAIL になった。
+
+**学び**: シェルスクリプトの構文チェックには文字クラス `[[:...]]` を含むパターンとの区別が必要。
+テストケースの grep パターンは「意図しないパターンにマッチしないか」を事前検証する。
+
+#### 2. Edit ツールの「File has been modified」エラー
+
+**現象**: CHANGELOG.md を Edit しようとしたタイミングで前のツール呼び出しが同ファイルを変更しており
+「File has been modified since read」エラーが発生した。
+
+**改善策**: 同一ファイルへの連続 Edit は、直前の Edit 完了を確認してから次の Edit を行う。
+並列ツール呼び出し時は同一ファイルへのアクセスが重ならないよう整理する。
+
+### ネクストアクション（将来セッション向け）
+
+| 優先度 | アクション |
+|---|---|
+| 中 | Issue #109 Parent-Child PBI Orchestrator Mode 仕様化（schemas/, docs/rfc/, Workflow 定義） |
+| 低 | `bin/plangate` バージョン表示を 0.2.0 に更新 |
+| 低 | TROUBLESHOOTING.md に review / exec / validate --mode のエラー対処を追記 |
+| 検討 | `plangate decompose <parent-pbi>` コマンドの RFC 策定 |


### PR DESCRIPTION
## Summary

- `docs/working/retrospective-2026-04-27.md` にセッション2の振り返りを追記
- v8.1.0（bin/plangate validate --mode / review / exec）実装セッションの記録

## 内容

- 成果: PR #99〜#108、GitHub Release v8.1.0
- うまくいったこと: RFC → 実装の直接接続、POSIX sh 準拠維持、テスト先行設計
- 改善点: grep パターン false positive、Edit ツールの file modified エラー
- ネクストアクション: Issue #109 仕様化ほか

🤖 Generated with [Claude Code](https://claude.com/claude-code)