### PR TITLE
docs(orchestrator): C-2 外部AIレビュー（Codex）+ CONDITIONAL 対応

### DIFF
--- a/docs/working/PBI-116/children/PBI-116-01.yaml
+++ b/docs/working/PBI-116/children/PBI-116-01.yaml
@@ -21,6 +21,7 @@ child_pbi:
     - AGENTS.md
     - docs/ai/project-rules.md
     - docs/ai/core-contract.md
+    - docs/ai-driven-development.md  # C-2 EX-01 対応: Iron Law 既存 6 項目を Core Contract 参照に切り替え
     - .claude/rules/**
     - .claude/commands/**
     - .claude/agents/**

--- a/docs/working/TASK-0039/INDEX.md
+++ b/docs/working/TASK-0039/INDEX.md
@@ -13,7 +13,7 @@
 | Title | Outcome-first Core Contract への移行（prompt slimming） |
 | 親 PBI | [PBI-116](../PBI-116/parent-plan.md) |
 | Mode | high-risk |
-| Phase | **PLAN-READY**（Parent C-3 APPROVED 2026-04-30、plan.md 作成可） |
+| Phase | **C3-WAIT**（C-1 PASS / C-2 CONDITIONAL 対応済 / Child C-3 ゲート待ち） |
 | 起票 | 2026-04-30 |
 
 ## 現在のフェーズ
@@ -26,18 +26,18 @@
 
 | ファイル | 状態 |
 |---------|------|
-| `pbi-input.md` | ✅ 作成済（Issue #117 を構造化） |
+| `pbi-input.md` | ✅ 作成済（Issue #117 を構造化、Iron Law 対応表追加 / C-2 EX-02） |
 | `INDEX.md` | ✅ 本ファイル |
-| `current-state.md` | ✅ 作成済 |
-| `plan.md` | ⏳ 未作成（Parent C-3 APPROVED 後） |
-| `todo.md` | ⏳ 未作成 |
-| `test-cases.md` | ⏳ 未作成 |
-| `review-self.md` | ⏳ 未作成（C-1 時） |
-| `review-external.md` | ⏳ 未作成（C-2 時） |
+| `current-state.md` | ✅ 更新済 |
+| `plan.md` | ✅ 作成済（C-2 EX-01/03/04/05 反映済） |
+| `todo.md` | ✅ 作成済 |
+| `test-cases.md` | ✅ 作成済（C-2 EX-04 反映済） |
+| `review-self.md` | ✅ C-1 完了（16 PASS / 1 WARN / 0 FAIL → PASS） |
+| `review-external.md` | ✅ C-2 完了（CONDITIONAL → 同 PR で対応） |
 | `status.md` | ⏳ 未作成（exec 開始時） |
-| `current-state.md` | ⏳ 未更新（タスク完了ごと） |
 | `handoff.md` | ⏳ 未作成（WF-05 時） |
-| `evidence/` | ✅ 空ディレクトリ |
+| `evidence/` | ✅ 空ディレクトリ（exec 時に inventory.md / verification.md 作成） |
+| `_codex-prompt.txt` | ✅ Codex C-2 入力プロンプト（再現性のため保持） |
 
 ## Progressive Disclosure 読み込み順
 

--- a/docs/working/TASK-0039/_codex-prompt.txt
+++ b/docs/working/TASK-0039/_codex-prompt.txt
@@ -1,0 +1,87 @@
+あなたは PlanGate ワークフローの外部AIレビュー（C-2）担当です。
+独立した第三者の視点で、以下の TASK-0039（PBI-116-01 / Issue #117 Outcome-first Core Contract）の計画ドキュメント群をレビューしてください。
+
+# 背景
+
+- このレビューは PlanGate の C-2 ゲート（C-1 セルフレビュー後の外部AIレビュー）に該当
+- 対象 PBI は high-risk モード（Iron Law: NO EXECUTION WITHOUT REVIEWED PLAN FIRST）
+- 親 PBI: PBI-116（最新実行モデル対応 / Orchestrator Mode 第一号）
+- Parent C-3 ゲート: APPROVED 済（2026-04-30）
+
+# レビュー対象
+
+以下 4 ファイルを読んで独立レビューしてください:
+
+1. docs/working/TASK-0039/pbi-input.md（PBI INPUT PACKAGE）
+2. docs/working/TASK-0039/plan.md（EXECUTION PLAN）
+3. docs/working/TASK-0039/todo.md（EXECUTION TODO）
+4. docs/working/TASK-0039/test-cases.md（テストケース）
+5. docs/working/TASK-0039/review-self.md（C-1 セルフレビュー結果、整合性確認用）
+
+合わせて以下も参考に:
+- docs/working/PBI-116/parent-plan.md（親 PBI 計画）
+- docs/working/PBI-116/children/PBI-116-01.yaml（子 PBI 仕様）
+- docs/working/PBI-116/notes-117-target-files.md（予備調査）
+
+# レビュー観点（最低 6 観点）
+
+1. **要件適合性**: pbi-input の AC-1〜AC-6 が plan.md / test-cases.md で完全カバーされているか
+2. **スコープ境界**: in_scope / out_of_scope と allowed_files / forbidden_files の境界が plan の作業と整合しているか
+3. **Iron Law 整合性**: Iron Law 7 項目の扱い（既存 6 項目 + 追加 2 項目）が plan / todo / test-cases で一貫しているか
+4. **削減目標の妥当性**: 「行数 50% 以下」「token 削減率 50% 以上」の数値目標は達成可能で適切か
+5. **テスト戦略**: doc-review PBI として TC-1〜TC-8 + TC-E1〜TC-E5 が AC を網羅し、自動化率も妥当か
+6. **リスク評価**: Risk L1〜L5 の severity / mitigation が現実的か。漏れている risk はないか
+
+# 追加観点（任意、見つかったら指摘）
+
+- C-1 セルフレビュー（review-self.md）の WARN 1 件（手動 E2E）の扱いは妥当か
+- PBI-116-03（Prompt Assembly）/ PBI-116-04（Structured Outputs）/ PBI-116-06（Tool Policy）との依存関係が plan 内で適切に切り分けられているか
+- 64 ファイルの棚卸しを 1 セッションで完了する見積もりは現実的か
+
+# 出力形式
+
+以下の Markdown 構造で簡潔に出力してください（前置き不要、本文のみ）:
+
+```
+# C-2 外部AIレビュー結果 — TASK-0039
+
+## サマリ
+
+| 区分 | 件数 |
+|------|------|
+| critical | <N> |
+| major | <N> |
+| minor | <N> |
+| info | <N> |
+
+総合判定: PASS / WARN / FAIL
+
+## 観点別判定
+
+### 1. 要件適合性
+- 判定: PASS / WARN / FAIL
+- コメント: <1〜2 行>
+
+### 2. スコープ境界
+...（同様に観点 6 まで）
+
+## 指摘事項
+
+### EX-01 [severity] <短いタイトル>
+- 該当箇所: <ファイル名:行番号 or セクション>
+- 指摘内容: <2〜3 行>
+- 推奨対応: <1〜2 行>
+
+### EX-02 ...
+
+## Questions（保留事項、Child C-3 で確認推奨）
+
+- Q1: <質問>
+- Q2: ...
+
+## Child C-3 ゲートへの推奨
+
+APPROVE / CONDITIONAL / REJECT のいずれか + 理由
+```
+
+各指摘は短く、根拠ベースで。改善提案も併記してください。

--- a/docs/working/TASK-0039/current-state.md
+++ b/docs/working/TASK-0039/current-state.md
@@ -5,29 +5,29 @@
 
 ## 現在のフェーズ
 
-**PLAN-READY**（Parent C-3 APPROVED 2026-04-30、plan.md 作成可）
+**C3-WAIT**（C-1 PASS / C-2 CONDITIONAL → 同 PR で対応 / Child C-3 ゲート待ち）
 
 ## 完了済
 
 - [x] Parent PBI（PBI-116）親計画書マージ（PR #126 / `9203c84`）
-- [x] 子 PBI YAML（PBI-116-01.yaml）作成
-- [x] 本 TASK の `pbi-input.md` 構造化（Issue #117 から）
-- [x] `INDEX.md` / `current-state.md` 作成
-- [x] **Parent C-3 ゲート APPROVED**（s977043, 2026-04-30）
+- [x] Parent C-3 ゲート APPROVED（s977043, 2026-04-30）
+- [x] 子 PBI YAML（PBI-116-01.yaml）作成 + allowed_files に ai-driven-development.md 追加（C-2 EX-01）
+- [x] pbi-input.md 構造化（Iron Law 対応表追加 / C-2 EX-02）
+- [x] plan.md 作成（C-2 EX-01/03/04/05 反映済）
+- [x] todo.md 作成
+- [x] test-cases.md 作成（C-2 EX-04 反映済）
+- [x] **C-1 セルフレビュー**: 16 PASS / 1 WARN / 0 FAIL → 総合 PASS
+- [x] **C-2 外部AIレビュー**（Codex）: CONDITIONAL（major 3 / minor 3 / info 1） → 同 PR で対応済
 
 ## ブロッカー
 
-なし
+なし（Child C-3 ゲート判断待ち）
 
-## 次のアクション（確定パス）
+## 次のアクション
 
-1. `plan.md` を作成（テンプレート準拠、Mode: high-risk）
-2. `todo.md` を作成（2-5 分粒度、TDD: RED → GREEN → REFACTOR）
-3. `test-cases.md` を作成（受入基準 → テストケース マッピング）
-4. C-1 セルフレビュー（17 項目）
-5. C-2 外部AIレビュー（Codex 必須、high-risk のため）
-6. Child C-3 ゲート判断 👤
-7. APPROVED 後 exec 開始（TDD）→ L-0 → V-1 → V-2 → V-3 → PR → Child C-4
+1. **Child C-3 ゲート判断** 👤（本 PR / `chore/PBI-116-01-c2-response` C-4 マージ後）
+2. APPROVED 後 exec 開始
+3. L-0 → V-1 → V-2 → V-3 → 子 PR → Child C-4
 
 ## 参照
 

--- a/docs/working/TASK-0039/pbi-input.md
+++ b/docs/working/TASK-0039/pbi-input.md
@@ -39,14 +39,21 @@ PlanGate には C-3 承認、C-4 レビュー、受入基準、検証証拠、ha
    Output discipline
    ```
 
-3. **Iron Law 7 項目の明示維持**（削減対象外）
-   - C-3 承認前に production code を変更しない
-   - PBI 外の scope を追加しない
-   - 検証証拠なしに完了扱いしない
-   - 失敗・未実行・残リスクを隠さない
-   - 承認済み plan と実装差分の整合性を崩さない
-   - 原因調査なしに修正しない（NO FIXES WITHOUT ROOT CAUSE INVESTIGATION）
-   - 2 段階レビューなしにマージしない（NO MERGE WITHOUT TWO-STAGE REVIEW）
+3. **Iron Law 7 項目の明示維持**（削減対象外、Core Contract が正本）
+
+   既存 `docs/ai-driven-development.md` の Iron Law 6 項目を再分類し、本 PBI で Core Contract に集約する 7 項目として整理する:
+
+   | # | Core Contract Iron Law（新 7 項目） | 既存 6 項目との対応 |
+   |---|----------------------------------|------------------|
+   | 1 | C-3 承認前に production code を変更しない | plan: NO EXECUTION WITHOUT REVIEWED PLAN FIRST（再表現） |
+   | 2 | PBI 外の scope を追加しない | exec: NO SCOPE CHANGE WITHOUT USER APPROVAL（再表現） |
+   | 3 | 検証証拠なしに完了扱いしない | self-review: NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE（再表現） |
+   | 4 | 失敗・未実行・残リスクを隠さない | （新規。verification honesty として独立明記） |
+   | 5 | 承認済み plan と実装差分の整合性を崩さない | brainstorming: NO CODE WITHOUT APPROVED DESIGN FIRST + plan の延長として明示 |
+   | 6 | 原因調査なしに修正しない | systematic-debugging: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST（既存項目を独立化） |
+   | 7 | 2 段階レビューなしにマージしない | subagent-driven-development: NO MERGE WITHOUT TWO-STAGE REVIEW（既存項目を独立化） |
+
+   **重要**: 既存 6 項目から「root cause」と「two-stage review」を **新たに追加するわけではなく**、既存 ai-driven-development.md の表で別フェーズに紐付いていた 2 項目を **Core Contract レベルの一般原則として独立化** する整理。実質的な制約数は 6 → 7（#4 verification honesty を独立明記）。
 
 4. **入口ファイルの薄型化**
    - `CLAUDE.md` / `AGENTS.md` は詳細手順ではなく、Core Contract と参照先への導線に寄せる

--- a/docs/working/TASK-0039/pbi-input.md
+++ b/docs/working/TASK-0039/pbi-input.md
@@ -1,6 +1,6 @@
 # PBI INPUT PACKAGE — TASK-0039 (PBI-116-01 / Issue #117)
 
-> **Status**: PREPARATORY ONLY — Parent C-3 ゲート（`docs/working/PBI-116/approvals/parent-c3.json`）APPROVED 待ち
+> **Status**: C-2 完了 / Child C-3 ゲート待ち（Parent C-3 APPROVED 2026-04-30、C-2 CONDITIONAL → 同 PR で対応済）
 > 親 PBI: [PBI-116](../PBI-116/parent-plan.md) / EPIC [#116](https://github.com/s977043/plangate/issues/116)
 > 子 PBI ID: PBI-116-01
 > Issue: [#117 Outcome-first Core Contract への移行（prompt slimming）](https://github.com/s977043/plangate/issues/117)

--- a/docs/working/TASK-0039/plan.md
+++ b/docs/working/TASK-0039/plan.md
@@ -6,9 +6,9 @@
 
 ## Goal
 
-PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLAUDE.md` / `AGENTS.md` を outcome-first 形式に再構成**し、**両ファイルの行数を 50% 以下に削減**する（測定対象は CLAUDE.md と AGENTS.md の 2 ファイルのみ、ベースラインはマージ前の最新 main 上の行数）。Core Contract を `docs/ai/core-contract.md` に独立定義し、各入口から参照する構造に統一する。
+PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLAUDE.md` / `AGENTS.md` を outcome-first 形式に再構成**し、**それぞれが個別に baseline の 50% 以下** に削減する（合計ではなく各ファイル単独評価、ベースラインはマージ前の最新 main 上の行数）。Core Contract を `docs/ai/core-contract.md` に独立定義し、各入口から参照する構造に統一する。
 
-> **削減対象の定義（C-2 EX-03 対応）**: 「常時ロード token 削減」の合否対象は **CLAUDE.md + AGENTS.md の 2 ファイルの行数** に固定する。`.claude/rules/` 等は段階的削減の対象だが本 PBI の合否判定には含めない（V2 候補）。
+> **削減対象の定義（C-2 EX-03 対応）**: 「常時ロード token 削減」の合否対象は **CLAUDE.md と AGENTS.md がそれぞれ単独で 50% 以下** に固定する（片方が削減できても他方が未達なら不合格）。`.claude/rules/` 等は段階的削減の対象だが本 PBI の合否判定には含めない（V2 候補）。
 
 ## Constraints / Non-goals
 
@@ -92,7 +92,7 @@ PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLA
 - **Owner**: agent
 - **Risk**: 中
 - 🚩 チェックポイント:
-  - **CLAUDE.md + AGENTS.md の行数 50% 以下**（baseline は本 PR 開始時の main 上の値）
+  - **CLAUDE.md と AGENTS.md がそれぞれ単独で baseline の 50% 以下**（合計ではなく各ファイル単独評価、baseline は本 PR 開始時の main 上の値）
   - Iron Law 7 項目は **Core Contract が正本**、CLAUDE.md / AGENTS.md は参照中心（本文を重複転記しない）
   - hard-mandate キーワード残存 → Iron Law 7 項目および AI 運用 4 原則以外がゼロ
 
@@ -148,8 +148,8 @@ PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLA
 
 ### Verification Automation
 - `grep -rnE "必ず|絶対|ALWAYS|NEVER" CLAUDE.md AGENTS.md docs/ai/ .claude/ plugin/plangate/` で残存件数を確認 → **Iron Law 7 項目および AI 運用 4 原則以外がゼロ**（4 原則は CLAUDE.md `<law>` セクションで意図的に維持）
-- `wc -l CLAUDE.md AGENTS.md` で削減率を測定（**合計 50% 以下**、合否対象はこの 2 ファイルのみ）
-- baseline は本 PR の base 時点（feat/PBI-116-01-impl ブランチ作成時）の値を `evidence/verification.md` に記録
+- `wc -l CLAUDE.md AGENTS.md` で削減率を測定（**各ファイルが個別に baseline の 50% 以下**、合否対象はこの 2 ファイルのみ）
+- baseline は本 PR の base 時点（feat/PBI-116-01-impl ブランチ作成時）の値を `evidence/verification.md` に記録（CLAUDE.md / AGENTS.md それぞれの行数）
 
 ## Risks & Mitigations
 

--- a/docs/working/TASK-0039/plan.md
+++ b/docs/working/TASK-0039/plan.md
@@ -6,7 +6,9 @@
 
 ## Goal
 
-PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLAUDE.md` / `AGENTS.md` を中心とした入口ファイルを outcome-first 形式に再構成**し、常時ロードされる token を半分以下に削減する。Core Contract を `docs/ai/core-contract.md` に独立定義し、各入口から参照する構造に統一する。
+PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLAUDE.md` / `AGENTS.md` を outcome-first 形式に再構成**し、**両ファイルの行数を 50% 以下に削減**する（測定対象は CLAUDE.md と AGENTS.md の 2 ファイルのみ、ベースラインはマージ前の最新 main 上の行数）。Core Contract を `docs/ai/core-contract.md` に独立定義し、各入口から参照する構造に統一する。
+
+> **削減対象の定義（C-2 EX-03 対応）**: 「常時ロード token 削減」の合否対象は **CLAUDE.md + AGENTS.md の 2 ファイルの行数** に固定する。`.claude/rules/` 等は段階的削減の対象だが本 PBI の合否判定には含めない（V2 候補）。
 
 ## Constraints / Non-goals
 
@@ -43,7 +45,11 @@ PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLA
 - **Output**: `evidence/inventory.md` — 64 ファイルの分類表、hard-mandate キーワード行番号、削減候補マーキング
 - **Owner**: agent
 - **Risk**: 中（見落としのリスク）
-- 🚩 チェックポイント: 64 ファイル分の grep 結果を `evidence/inventory.md` に集約、削減候補を 3 段階（必須/推奨/保留）で分類
+- 🚩 チェックポイント:
+  - **必須**: 64 ファイル全件で grep 実行 + 結果記録
+  - **本 PBI で編集する優先層**: 入口（CLAUDE.md / AGENTS.md）+ 共通（project-rules.md / ai-driven-development.md）+ 主要コマンド（ai-dev-workflow.md ローカル/Plugin）+ working-context.md（ローカル/Plugin）
+  - **本 PBI で編集しない（V2 候補）**: hard-mandate ヒットなしの agents（19 件）、skills（12 件）等
+- C-2 EX-05 対応: 棚卸し範囲（全件）と編集範囲（優先層）を明示分離
 
 ### Step 2: Core Contract 定義（Phase 2）
 
@@ -82,10 +88,13 @@ PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLA
 
 ### Step 7: 検証（Phase 4）
 
-- **Output**: `evidence/verification.md` — 削減前後の token 比較、grep 結果の差分、Core Contract 参照の到達性確認
+- **Output**: `evidence/verification.md` — 削減前後の比較、grep 結果の差分、Core Contract 参照の到達性確認
 - **Owner**: agent
 - **Risk**: 中
-- 🚩 チェックポイント: token 削減率 50% 以上を達成 / Iron Law 7 項目は **Core Contract が正本** で、CLAUDE.md / AGENTS.md は参照中心（本文を重複転記しない）
+- 🚩 チェックポイント:
+  - **CLAUDE.md + AGENTS.md の行数 50% 以下**（baseline は本 PR 開始時の main 上の値）
+  - Iron Law 7 項目は **Core Contract が正本**、CLAUDE.md / AGENTS.md は参照中心（本文を重複転記しない）
+  - hard-mandate キーワード残存 → Iron Law 7 項目および AI 運用 4 原則以外がゼロ
 
 ### Step 8: 完了（PR 作成）
 
@@ -139,7 +148,8 @@ PlanGate の中核ルール（Iron Law 7 項目）を維持したまま、**`CLA
 
 ### Verification Automation
 - `grep -rnE "必ず|絶対|ALWAYS|NEVER" CLAUDE.md AGENTS.md docs/ai/ .claude/ plugin/plangate/` で残存件数を確認 → **Iron Law 7 項目および AI 運用 4 原則以外がゼロ**（4 原則は CLAUDE.md `<law>` セクションで意図的に維持）
-- `wc -l CLAUDE.md AGENTS.md` で削減率を測定（50% 以上削減目標）
+- `wc -l CLAUDE.md AGENTS.md` で削減率を測定（**合計 50% 以下**、合否対象はこの 2 ファイルのみ）
+- baseline は本 PR の base 時点（feat/PBI-116-01-impl ブランチ作成時）の値を `evidence/verification.md` に記録
 
 ## Risks & Mitigations
 

--- a/docs/working/TASK-0039/review-external.md
+++ b/docs/working/TASK-0039/review-external.md
@@ -1,0 +1,102 @@
+# C-2 外部AIレビュー結果 — TASK-0039
+
+> 実施: 2026-04-30 / Codex CLI (`codex-cli 0.124.0`) / `codex exec` 経由
+> 入力プロンプト: [`_codex-prompt.txt`](./_codex-prompt.txt)
+> 対象: pbi-input.md / plan.md / todo.md / test-cases.md / review-self.md（+ 親 PBI 周辺ドキュメント）
+
+## サマリ
+
+| 区分 | 件数 |
+|------|------|
+| critical | 0 |
+| major | 3 |
+| minor | 3 |
+| info | 1 |
+
+**総合判定: WARN（CONDITIONAL）**
+
+## 観点別判定
+
+### 1. 要件適合性
+- 判定: WARN
+- コメント: AC-1〜AC-6 は plan/test-cases に概ね対応。ただし AC-4 の「各 phase」は TC-6 の確認方法が曖昧で、実行可能な検査条件が不足。
+
+### 2. スコープ境界
+- 判定: FAIL
+- コメント: plan/todo/test-cases は `docs/ai-driven-development.md` 更新を前提にしているが、子 PBI YAML の allowed_files に含まれていない。
+
+### 3. Iron Law 整合性
+- 判定: WARN
+- コメント: Core Contract で保持する方針は明確。ただし「既存 6 項目 + 追加 2 項目」と「Iron Law 7 項目」の数え方が混在している。
+
+### 4. 削減目標の妥当性
+- 判定: WARN
+- コメント: `CLAUDE.md` 43 行、`AGENTS.md` 61 行を 50% 以下にする目標は厳しめ。token 50% 削減の測定対象も plan 内で揺れている。
+
+### 5. テスト戦略
+- 判定: WARN
+- コメント: doc-review PBI として網羅性は高いが、TC-7 は grep の存在確認だけでは制約維持の検証として弱い。手動 E2E WARN は妥当。
+
+### 6. リスク評価
+- 判定: WARN
+- コメント: L1〜L5 は現実的。ただし allowed_files 不整合、削減目標未達、Core Contract 正本化による既存文書移行漏れが明示リスク化されていない。
+
+## 指摘事項
+
+### EX-01 [major] `docs/ai-driven-development.md` が allowed_files 外
+- 該当箇所: `plan.md:152`, `plan.md:158-159`, `todo.md:11`, `test-cases.md:70-74`, `PBI-116-01.yaml:19-30`
+- 指摘内容: plan/test-cases は `ai-driven-development.md` を Core Contract 参照へ切替える前提だが、allowed_files に含まれていない。high-risk の scope discipline 上、このまま exec するとスコープ違反になる。
+- 推奨対応: Child C-3 前に `docs/ai-driven-development.md` を allowed_files に追加するか、本 PBI では「確認のみ」に落として更新を別 PBI に分離する。
+
+### EX-02 [major] Iron Law の項目数定義が不整合
+- 該当箇所: `pbi-input.md:42-49`, `pbi-input.md:100`, `docs/ai-driven-development.md:102-109`
+- 指摘内容: 既存 `docs/ai-driven-development.md` は 6 項目で、その中に root cause と two-stage review が既に含まれている。一方 pbi-input は「既存 6 項目を 7 項目（root cause + two-stage review 追加）に拡張」としており、数え方が合わない。
+- 推奨対応: Core Contract の Iron Law 7 項目を正本として、既存 6 項目から何を統合・分割・追加するのかを plan に明記する。
+
+### EX-03 [major] 削減目標の測定対象が揺れている
+- 該当箇所: `plan.md:9`, `plan.md:88`, `plan.md:142`, `todo.md:49`, `test-cases.md:32-42`
+- 指摘内容: Goal は「常時ロード token 半分以下」、TC-3/TC-4 は `CLAUDE.md` / `AGENTS.md` の行数 50% 以下、T-23 は「主要ファイル」も含む token 削減率としている。合否判定の母数が不明。
+- 推奨対応: baseline/after の対象を `CLAUDE.md` + `AGENTS.md` のみか、常時ロード一式かに固定し、token 測定コマンドまたは算出方法を明記する。
+
+### EX-04 [minor] TC-7 の制約維持検証が弱い
+- 該当箇所: `test-cases.md:56-60`
+- 指摘内容: `C-3|C-4|scope discipline|verification honesty` が少なくとも 1 ファイルに残るだけでは、制約が弱化していないことを確認できない。
+- 推奨対応: Core Contract Hard constraints 内で該当制約が MUST 相当として残ること、入口ファイルから到達可能であることを期待出力に追加する。
+
+### EX-05 [minor] 64 ファイル棚卸しと 1 セッション実行の整合が曖昧
+- 該当箇所: `plan.md:43-46`, `plan.md:149`, `todo.md:16-17`
+- 指摘内容: Step 1/T-3 は 64 ファイル全体の棚卸し完了を要求する一方、L2 mitigation は「1 セッション内では入口 + 共通 + 必要最小限」に絞るとしている。
+- 推奨対応: 64 ファイルは全件 grep 記録まで必須、編集対象は優先層に限定、のように完了条件を分離する。
+
+### EX-06 [minor] TASK 状態表示が古い
+- 該当箇所: `INDEX.md:32-38`, `pbi-input.md:3`, `current-state.md:8`
+- 指摘内容: plan/todo/test-cases/review-self が存在するが、INDEX/current-state/pbi-input は PLAN-READY や未作成表示のまま。
+- 推奨対応: Child C-3 前に `current-state.md` と INDEX の状態を C-2/C-3 待ちへ更新する。
+
+### EX-07 [info] 手動 E2E WARN の扱いは妥当
+- 該当箇所: `review-self.md:42-45`, `test-cases.md:82-92`
+- 指摘内容: Claude Code / Codex CLI 起動確認は環境依存があり、doc-review PBI で完全自動化しない判断は妥当。
+- 推奨対応: `evidence/verification.md` に実施日時、実行者、結果、未実行理由を必ず残す。
+
+## Questions（保留事項、Child C-3 で確認推奨）
+
+- Q1: `docs/ai-driven-development.md` の更新は本 PBI の scope に含めますか？
+- Q2: Iron Law 7 項目の正確な内訳は、既存 6 項目の再分類ですか、それとも新規追加を含みますか？
+- Q3: token 50% 削減の合否対象は `CLAUDE.md` / `AGENTS.md` のみですか、常時ロード文書全体ですか？
+- Q4: 64 ファイル棚卸しは全件レビュー完了まで必須ですか、全件 grep + 優先ファイル編集で十分ですか？
+
+## Child C-3 ゲートへの推奨
+
+**CONDITIONAL** — 計画の方向性と AC カバーは概ね妥当。ただし `docs/ai-driven-development.md` の allowed_files 不整合、Iron Law 7 項目の定義、削減率の測定母数は exec 前に修正が必要。
+
+## CONDITIONAL 対応サマリ（同 PR 内で実施）
+
+| ID | 対応方針 |
+|----|---------|
+| EX-01 | `docs/ai-driven-development.md` を `PBI-116-01.yaml` の allowed_files に追加（Q1: scope に含める） |
+| EX-02 | Core Contract の Iron Law 7 項目を正本とし、既存 6 項目との対応表を plan に明記（Q2: 既存 6 項目の再分類 + root cause / two-stage review を独立化） |
+| EX-03 | 削減目標を `CLAUDE.md` + `AGENTS.md` の行数のみに固定、Goal の表現も統一（Q3: 入口 2 ファイルのみ） |
+| EX-04 | TC-7 の期待出力を強化（Core Contract に MUST 相当残存 + 入口から到達可能） |
+| EX-05 | T-3 / Step 1 の完了条件を「全件 grep 記録は必須、編集対象は優先層」に分離（Q4: grep 必須 + 優先編集） |
+| EX-06 | INDEX.md / current-state.md / pbi-input.md の状態表示を「C-2 完了 / Child C-3 待ち」に更新 |
+| EX-07 | 対応不要（info、運用時に注意） |

--- a/docs/working/TASK-0039/test-cases.md
+++ b/docs/working/TASK-0039/test-cases.md
@@ -55,9 +55,14 @@
 
 ### TC-7: 既存ゲート（C-3 / C-4 / Iron Law）の維持
 - 前提条件: 変更後の `CLAUDE.md` / `AGENTS.md` / `docs/ai/core-contract.md`
-- 入力: `grep -E "C-3|C-4|scope discipline|verification honesty"` を実行
-- 期待出力: 各キーワードが少なくとも 1 ファイルに残存し、削除されていない
+- 入力:
+  - `grep -E "C-3|C-4|scope discipline|verification honesty" docs/ai/core-contract.md` を実行
+  - `grep -E "core-contract.md" CLAUDE.md AGENTS.md` を実行
+- 期待出力:
+  - **Core Contract Hard constraints 内で各キーワードが MUST 相当として明示されている**（単なる存在確認ではなく、制約として機能していること）
+  - **CLAUDE.md / AGENTS.md から `docs/ai/core-contract.md` への参照リンクが存在し、到達可能**
 - 種別: 自動（grep）+ doc-review
+- C-2 EX-04 対応: 単純な存在確認ではなく、Core Contract での MUST 相当残存と入口からの到達性を確認
 
 ### TC-8: 既存リンクの到達性
 - 前提条件: 変更後の `CLAUDE.md` / `AGENTS.md` / `docs/ai/project-rules.md`


### PR DESCRIPTION
## Summary

PR #129 マージ後、TASK-0039 の **C-2 外部AIレビュー** を Codex CLI で実施。判定 **CONDITIONAL**（major 3 / minor 3 / info 1）を **同 PR で全件対応**。Child C-3 ゲート待機まで。

## C-2 結果

- 実施: codex-cli 0.124.0、stdin 経由
- 入力: \`docs/working/TASK-0039/_codex-prompt.txt\`（再現性のため保持）
- 出力: \`docs/working/TASK-0039/review-external.md\`
- 総合判定: WARN / Child C-3 推奨: **CONDITIONAL**

## CONDITIONAL 対応（major 3 件）

| ID | 対応 |
|----|------|
| **EX-01** | \`PBI-116-01.yaml\` の allowed_files に \`docs/ai-driven-development.md\` を追加（Iron Law 既存 6 項目を Core Contract 参照に切り替えるため scope に含める）|
| **EX-02** | \`pbi-input.md\` に Iron Law 7 項目 ↔ 既存 6 項目の対応表を追加（「6+2=8」誤読を防ぎ、既存 6 項目の再分類 + verification honesty の独立化として明示）|
| **EX-03** | \`plan.md\` の削減目標を **CLAUDE.md + AGENTS.md の 2 ファイル行数** のみに固定（Goal / Verification Automation を統一、baseline 記録方法を明記）|

## CONDITIONAL 対応（minor 3 件）

| ID | 対応 |
|----|------|
| **EX-04** | \`test-cases.md\` TC-7 の期待出力を強化（Core Contract MUST 相当 + 入口からの到達性）|
| **EX-05** | \`plan.md\` Step 1 の完了条件を「全件 grep 必須 / 編集対象は優先層」に分離 |
| **EX-06** | \`INDEX.md\` / \`current-state.md\` / \`pbi-input.md\` の Status を **C3-WAIT** に更新 |

## TASK-0039 状態遷移

| Phase | Before | After |
|-------|--------|-------|
| TASK-0039 | PLAN-READY | **C3-WAIT**（C-1 PASS / C-2 CONDITIONAL 対応済 / Child C-3 待ち）|

## ゲート進行

| ゲート | 結果 |
|-------|------|
| Parent C-3 | ✅ APPROVED（PR #128 / \`13df737\`）|
| C-1 セルフレビュー | ✅ 16 PASS / 1 WARN / 0 FAIL → 総合 PASS（PR #129 / \`1786f78\`）|
| **C-2 外部AIレビュー** | ✅ **CONDITIONAL → 同 PR で対応済**（本 PR）|
| Child C-3 ゲート | ⏳ 本 PR マージ後に判断 👤 |

## 次ステップ（本 PR マージ後）

1. **Child C-3 ゲート判断** 👤 → APPROVED / CONDITIONAL / REJECTED
2. APPROVED 後 exec 開始（doc-review として）
3. L-0 → V-1 → V-2 → V-3 → 子 PR → Child C-4

## Test plan

- [ ] \`review-external.md\` が Codex 出力を完全に保持
- [ ] \`PBI-116-01.yaml\` の allowed_files に \`docs/ai-driven-development.md\` が追加
- [ ] \`pbi-input.md\` の Iron Law 対応表で 7 項目 ↔ 既存 6 項目の整理が明示
- [ ] \`plan.md\` の Goal が CLAUDE.md + AGENTS.md 2 ファイル行数 50% 以下に固定
- [ ] \`test-cases.md\` TC-7 が Core Contract MUST 相当 + 入口到達性を要求

🤖 Generated with [Claude Code](https://claude.com/claude-code)