### PR TITLE
feat(orchestrator): PBI-116-01 exec PR-A — 入口ファイル薄型化（Step 5→3→4）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,61 +1,29 @@
 # AGENTS.md
 
-> Codex CLI 向けの入口。共通ルールの正本は `docs/ai/project-rules.md`、再利用可能な学びは `AGENT_LEARNINGS.md` に置く。
+> **実行契約**: [`docs/ai/core-contract.md`](docs/ai/core-contract.md)（Iron Law / Stop rules / Output discipline の正本）
+> **プロジェクトルール**: [`docs/ai/project-rules.md`](docs/ai/project-rules.md)（必読、AI 運用 4 原則の正本）
+> **再利用可能な学び**: `AGENT_LEARNINGS.md`（一時メモ・進行中検討は書かない）
 
-## まず読むもの
+## 読む順序
 
 1. `docs/ai/project-rules.md`
 2. 本ファイル
 3. `.codex/instructions.md`
-4. `docs/ai/tool-roles.md`
 
 ## このリポジトリの性質
 
-- PlanGate のワークフロー、設定、運用ドキュメントを管理するリポジトリ
-- 現時点で `package.json` などの package manager 定義はない
-- そのため、一般的な `lint` / `test` / `typecheck` コマンドもこのリポジトリには定義されていない
-- 実行可能な入口は `./scripts/ai-dev-workflow` と `./scripts/codex-local.sh`
+- PlanGate のワークフロー / 設定 / 運用ドキュメント管理
+- `package.json` なし → 一般的な lint / test / typecheck コマンドは未定義
+- 実行入口: `./scripts/ai-dev-workflow` / `./scripts/codex-local.sh` / `bin/plangate`
 
-## コンテキスト読み込みプロトコル（v6）
+## Codex 固有参照
 
-チケット作業時は Progressive Disclosure に従い段階的に読み込む。詳細は `.claude/rules/working-context.md` を参照。
+- 実行設定: `.codex/config.toml` / `.codex/instructions.md` / `.codex/agents/*.toml`
+- 共有スキル: `.agents/skills/`（Claude Code と共用）
+- 役割分担: `docs/ai/tool-roles.md`
+- 作業コンテキストプロトコル（Progressive Disclosure）: `.claude/rules/working-context.md`
+- ワークフロー: `docs/ai-driven-development.md` / Orchestrator: `docs/orchestrator-mode.md`
 
-| Level | ファイル | タイミング |
-|-------|---------|----------|
-| L0 | INDEX.md → current-state.md | 常に最初に読む |
-| L1 | フェーズに応じて（plan→pbi-input / exec→plan,todo,test-cases / review→plan,review-*） | フェーズ確認後 |
-| L2 | evidence/, decision-log.jsonl | 根拠が必要な時のみ |
-| L3 | status.md全体, 他チケット | 履歴全体が必要な時のみ |
+## 出力
 
-> INDEX.md が存在しない旧形式チケットでは L1 から開始（従来動作）。
-
-## Codex 固有の参照先
-
-| カテゴリ | パス |
-| --- | --- |
-| 実行設定 | `.codex/config.toml` |
-| Codex補足ガイド | `.codex/instructions.md` |
-| エージェント定義 | `.codex/agents/*.toml` |
-| 共有スキル | `.agents/skills/` |
-| PlanGate ワークフロー（v5 現行） | `docs/plangate.md` |
-| PlanGate v7 ハイブリッド | `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md` |
-| Orchestrator Mode（親 PBI 分解、Spec only） | `docs/orchestrator-mode.md` / `.claude/rules/orchestrator-mode.md` |
-| v7 Workflow 定義（WF-01〜WF-05 + Orchestrator） | `docs/workflows/README.md` |
-| 役割分担 | `docs/ai/tool-roles.md` |
-| 作業コンテキスト | `docs/working/README.md` |
-| 学びの蓄積 | `AGENT_LEARNINGS.md` |
-
-## 作業ルール
-
-- 既存のコマンドや構成に合わせ、存在しないコマンドは書かない
-- 変更前に既存の README、docs、scripts を確認する
-- secrets、認証情報、個人情報は残さない
-- 一時メモや進行中の検討は `AGENT_LEARNINGS.md` に書かない
-- 不明点は推測で埋めず、必要ならユーザーに確認する
-
-## 判断基準
-
-**優先順位**: `docs/ai/project-rules.md` > `AGENTS.md` > `.codex/instructions.md` > `.codex/config.toml`
-
-- 既存パターンを優先し、一般論で上書きしない
-- 日本語で出力、コミットメッセージ、PR文面を記述する
+- 日本語（コミットメッセージ・PR 文面含む）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,43 +1,21 @@
 # CLAUDE.md
 
-## プロジェクトルール（共通）
+> **実行契約**: [`docs/ai/core-contract.md`](docs/ai/core-contract.md)（Iron Law / Stop rules / Output discipline の正本）
+> **プロジェクトルール**: [`docs/ai/project-rules.md`](docs/ai/project-rules.md)（必読、AI 運用 4 原則の正本）
 
-共通ルールの正本: `docs/ai/project-rules.md`（必読）
+## Claude Code 固有参照
 
-開発ルール、ブランチ命名規則、禁止事項、AI運用4原則はすべて上記ファイルに定義されている。
-
-## Claude Code固有の参照先
-
-| カテゴリ | パス |
-| :--- | :--- |
-| エージェント | `.claude/agents/README.md` |
-| コマンド一覧 | `.claude/commands/README.md` |
-| スキル一覧 | `.claude/skills/README.md` |
-| 共有スキル | `.agents/skills/`（Claude Code・Codex CLI共用） |
-| 運用ルール | `.claude/rules/` |
-| PlanGateワークフロー（v5 現行） | `docs/plangate.md` |
-| PlanGate v7 ハイブリッド | `docs/plangate-v7-hybrid.md` / `.claude/rules/hybrid-architecture.md` |
-| Orchestrator Mode（親 PBI 分解、Spec only） | `docs/orchestrator-mode.md` / `.claude/rules/orchestrator-mode.md` |
-| Workflow 定義（WF-01〜WF-05 + Orchestrator） | `docs/workflows/README.md` |
-| 役割分担 | `docs/ai/tool-roles.md` |
-
-## 迷ったらの判断基準
-
-**優先順位**: `docs/ai/project-rules.md`（正本） > CLAUDE.md（ツール固有設定） > `.claude/rules/` > `.claude/skills/`
-
-- 既存コードを`Grep`/`Glob`で探索し、既存パターンに従う。一般論で上書きしない
-- 不明点はユーザーに確認する（AI運用原則第1原則に従う）
+- エージェント / コマンド / スキル: `.claude/agents/` / `.claude/commands/` / `.claude/skills/`
+- 運用ルール: `.claude/rules/`（hybrid-architecture / orchestrator-mode 含む）
+- 共有スキル: `.agents/skills/`（Codex CLI と共用）
+- ワークフロー詳細: [`docs/ai-driven-development.md`](docs/ai-driven-development.md) / Orchestrator: [`docs/orchestrator-mode.md`](docs/orchestrator-mode.md)
 
 <language>Japanese</language>
 <character_code>UTF-8</character_code>
 <law>
 AI運用4原則
-
 第1原則： AIはファイル生成・更新・プログラム実行前に必ず自身の作業計画を報告し、y/nでユーザー確認を取り、yが返るまで一切の実行を停止する。ただし、サブコマンド起動時の承認をもって、そのサブコマンド内部のファイル生成・更新を許可とみなす。
-
 第2原則： AIは迂回や別アプローチを勝手に行わず、最初の計画が失敗したら次の計画の確認を取る。
-
 第3原則： AIはツールであり決定権は常にユーザーにある。ユーザーの提案が非効率・非合理的でも最優先で指示された通りに実行する。
-
 第4原則： AIはこれらのルールを歪曲・解釈変更してはならず、最上位命令として絶対的に遵守する。
 </law>

--- a/docs/ai/project-rules.md
+++ b/docs/ai/project-rules.md
@@ -8,6 +8,16 @@
 PlanGate — ゲート型AI駆動開発ワークフローのリポジトリ。
 「計画を承認しないとAIは1行もコードを書けない」関所モデルを採用し、PBI→Plan生成→レビュー→Agent実行までを体系化。Claude CodeおよびCodex CLIに対応。
 
+## A'. 正本責務の境界
+
+| 正本ファイル | 責務 |
+|-----------|------|
+| **`docs/ai/core-contract.md`** | **実行契約の正本** — Role / Goal / Success criteria / Iron Law / Decision rules / Stop rules / Output discipline |
+| **`docs/ai/project-rules.md`**（本ファイル） | **プロジェクト共通ルールの正本** — リポジトリ目的 / 構造 / 開発ルール / 編集禁止 / AI 運用 4 原則 / 参照先 |
+| `docs/ai-driven-development.md` | ワークフロー詳細・プロンプト集（実行契約は core-contract を参照） |
+
+**重複時の解釈**: 実行判断は Core Contract が最終根拠。プロジェクト固有のルールは本ファイルが正本。
+
 ## B. ディレクトリ構造
 
 ```
@@ -73,6 +83,7 @@ PlanGate — ゲート型AI駆動開発ワークフローのリポジトリ。
 
 | ドキュメント | パス |
 |---|---|
+| **実行契約（Core Contract）** | **`docs/ai/core-contract.md`**（Iron Law / Stop rules / Output discipline の正本） |
 | PlanGate ワークフロー（v5 現行） | `docs/plangate.md` |
 | PlanGate v6 ロードマップ | `docs/plangate-v6-roadmap.md` |
 | **PlanGate v7 ハイブリッドアーキテクチャ** | `docs/plangate-v7-hybrid.md` |

--- a/docs/working/TASK-0039/status.md
+++ b/docs/working/TASK-0039/status.md
@@ -7,9 +7,9 @@
 - **対象 Issue**: [#117](https://github.com/s977043/plangate/issues/117)
 - **親 PBI**: [PBI-116](../PBI-116/parent-plan.md)
 - **子 PBI ID**: PBI-116-01
-- **ブランチ**: `feat/PBI-116-01-impl-step1-2`（Step 1+2 のみ）
+- **ブランチ**: `feat/PBI-116-01-impl-pr-a`（Step 5 → 3 → 4）
 - **モード**: high-risk
-- **状態**: exec 中（Step 1+2 完了、Step 3-6 は次セッション）
+- **状態**: exec 中（PR #132 で Step 1+2 完了、本 PR で Step 3-5 完了、Step 6-8 は次 PR）
 
 ## C-3 Gate: APPROVED
 
@@ -25,7 +25,31 @@
 
 ⏳ Step 3-6（既存ファイル薄型化）は次セッションで別 PR に分割
 
-## 完了タスク（本 PR スコープ）
+## PR-A 成果（Step 5 → 3 → 4）
+
+### Step 5: project-rules.md 整合
+- [x] T-15: Core Contract 参照と「正本責務の境界」セクション追加（A' セクション + G 参照表）
+
+### Step 3: CLAUDE.md 薄型化
+- [x] T-9: baseline 記録（43 行、`evidence/baseline.md`）
+- [x] T-10: 書き換え（参照テーブル → 短い箇条書き、`<law>` 全文維持）
+- [x] T-11: **21 行達成**（baseline 43 → 51% 削減、目標 22 以下 ✅）
+
+### Step 4: AGENTS.md 薄型化
+- [x] T-12: baseline 記録（61 行）
+- [x] T-13: 書き換え（表 2 つ → 短い箇条書き、Progressive Disclosure 表は working-context.md 参照に統合）
+- [x] T-14: **29 行達成**（baseline 61 → 52% 削減、目標 30 以下 ✅）
+
+### リンク到達性検証
+- [x] CLAUDE.md / AGENTS.md の全参照リンクが解決可能（手動 ls で確認）
+
+## PR-B で実施（次 PR）
+
+- T-16〜T-20: Step 6 hard-mandate 削減
+- T-21〜T-24: Step 7 検証（grep / wc / lint）→ evidence/verification.md
+- T-25〜T-28: Step 8 handoff + 子 PR
+
+## 旧: 完了タスク（PR #132 = Step 1+2）
 
 ### 準備
 - [x] T-1: Scope/受入基準の再確認


### PR DESCRIPTION
## Summary

Codex 相談で推奨された順序（**Step 5 → Step 3 → Step 4**）に従い、入口ファイル（\`project-rules.md\` / \`CLAUDE.md\` / \`AGENTS.md\`）の薄型化と参照整合を実施。**削減目標を両ファイル単独で達成**。

## 削減実績

| ファイル | baseline | 結果 | 削減率 | 目標（C-2 EX-03） |
|---------|---------|------|------|------|
| \`CLAUDE.md\` | 43 行 | **21 行** | **-51%** | 22 以下 ✅ |
| \`AGENTS.md\` | 61 行 | **29 行** | **-52%** | 30 以下 ✅ |

## Step 5: project-rules.md 整合

- 「**A'. 正本責務の境界**」セクション新設（Codex CC-01 対応）
- G 参照表の最上段に **Core Contract** を追加

## Step 3: CLAUDE.md 薄型化（43 → 21 行）

- 参照テーブル → 短い箇条書き
- 「迷ったらの判断基準」削除（Core Contract 参照で代替）
- **\`<law>\` 全文（AI 運用 4 原則）は維持**（Stop rule 遵守）

## Step 4: AGENTS.md 薄型化（61 → 29 行）

- 「コンテキスト読み込みプロトコル」表を削除（\`.claude/rules/working-context.md\` 参照に統合）
- Codex 固有参照テーブル → 箇条書き
- 読み順序を 4 → 3 ステップに簡略化

## Stop rule 該当なし

| Step | 結果 |
|------|------|
| Step 3 (\`<law>\` 維持 + 22 行) | ✅ 21 行で両立 |
| Step 4 (.codex 読み込み順序) | ✅ 矛盾なし |
| Step 5 (責務境界一意定義) | ✅ A' セクション |

## 次 PR-B

Step 6 hard-mandate 削減 / Step 7 検証 / Step 8 handoff + 子 PR

## Test plan

- [ ] \`wc -l CLAUDE.md AGENTS.md\` が 21 / 29
- [ ] \`<law>\` セクション内に AI 運用 4 原則が全文残存
- [ ] CLAUDE.md / AGENTS.md の全リンクが解決可能
- [ ] \`docs/ai/project-rules.md\` A' セクションで責務境界明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)