### PR TITLE
feat(orchestrator): PBI-116-02 (#118) Model Profile preparatory + plan/todo/test-cases

### DIFF
--- a/docs/working/TASK-0040/INDEX.md
+++ b/docs/working/TASK-0040/INDEX.md
@@ -1,0 +1,50 @@
+# TASK-0040 INDEX
+
+> Progressive Disclosure 用索引（Level 0、常時読み込み対象）
+
+## 基本情報
+
+| 項目 | 値 |
+|------|---|
+| TASK ID | TASK-0040 |
+| 子 PBI ID | PBI-116-02 |
+| Issue | [#118](https://github.com/s977043/plangate/issues/118) |
+| Title | Model Profile layer 追加（実行モデル別 reasoning / verbosity / context policy） |
+| 親 PBI | [PBI-116](../PBI-116/parent-plan.md) |
+| Mode | standard |
+| Phase | **C3-WAIT**（preparatory + plan/todo/test-cases 完了、C-2 Codex → Child C-3 ゲート待ち） |
+| 起票 | 2026-04-30 |
+
+## 現在のフェーズ
+
+⏳ **Child C-3 ゲート待ち**（C-1 完了、C-2 Codex は次セッション）
+
+## ファイル一覧
+
+| ファイル | 状態 |
+|---------|------|
+| `pbi-input.md` | ✅ 作成済（Issue #118 を構造化、interface-preflight 参照） |
+| `INDEX.md` | ✅ 本ファイル |
+| `current-state.md` | ✅ 作成済 |
+| `plan.md` | ✅ 作成済（Mode: standard、Step 1-4） |
+| `todo.md` | ✅ 作成済（2-5 分粒度） |
+| `test-cases.md` | ✅ 作成済 |
+| `review-self.md` | ✅ C-1 完了 |
+| `review-external.md` | ⏳ C-2 Codex（次セッション） |
+| `approvals/c3.json` | ⏳ Child C-3（人間判断） |
+| `status.md` | ⏳ exec 開始時 |
+| `handoff.md` | ⏳ WF-05 時 |
+| `evidence/` | ✅ 空（exec 時に inventory.md / verification.md） |
+
+## ネクストアクション
+
+1. ✅ 本 PR の C-4 ゲート（Gemini レビュー対応 + マージ）
+2. ⏳ C-2 Codex 外部AIレビュー（次セッション）
+3. ⏳ Child C-3 ゲート判断 👤
+4. ⏳ exec 開始（model-profiles.yaml + 4 プロファイル定義）→ L-0 → V-1〜V-3 → 子 PR → Child C-4
+
+## 並行実行関係（Codex Phase 2 戦略）
+
+- 順序: PBI-116-02 (本 TASK) → PBI-116-06 → PBI-116-04
+- Interface preflight: [`docs/working/PBI-116/interface-preflight.md`](../PBI-116/interface-preflight.md)
+- 02 と 06 の `tool_policy` / `validation_bias` 接続点は事前合意済み

--- a/docs/working/TASK-0040/current-state.md
+++ b/docs/working/TASK-0040/current-state.md
@@ -1,0 +1,35 @@
+# TASK-0040 Current State
+
+> 「今どこにいて、次に何をするか」のスナップショット
+
+## 現在のフェーズ
+
+**C3-WAIT**（preparatory + plan/todo/test-cases + C-1 完了、Child C-3 ゲート待ち）
+
+## 完了済
+
+- [x] 親 PBI PBI-116 Phase 1 (PBI-116-01) 完了（PR #126〜#135 マージ済）
+- [x] Phase 2 戦略 Codex 相談で確定（PR #136）
+- [x] interface-preflight.md 合意（02 と 06 の tool_policy 接続点）
+- [x] 本 TASK preparatory（pbi-input.md / INDEX.md / current-state.md）
+- [x] 本 TASK plan/todo/test-cases 作成
+- [x] C-1 セルフレビュー（17 項目）
+
+## ブロッカー
+
+なし（C-2 Codex 待ち、その後 Child C-3）
+
+## 次のアクション
+
+1. 本 PR C-4 ゲート（Gemini レビュー対応 → マージ）
+2. C-2 Codex 外部AIレビュー（次セッション）
+3. Child C-3 ゲート判断 👤
+4. APPROVED 後 exec 開始
+
+## 参照
+
+- 親 PBI: [`docs/working/PBI-116/parent-plan.md`](../PBI-116/parent-plan.md)
+- 子 PBI YAML: [`docs/working/PBI-116/children/PBI-116-02.yaml`](../PBI-116/children/PBI-116-02.yaml)
+- Issue: https://github.com/s977043/plangate/issues/118
+- Interface preflight: [`docs/working/PBI-116/interface-preflight.md`](../PBI-116/interface-preflight.md)
+- Phase 1 成果（基盤）: [`docs/ai/core-contract.md`](../../ai/core-contract.md)

--- a/docs/working/TASK-0040/pbi-input.md
+++ b/docs/working/TASK-0040/pbi-input.md
@@ -1,0 +1,123 @@
+# PBI INPUT PACKAGE — TASK-0040 (PBI-116-02 / Issue #118)
+
+> **Status**: C-1 完了 / C-2 Codex 待ち / Child C-3 ゲート待ち
+> 親 PBI: [PBI-116](../PBI-116/parent-plan.md) / Phase 2 / Codex 戦略採用順序の **1 番目**
+> Issue: [#118 Model Profile layer 追加（実行モデル別 reasoning / verbosity / context policy）](https://github.com/s977043/plangate/issues/118)
+> Mode: standard
+> Interface preflight: [`docs/working/PBI-116/interface-preflight.md`](../PBI-116/interface-preflight.md)
+
+## Context / Why
+
+PlanGate の Core Contract（[`docs/ai/core-contract.md`](../../ai/core-contract.md)、Phase 1 成果）と Gate 条件はモデル非依存であるべきだが、実行モデルごとに最適な runtime parameter は異なる。
+
+特に、GPT-5.5 / GPT-5.5 Pro / Mini / legacy model では、reasoning effort、verbosity、context budget、tool policy、validation depth の適切な初期値が変わる。これをプロンプト全文の分岐で吸収すると、保守負荷が高くなり、Gate 条件のズレやルール更新漏れが起きやすい。
+
+本 PBI では、モデル差分を `model-profiles.yaml` のような薄い設定層に閉じ込め、PlanGate Core を共通に保ったまま、実行モデルに応じた安全な制御を可能にする。
+
+## What
+
+### In scope
+
+1. **Model Profile schema の定義**
+
+   設定項目:
+   - `family`: gpt-5 / gpt-5-pro / gpt-5-mini / legacy
+   - `role`: default_reasoning / advanced_reasoning / fast_lightweight / unknown
+   - `reasoning_effort_by_mode`: ultra_light / light / standard / high_risk / critical 各モードでの effort 値
+   - `verbosity_by_phase`: classify / plan / execute / review / handoff 各 phase での verbosity 値
+   - `max_context_policy`: compact / standard / expanded
+   - **`tool_policy`**: `narrow` / `allowed_tools_by_phase` / `expanded`（interface-preflight 合意）
+   - **`validation_bias`**: `lenient` / `normal` / `strict`（interface-preflight 合意）
+   - `structured_outputs`: bool
+   - `adapter`: outcome_first / outcome_first_strict / explicit_short / legacy_or_unknown
+
+2. **4 プロファイル定義**
+   - `gpt-5_5`: 標準実行モデル
+   - `gpt-5_5_pro`: 強力推論モデル
+   - `gpt-5_mini`: 高速軽量モデル
+   - `legacy_or_unknown`: フォールバック
+
+3. **PlanGate 5 mode と reasoning effort のマッピング**
+
+   | PlanGate mode | gpt-5_5 | gpt-5_5_pro | gpt-5_mini | legacy_or_unknown |
+   |---|---|---|---|---|
+   | ultra-light | low | low | low | low |
+   | light | low | low/medium | low | low |
+   | standard | medium | medium/high | low/medium | medium |
+   | high-risk | high | high | medium 推奨外 | high |
+   | critical | high | high/xhigh | disallow | high |
+
+4. **phase 別 verbosity の定義**
+
+   - classify: low / plan: medium / execute: low / review: medium-high / handoff: medium
+
+5. **context budget policy の定義**
+
+   - compact / standard / expanded（用途・コスト・品質のトレードオフ）
+
+### Out of scope
+
+- モデル別プロンプト全文の fork（→ PBI-116-03 Prompt Assembly で対応）
+- provider 実行ランタイムの大規模改修
+- eval runner の実装（→ PBI-116-05 Eval Cases で対応）
+- Structured Outputs schema の実装詳細（→ PBI-116-04 で対応）
+- Tool Policy の実 tool 列挙（→ PBI-116-06 で対応、本 PBI は値域定義のみ）
+
+## 受入基準
+
+- [ ] AC-1: `model-profiles.yaml` または同等のドキュメント（`docs/ai/model-profiles.yaml` + `docs/ai/model-profiles.md`）が追加されている
+- [ ] AC-2: GPT-5.5 / Pro / Mini / legacy_or_unknown のプロファイルが定義されている（4 件すべて）
+- [ ] AC-3: reasoning effort が PlanGate mode 別に定義されている（5 mode × 4 profile マトリクス）
+- [ ] AC-4: verbosity が phase 別に定義されている（5 phase × 4 profile）
+- [ ] AC-5: context budget policy が compact / standard / expanded 等で定義されている
+- [ ] AC-6: critical mode で小型/高速モデル (gpt-5_mini) を disallow できる方針がある
+- [ ] AC-7: Core Contract / Gate / Artifact schema はモデル別に変えないことが明記されている
+- [ ] AC-8: `tool_policy` / `validation_bias` 値域が interface-preflight.md と整合している（PBI-116-06 と接続可能）
+
+## Notes from Refinement
+
+- **Phase 2 戦略**: Codex 相談で確定（PR #136 / interface-preflight.md）
+- **着手順序**: 本 TASK が Phase 2 の最初（PBI-116-06 の前提となる schema 確立）
+- **接続合意**: 02 (本 TASK) が `tool_policy` / `validation_bias` の値域を定義、06 がそれを参照して実 tool 列挙
+
+## Estimation Evidence
+
+### Risks
+
+| ID | Risk | Severity | Mitigation |
+|----|------|---------|----------|
+| L1 | tool_policy / validation_bias の値域が PBI-116-06 と乖離 | medium | interface-preflight.md 準拠（既に合意済）、plan.md で値域を明示転記 |
+| L2 | reasoning effort × mode マトリクスの値が実モデル挙動と乖離 | medium | 設計段階で確定、検証は PBI-116-05 (Eval Cases) で実施 |
+| L3 | schema YAML が既存 `schemas/` と命名衝突 | low | `docs/ai/model-profiles.yaml` 配置、`schemas/model-profile.schema.json` で別配置 |
+| L4 | プロファイル定義が大きくなり保守負荷増 | low | 4 プロファイルに限定、追加は別 PBI |
+
+### Unknowns
+
+- Q1: `model-profiles.yaml` を YAML / JSON Schema どちらで本体定義するか？
+  - A1: YAML（人間可読性優先）+ JSON Schema を `schemas/model-profile.schema.json` に併設
+- Q2: `gpt-5_5_pro` の `reasoning_effort` で `xhigh` を採用するか？
+  - A2: critical mode で `high/xhigh` 候補表現で柔軟性を持たせる
+- Q3: `gpt-5_mini` を critical mode で `disallow` する強制方法は？
+  - A3: profile レベルで `disallowed_modes: [critical]` を許容、解決は PBI-116-03 Prompt Assembly で
+
+### Assumptions
+
+- Phase 1 成果（Core Contract）がモデル非依存であることを前提
+- interface-preflight.md の合意が PBI-116-06 でも維持される
+- 本 PBI は doc-only（実装は YAML / Markdown のみ、コード変更なし）
+- Plugin 配布版との同期は本 PBI scope 外（V2 候補）
+
+## Parent PBI との関係
+
+| 親 AC | 本 PBI でのカバー |
+|------|-----------------|
+| parent-AC-2 | Model Profile として設定化（直接対応） |
+
+## 関連リンク
+
+- 親計画: [`docs/working/PBI-116/parent-plan.md`](../PBI-116/parent-plan.md)
+- 子 PBI YAML: [`docs/working/PBI-116/children/PBI-116-02.yaml`](../PBI-116/children/PBI-116-02.yaml)
+- Issue: https://github.com/s977043/plangate/issues/118
+- Interface preflight: [`docs/working/PBI-116/interface-preflight.md`](../PBI-116/interface-preflight.md)
+- Codex Phase 2 戦略: [`docs/working/PBI-116/_codex-phase2-consult-result.md`](../PBI-116/_codex-phase2-consult-result.md)
+- Phase 1 成果（基盤）: [`docs/ai/core-contract.md`](../../ai/core-contract.md)

--- a/docs/working/TASK-0040/plan.md
+++ b/docs/working/TASK-0040/plan.md
@@ -1,0 +1,152 @@
+# EXECUTION PLAN — TASK-0040 (PBI-116-02 / Issue #118)
+
+> 親 PBI: [PBI-116](../PBI-116/parent-plan.md) / Parent C-3 APPROVED（PR #128）/ Phase 2 戦略確定（PR #136）
+> Issue: [#118 Model Profile layer 追加](https://github.com/s977043/plangate/issues/118)
+> Mode: **standard**
+
+## Goal
+
+GPT-5.5 系の実行モデルごとの差分（reasoning effort / verbosity / context budget / tool policy / validation depth）を **`docs/ai/model-profiles.yaml`** という薄い設定層に閉じ込める。PlanGate Core はモデル非依存で維持し、4 プロファイル（gpt-5_5 / gpt-5_5_pro / gpt-5_mini / legacy_or_unknown）を定義する。
+
+## Constraints / Non-goals
+
+### Constraints
+
+- Core Contract / Gate / Artifact schema は変更しない（モデル非依存維持）
+- `tool_policy` / `validation_bias` の値域は [`interface-preflight.md`](../PBI-116/interface-preflight.md) に準拠
+- 既存 `schemas/` 配下のスキーマと命名衝突しない
+- doc-only PBI（コード変更なし、YAML + Markdown のみ）
+
+### Non-goals
+
+- モデル別プロンプト全文の fork（→ PBI-116-03）
+- provider 実行ランタイム改修
+- eval runner 実装（→ PBI-116-05）
+- Structured Outputs schema 詳細（→ PBI-116-04）
+- Tool Policy の実 tool 列挙（→ PBI-116-06）
+
+## Approach Overview
+
+4 ステップで進める:
+
+1. schema 定義（Markdown + JSON Schema）
+2. 4 プロファイル定義（YAML）
+3. mode × profile マトリクス + verbosity / context budget policy 表
+4. 検証（schema-validate / リンク到達性）+ handoff
+
+## Work Breakdown (Steps)
+
+### Step 1: schema 定義
+
+- **Output**: `docs/ai/model-profiles.md`（schema 仕様 Markdown）+ `schemas/model-profile.schema.json`（JSON Schema）
+- **Owner**: agent
+- **Risk**: 低
+- 🚩 チェックポイント: schema フィールド全 9 種（family / role / reasoning_effort_by_mode / verbosity_by_phase / max_context_policy / tool_policy / validation_bias / structured_outputs / adapter）が定義され、interface-preflight.md と整合
+
+### Step 2: 4 プロファイル定義
+
+- **Output**: `docs/ai/model-profiles.yaml`
+- **Owner**: agent
+- **Risk**: 中（reasoning effort 値の妥当性）
+- 🚩 チェックポイント: 4 プロファイル（gpt-5_5 / gpt-5_5_pro / gpt-5_mini / legacy_or_unknown）が schema 準拠で定義
+
+### Step 3: マトリクス + verbosity + context budget
+
+- **Output**: `docs/ai/model-profiles.md` 内に 3 表追加
+- **Owner**: agent
+- **Risk**: 低
+- 🚩 チェックポイント:
+  - reasoning_effort × mode × profile の 5×4 マトリクス完備
+  - verbosity_by_phase × profile の 5×4 表完備
+  - context_budget_policy 3 段階定義
+  - critical mode で gpt-5_mini disallow の方針明記
+
+### Step 4: 検証 + handoff
+
+- **Output**: `evidence/verification.md` + `handoff.md` + 子 PR
+- **Owner**: agent
+- **Risk**: 低
+- 🚩 チェックポイント:
+  - YAML が schema-validate で PASS
+  - 受入基準 8 項目すべて確認
+  - interface-preflight.md と整合（tool_policy / validation_bias 値域一致）
+
+## Files / Components to Touch
+
+### 新規作成
+
+- `docs/ai/model-profiles.md`（schema 仕様 + マトリクス）
+- `docs/ai/model-profiles.yaml`（4 プロファイル定義）
+- `schemas/model-profile.schema.json`（JSON Schema）
+- `docs/working/TASK-0040/evidence/verification.md`
+- `docs/working/TASK-0040/handoff.md`
+
+### 触らない（forbidden_files、PBI-116-02.yaml 準拠）
+
+- `CLAUDE.md`, `AGENTS.md`
+- `.claude/rules/**`, `.claude/commands/**`, `.claude/agents/**`
+- `plugin/plangate/**`
+- `bin/**`
+- `.github/workflows/**`
+- 既存 `schemas/*.schema.json`（model-profile.schema.json は新規追加のみ）
+
+## Testing Strategy
+
+### Unit
+- 該当なし（doc-only）
+
+### Integration
+- **Markdown lint**: 全更新ファイルで 0 error
+- **schema-validate**: `model-profiles.yaml` を `schemas/model-profile.schema.json` で validate（手動 or jsonschema cli）
+
+### E2E
+- 該当なし（実装なし）
+
+### Edge cases
+- profile に未知の値が含まれる場合の schema validation
+- mode × profile マトリクスの欠損セル検出
+
+### Verification Automation
+- `python -m jsonschema -i docs/ai/model-profiles.yaml schemas/model-profile.schema.json`（または yajsv 等）
+- `grep -E "^(gpt-5_5|gpt-5_5_pro|gpt-5_mini|legacy_or_unknown):"`  で 4 プロファイル存在確認
+
+## Risks & Mitigations
+
+| ID | Risk | Severity | Mitigation |
+|----|------|----------|-----------|
+| L1 | tool_policy / validation_bias の値域が PBI-116-06 と乖離 | medium | interface-preflight.md 準拠、plan.md で値域明示 |
+| L2 | reasoning effort × mode マトリクス値が実モデル挙動と乖離 | medium | 設計段階で確定、検証は PBI-116-05 で |
+| L3 | schema YAML が既存 schemas/ と命名衝突 | low | `model-profile.schema.json` で命名独立 |
+| L4 | プロファイル定義が大きくなり保守負荷増 | low | 4 プロファイルに限定、追加は別 PBI |
+
+## Questions / Unknowns
+
+- Q1: schema は YAML / JSON どちらで本体定義？
+  - A1: YAML（人間可読性）+ JSON Schema 併設
+- Q2: `xhigh` reasoning_effort 採用？
+  - A2: `high/xhigh` 候補表現で柔軟性
+- Q3: gpt-5_mini の critical mode disallow 強制方法？
+  - A3: `disallowed_modes: [critical]` フィールド追加
+
+## Mode判定
+
+**モード**: **standard**
+
+判定根拠:
+- 変更ファイル数: 3-5（新規のみ、既存ファイル変更なし）→ standard
+- 受入基準数: 8 → standard
+- 変更種別: doc-only（YAML + Markdown + JSON Schema） → light/standard
+- リスク: 中（schema 設計の妥当性）→ standard
+- ロールバック: PR revert で容易 → standard
+- **最終判定**: **standard**（子 PBI YAML PBI-116-02 mode と整合）
+
+## Stop rules
+
+各 Step で以下が発生した場合は即停止し、ユーザー確認を求める:
+
+| Step | Stop trigger |
+|------|------------|
+| Step 1 | schema フィールドが interface-preflight.md と乖離 |
+| Step 2 | プロファイル値が plan.md 仕様から逸脱 |
+| Step 3 | mode × profile マトリクスに矛盾発生 |
+| Step 4 | schema-validate が FAIL、または受入基準 8 項目に未達 |

--- a/docs/working/TASK-0040/review-self.md
+++ b/docs/working/TASK-0040/review-self.md
@@ -1,0 +1,117 @@
+# C-1 SELF REVIEW — TASK-0040 (PBI-116-02 / Issue #118)
+
+> 17 項目セルフレビュー。各項目を PASS / WARN / FAIL で判定。
+
+## サマリ
+
+| 区分 | PASS | WARN | FAIL |
+|------|------|------|------|
+| Plan（7 項目） | 7 | 0 | 0 |
+| ToDo（5 項目） | 5 | 0 | 0 |
+| TestCases（5 項目） | 5 | 0 | 0 |
+| **合計（17 項目）** | **17** | **0** | **0** |
+
+**総合判定**: **PASS**
+
+## Plan チェック（7 項目）
+
+### C1-PLAN-01: 受入基準網羅性
+- **判定**: PASS
+- **根拠**: pbi-input AC-1〜AC-8 が plan.md / test-cases.md に完全マッピング
+
+### C1-PLAN-02: Unknowns 処理
+- **判定**: PASS
+- **根拠**: Q1〜Q3 を提示、A1〜A3 で初期方針記述
+
+### C1-PLAN-03: スコープ制御
+- **判定**: PASS
+- **根拠**: Constraints / Non-goals 明示。子 PBI YAML の forbidden_files と整合。「Tool Policy 実装は PBI-116-06」「Prompt Assembly は PBI-116-03」と他 PBI への分離明示
+
+### C1-PLAN-04: テスト戦略
+- **判定**: PASS
+- **根拠**: schema-validate / grep / 目視 / negative test までカバー
+
+### C1-PLAN-05: Work Breakdown Output
+- **判定**: PASS
+- **根拠**: Step 1-4 各々に具体的 Output（schema.json / .md / .yaml / verification.md / handoff.md）明記
+
+### C1-PLAN-06: 依存関係
+- **判定**: PASS
+- **根拠**: Step 1 (schema) → 2 (profile) → 3 (matrix) → 4 (verify) の順序が記述
+
+### C1-PLAN-07: 動作検証自動化
+- **判定**: PASS
+- **根拠**: schema-validate (jsonschema CLI) / grep / 目視の組み合わせ。自動化率 9/12
+
+## ToDo チェック（5 項目）
+
+### C1-TODO-01: タスク粒度（必須）
+- **判定**: PASS
+- **根拠**: T-1〜T-23 が各 2-5 分粒度（schema フィールド追加 / プロファイル 1 件定義 / 表 1 つ追加 等）
+
+### C1-TODO-02: depends_on 設定（必須）
+- **判定**: PASS
+- **根拠**: 全 23 タスクに depends_on 明記
+
+### C1-TODO-03: チェックポイント設定（推奨）
+- **判定**: PASS
+- **根拠**: 全タスクに 🚩 マーク
+
+### C1-TODO-04: Iron Law 遵守（必須）
+- **判定**: PASS
+- **根拠**: todo.md 冒頭で Iron Law 明示、スコープ外作業禁止を明記
+
+### C1-TODO-05: 完了条件（推奨）
+- **判定**: PASS
+- **根拠**: 各タスクに動詞 + 対象 + 完了確認方法（schema.json 完成 / プロファイル定義 / lint 0 error 等）
+
+## TestCases チェック（5 項目）
+
+### C1-TC-01: 受入基準との紐付き（必須）
+- **判定**: PASS
+- **根拠**: AC-1〜AC-8 が TC-1〜TC-9 にマッピング、抜け漏れなし
+
+### C1-TC-02: Edge case 網羅（必須）
+- **判定**: PASS
+- **根拠**: TC-E1〜TC-E3 定義（schema-validate PASS / negative test / 命名衝突）
+
+### C1-TC-03: 自動化可否（推奨）
+- **判定**: PASS
+- **根拠**: 自動化サマリで全 TC を完全/部分/不可で分類
+
+### C1-TC-04: 検証コマンド明示
+- **判定**: PASS
+- **根拠**: 各 TC に grep / ls / jsonschema コマンド明記
+
+### C1-TC-05: 期待出力の具体性
+- **判定**: PASS
+- **根拠**: 「20 セル全埋め」「3 段階すべてヒット」「PASS / FAIL」など具体値
+
+## 総合判定
+
+**判定**: **PASS**
+
+### 根拠サマリ
+- 17 項目すべて PASS（Phase 1 PBI-116-01 と同等の品質、interface-preflight 合意により WARN 解消）
+- スコープ・依存・テスト戦略の全てで重大な欠陥なし
+
+### Child C-3 ゲートへの推奨
+
+- **APPROVE 候補**: 計画品質は exec 開始可能なレベル
+- **CONDITIONAL の場合の指摘候補**: なし（特に懸念点なし）
+- **REJECT 候補**: なし
+
+### 次の必須ステップ
+
+1. C-2 外部AIレビュー（Codex 推奨、standard モードでは optional だが安全のため実施）— 次セッション
+2. Child C-3 ゲート判断 — 👤 ユーザー
+3. APPROVED 後 exec 開始
+
+## メタ情報
+
+| 項目 | 値 |
+|------|---|
+| レビュー対象 | plan.md / todo.md / test-cases.md |
+| レビュー実施者 | Claude (self-review) |
+| 実施日 | 2026-04-30 |
+| 17 項目チェックリスト出典 | docs/ai-driven-development.md / .claude/rules/working-context.md |

--- a/docs/working/TASK-0040/test-cases.md
+++ b/docs/working/TASK-0040/test-cases.md
@@ -1,0 +1,101 @@
+# TEST CASES — TASK-0040 (PBI-116-02 / Issue #118)
+
+> doc-only PBI のため、テストケースは schema-validate / grep / リンク到達性 / 表完備性が中心。
+
+## 受入基準 → テストケース マッピング
+
+| 受入基準 | TC ID | 種別 |
+|---------|------|------|
+| AC-1: model-profiles.yaml/md 追加 | TC-1, TC-2 | 自動（ls）+ doc-review |
+| AC-2: 4 プロファイル定義 | TC-3 | 自動（grep） |
+| AC-3: reasoning effort × mode マトリクス | TC-4 | doc-review + 自動 |
+| AC-4: verbosity × phase 表 | TC-5 | doc-review |
+| AC-5: context budget policy | TC-6 | doc-review |
+| AC-6: critical mode で gpt-5_mini disallow | TC-7 | 自動（grep） |
+| AC-7: Core / Gate / Artifact schema 不変宣言 | TC-8 | doc-review |
+| AC-8: tool_policy / validation_bias 値域整合 | TC-9 | 自動（grep） |
+
+## テストケース一覧
+
+### TC-1: docs/ai/model-profiles.yaml が存在
+- 入力: `ls docs/ai/model-profiles.yaml`
+- 期待: ファイル存在
+- 種別: 自動
+
+### TC-2: docs/ai/model-profiles.md が存在し schema 仕様を含む
+- 入力: `grep -E "^## " docs/ai/model-profiles.md`
+- 期待: schema 仕様 / プロファイル説明 / マトリクスの各セクション
+- 種別: 自動 + doc-review
+
+### TC-3: 4 プロファイル定義
+- 入力: `grep -E "^  (gpt-5_5|gpt-5_5_pro|gpt-5_mini|legacy_or_unknown):" docs/ai/model-profiles.yaml`
+- 期待: 4 件すべてマッチ
+- 種別: 自動
+
+### TC-4: reasoning effort × mode マトリクス
+- 入力: model-profiles.md の該当表を目視確認
+- 期待: 5 mode (ultra-light / light / standard / high-risk / critical) × 4 profile = 20 セル全埋め
+- 種別: doc-review + 自動（テーブル行数 grep）
+
+### TC-5: verbosity × phase 表
+- 入力: 該当表を目視確認
+- 期待: 5 phase (classify / plan / execute / review / handoff) × 4 profile = 20 セル全埋め
+- 種別: doc-review
+
+### TC-6: context budget policy
+- 入力: `grep -E "compact|standard|expanded" docs/ai/model-profiles.md`
+- 期待: 3 段階すべてヒット + 用途説明あり
+- 種別: 自動 + doc-review
+
+### TC-7: critical mode で gpt-5_mini disallow
+- 入力: `grep -A 2 "gpt-5_mini" docs/ai/model-profiles.yaml | grep -E "disallowed_modes|critical"`
+- 期待: `disallowed_modes: [critical]` または同等表現
+- 種別: 自動
+
+### TC-8: Core / Gate / Artifact schema 不変宣言
+- 入力: `grep -E "Core Contract|Gate|Artifact" docs/ai/model-profiles.md`
+- 期待: 「これらはモデル別に変えない」旨の明示
+- 種別: doc-review
+
+### TC-9: tool_policy / validation_bias 値域整合
+- 入力:
+  - `grep -E "narrow|allowed_tools_by_phase|expanded" docs/ai/model-profiles.yaml`
+  - `grep -E "lenient|normal|strict" docs/ai/model-profiles.yaml`
+- 期待: interface-preflight.md と完全一致
+- 種別: 自動 + doc-review
+
+## エッジケース
+
+### TC-E1: schema-validate
+- 入力: `python -m jsonschema -i docs/ai/model-profiles.yaml schemas/model-profile.schema.json`（または yajsv）
+- 期待: PASS
+- 種別: 自動（手動可）
+
+### TC-E2: profile 値域逸脱検出
+- 入力: わざと不正な reasoning_effort 値を入れて schema-validate
+- 期待: FAIL を返す
+- 種別: 自動（手動）
+
+### TC-E3: 既存 schemas/ との命名衝突
+- 入力: `ls schemas/ | grep -i model`
+- 期待: `model-profile.schema.json` のみ（既存と衝突なし）
+- 種別: 自動
+
+## 自動化サマリ
+
+| TC | 自動化可否 |
+|----|----------|
+| TC-1 | ✅ ls |
+| TC-2 | △ grep + 目視 |
+| TC-3 | ✅ grep |
+| TC-4 | △ grep（行数）+ 目視 |
+| TC-5 | ✗ doc-review |
+| TC-6 | △ grep + 目視 |
+| TC-7 | ✅ grep |
+| TC-8 | ✗ doc-review |
+| TC-9 | ✅ grep |
+| TC-E1 | ✅ jsonschema CLI |
+| TC-E2 | ✅ negative test |
+| TC-E3 | ✅ ls |
+
+自動化率: 9/12 が完全 / 部分自動化可能。

--- a/docs/working/TASK-0040/todo.md
+++ b/docs/working/TASK-0040/todo.md
@@ -1,0 +1,64 @@
+# EXECUTION TODO — TASK-0040 (PBI-116-02 / Issue #118)
+
+> [`plan.md`](./plan.md) の Work Breakdown を 2-5 分粒度に分解。
+> Iron Law: `NO SCOPE CHANGE WITHOUT USER APPROVAL`
+
+## 🤖 Agentタスク
+
+### 準備フェーズ
+
+- [ ] 🚩 T-1: Scope/受入基準を再掲し、作業範囲を固定する [Owner: agent] [depends_on: -] [files: -]
+- [ ] 🚩 T-2: interface-preflight.md を再読込し、tool_policy / validation_bias 値域を確認 [Owner: agent] [depends_on: T-1] [files: docs/working/PBI-116/interface-preflight.md]
+
+### 実装フェーズ
+
+#### Step 1: schema 定義
+- [ ] 🚩 T-3: schemas/model-profile.schema.json skeleton 作成（JSON Schema 2020-12 準拠） [Owner: agent] [depends_on: T-2] [files: schemas/model-profile.schema.json]
+- [ ] 🚩 T-4: schema フィールド 9 種を定義（family/role/reasoning_effort_by_mode/verbosity_by_phase/max_context_policy/tool_policy/validation_bias/structured_outputs/adapter） [Owner: agent] [depends_on: T-3] [files: schemas/model-profile.schema.json]
+- [ ] 🚩 T-5: docs/ai/model-profiles.md skeleton 作成（schema 仕様 + 用途説明） [Owner: agent] [depends_on: T-4] [files: docs/ai/model-profiles.md]
+
+#### Step 2: 4 プロファイル定義
+- [ ] 🚩 T-6: docs/ai/model-profiles.yaml skeleton 作成（version + defaults + models セクション） [Owner: agent] [depends_on: T-5] [files: docs/ai/model-profiles.yaml]
+- [ ] 🚩 T-7: gpt-5_5 プロファイル定義 [Owner: agent] [depends_on: T-6] [files: docs/ai/model-profiles.yaml]
+- [ ] 🚩 T-8: gpt-5_5_pro プロファイル定義 [Owner: agent] [depends_on: T-7] [files: docs/ai/model-profiles.yaml]
+- [ ] 🚩 T-9: gpt-5_mini プロファイル定義（disallowed_modes: [critical] 含む） [Owner: agent] [depends_on: T-8] [files: docs/ai/model-profiles.yaml]
+- [ ] 🚩 T-10: legacy_or_unknown プロファイル定義 [Owner: agent] [depends_on: T-9] [files: docs/ai/model-profiles.yaml]
+
+#### Step 3: マトリクス + verbosity + context budget
+- [ ] 🚩 T-11: model-profiles.md に reasoning_effort × mode × profile マトリクス（5×4）追加 [Owner: agent] [depends_on: T-10] [files: docs/ai/model-profiles.md]
+- [ ] 🚩 T-12: model-profiles.md に verbosity_by_phase × profile（5×4）表追加 [Owner: agent] [depends_on: T-11] [files: docs/ai/model-profiles.md]
+- [ ] 🚩 T-13: model-profiles.md に context_budget_policy 3 段階定義追加 [Owner: agent] [depends_on: T-12] [files: docs/ai/model-profiles.md]
+- [ ] 🚩 T-14: critical mode で gpt-5_mini disallow 方針を明記 [Owner: agent] [depends_on: T-13] [files: docs/ai/model-profiles.md]
+
+### 検証フェーズ
+
+- [ ] 🚩 T-15: schema-validate 実行（YAML が JSON Schema を満たすか） [Owner: agent] [depends_on: T-14] [files: -]
+- [ ] 🚩 T-16: markdown lint 実行（全更新ファイル 0 error） [Owner: agent] [depends_on: T-15] [files: -]
+- [ ] 🚩 T-17: interface-preflight.md との整合性確認（tool_policy / validation_bias 値域一致） [Owner: agent] [depends_on: T-16] [files: -]
+- [ ] 🚩 T-18: 受入基準 8 項目の全確認 [Owner: agent] [depends_on: T-17] [files: -]
+- [ ] 🚩 T-19: evidence/verification.md 記録 [Owner: agent] [depends_on: T-18] [files: docs/working/TASK-0040/evidence/verification.md]
+
+### 完了フェーズ
+
+- [ ] 🚩 T-20: handoff.md 作成（必須 6 要素） [Owner: agent] [depends_on: T-19] [files: docs/working/TASK-0040/handoff.md]
+- [ ] 🚩 T-21: status.md 更新 [Owner: agent] [depends_on: T-20] [files: docs/working/TASK-0040/status.md]
+- [ ] 🚩 T-22: コミット作成 [Owner: agent] [depends_on: T-21] [files: -]
+- [ ] 🚩 T-23: push + PR 作成 [Owner: agent] [depends_on: T-22] [files: -]
+
+## 👤 Humanタスク
+
+- [ ] **C-3**: plan/todo/test-cases の人間レビュー（exec 前ゲート） [Owner: human]
+- [ ] **C-4**: PR レビュー・承認（GitHub 上） [Owner: human]
+
+## ⚠️ 依存関係
+
+- 親 PBI Parent C-3: ✅ APPROVED（2026-04-30）
+- Phase 1 (PBI-116-01): ✅ done（Core Contract 確立）
+- 本 TASK Child C-3: ⏳ 待機中（C-2 Codex レビュー後）
+- exec 完了 → L-0 → V-1 → V-2 → V-3 → 子 PR → Child C-4
+
+## タスク粒度ルール
+
+- 各タスク 2-5 分粒度（YAML/Markdown 編集の小単位）
+- スコープ外作業禁止（Iron Law）
+- Stop rule（plan.md 末尾）に該当する状況では即停止


### PR DESCRIPTION
## Summary

**Phase 2 着手の最初の PR**。Codex 戦略採用順序の 1 番目（PBI-116-02 → 06 → 04）。preparatory + plan/todo/test-cases + C-1 を **1 PR に統合**（Codex D5 採用）。

実装には踏み込まない。Child C-3 ゲート前で停止。

## 成果物（7 ファイル / 642 insertions）

| ファイル | 内容 |
|---------|------|
| \`pbi-input.md\` | Issue #118 構造化、interface-preflight 参照、AC 8 項目、Risk L1〜L4 |
| \`INDEX.md\` | Phase: C3-WAIT |
| \`current-state.md\` | ブロッカーなし、C-2 → Child C-3 待ち |
| \`plan.md\` | Mode: standard、Step 1-4（schema → profile → matrix → 検証） |
| \`todo.md\` | T-1〜T-23（2-5 分粒度） |
| \`test-cases.md\` | TC-1〜TC-9 + TC-E1〜TC-E3（自動化率 9/12） |
| \`review-self.md\` | **17 項目すべて PASS**（Phase 1 と同等品質） |

## 設計上の主要決定

| 項目 | 決定 |
|------|------|
| schema 形式 | YAML 本体 + JSON Schema (\`schemas/model-profile.schema.json\`) 併設 |
| プロファイル | gpt-5_5 / gpt-5_5_pro / gpt-5_mini / legacy_or_unknown（4 件） |
| critical mode 制限 | gpt-5_mini に \`disallowed_modes: [critical]\` |
| tool_policy 値域 | \`narrow\` / \`allowed_tools_by_phase\` / \`expanded\`（interface-preflight 準拠） |
| validation_bias 値域 | \`lenient\` / \`normal\` / \`strict\`（interface-preflight 準拠） |
| Mode 判定 | **standard** |

## C-1 セルフレビュー結果

| 区分 | PASS | WARN | FAIL |
|------|------|------|------|
| Plan（7 項目） | 7 | 0 | 0 |
| ToDo（5 項目） | 5 | 0 | 0 |
| TestCases（5 項目） | 5 | 0 | 0 |
| **合計** | **17** | **0** | **0** |

→ **総合 PASS**（Phase 1 で WARN だった手動 E2E は doc-only PBI のため該当せず）

## 次ステップ（次セッション、本 PR マージ後）

1. **C-2 Codex 外部AIレビュー**（standard モードでは optional、安全のため実施）
2. **Child C-3 ゲート判断** 👤
3. APPROVED 後 exec 開始
   - Step 1: \`schemas/model-profile.schema.json\` 新規作成
   - Step 2: \`docs/ai/model-profiles.yaml\` で 4 プロファイル定義
   - Step 3: \`docs/ai/model-profiles.md\` で matrix + verbosity + context budget
   - Step 4: schema-validate / handoff

## Phase 2 進行ステータス

\`\`\`
[Phase 2 開始]
PBI-116-02 (本 PR)         ⏳ 計画完了、C-2 → Child C-3 待ち
PBI-116-06 (#122)          ⏳ 次に着手予定
PBI-116-04 (#120)          ⏳ 並行 / 後追い予定
\`\`\`

## Test plan

- [ ] \`pbi-input.md\` が PBI INPUT PACKAGE 形式 + interface-preflight 参照
- [ ] \`plan.md\` Mode: standard、Step 1-4 + Stop rules
- [ ] \`todo.md\` 2-5 分粒度、Iron Law 明示
- [ ] \`test-cases.md\` AC-1〜AC-8 → TC-1〜TC-9 マッピング
- [ ] \`review-self.md\` 17 項目すべて PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)