### PR TITLE
docs: post-merge maintenance for v8.2 (CHANGELOG / retrospective / cross-references)

### DIFF
--- a/.claude/rules/working-context.md
+++ b/.claude/rules/working-context.md
@@ -32,6 +32,8 @@ Ready → In Progress
 
 ## ディレクトリ構造
 
+### 単一 PBI（標準）
+
 ```text
 docs/working/
 └── TASK-{ticket-number}/
@@ -53,6 +55,30 @@ docs/working/
         ├── verification/    #   動作検証スクリーンショット・ログ
         └── e2e/             #   E2E 検証結果
 ```
+
+### 親 PBI（Orchestrator Mode）
+
+親 PBI を扱う場合は別ディレクトリ `docs/working/PBI-{number}/` を併用する。詳細は [`docs/orchestrator-mode.md`](../../docs/orchestrator-mode.md) を参照。
+
+```text
+docs/working/
+└── PBI-{parent-number}/
+    ├── parent-plan.md          # 親計画（テンプレート: docs/working/templates/parent-plan.md）
+    ├── dependency-graph.md     # 子 PBI 依存関係グラフ
+    ├── parallelization-plan.md # 並行実行計画
+    ├── integration-plan.md     # 統合チェック / 親完了条件
+    ├── risk-report.md          # 親 PBI レベルの集約リスク
+    ├── approvals/
+    │   ├── parent-c3.json      # 親計画ゲート承認
+    │   └── parent-integration.json  # 統合ゲート承認
+    ├── children/
+    │   ├── PBI-{n}-01.yaml     # 子 PBI 仕様（schema: docs/schemas/child-pbi.yaml）
+    │   ├── PBI-{n}-02.yaml
+    │   └── ...
+    └── handoff.md              # 親 PBI 完了時の引き継ぎ（必須）
+```
+
+子 PBI の作業コンテキストは既存の `TASK-XXXX/` 構造を再利用する想定。実装は別 PBI（[`docs/orchestrator-mode.md`](../../docs/orchestrator-mode.md) の V2 範囲）。
 
 ## コンテキスト読み込みプロトコル（Progressive Disclosure）
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@
 | 共有スキル | `.agents/skills/` |
 | PlanGate ワークフロー（v5 現行） | `docs/plangate.md` |
 | PlanGate v7 ハイブリッド | `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md` |
-| v7 Workflow 定義（WF-01〜WF-05） | `docs/workflows/README.md` |
+| Orchestrator Mode（親 PBI 分解、Spec only） | `docs/orchestrator-mode.md` / `.claude/rules/orchestrator-mode.md` |
+| v7 Workflow 定義（WF-01〜WF-05 + Orchestrator） | `docs/workflows/README.md` |
 | 役割分担 | `docs/ai/tool-roles.md` |
 | 作業コンテキスト | `docs/working/README.md` |
 | 学びの蓄積 | `AGENT_LEARNINGS.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ PlanGate の主要リリース履歴。
 
 このファイルは各リリース時点の内容を記録するものであり、この pull request の差分一覧ではない。
 
+## v8.2.0 - 2026-04-28
+
+feat: Parent-Child PBI Orchestrator Mode 仕様策定 + ドキュメント同期 (#111 #112 #114)
+
+### Added
+
+- `docs/orchestrator-mode.md` — Parent-Child PBI Orchestrator Mode のアーキテクチャ正本（Issue #109、Spec only / 実装は別 PBI）
+- `docs/schemas/child-pbi.yaml` — 子 PBI YAML スキーマ + バリデーション規則
+- `docs/workflows/orchestrator-decomposition.md` — 親 PBI → 子 PBI 分解 Workflow（D-1〜D-7）
+- `docs/workflows/orchestrator-integration.md` — 子 PBI 統合 → 親 PBI 完了判定 Workflow（I-1〜I-4 + Gap 分岐）
+- `docs/working/templates/parent-plan.md` / `dependency-graph.md` / `parallelization-plan.md` / `integration-plan.md` — 親 PBI 用 4 種テンプレート
+- `.claude/rules/orchestrator-mode.md` — Gate 不変条件（ChildExecAllowed / ParentDone / NewChildPBIAllowed）の正本
+- `docs/rfc/plangate-decompose.md` — `plangate decompose` CLI RFC（Status: Draft）
+- `scripts/check-orchestrator-docs.sh` — Orchestrator Mode ドキュメント整合性検証スクリプト（TC-01〜TC-20）
+- README に CLI セクション追加（`bin/plangate init/status/validate/review/exec` の使用例）
+- README「中核アイデア」表に Control OS 行追加
+
+### Changed
+
+- `docs/plangate-v7-hybrid.md` — Mode×Gate×Skill 表を `skill-policy-router` 正本に同期、`critical` の rollback / security review / staged deploy を補足
+- `docs/plangate-plugin-migration.md` — Rules (8) → (9) 修正、Provider RFC と Workflow DSL 接続を「完了済み」に移動、14 skills 呼び出し例追加
+- `docs/plangate.md` — 「ライト / フル」2 分類 → 5 モード表へ置換
+- `docs/ai-driven-development.md` — `フルのみ` → `high-risk / critical のみ` に置換、5 モード表へ更新
+- `README.md` / `README_en.md` — install warning を NOTE に緩和（dual-mode 可・`plangate:` prefix 注記）、Repository Layout に `/bin` `/workflows` `/tests` を追加、Testing を v8.1.0 の 10 件テストに更新
+- `docs/index.md` — Orchestrator Mode 仕様へのリンク追加
+
 ## v8.1.0 - 2026-04-27
 
 feat: Provider CLI 対応 — validate --mode、review（Gemini CLI）、exec（OpenCode）コマンド追加 (#107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ PlanGate の主要リリース履歴。
 
 ## v8.2.0 - 2026-04-28
 
-feat: Parent-Child PBI Orchestrator Mode 仕様策定 + ドキュメント同期 (#111 #112 #114)
+feat: Parent-Child PBI Orchestrator Mode 仕様策定 + ドキュメント同期 (#111 #112 #113 #114)
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@
 | 運用ルール | `.claude/rules/` |
 | PlanGateワークフロー（v5 現行） | `docs/plangate.md` |
 | PlanGate v7 ハイブリッド | `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md` |
-| Workflow 定義（WF-01〜WF-05） | `docs/workflows/README.md` |
+| Orchestrator Mode（親 PBI 分解、Spec only） | `docs/orchestrator-mode.md` / `.claude/rules/orchestrator-mode.md` |
+| Workflow 定義（WF-01〜WF-05 + Orchestrator） | `docs/workflows/README.md` |
 | 役割分担 | `docs/ai/tool-roles.md` |
 
 ## 迷ったらの判断基準

--- a/docs/working/retrospective-2026-04-28.md
+++ b/docs/working/retrospective-2026-04-28.md
@@ -1,0 +1,158 @@
+# セッション振り返り — 2026-04-28
+
+## セッション概要
+
+PlanGate v8.2 マイルストーン（Issue #109 + #111）を 1 セッションで処理。
+Parent-Child PBI Orchestrator Mode の **仕様文書群** を確定し、上位ドキュメント（README / migration guide / hybrid / plangate / ai-driven-development）を v8.1 実装に同期させた。
+
+## 成果
+
+### マージした PR（3件）
+
+| PR | 内容 | Issue |
+|----|------|-------|
+| #113 | docs sync v7-hybrid / migration / README / plangate / ai-driven-development to v8.1.0 | #111 |
+| #112 | docs sync README with v8.1 CLI and plugin guidance（rebase 後マージ）| — |
+| #114 | feat: spec Parent-Child PBI Orchestrator Mode (TASK-0038) | #109 |
+
+### クローズした issue（2件）
+
+- #109 [P2] Parent-Child PBI Orchestrator Mode（仕様策定）
+- #111 docs: v8.1 時点の Control OS / Workflow DSL / CLI 実装にドキュメントを同期する
+
+### 新規追加ドキュメント（11件）
+
+- アーキ正本: `docs/orchestrator-mode.md`
+- Schema: `docs/schemas/child-pbi.yaml`
+- Workflow: `docs/workflows/orchestrator-{decomposition,integration}.md`
+- Template: `docs/working/templates/{parent-plan,dependency-graph,parallelization-plan,integration-plan}.md`
+- Rule: `.claude/rules/orchestrator-mode.md`
+- RFC: `docs/rfc/plangate-decompose.md`
+- 検証: `scripts/check-orchestrator-docs.sh`
+
+---
+
+## うまくいったこと
+
+### 1. PlanGate v5 ワークフローの完全 1 セッション実行
+
+TASK-0038 で `working context → pbi-input → plan + todo + test-cases → review-self → C-3 → exec → V-1 → handoff → PR → C-4` のフルサイクルを 1 セッションで完走できた。
+特に Phase A（仕様策定の前準備）から C-3 提出までを一気通貫で実施し、人間レビューゲートで停止する制御が機能した。
+
+### 2. C-1 セルフレビュー 17 項目の網羅
+
+`docs/working/TASK-0038/review-self.md` で全 17 項目を PASS で評価。
+plan 内の Work Breakdown 表に「カバー AC」列を追加することで、AC ↔ Step の対応が一目で確認できる構造になった。
+
+### 3. PR #112 と #113 の競合解消
+
+ユーザーが先に PR #112 を作成、私が後に PR #113 を作成・マージしたため、#112 が conflict 状態になった。
+rebase で main の最新（#113 反映後）に追従し、conflict 6 箇所を解消、#112 独自部分（CLI セクション + Control OS 行）のみ残してマージできた。
+**結果: 重複なく両 PR の意図を取り込み、PR チェイン全体が整合した状態でマージ完了。**
+
+### 4. 自動レビューへの即応
+
+Gemini Code Assist が PR #114 に 5 件の自動レビューを残した（high 1 / medium 4）。
+うち 4 件（TC-13 範囲限定、TC-09 grep 簡素化、id 正規表現の親子分離、handoff.md or equivalent の曖昧表現）を即修正、1 件（ScopeBoundaryDefined の both required）は意図的設計として説明・resolve。
+**branch protection の `required_review_thread_resolution: true` が想定通り機能し、レビューを resolve するまでマージできない構造を確認できた。**
+
+### 5. 検証スクリプトによる回帰防止
+
+`scripts/check-orchestrator-docs.sh`（TC-01〜TC-20）を本 PBI の成果物として同梱したため、
+将来的にドキュメントを編集する際の整合性検証が機械化された。
+特に「ドキュメント間のリンク網羅」「状態名の表記揺れ」をスクリプトで検出可能。
+
+---
+
+## 改善点・学んだこと
+
+### 1. markdownlint の自動修正がプリエクシスティングファイルを巻き込む
+
+**現象**: `markdownlint-cli2 --fix` を新規ファイル群に対して実行したところ、
+glob 範囲の指定が広すぎて、無関係なテンプレート（`current-state.md`, `design.md`, `handoff.md`, `review-external.md` 等）も整形対象に巻き込まれた。
+
+**対応**: 巻き込まれた変更を `git checkout HEAD --` で復元し、対象だけステージし直した。
+
+**改善策**:
+- `markdownlint-cli2 --fix` を実行する前に対象 glob を限定する
+- 実行後に `git diff --name-only` で意図しない変更がないかチェックしてから add する
+- もしくは `.markdownlint-cli2.jsonc` の glob を狭める検討
+
+### 2. CI 対象範囲外でも markdownlint をローカル実行する
+
+**現象**: CI の Markdown lint 対象は `docs/workflows/**/*.md` 等の限定 glob。
+新規追加した `docs/orchestrator-mode.md` 等は CI 対象外で、PR 後の手動修正リスクがあった。
+
+**学び**: CI が対象外でも、新規追加文書はローカルで lint してから push する。
+本セッションでは CI Lint 対象外のファイルが含まれたが、結果的に CI で問題が出たのは `docs/workflows/orchestrator-*.md` のみだった（ここは CI 対象）。
+
+### 3. branch protection ruleset と review_thread resolution
+
+**現象**: PR #114 マージ時に「A conversation must be resolved before this pull request can be merged」エラー。
+Gemini Code Assist が自動でレビューコメントを残し、すべて resolve しないとマージ不可。
+
+**学び**:
+- リポジトリの ruleset で `required_review_thread_resolution: true` が有効になっている
+- Bot レビューでも resolve が必要。実害がない指摘も「addressed / not addressed」を明示して resolve する必要がある
+- これは意図的に維持すべき品質ガード（自動レビューの指摘を「無視」せず必ず判断する強制）
+
+### 4. PR #112 の事前存在の検出漏れ
+
+**現象**: 「PR を確認して」と 2 回言われた際、最初は OPEN PR を 0 件と判定した。
+実は #112 が OPEN だったが、初回の `gh pr list --state open` が空だった可能性（API のキャッシュ or タイミング）。
+
+**学び**: PR 確認時は `--json` で詳細を取って二重確認する。
+特に「直近作成された PR を見落とす」リスクがある場合、`--limit` を増やす + `--state all` も併用する。
+
+### 5. ローカル main の squash-merge 乖離
+
+**現象**: `git checkout main && git pull` で merge commit が自動生成された。
+ローカル main の commit hash（PR #110 の squash 前）と remote main の hash が異なるため。
+
+**対応**: `git checkout origin/main -- .` で完全に origin に揃え直し、`git branch -f main origin/main` でローカル main をリセット。
+
+**改善策**:
+- ローカル main は常に `git fetch && git reset --hard origin/main` で同期する運用を徹底
+- もしくは squash-merge 時にリモートを起点としてブランチを切り直す
+
+---
+
+## 学習として固定化したこと（memory に保存済み）
+
+- **GitHub アカウント切り替え**: `s977043/plangate` への push 前に `gh auth switch --user s977043` が必須（`feedback_github_account_switch.md`）
+
+---
+
+## ネクストアクション
+
+### 即時候補
+
+- 本振り返り PR をマージ後、CHANGELOG v8.2.0 と本 retrospective が main に反映される
+- v8.2 GitHub Release を作成（タグ + 本 CHANGELOG エントリをコピー）
+
+### 後続 PBI 候補（TASK-0038 handoff.md より）
+
+1. `plangate decompose --mode manual` 最小実装（Phase 1）
+2. `plangate decompose --mode assisted`（heuristic 実装、Phase 2）
+3. Parent Supervisor / Integration Agent の Skill / Agent ファイル化
+4. Hook による Gate 不変条件の機械強制
+5. Workflow DSL（`workflows/orchestrator-*.yaml`）対応
+6. dependency-graph / coverage-matrix の自動生成
+7. GitHub Issue sub-issue API 連携（`OQ-1` 解決）
+
+### プロセス改善
+
+- `markdownlint-cli2 --fix` の glob 限定運用ガイドを `.claude/rules/` に追加検討
+- ローカル main 同期手順を `CONTRIBUTING.md` に追加検討
+
+---
+
+## 参照
+
+- PR #113: <https://github.com/s977043/plangate/pull/113>
+- PR #112: <https://github.com/s977043/plangate/pull/112>
+- PR #114: <https://github.com/s977043/plangate/pull/114>
+- Issue #109: <https://github.com/s977043/plangate/issues/109>
+- Issue #111: <https://github.com/s977043/plangate/issues/111>
+- TASK-0038 handoff: `docs/working/TASK-0038/handoff.md`
+- 前セッション: `docs/working/retrospective-2026-04-27.md`

--- a/docs/working/retrospective-2026-04-28.md
+++ b/docs/working/retrospective-2026-04-28.md
@@ -154,5 +154,5 @@ Gemini Code Assist が自動でレビューコメントを残し、すべて res
 - PR #114: <https://github.com/s977043/plangate/pull/114>
 - Issue #109: <https://github.com/s977043/plangate/issues/109>
 - Issue #111: <https://github.com/s977043/plangate/issues/111>
-- TASK-0038 handoff: `docs/working/TASK-0038/handoff.md`
-- 前セッション: `docs/working/retrospective-2026-04-27.md`
+- TASK-0038 handoff: [docs/working/TASK-0038/handoff.md](TASK-0038/handoff.md)
+- 前セッション: [docs/working/retrospective-2026-04-27.md](retrospective-2026-04-27.md)

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -142,10 +142,15 @@ Hooks are not implemented in this version (directory structure reserved). Planne
 - Post-install behavior depends on Claude Code internals (refer to runtime verification results)
 - `test-engineer` and `release-manager` agents are not bundled (they do not exist in `.claude/` either)
 
+## Future / RFC
+
+- **Parent-Child PBI Orchestrator Mode** (specification only, see [`docs/orchestrator-mode.md`](../../docs/orchestrator-mode.md) and [`docs/rfc/plangate-decompose.md`](../../docs/rfc/plangate-decompose.md)): a layer above single-PBI control that decomposes a parent PBI into multiple child PBIs and runs each through PlanGate. Implementation (Parent Supervisor / Integration Agent / `plangate decompose` CLI / Hook-based gate enforcement) is tracked in follow-up PBIs.
+
 ## References
 
 - Migration guide: [docs/plangate-plugin-migration.md](../../docs/plangate-plugin-migration.md)
-- Project repository: https://github.com/s977043/plangate
+- Orchestrator Mode spec: [docs/orchestrator-mode.md](../../docs/orchestrator-mode.md)
+- Project repository: <https://github.com/s977043/plangate>
 - Parent issue: [#16](https://github.com/s977043/plangate/issues/16)
 
 ## License


### PR DESCRIPTION
## Summary

本日マージされた 3 PR（#112 / #113 / #114）の事後整備。Orchestrator Mode 仕様策定（TASK-0038, #109）と Control OS / v8.1 ドキュメント同期（#111）の完了を CHANGELOG・既存ドキュメントに反映。

## A. CHANGELOG + 振り返り

- `CHANGELOG.md` — v8.2.0 エントリ追加（Added 10 件 + Changed 6 件）
- `docs/working/retrospective-2026-04-28.md` — 本日セッションの振り返り
  - うまくいったこと: PlanGate v5 ワークフロー 1 セッション完走 / C-1 17 項目網羅 / PR #112-#113 conflict 解消 / 自動レビュー即応 / 検証スクリプト同梱
  - 改善点: markdownlint --fix の glob 限定 / CI 対象外でもローカル lint / branch protection の review thread resolution / ローカル main 同期手順

## B. 既存ドキュメントへの Orchestrator Mode 参照追加

- `CLAUDE.md` — Claude Code 固有の参照先表に追加
- `AGENTS.md` — Codex 固有の参照先表に追加
- `.claude/rules/working-context.md` — ディレクトリ構造を「単一 PBI」「親 PBI（Orchestrator Mode）」の 2 セクションに整理、`docs/working/PBI-XXX/` の構造を明示
- `plugin/plangate/README.md` — Future / RFC セクション追加（spec only、実装は follow-up PBI）

## C. リンク監査

- Python スクリプトで本セッション関連 19 ファイルの相対リンクを全件チェック
- 結果: **全リンク解決**（broken link 0 件）

## Test plan

- [x] `sh scripts/check-orchestrator-docs.sh` — 20/20 PASS
- [x] `sh tests/run-tests.sh` — 10/10 PASS（回帰なし）
- [x] `npx markdownlint-cli2 README.md CHANGELOG.md docs/index.md docs/workflows/**/*.md` — 0 errors
- [x] 19 ファイルの相対リンク監査 — 全リンク解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)