### PR TITLE
feat(orchestrator): PBI-116-03 (#119) exec — Prompt Assembly 4 層化

### DIFF
--- a/docs/ai/adapters/explicit_short.md
+++ b/docs/ai/adapters/explicit_short.md
@@ -1,0 +1,47 @@
+# Model Adapter: explicit_short
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の model_adapter / 4 種の 1 つ
+> 想定モデル: **gpt-5_mini**（高速軽量モデル、[`model-profiles.yaml`](../model-profiles.yaml) `gpt-5_mini`）
+
+## Style
+
+- **明示的かつ短い指示**:
+  - outcome の代わりに「具体手順を 1〜3 ステップ」
+  - Success criteria は 1 行で
+  - 探索範囲を抑制（`tool_policy: narrow`）
+- 軽量タスク向け（ultra-light / light モード中心）
+
+## Verbosity
+
+| Phase | verbosity |
+|-------|----------|
+| classify | low |
+| plan | low |
+| execute | low |
+| review | low |
+| handoff | low |
+| approve-wait | （不適用） |
+| verify | low（review 継承）|
+
+すべて `low`（軽量・短文）。
+
+## Output discipline
+
+- 自然言語は短く
+- Markdown 成果物の構造は維持（必須要素は省かない）
+- schema 準拠出力は schema 側で形式強制（プロンプトに JSON 例を埋めない）
+
+## Reasoning
+
+- `reasoning_effort_by_mode`: 全 mode で low（critical 除く）
+- **critical mode は disallowed**（[`model-profiles.yaml`](../model-profiles.yaml) `disallowed_modes: [critical]`）
+
+## 制限
+
+- critical mode タスクには使用不可
+- 探索 / 多段推論を要するタスク（high-risk）には推奨しない（`gpt-5_5` / `gpt-5_5_pro` を使う）
+
+## 関連
+
+- [`model-profiles.yaml`](../model-profiles.yaml) `models.gpt-5_mini`
+- [`tool-policy.md`](../tool-policy.md) `tool_policy: narrow` の射影

--- a/docs/ai/adapters/legacy_or_unknown.md
+++ b/docs/ai/adapters/legacy_or_unknown.md
@@ -1,0 +1,49 @@
+# Model Adapter: legacy_or_unknown
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の model_adapter / 4 種の 1 つ
+> 想定モデル: **legacy_or_unknown**（フォールバック、[`model-profiles.yaml`](../model-profiles.yaml) `legacy_or_unknown`）
+
+## Style
+
+- **安全側に倒す**:
+  - outcome の表現は明示的に（推論能力が低いモデル想定）
+  - Iron Law / Hard constraints はプロンプト本文に再掲（base_contract 参照だけで効かない可能性に備え）
+  - tool_policy は標準（`allowed_tools_by_phase`）
+- 未知モデル / レガシーモデル / プロファイル未設定時のフォールバック
+
+## Verbosity
+
+| Phase | verbosity |
+|-------|----------|
+| classify | low |
+| plan | medium |
+| execute | medium |
+| review | medium |
+| handoff | medium |
+| approve-wait | （不適用） |
+| verify | medium（review 継承）|
+
+→ `gpt-5_5` よりやや冗長（モデル理解力に余裕を持たせる）
+
+## Output discipline
+
+- schema 準拠は維持するが、JSON 出力で多少のずれを許容（`additionalProperties: true` 寄り、ただし機械検証は別 phase で）
+- Markdown 成果物の必須要素は省略しない
+
+## Reasoning
+
+- `reasoning_effort_by_mode`: `gpt-5_5` と同等（low/low/medium/high/high）
+- xhigh は使わない
+
+## フォールバック条件
+
+以下の場合、本 adapter が選択される:
+
+1. `model-profiles.yaml` に該当 profile が見つからない
+2. `family: legacy` 指定
+3. profile.adapter が未指定
+
+## 関連
+
+- [`model-profiles.yaml`](../model-profiles.yaml) `models.legacy_or_unknown`
+- 安全動作優先のため [`hook-enforcement.md`](../hook-enforcement.md) の不変条件強制が特に重要

--- a/docs/ai/adapters/outcome_first.md
+++ b/docs/ai/adapters/outcome_first.md
@@ -1,0 +1,40 @@
+# Model Adapter: outcome_first
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の model_adapter / 4 種の 1 つ
+> 想定モデル: **gpt-5_5**（標準実行モデル、[`model-profiles.yaml`](../model-profiles.yaml) `gpt-5_5`）
+
+## Style
+
+- **outcome 駆動**: Role / Goal / Success criteria / Hard constraints / Decision rules / Available evidence / Stop rules / Output discipline の 8 セクション順守
+- 「やり方」より「達成すべき outcome」を強調
+- モデルに判断余地を残す（細かい手順を縛らない）
+
+## Verbosity
+
+[`model-profiles.yaml`](../model-profiles.yaml) の `gpt-5_5.verbosity_by_phase` 値に従う:
+
+| Phase | verbosity |
+|-------|----------|
+| classify | low |
+| plan | medium |
+| execute | low |
+| review | medium |
+| handoff | medium |
+| approve-wait | （不適用） |
+| verify | medium（review 継承）|
+
+## Output discipline
+
+- Markdown 成果物は `core-contract.md` の Output discipline に従う
+- 機械判定結果は [`structured-outputs.md`](../structured-outputs.md) の schema に準拠
+- Iron Law / 4 原則は重複転記せず、`base_contract` への参照で十分
+
+## Reasoning
+
+- `reasoning_effort_by_mode` は profile 値（low / medium / high）に従う
+- critical mode で xhigh は使わない（`gpt-5_5_pro` の役割）
+
+## 関連
+
+- [`model-profiles.yaml`](../model-profiles.yaml) `models.gpt-5_5`
+- [`prompt-assembly.md`](../prompt-assembly.md) § 5 解決ロジック

--- a/docs/ai/adapters/outcome_first_strict.md
+++ b/docs/ai/adapters/outcome_first_strict.md
@@ -1,0 +1,47 @@
+# Model Adapter: outcome_first_strict
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の model_adapter / 4 種の 1 つ
+> 想定モデル: **gpt-5_5_pro**（強力推論モデル、[`model-profiles.yaml`](../model-profiles.yaml) `gpt-5_5_pro`）
+
+## Style
+
+- `outcome_first` の派生で **検証厳格化**:
+  - 各 Stop rule の検証ログ強制
+  - C-2 / V-3 必須化
+  - 検証 evidence 不足時は明示的に「未検証」と記録
+- 高度な推論を要する high-risk / critical 向け
+
+## Verbosity
+
+| Phase | verbosity |
+|-------|----------|
+| classify | low |
+| plan | medium |
+| execute | low |
+| review | **high**（詳細レビュー）|
+| handoff | medium |
+| approve-wait | （不適用） |
+| verify | high（review 継承）|
+
+## Output discipline
+
+- `outcome_first` と同等 + 検証 evidence の詳細記録
+- review / verify 段階で findings の category / severity を明示
+- [`schemas/review-result.schema.json`](../../../schemas/review-result.schema.json) 準拠厳格
+
+## Reasoning
+
+- `reasoning_effort_by_mode`: standard 以上で high、critical で **xhigh 選択肢あり**（`allowed_efforts: [low, medium, high, xhigh]`）
+- 探索範囲拡張（`tool_policy: expanded`）
+
+## validation_bias: strict
+
+[`hook-enforcement.md`](../hook-enforcement.md) の追加条件 EHS-1〜EHS-3 が適用される:
+- V-3 必須化
+- handoff 必須 6 要素チェック厳格化
+- V-1 fix loop 上限 5 で ABORT
+
+## 関連
+
+- [`model-profiles.yaml`](../model-profiles.yaml) `models.gpt-5_5_pro`
+- [`tool-policy.md`](../tool-policy.md) `tool_policy: expanded` の射影

--- a/docs/ai/contracts/approve-wait.md
+++ b/docs/ai/contracts/approve-wait.md
@@ -1,0 +1,32 @@
+# Phase Contract: approve-wait
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+> **AI 出力なし** — ユーザー承認待ち phase
+
+## Goal
+
+C-3 / Parent C-3 / Child C-3 ゲートの **人間判断を待つ**。AI は本 phase で write tool を一切使わない。
+
+## Success criteria
+
+- `approvals/c3.json` に `c3_status: APPROVED` または `CONDITIONAL` または `REJECTED` が記録される
+- `plan_hash` が記録され、後続の整合性検証に使われる
+
+## Stop rules
+
+- AI が誤って write tool を起動 → Hook で即 block（[`hook-enforcement.md`](../hook-enforcement.md) EH-2）
+- 承認なしに次 phase へ進もうとした → block
+
+## Output discipline
+
+- AI 出力なし（待機状態）
+- ユーザー入力（APPROVED / CONDITIONAL / REJECTED）のみ
+
+## verbosity 不適用
+
+Prompt Assembly の verbosity 解決では本 phase は **不適用**（[`prompt-assembly.md`](../prompt-assembly.md) § 4 schema 互換参照）。
+
+## 関連
+
+- [`tool-policy.md`](../tool-policy.md) — approve-wait phase で write 全禁止
+- [`schemas/c3-approval.schema.json`](../../../schemas/c3-approval.schema.json)

--- a/docs/ai/contracts/classify.md
+++ b/docs/ai/contracts/classify.md
@@ -1,0 +1,28 @@
+# Phase Contract: classify
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の 4 層構造 / phase_contract / 7 phase の 1 つ
+
+## Goal
+
+PBI の規模 / リスク / 影響範囲から **PlanGate 5 mode**（ultra-light / light / standard / high-risk / critical）を判定する。
+
+## Success criteria
+
+- 5 mode のいずれかに分類されている
+- 判定根拠（fileCountEstimate / acceptanceCriteriaCount / changeKind / riskLevel / rollbackComplexity）が記録されている
+- 結果が [`schemas/mode-classification.schema.json`](../../../schemas/mode-classification.schema.json) 準拠
+
+## Stop rules
+
+- 受入基準が曖昧で mode 判定不能 → ユーザーに仕様確定を求めて停止
+- 例外ルール適用（security / schema-change / breaking-api）の判定が割れる → 停止
+
+## Output discipline
+
+- Markdown（plan.md の Mode 判定セクション）+ JSON（mode-classification.json、任意）
+- 根拠を簡潔に列挙（10 行以内）
+
+## 関連
+
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 5 mode 分類正本
+- [`schemas/mode-classification.schema.json`](../../../schemas/mode-classification.schema.json)

--- a/docs/ai/contracts/execute.md
+++ b/docs/ai/contracts/execute.md
@@ -1,0 +1,32 @@
+# Phase Contract: execute
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+
+## Goal
+
+承認済 plan / todo / test-cases に従って実装する。todo の各タスクを 2-5 分粒度で順次実行。
+
+## Success criteria
+
+- todo の全 🤖 Agent タスクが完了
+- 各タスクで test 実行（TDD: RED → GREEN → REFACTOR）
+- scope 外ファイルへの編集ゼロ（[`tool-policy.md`](../tool-policy.md) allowed_files 準拠）
+- Iron Law: `NO SCOPE CHANGE WITHOUT USER APPROVAL`
+
+## Stop rules
+
+- scope 外作業が必要と判明 → 即停止、ユーザー確認
+- test FAIL の root cause が不明 → 停止（Iron Law #6: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION）
+- plan_hash 改竄検知 → block（[`hook-enforcement.md`](../hook-enforcement.md) EH-3）
+- 承認なし production code 編集要求 → block（EH-1）
+
+## Output discipline
+
+- 実装コード（`allowed_files` glob 内のみ）
+- コミット履歴（チェックポイント単位）
+- status.md にリアルタイム進捗
+
+## 関連
+
+- [`tool-policy.md`](../tool-policy.md) — exec phase の allowed tools
+- [`hook-enforcement.md`](../hook-enforcement.md) EH-1 / EH-3 / EH-6

--- a/docs/ai/contracts/handoff.md
+++ b/docs/ai/contracts/handoff.md
@@ -1,0 +1,36 @@
+# Phase Contract: handoff
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+> WF-05 Verify & Handoff の出力 phase
+
+## Goal
+
+PBI 完了時に **必須 6 要素** を含む `handoff.md` を発行する。次の担当者が 5 分で状況把握できるサマリ。
+
+## Success criteria
+
+必須 6 要素すべて記述（[`schemas/handoff-summary.schema.json`](../../../schemas/handoff-summary.schema.json) 準拠）:
+
+1. **要件適合確認結果**（AC × 判定）
+2. **既知課題一覧**（Severity / open or closed）
+3. **V2 候補**（次 PBI への引き継ぎ）
+4. **妥協点**（選んだ実装と諦めた代替）
+5. **引き継ぎ文書**（5 分サマリ + 触らないファイル + 次のステップ）
+6. **テスト結果サマリ**（layer × decision）
+
+## Stop rules
+
+- 必須 6 要素のいずれかが未記述 → block（[`hook-enforcement.md`](../hook-enforcement.md) EHS-2）
+- AC FAIL が open のまま完了扱い → 停止（Iron Law #4: 失敗を隠さない）
+- WARN が evidence なしで完了扱い → 停止
+
+## Output discipline
+
+- `docs/working/TASK-XXXX/handoff.md`（Markdown 本文）
+- handoff-summary.json（schema 準拠メタ、任意）
+
+## 関連
+
+- [`docs/working/templates/handoff.md`](../../working/templates/handoff.md) — テンプレ
+- [`schemas/handoff-summary.schema.json`](../../../schemas/handoff-summary.schema.json)
+- [`.claude/rules/working-context.md`](../../../.claude/rules/working-context.md) — handoff 必須化（Rule 5）

--- a/docs/ai/contracts/plan.md
+++ b/docs/ai/contracts/plan.md
@@ -1,0 +1,29 @@
+# Phase Contract: plan
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+
+## Goal
+
+PBI INPUT PACKAGE から `plan.md` / `todo.md` / `test-cases.md` を生成する。「作文」ではなく「実行可能な計画」。
+
+## Success criteria
+
+- Goal / Constraints / Approach Overview / Work Breakdown / Files / Testing Strategy / Risks / Mode 判定がすべて含まれる
+- todo.md は 2-5 分粒度、depends_on / Owner / files が全タスクに記述
+- test-cases.md は AC → TC マッピングと自動化可否
+- Iron Law: `NO EXECUTION WITHOUT REVIEWED PLAN FIRST`
+
+## Stop rules
+
+- 受入基準が plan / test-cases に完全カバーできない → ユーザーに仕様確認
+- scope 外作業が必要と判明 → 別 PBI として起票し、本 PBI では扱わない
+
+## Output discipline
+
+- Markdown 3 ファイル（plan / todo / test-cases）
+- frontmatter 不要（schema 化は plan-output 等で別 PBI）
+
+## 関連
+
+- [`docs/working/templates/`](../../working/templates/) テンプレ
+- [`schemas/plan.schema.json`](../../../schemas/plan.schema.json)（既存 frontmatter schema）

--- a/docs/ai/contracts/review.md
+++ b/docs/ai/contracts/review.md
@@ -1,0 +1,29 @@
+# Phase Contract: review
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+> Prompt Assembly では `verify`（受入確認）から分離し、**設計品質レビュー** に特化
+
+## Goal
+
+実装の **設計品質**（可読性 / 保守性 / 拡張性 / セキュリティ / Plugin 同期）をレビューする。受入基準の機械突合は `verify` phase で実施。
+
+## Success criteria
+
+- 設計品質の判定（PASS / WARN / FAIL）が記録
+- findings が [`schemas/review-result.schema.json`](../../../schemas/review-result.schema.json) 準拠
+- C-1 セルフレビュー（17 項目）+ C-2 外部AIレビュー（high-risk / standard で実施）
+
+## Stop rules
+
+- C-2 で critical 発生 → C-3 ゲート前に即修正 or REJECT
+- レビュー対象に Iron Law 違反検知 → block
+
+## Output discipline
+
+- `review-self.md` / `review-external.md`（Markdown 詳細）
+- review-result.json（schema 準拠メタ、任意）
+
+## 関連
+
+- [`schemas/review-result.schema.json`](../../../schemas/review-result.schema.json) — phase: C-1 / C-2 / V-3
+- [`.claude/rules/review-principles.md`](../../../.claude/rules/review-principles.md)

--- a/docs/ai/contracts/verify.md
+++ b/docs/ai/contracts/verify.md
@@ -1,0 +1,35 @@
+# Phase Contract: verify
+
+> [`prompt-assembly.md`](../prompt-assembly.md) の phase_contract / 7 phase の 1 つ
+> Prompt Assembly で `review` から分離独立化（[`core-contract.md`](../core-contract.md) v1 では review に包含）
+
+## Goal
+
+`test-cases.md` の各 TC を実行し、**受入基準（AC）と機械突合** する。V-1 受け入れ検査。
+
+## Success criteria
+
+- 全 TC が PASS / WARN / FAIL / SKIP のいずれかに判定
+- AC × TC マトリクスが [`schemas/acceptance-result.schema.json`](../../../schemas/acceptance-result.schema.json) 準拠
+- fix loop は最大 5 回（超過時 ABORT、[`hook-enforcement.md`](../hook-enforcement.md) EHS-3）
+
+## Stop rules
+
+- TC FAIL の root cause 不明 → 停止
+- fix loop が 5 回超過 → ABORT、ユーザー判断にエスカレーション
+- test-cases.md なしで進行しようとした → block（EH-4）
+- 検証ログなしで PR 作成しようとした → block（EH-5）
+
+## Output discipline
+
+- `evidence/verification.md` または `evidence/v1-acceptance-result.md`
+- acceptance-result.json（schema 準拠、任意）
+
+## verbosity 継承
+
+Prompt Assembly の verbosity 解決では本 phase は **`review` の verbosity を継承**（[`prompt-assembly.md`](../prompt-assembly.md) § 4 schema 互換参照）。
+
+## 関連
+
+- [`schemas/acceptance-result.schema.json`](../../../schemas/acceptance-result.schema.json)
+- [`docs/ai/structured-outputs.md`](../structured-outputs.md) — V-1 出力の schema 化方針

--- a/docs/ai/prompt-assembly.md
+++ b/docs/ai/prompt-assembly.md
@@ -1,0 +1,170 @@
+# Prompt Assembly — Core / Phase / Risk / Model Adapter 4 層化
+
+> **Status**: v1（PBI-116-03 で初版確立、Phase 3 / PBI-116）
+> 関連: [`core-contract.md`](./core-contract.md) / [`model-profiles.md`](./model-profiles.md) / [`responsibility-boundary.md`](./responsibility-boundary.md) / [`structured-outputs.md`](./structured-outputs.md)
+
+## 1. 目的
+
+PlanGate の **不変制約（Iron Law）/ phase 別成功条件 / mode 別検証深度 / モデル別補正** を、変更頻度と責務が異なる 4 つの独立層に分離する。これにより:
+
+- モデル変更時にプロンプト全文を fork せず adapter 差替えで対応
+- phase / mode 追加時に独立した skeleton を追加するだけで拡張可能
+- Eval（PBI-116-05）で各層を独立検証可能
+
+## 2. 4 層構造
+
+```text
+base_contract        ← Phase 1 / docs/ai/core-contract.md
++ phase_contract     ← classify / plan / approve-wait / execute / review / verify / handoff
++ risk_mode_contract ← ultra_light / light / standard / high_risk / critical
++ model_adapter      ← Phase 2 / Model Profile.adapter（outcome_first / outcome_first_strict / explicit_short / legacy_or_unknown）
+= 実プロンプト
+```
+
+### 各層の責務（境界マトリクス）
+
+| Layer | 役割 | 変更頻度 | 配置 |
+|-------|------|--------|------|
+| `base_contract` | PlanGate 不変ルール（Iron Law / scope discipline / verification honesty）| **不変**（モデル / phase / mode 越境） | `docs/ai/core-contract.md`（Phase 1 成果） |
+| `phase_contract` | phase 別の Goal / Success criteria / Stop rules / Output discipline | 中（phase 追加時） | `docs/ai/contracts/<phase>.md` |
+| `risk_mode_contract` | mode 別の検証深度（C-2/V-2/V-3 必要性、fix loop 上限）+ Gate 要件 | 低（mode 分類調整時） | `docs/ai/contracts/<mode>.md` 相当（本 PBI では概念のみ、詳細は `mode-classification.md`）|
+| `model_adapter` | モデル別の verbosity / reasoning effort / 出力 style 補正 | 高（モデル世代変更時） | `docs/ai/adapters/<adapter>.md` |
+
+## 3. 上位概念との接続（C-2 EX-03-05 対応）
+
+Prompt Assembly の 4 層は、**[`responsibility-boundary.md`](./responsibility-boundary.md) の Prompt layer 内サブ構造** である。Tool Policy / Hook / CLI validate は **別 layer** であり、本 PBI scope 外:
+
+```text
+[Responsibility Boundary]
+├── Prompt Layer
+│   └── Prompt Assembly（本 PBI、4 層）
+├── Tool Policy Layer (PBI-116-06 / docs/ai/tool-policy.md)
+├── Hook Layer (PBI-116-06 / docs/ai/hook-enforcement.md)
+└── CLI / validate Layer (別 PBI)
+```
+
+Eval（PBI-116-05）は本 4 層を切り分けて独立検証する。
+
+## 4. Phase 1 / 2 互換説明
+
+### Core Contract v1 互換（C-2 EX-03-01 対応）
+
+Phase 1 [`core-contract.md`](./core-contract.md) § 3 の Success criteria 表は **6 phase**（classify / plan / approve-wait / execute / review / handoff）で `review` に受入確認を包含。
+
+Prompt Assembly では **`verify` を `review` から分離** し独立 layer として明示化する（**7 phase**）:
+
+| Core Contract v1 (6) | Prompt Assembly (7) | 変更点 |
+|--------------------|--------------------|------|
+| review（受入確認 + 設計品質）| **review**（設計品質）+ **verify**（受入確認）| `verify` を独立化 |
+| その他 5 phase | classify / plan / approve-wait / execute / handoff | 不変 |
+
+→ 既存 Core Contract は変更しない。Prompt Assembly は **拡張的解釈** として 7 phase を採用。
+
+### Phase 2 schema 互換（verbosity_by_phase）
+
+[`schemas/model-profile.schema.json`](../../schemas/model-profile.schema.json) の `verbosity_by_phase` は **5 phase**（classify / plan / execute / review / handoff）。Prompt Assembly が新設する 2 phase の解決方針:
+
+| Prompt Assembly phase | schema 対応 | 解決方針 |
+|---------------------|----------|--------|
+| `approve-wait` | なし | **verbosity 不適用**（ユーザー承認待ち、AI 出力なし） |
+| `verify` | なし | **`review` の verbosity を継承**（review と verify はレビュー観点で連続） |
+
+→ schema 変更は本 PBI scope 外、解決ロジック側で吸収。
+
+## 5. 解決ロジック（擬似コード）
+
+```typescript
+// Prompt Assembly の入力型
+type PlanGatePromptContext = {
+  taskId: string;             // TASK-XXXX
+  phase: PhaseId;             // 7 phase enum
+  mode: ModeId;               // 5 mode enum
+  modelProfile: string;       // "gpt-5_5" 等、model-profiles.yaml キー
+  taskContext: string;        // pbi-input + plan + status のサマリ
+};
+
+type PhaseId = "classify" | "plan" | "approve-wait" | "execute" | "review" | "verify" | "handoff";
+type ModeId = "ultra_light" | "light" | "standard" | "high_risk" | "critical";
+
+// 4 層を組み立てる
+function assemble(ctx: PlanGatePromptContext): string {
+  const baseContract = readMarkdown("docs/ai/core-contract.md");
+  const phaseContract = readMarkdown(`docs/ai/contracts/${ctx.phase}.md`);
+  const riskModeContract = lookupRiskMode(ctx.mode); // mode-classification.md 参照
+  const profile = readYaml("docs/ai/model-profiles.yaml").models[ctx.modelProfile];
+  const modelAdapter = readMarkdown(`docs/ai/adapters/${profile.adapter}.md`);
+
+  // verbosity 解決（Phase 2 schema 互換）
+  const verbosity = resolveVerbosity(ctx.phase, profile.verbosity_by_phase);
+  // - approve-wait → 不適用
+  // - verify → review の値を継承
+  // - その他 → schema の値
+
+  return [
+    baseContract,         // 不変（必ず先頭）
+    phaseContract,        // phase 固有
+    riskModeContract,     // mode 別 Gate 要件
+    modelAdapter,         // モデル別 style + verbosity 適用
+    ctx.taskContext,      // TASK 固有（最後）
+  ].join("\n\n");
+}
+
+function resolveVerbosity(phase: PhaseId, byPhase: Record<string, "low"|"medium"|"high">): "low"|"medium"|"high"|null {
+  if (phase === "approve-wait") return null;          // 不適用
+  if (phase === "verify") return byPhase["review"];   // review 継承
+  return byPhase[phase];                              // schema 値
+}
+```
+
+実装言語の選択（TypeScript / shell / Python）は本 PBI scope 外（別 PBI で決定）。
+
+## 6. モデル別 prompt full fork を避ける方針
+
+| アンチパターン | 推奨 |
+|------------|------|
+| モデルごとに plan.md / exec.md を fork | `model_adapter` だけ差し替え、他 3 層は共通 |
+| プロンプトに巨大な JSON 例を埋め込み | [`structured-outputs.md`](./structured-outputs.md) の schema 参照に置き換え |
+| `必ず` / `絶対` をプロンプトに散在 | Iron Law を `core-contract.md` の Hard constraints に集約（Phase 1 で達成） |
+
+## 7. .claude/ と plugin/plangate/ への適用
+
+本 4 層構造は `docs/ai/*` で **一般化された定義**。実利用は:
+
+- `.claude/commands/ai-dev-workflow.md` などのコマンド層から本層を参照
+- `plugin/plangate/commands/ai-dev-workflow.md` など Plugin 配布版も同じ層を参照
+- 配布形態固有の差分は Plugin 限定 rules で表現（[`responsibility-boundary.md`](./responsibility-boundary.md) § 6 共存方針）
+
+実装層への適用は本 PBI scope 外（別 PBI / Plugin 同期 PBI で対応）。
+
+## 8. phase / adapter 一覧
+
+### 7 Phase Contract
+
+| Phase | ファイル | 役割 |
+|-------|---------|------|
+| classify | [`contracts/classify.md`](./contracts/classify.md) | mode 判定 |
+| plan | [`contracts/plan.md`](./contracts/plan.md) | 計画策定 |
+| approve-wait | [`contracts/approve-wait.md`](./contracts/approve-wait.md) | C-3 承認待機 |
+| execute | [`contracts/execute.md`](./contracts/execute.md) | 実装 |
+| review | [`contracts/review.md`](./contracts/review.md) | 設計品質レビュー |
+| verify | [`contracts/verify.md`](./contracts/verify.md) | 受入確認 |
+| handoff | [`contracts/handoff.md`](./contracts/handoff.md) | 引き継ぎ |
+
+### 4 Model Adapter（schema enum 全件）
+
+| Adapter | ファイル | 想定モデル |
+|---------|---------|----------|
+| outcome_first | [`adapters/outcome_first.md`](./adapters/outcome_first.md) | gpt-5_5（標準） |
+| outcome_first_strict | [`adapters/outcome_first_strict.md`](./adapters/outcome_first_strict.md) | gpt-5_5_pro（強力推論） |
+| explicit_short | [`adapters/explicit_short.md`](./adapters/explicit_short.md) | gpt-5_mini（軽量） |
+| legacy_or_unknown | [`adapters/legacy_or_unknown.md`](./adapters/legacy_or_unknown.md) | フォールバック |
+
+将来 `schemas/model-profile.schema.json` の `adapter` enum が拡張されたら、対応する `adapters/<name>.md` を追加（C-2 EX-03-04 方針）。
+
+## 関連
+
+- 親計画: [`docs/working/PBI-116/parent-plan.md`](../working/PBI-116/parent-plan.md)
+- TASK: [`docs/working/TASK-0043/`](../working/TASK-0043/)
+- Phase 1: [`core-contract.md`](./core-contract.md)
+- Phase 2: [`model-profiles.md`](./model-profiles.md) / [`model-profiles.yaml`](./model-profiles.yaml) / [`tool-policy.md`](./tool-policy.md) / [`hook-enforcement.md`](./hook-enforcement.md) / [`responsibility-boundary.md`](./responsibility-boundary.md) / [`structured-outputs.md`](./structured-outputs.md)
+- 接続先 Phase 4: PBI-116-05 (Eval Cases) で 4 層を独立検証

--- a/docs/working/TASK-0043/evidence/verification.md
+++ b/docs/working/TASK-0043/evidence/verification.md
@@ -1,0 +1,112 @@
+# Verification — TASK-0043 Step 7（exec PBI-116-03）
+
+> 実施: 2026-04-30 / exec ブランチ `feat/PBI-116-03-impl`
+
+## TC-1: 4 層定義
+
+```bash
+grep -cE "base_contract|phase_contract|risk_mode_contract|model_adapter" docs/ai/prompt-assembly.md
+# → 9（4 層すべて複数箇所で言及、責務マトリクス + 構造図 + 解決ロジック）
+```
+
+✅ PASS
+
+## TC-2: 各層の責務境界
+
+prompt-assembly.md § 2 で 4 layer × 役割 / 変更頻度 / 配置の責務マトリクス完備。✅ PASS
+
+## TC-3: 7 phase contract
+
+```bash
+ls docs/ai/contracts/*.md | wc -l
+# → 7
+```
+
+classify / plan / approve-wait / execute / review / verify / handoff すべて存在、各 50 行以下。✅ PASS
+
+## TC-4: 4 model adapter（schema enum 全件）
+
+```bash
+ls docs/ai/adapters/*.md | wc -l
+# → 4
+```
+
+outcome_first / outcome_first_strict / explicit_short / legacy_or_unknown すべて存在。✅ PASS
+
+## TC-5: prompt full fork 回避方針
+
+prompt-assembly.md § 6「モデル別 prompt full fork を避ける方針」セクション + § 1 冒頭「モデル変更時にプロンプト全文を fork せず adapter 差替え」明記。✅ PASS
+
+## TC-6: .claude / plugin 両適用構造
+
+prompt-assembly.md § 7「`.claude/` と `plugin/plangate/` への適用」で論理的な適用範囲を明示。✅ PASS
+
+## TC-7: 解決ロジック（擬似コード）
+
+prompt-assembly.md § 5 で TypeScript 型定義（`PlanGatePromptContext` / `PhaseId` / `ModeId`）+ `assemble()` / `resolveVerbosity()` 関数の擬似コード。✅ PASS
+
+## TC-E1: adapter enum 完全一致（C-2 EX-03-03 強化）
+
+```bash
+jq -r '."$defs".profile.properties.adapter.enum[]' schemas/model-profile.schema.json | sort > /tmp/schema-adapters.txt
+ls docs/ai/adapters/*.md | xargs -I {} basename {} .md | sort > /tmp/doc-adapters.txt
+diff /tmp/schema-adapters.txt /tmp/doc-adapters.txt
+# → empty（PASS、完全一致）
+```
+
+✅ PASS
+
+## TC-E2: 過剰肥大化防止
+
+```bash
+wc -l docs/ai/prompt-assembly.md docs/ai/contracts/*.md docs/ai/adapters/*.md
+```
+
+- prompt-assembly.md: 170 行（200 以下 ✅）
+- contracts/*.md: 28-36 行（各 50 以下 ✅）
+- adapters/*.md: 40-49 行（各 50 以下 ✅）
+- **合計: 574 行**（700 以下 ✅）
+
+✅ PASS
+
+## TC-E3: 既存 docs/ai/ との命名衝突
+
+```bash
+ls docs/ai/contracts/ docs/ai/adapters/
+```
+
+新規サブディレクトリ `contracts/` `adapters/` で既存 `docs/ai/*.md`（core-contract / model-profiles / structured-outputs / responsibility-boundary / tool-policy / hook-enforcement）と衝突なし。✅ PASS
+
+## 受入基準 7 項目の総合判定
+
+| AC | TC | 判定 |
+|----|----|----|
+| AC-1: 4 層定義 | TC-1 | ✅ |
+| AC-2: 各層の責務境界 | TC-2 | ✅ |
+| AC-3: 7 phase contract | TC-3 | ✅ |
+| AC-4: 4 model adapter（schema enum 全件） | TC-4 | ✅ |
+| AC-5: prompt full fork 回避方針 | TC-5 | ✅ |
+| AC-6: .claude / plugin 両適用構造 | TC-6 | ✅ |
+| AC-7: 解決ロジック（擬似コード） | TC-7 | ✅ |
+
+**総合: 7/7 PASS**
+
+## C-2 全 5 件の対応確認
+
+| ID | 対応箇所 | 確認 |
+|----|---------|------|
+| EX-03-01 (major) | prompt-assembly.md § 4 | ✅ Core Contract v1 互換説明（6→7 phase） |
+| EX-03-02 (major) | PBI-116-03.yaml allowed_files に `docs/working/TASK-0043/**` | ✅ 前 PR で対応済 |
+| EX-03-03 (minor) | TC-E1 jq + diff | ✅ 完全一致確認 |
+| EX-03-04 (minor) | adapter 4 種 = schema enum 全件 | ✅ 完全一致 |
+| EX-03-05 (info) | prompt-assembly.md § 3「上位概念との接続」 | ✅ Responsibility Boundary との関係明示 |
+
+## Phase 2 verbosity 互換確認（追加 Gemini 指摘対応）
+
+prompt-assembly.md § 4「Phase 2 schema 互換」 + § 5 解決ロジック `resolveVerbosity()`:
+
+- approve-wait → null（不適用）
+- verify → review 値継承
+- 他 5 phase → schema 値そのまま
+
+contracts/approve-wait.md と contracts/verify.md でも明記。✅ PASS

--- a/docs/working/TASK-0043/handoff.md
+++ b/docs/working/TASK-0043/handoff.md
@@ -1,0 +1,119 @@
+---
+task_id: TASK-0043
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-04-30
+author: Claude (PBI-116-03 exec)
+v1_release: TBD (本 PR マージ後)
+---
+
+# TASK-0043 Handoff Package
+
+> WF-05 Verify & Handoff の出力。PBI-116-03（Issue #119 Prompt Assembly を 4 層化）。
+> 親 PBI: [PBI-116](../PBI-116/parent-plan.md) / **Phase 3** / Mode: high-risk
+
+## メタ情報
+
+```yaml
+task: TASK-0043
+related_issue: https://github.com/s977043/plangate/issues/119
+parent_pbi: PBI-116
+covers_parent_ac: [parent-AC-3]
+mode: high-risk
+author: Claude
+issued_at: 2026-04-30
+exec_pr: TBD
+```
+
+## 1. 要件適合確認結果
+
+| AC | 判定 | 根拠 |
+|----|------|---------|
+| AC-1: 4 層定義 | PASS | prompt-assembly.md § 2 構造図 + 責務マトリクス |
+| AC-2: 各層の責務境界 | PASS | § 2 マトリクスで役割 / 変更頻度 / 配置を明示 |
+| AC-3: 7 phase contract | PASS | contracts/*.md 7 ファイル、各 28-36 行 |
+| AC-4: 4 model adapter（schema enum 全件） | PASS | adapters/*.md 4 ファイル、jq + diff で schema 一致確認 |
+| AC-5: prompt full fork 回避方針 | PASS | § 6 アンチパターン表 + § 1 冒頭明示 |
+| AC-6: .claude / plugin 両適用構造 | PASS | § 7 適用範囲明示、Plugin 限定との共存 |
+| AC-7: 解決ロジック（擬似コード） | PASS | § 5 TypeScript 型定義 + assemble() / resolveVerbosity() |
+
+**総合: 7/7 PASS**
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補 |
+|------|---------|------|---------|
+| 実装言語選択（TypeScript / shell / Python）未確定 | info | accepted | Yes（別 PBI で実装決定） |
+| `verify` phase の Core Contract v1 統合は次回更新で | minor | accepted | Yes（core-contract.md v2 で 7 phase 化検討） |
+| `risk_mode_contract` ファイル化未実施（概念のみ）| info | accepted | Yes（必要時に contracts/<mode>.md として独立化）|
+| Plugin 配布版（`plugin/plangate/commands/`）への適用は別 PBI | info | accepted | Yes（Plugin 同期 PBI） |
+| schema 完全 validate（jsonschema CLI）は環境依存で省略 | minor | accepted | No（CI で対応可能）|
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 優先度 |
+|--------|------|------|
+| 実 prompt 組み立て CLI 実装（`bin/plangate-prompt-assemble`） | 本 PBI は擬似コードまで | High（Phase 4 / 別 PBI）|
+| Core Contract v2 化（7 phase 統合） | v1 は 6 phase で互換扱い | Medium |
+| risk_mode_contract のファイル化 | 5 mode × phase の検証深度を独立 | Medium |
+| Plugin 配布版（`plugin/plangate/commands/`）への適用 | 一般化された定義の Plugin 同期 | Medium（Plugin 同期 PBI）|
+| schema 準拠率 eval（PBI-116-05）で 4 層独立検証 | base/phase/mode/adapter 切り分け検証 | High（PBI-116-05）|
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| `verify` を `review` から分離（Prompt Assembly 7 phase） | Core Contract v1 と同じ 6 phase | Eval（PBI-116-05）で受入確認と設計品質を独立検証可能に |
+| verbosity_by_phase 解決を adapter 内 logic で吸収 | Phase 2 schema を 7 phase に拡張 | schema 不変原則を維持、解決層で互換確保 |
+| risk_mode_contract をファイル化せず概念のみ | mode 別 contracts/<mode>.md 作成 | 本 PBI 範囲を 4 層 + 7 phase + 4 adapter に絞る、mode は mode-classification.md 参照 |
+| 解決ロジックは TypeScript 型定義 + 擬似コード | shell / Python 実装 | doc-only 制約遵守、実装言語は別 PBI で決定 |
+| 各 contracts/*.md 50 行以下 | 詳細な仕様記述 | base_contract で詳細を扱い、phase 固有のみに絞る |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+PBI-116-03 (#119 Prompt Assembly) の exec 完了。Phase 3 / high-risk PBI。
+
+12 個の新規 Markdown ファイル:
+- `docs/ai/prompt-assembly.md`（170 行、4 層 + 解決ロジック + 互換説明）
+- `docs/ai/contracts/{classify,plan,approve-wait,execute,review,verify,handoff}.md`（7 件、各 28-36 行）
+- `docs/ai/adapters/{outcome_first,outcome_first_strict,explicit_short,legacy_or_unknown}.md`（4 件、各 40-49 行）
+
+合計 574 行で目安 700 以下を達成。adapter enum は schema と完全一致（jq + diff PASS）。
+
+Phase 1 (Core Contract) + Phase 2 (Model Profile / Tool Policy / Structured Outputs / Responsibility Boundary) を統合する設計層。Phase 4 (PBI-116-05 Eval) で各層を独立検証する前提を提供。
+
+### 触れないでほしいファイル
+
+- `docs/ai/prompt-assembly.md` § 2 構造図 / § 5 解決ロジック型定義: 実装層からの参照キー
+- `docs/ai/adapters/*.md` ファイル名: schema enum と一致必須（変更時は schema も同時更新）
+- `docs/ai/contracts/*.md` ファイル名: 7 phase 識別子の正本
+- 既存 `core-contract.md` / `model-profiles.yaml` / その他 Phase 1/2 成果物: 不変
+
+### 次に手を入れるなら
+
+- **V2-1（High, PBI-116-05）**: 4 層を独立検証する eval cases 追加、schema 準拠率測定
+- **V2-2（High, 別 PBI）**: 実 CLI 実装（`bin/plangate-prompt-assemble`）
+- **V2-3（Medium）**: Core Contract v2 化（7 phase 統合）
+- **V2-4（Medium）**: Plugin 配布版への適用（同期 PBI）
+
+### 参照リンク
+
+- 親 PBI: [`docs/working/PBI-116/parent-plan.md`](../PBI-116/parent-plan.md)
+- Issue: https://github.com/s977043/plangate/issues/119
+- Phase 1: [`docs/ai/core-contract.md`](../../ai/core-contract.md)
+- Phase 2: [`model-profiles.md`](../../ai/model-profiles.md) / [`responsibility-boundary.md`](../../ai/responsibility-boundary.md) / [`tool-policy.md`](../../ai/tool-policy.md) / [`hook-enforcement.md`](../../ai/hook-enforcement.md) / [`structured-outputs.md`](../../ai/structured-outputs.md)
+- C-1 / C-2 / Child C-3: [`review-self.md`](./review-self.md) / [`review-external.md`](./review-external.md) / [`approvals/c3.json`](./approvals/c3.json)
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| 自動（grep / wc / ls / jq + diff） | 7 | 7 | 0 | 高 |
+| doc-review | 3 | 3 | 0 | 高 |
+| 手動 E2E | — | — | — | 該当なし |
+
+**FAIL / SKIP の詳細**: なし
+**注**: 単体テストは doc-only PBI のため対象外。実 CLI 実装は別 PBI のため runtime テストは scope 外。

--- a/docs/working/TASK-0043/status.md
+++ b/docs/working/TASK-0043/status.md
@@ -1,0 +1,64 @@
+# TASK-0043 Status
+
+## 全体構成
+
+- 対象 Issue: [#119](https://github.com/s977043/plangate/issues/119)
+- 親 PBI: [PBI-116](../PBI-116/parent-plan.md)
+- 子 PBI ID: PBI-116-03
+- ブランチ: `feat/PBI-116-03-impl`
+- モード: high-risk
+- 状態: **EXEC-COMPLETE**（Step 1〜3 完了、子 PR 作成 → Child C-4 ゲート待ち）
+
+## C-3 Gate: APPROVED
+
+- 判定: APPROVED（2026-04-30T08:00:00Z、s977043）
+- 記録: [`approvals/c3.json`](./approvals/c3.json)
+- plan_hash: `sha256:560ea44c...`
+
+## 完了タスク
+
+### 準備
+- [x] T-1: Scope 再掲
+- [x] T-2: Phase 1 / Phase 2 成果物確認
+
+### Step 1: prompt-assembly.md
+- [x] T-3〜T-8: 4 層構造 / 責務マトリクス / 7 phase / 4 adapter / 解決ロジック / fork 回避方針
+
+### Step 2: 7 phase contracts + 4 model adapters skeleton
+- [x] T-9〜T-15: contracts/{classify,plan,approve-wait,execute,review,verify,handoff}.md
+- [x] T-16〜T-19: adapters/{outcome_first,outcome_first_strict,explicit_short,legacy_or_unknown}.md
+
+### 検証
+- [x] T-20: 自動検証（grep / wc / ls / jq + diff）
+- [x] T-21: Phase 1 / 2 整合性確認
+- [x] T-22: markdown lint（CI で確認）
+- [x] T-23: evidence/verification.md 記録
+
+### 完了
+- [x] T-24: handoff.md（必須 6 要素）
+- [x] T-25: status.md（本ファイル）
+- [ ] T-26: コミット + push + 子 PR 作成（実行中）
+
+## C-2 全 5 件対応確認
+
+- EX-03-01 (major): prompt-assembly.md § 4 で Core Contract v1 互換明示 ✅
+- EX-03-02 (major): allowed_files に `docs/working/TASK-0043/**` 追加（前 PR）✅
+- EX-03-03 (minor): TC-E1 jq + diff 強化 ✅
+- EX-03-04 (minor): adapter 4 種 = schema enum 完全一致 ✅
+- EX-03-05 (info): prompt-assembly.md § 3 上位概念接続 ✅
+
+## 受入基準
+
+7/7 PASS（verification.md 記録）
+
+## 関連 PR
+
+- PR #145: PBI-116-03 plan（マージ済 f8c6b5d）
+- PR #146: C-2 + CONDITIONAL 対応 + Child C-3 APPROVED（マージ済 dfa7f1e）
+- 本 PR: PBI-116-03 exec 成果物（prompt-assembly.md + 7 contracts + 4 adapters）
+
+## 次ステップ
+
+- 子 PR Child C-4 ゲート判断 👤
+- マージ後 PBI-116-03.yaml state: approved → done
+- **Phase 3 完了** → Phase 4 (PBI-116-05 Eval Cases) 着手可


### PR DESCRIPTION
## Summary

**Phase 3 の唯一の exec PR**。Phase 1 (Core Contract) + Phase 2 (Model Profile / Tool Policy / Structured Outputs / Responsibility Boundary) を統合する設計層。**受入基準 7/7 PASS**。

## 成果物（12 新規 Markdown / 計 574 行）

| ファイル | 行数 | 内容 |
|---------|-----|------|
| \`docs/ai/prompt-assembly.md\` | 170 | 4 層構造 + 解決ロジック + Phase 1/2 互換説明 |
| \`docs/ai/contracts/classify.md\` | 28 | mode 判定 phase |
| \`docs/ai/contracts/plan.md\` | 29 | 計画策定 phase |
| \`docs/ai/contracts/approve-wait.md\` | 32 | C-3 承認待機 phase（verbosity 不適用）|
| \`docs/ai/contracts/execute.md\` | 32 | 実装 phase |
| \`docs/ai/contracts/review.md\` | 29 | 設計品質レビュー phase |
| \`docs/ai/contracts/verify.md\` | 35 | 受入確認 phase（verbosity は review 継承）|
| \`docs/ai/contracts/handoff.md\` | 36 | 引き継ぎ phase |
| \`docs/ai/adapters/outcome_first.md\` | 40 | gpt-5_5 標準 |
| \`docs/ai/adapters/outcome_first_strict.md\` | 47 | gpt-5_5_pro 強力推論 |
| \`docs/ai/adapters/explicit_short.md\` | 47 | gpt-5_mini 軽量（critical 禁止）|
| \`docs/ai/adapters/legacy_or_unknown.md\` | 49 | フォールバック |

## 設計上の主要決定

| 項目 | 決定 |
|------|------|
| 4 層構造 | \`base_contract\` / \`phase_contract\` / \`risk_mode_contract\` / \`model_adapter\` |
| 7 phase | classify / plan / approve-wait / execute / review / verify / handoff |
| 4 adapter | schema enum と完全一致（jq + diff PASS）|
| verbosity 解決 | approve-wait 不適用、verify は review 継承 |
| 解決ロジック | TypeScript 型定義 + \`assemble()\` / \`resolveVerbosity()\` 擬似コード |
| 制約 | doc-only（実 CLI は別 PBI）|

## C-2 全 5 件対応確認

| ID | 重要度 | 確認 |
|----|------|------|
| EX-03-01 | major | ✅ Core Contract v1 互換（6→7 phase）|
| EX-03-02 | major | ✅ allowed_files 拡張済（前 PR）|
| EX-03-03 | minor | ✅ adapter enum jq + diff 完全一致 |
| EX-03-04 | minor | ✅ adapter 4 種 = schema enum 全件 |
| EX-03-05 | info | ✅ Responsibility Boundary 接続明示 |

## 受入基準（7/7 PASS）

| AC | 内容 | 判定 |
|----|------|------|
| AC-1 | 4 層定義 | ✅ |
| AC-2 | 各層の責務境界 | ✅ |
| AC-3 | 7 phase contract | ✅ |
| AC-4 | 4 model adapter（schema enum 全件） | ✅ |
| AC-5 | prompt full fork 回避方針 | ✅ |
| AC-6 | .claude / plugin 両適用構造 | ✅ |
| AC-7 | 解決ロジック（擬似コード） | ✅ |

## 検証

- adapter enum: schema vs adapters/*.md ファイル名 = jq + sort + diff PASS（完全一致）
- 行数: 174（prompt-assembly）+ 221（contracts 7 × 平均 31.5）+ 183（adapters 4 × 平均 45.7） = **574 行**（目安 700 以下達成）
- 既存 docs/ai/*.md と命名衝突なし
- Stop rule 該当なし

## 次ステップ

- 子 PR Child C-4 ゲート判断 👤
- マージ後 PBI-116-03.yaml state: approved → done
- **Phase 3 完了** → Phase 4 (PBI-116-05 Eval Cases) 着手可

🤖 Generated with [Claude Code](https://claude.com/claude-code)