### PR TITLE
refactor(tests): TA-04〜07 を tests/extras/ に分離 (#170)

### DIFF
--- a/docs/working/TASK-0050/handoff.md
+++ b/docs/working/TASK-0050/handoff.md
@@ -1,0 +1,84 @@
+---
+task_id: TASK-0050
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-05-01
+author: qa-reviewer
+v1_release: ""
+related_issue: 170
+---
+
+# Handoff: TASK-0050 / Issue #170 — tests/extras/ 分離
+
+## メタ情報
+
+```yaml
+task: TASK-0050
+related_issue: https://github.com/s977043/plangate/issues/170
+author: qa-reviewer
+issued_at: 2026-05-01
+v1_release: <PR マージ後に SHA>
+```
+
+## 1. 要件適合確認結果
+
+| AC | 判定 | 根拠 |
+|----|------|------|
+| AC-1: `sh tests/run-tests.sh` 21/21 PASS 維持 | PASS | `Results: 21 passed, 0 failed` を確認 |
+| AC-2: extras/*.sh 追加で完結 | PASS | run-tests.sh は base test + loader、TA-04〜07 が `tests/extras/ta-NN-*.sh` に移動 |
+| AC-3: README に追加手順明示 | PASS | `tests/extras/README.md` に命名規約 / source 規約 / 追加手順 / 例 / 関連リンクの 5 セクション |
+
+**総合**: **3 / 3 PASS**
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 |
+|------|---------|------|
+| extras 内の関数定義が他 extras に漏れる（共通 namespace）| info | accepted（運用で衝突回避）|
+| glob ソート順序が一部の古い shell で不安定 | info | accepted（`ta-NN-` プレフィクスで自然順序、bash/zsh/dash で動作確認済）|
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 優先度 |
+|--------|------|--------|
+| extras を関数定義中心の構造に再設計（namespace 分離）| 関数衝突回避 | Low |
+| `tests/extras/_common.sh` 共通ヘルパ | DRY 化（現状 `run_pr_link_fixture` 等が ta-04 内に閉じている）| Low |
+
+## 4. 妥協点
+
+| 選択 | 諦めた代替 | 理由 |
+|------|-----------|------|
+| source 方式（同一プロセス）| sub-process 起動 | `pass` / `fail` カウンタを直接更新できる、最小変更 |
+| `ta-NN-*.sh` 命名 | 番号なし命名 | glob ソートで実行順序を担保 |
+| extras/README.md は単一 file | 各 extras に doc 分散 | 追加手順を 1 箇所で管理 |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+`tests/run-tests.sh` の末尾領域コンフリクト問題（retrospective 2026-05-01 P-2）を解消するため、TA-04〜07 を `tests/extras/ta-NN-*.sh` に分離。本体は base test（TA-01〜03）+ extras loader にスリム化。後続 PBI でテスト追加するときは `tests/extras/` にファイルを置くだけで本体編集不要 → コンフリクト源根絶。
+
+主要成果:
+- `tests/extras/` 新設、TA-04〜07 を 4 ファイルに分離（内容無変更）
+- `tests/run-tests.sh` を loader 化
+- `tests/extras/README.md` で命名規約 + 追加手順 + 例を文書化
+- 21 件 PASS 維持
+
+### 触れないでほしいファイル
+
+- `tests/extras/*.sh` の冒頭コメント: source される前提を明示しているため
+- `tests/run-tests.sh` の loader ブロック: glob 順序が tests 順序を決定する
+
+### 次に手を入れるなら
+
+- 新 PBI でテスト追加: `tests/extras/ta-NN-<name>.sh` を追加するだけ
+- アンチパターン: `tests/run-tests.sh` 末尾領域に直接挿入（衝突再発）
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP |
+|---------|------|------|-----------|
+| Integration（loader 経由）| 21 | 21 | 0 / 0 |
+
+検証コマンド: `sh tests/run-tests.sh` → `Results: 21 passed, 0 failed`

--- a/docs/working/TASK-0050/pbi-input.md
+++ b/docs/working/TASK-0050/pbi-input.md
@@ -1,0 +1,26 @@
+# PBI INPUT PACKAGE: TASK-0050 / Issue #170
+
+> Source: [#170 tests/run-tests.sh 拡張ポイント分離](https://github.com/s977043/plangate/issues/170)
+> Mode: **light**
+
+## Context / Why
+
+retrospective 2026-05-01 P-2 / Try T-4。5 PBI 連続実装で `tests/run-tests.sh` 末尾領域が衝突源になり、3 PR でコンフリクト解決を要した。今後の PBI 連続実装で同じ問題を起こさないよう、拡張ポイントを別ファイルに分離する。
+
+## What
+
+### In scope
+- `tests/extras/` ディレクトリ新設
+- 既存 TA-04 / TA-05 / TA-06 / TA-07 を `tests/extras/ta-NN-*.sh` へ移動
+- `tests/run-tests.sh` 末尾に `for extra in "$EXTRAS_DIR"/ta-*.sh; do . "$extra"; done` を追加
+- `tests/extras/README.md` で拡張方法を記述
+
+### Out of scope
+- 既存 TA-01〜TA-03 の分離（base test として本体に残す）
+- glob ソート順の保証（ta-NN プレフィクスで自然順序）
+
+## Acceptance Criteria
+
+- AC-1: `sh tests/run-tests.sh` が **21/21 PASS** を維持
+- AC-2: 新 TA-NN 追加が `tests/extras/` への新規ファイル追加だけで完結（run-tests.sh 編集不要）
+- AC-3: `tests/extras/README.md` に新規追加手順 + 規約が明文化

--- a/docs/working/TASK-0050/plan.md
+++ b/docs/working/TASK-0050/plan.md
@@ -1,0 +1,43 @@
+# EXECUTION PLAN: TASK-0050 / Issue #170
+
+> Mode: **light**
+
+## Goal
+
+`tests/run-tests.sh` を base + extras loader 構造に変える。後続 PBI が `tests/extras/` にファイル追加するだけでテスト追加完了する仕組みにし、末尾領域コンフリクトを根絶する。
+
+## Approach
+
+1. `tests/extras/` 新設 + 既存 TA-04〜TA-07 を 4 ファイルに分離（コピー、内容無変更）
+2. `tests/run-tests.sh` から旧 TA-04〜TA-07 を削除し、`for extra in "$EXTRAS_DIR"/ta-*.sh; do . "$extra"; done` を追加
+3. `tests/extras/README.md` で source 規約 + 新規追加手順を明示
+4. `sh tests/run-tests.sh` で 21 件 PASS 維持を確認
+
+## 変更ファイル
+
+| ファイル | 種別 |
+|---------|------|
+| `tests/extras/ta-04-check-pr-issue-link.sh` | 新規（既存 TA-04 移動）|
+| `tests/extras/ta-05-validate-schemas.sh` | 新規（既存 TA-05 移動）|
+| `tests/extras/ta-06-hooks.sh` | 新規（既存 TA-06 移動）|
+| `tests/extras/ta-07-eval-runner.sh` | 新規（既存 TA-07 移動）|
+| `tests/extras/README.md` | 新規（規約 + 追加手順）|
+| `tests/run-tests.sh` | 編集（loader 化、TA-04〜07 を削除）|
+| `docs/working/TASK-0050/*` | 新規 |
+
+## Mode判定
+
+light（CI 影響なし、テスト構造の純粋なリファクタリング、後方互換維持）
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|----------|
+| source 順序が glob で安定しない環境がある | `ta-NN-` プレフィクス + POSIX `set -e` で順序を明示 |
+| extras/ 内で `set -eu` を再宣言 → 干渉 | extras 側は `set` 不宣言（base に任せる）|
+| シェル変数 scope の違い | source は同一プロセスなので `pass` / `fail` がそのまま参照される |
+
+## 確認方法
+
+- `sh tests/run-tests.sh` → `Results: 21 passed, 0 failed`
+- diff で TA-04〜07 のロジックが完全コピーであること確認

--- a/docs/working/TASK-0050/test-cases.md
+++ b/docs/working/TASK-0050/test-cases.md
@@ -1,0 +1,29 @@
+# TEST CASES: TASK-0050 / Issue #170
+
+| AC | TC | 検証 |
+|----|----|------|
+| AC-1 | TC-1 | `sh tests/run-tests.sh` で 21/21 PASS |
+| AC-2 | TC-2 | `tests/extras/` 配下に 4 ファイル + README、本体は loader 化 |
+| AC-3 | TC-3 | README に「新規追加手順」セクションあり |
+
+## TC-1
+
+```sh
+sh tests/run-tests.sh
+# 期待: Results: 21 passed, 0 failed
+```
+
+## TC-2
+
+```sh
+ls tests/extras/
+# 期待: README.md ta-04-check-pr-issue-link.sh ta-05-validate-schemas.sh ta-06-hooks.sh ta-07-eval-runner.sh
+grep -c "for extra in" tests/run-tests.sh
+# 期待: 1 以上
+```
+
+## TC-3
+
+```sh
+grep -E "新しいテスト追加方法|新規追加手順|規約" tests/extras/README.md
+```

--- a/docs/working/TASK-0050/todo.md
+++ b/docs/working/TASK-0050/todo.md
@@ -1,0 +1,13 @@
+# EXECUTION TODO: TASK-0050 / Issue #170
+
+> Mode: **light**
+
+- [x] PBI INPUT
+- [x] plan + test-cases
+- [x] tests/extras/ 新設 + 4 ファイル作成
+- [x] tests/extras/README.md
+- [x] tests/run-tests.sh を loader 化
+- [x] sh tests/run-tests.sh で 21 件 PASS 確認
+- [x] handoff.md
+- [x] commit + push + PR
+- [ ] CI 緑確認 → C-4

--- a/tests/extras/README.md
+++ b/tests/extras/README.md
@@ -1,0 +1,52 @@
+# tests/extras/
+
+`tests/run-tests.sh` から source される拡張テストブロック群。
+
+## 命名規約
+
+`ta-NN-<short-name>.sh` 形式。`ta-` プレフィクス + 連番 + 1 行説明。
+
+## 規約
+
+各 `.sh` は **source される前提**:
+
+- `pass` / `fail` カウンタを直接更新する（数値変数）
+- `assert_pass` / `assert_fail` 関数が利用可能（run-tests.sh で定義済）
+- `PLANGATE_BIN` / `FIXTURES_DIR` 変数が利用可能
+- shebang 不要（実行権限も不要）
+- `set -eu` は run-tests.sh 側で済ませているので各 extras は前提とする
+
+## 新しいテスト追加方法（Issue #170）
+
+1. 新 PBI で対象機能のテストを書きたいとき:
+   ```sh
+   # 例: TA-08 を追加する場合
+   touch tests/extras/ta-08-<name>.sh
+   ```
+2. ファイル冒頭に役割コメントを書く（このファイル末尾の例参照）
+3. ローカルで `sh tests/run-tests.sh` を走らせ、新ブロックが拾われ全 PASS することを確認
+4. **`tests/run-tests.sh` の本体には触れない**（loader が `tests/extras/*.sh` を自動発見する）
+
+これにより PBI 連続実装時の `tests/run-tests.sh` 末尾領域コンフリクトを回避する（Issue #170 / retrospective P-2 対応）。
+
+## 例
+
+```sh
+# tests/extras/ta-08-foo.sh
+
+printf '\n=== TA-08: foo subsystem ===\n'
+
+if sh "$PLANGATE_BIN" foo --check >/dev/null 2>&1; then
+  printf '[PASS] foo: --check → exit 0\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] foo: --check failed\n'
+  fail=$((fail + 1))
+fi
+```
+
+## 関連
+
+- 親 issue: [#170](https://github.com/s977043/plangate/issues/170)
+- TASK: `docs/working/TASK-0050/`
+- retrospective: `docs/working/retrospective-2026-05-01.md` § P-2 / T-4

--- a/tests/extras/ta-04-check-pr-issue-link.sh
+++ b/tests/extras/ta-04-check-pr-issue-link.sh
@@ -1,0 +1,37 @@
+# tests/extras/ta-04-check-pr-issue-link.sh
+# Sourced by tests/run-tests.sh — relies on $pass / $fail / $PLANGATE_BIN / $FIXTURES_DIR
+# Issue #170 で run-tests.sh から分離
+
+printf '\n=== TA-04: check-pr-issue-link.sh ===\n'
+
+PR_LINK_SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/scripts/check-pr-issue-link.sh"
+PR_LINK_FIXTURES="$FIXTURES_DIR/check-pr-issue-link"
+
+run_pr_link_fixture() {
+  fixture_dir=$1
+  expected=$2
+  label=$3
+  out=$(sh "$PR_LINK_SCRIPT" \
+    --body-file "$fixture_dir/body.txt" \
+    --labels-file "$fixture_dir/labels.txt" \
+    --changed-files "$fixture_dir/changed-files.txt" 2>&1) || {
+    printf '[FAIL] %s — script exited non-zero: %s\n' "$label" "$out"
+    fail=$((fail + 1))
+    return
+  }
+  case "$out" in
+    "$expected"*)
+      printf '[PASS] %s — got %s\n' "$label" "$expected"
+      pass=$((pass + 1))
+      ;;
+    *)
+      printf '[FAIL] %s — expected prefix %s, got: %s\n' "$label" "$expected" "$out"
+      fail=$((fail + 1))
+      ;;
+  esac
+}
+
+run_pr_link_fixture "$PR_LINK_FIXTURES/pass" "PASS" "pass: closes #N present"
+run_pr_link_fixture "$PR_LINK_FIXTURES/warn" "WARN" "warn: no closing keyword"
+run_pr_link_fixture "$PR_LINK_FIXTURES/skip-label" "SKIP" "skip-label: documentation label"
+run_pr_link_fixture "$PR_LINK_FIXTURES/skip-marker" "SKIP" "skip-marker: HTML comment marker"

--- a/tests/extras/ta-05-validate-schemas.sh
+++ b/tests/extras/ta-05-validate-schemas.sh
@@ -1,0 +1,35 @@
+# tests/extras/ta-05-validate-schemas.sh
+# Sourced by tests/run-tests.sh
+# Issue #170 で run-tests.sh から分離
+
+printf '\n=== TA-05: validate-schemas (Issue #158) ===\n'
+
+if python3 -c 'import jsonschema' >/dev/null 2>&1; then
+  SCHEMA_FIXTURES="$FIXTURES_DIR/schema-validate"
+
+  if sh "$PLANGATE_BIN" validate-schemas "$SCHEMA_FIXTURES/valid/c3.json" >/dev/null 2>&1; then
+    printf '[PASS] valid/c3.json passes c3-approval schema\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] valid/c3.json — expected PASS\n'
+    fail=$((fail + 1))
+  fi
+
+  if ! sh "$PLANGATE_BIN" validate-schemas "$SCHEMA_FIXTURES/invalid/c3.json" >/dev/null 2>&1; then
+    printf '[PASS] invalid/c3.json fails c3-approval schema (exit non-zero)\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] invalid/c3.json — expected FAIL\n'
+    fail=$((fail + 1))
+  fi
+
+  if sh "$PLANGATE_BIN" validate-schemas 2>&1 | grep -q 'Usage'; then
+    printf '[PASS] validate-schemas: no args emits Usage text\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] validate-schemas: usage text missing\n'
+    fail=$((fail + 1))
+  fi
+else
+  printf '[SKIP] validate-schemas suite — jsonschema package not installed (CI will install it)\n'
+fi

--- a/tests/extras/ta-06-hooks.sh
+++ b/tests/extras/ta-06-hooks.sh
@@ -1,0 +1,18 @@
+# tests/extras/ta-06-hooks.sh
+# Sourced by tests/run-tests.sh
+# Issue #170 で run-tests.sh から分離
+
+printf '\n=== TA-06: hooks (Issue #157) ===\n'
+
+HOOK_TESTS_SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/hooks/run-tests.sh"
+if [ -f "$HOOK_TESTS_SCRIPT" ]; then
+  if sh "$HOOK_TESTS_SCRIPT" >/dev/null 2>&1; then
+    printf '[PASS] tests/hooks/run-tests.sh — all hook unit tests\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] tests/hooks/run-tests.sh — see "sh tests/hooks/run-tests.sh" output\n'
+    fail=$((fail + 1))
+  fi
+else
+  printf '[SKIP] tests/hooks/run-tests.sh not found\n'
+fi

--- a/tests/extras/ta-07-eval-runner.sh
+++ b/tests/extras/ta-07-eval-runner.sh
@@ -1,0 +1,52 @@
+# tests/extras/ta-07-eval-runner.sh
+# Sourced by tests/run-tests.sh
+# Issue #170 で run-tests.sh から分離
+
+printf '\n=== TA-07: eval-runner (Issue #156) ===\n'
+
+if python3 -c 'import jsonschema' >/dev/null 2>&1; then
+  EVAL_FIXTURE="$FIXTURES_DIR/eval-runner/sample-task"
+  EVAL_TASK_NAME="TASK-9990"
+  EVAL_TASK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/docs/working/$EVAL_TASK_NAME"
+
+  cleanup_eval() { rm -rf "$EVAL_TASK_DIR"; }
+  trap cleanup_eval EXIT INT TERM
+
+  cleanup_eval
+  mkdir -p "$EVAL_TASK_DIR/approvals"
+  cp "$EVAL_FIXTURE/handoff.md" "$EVAL_TASK_DIR/handoff.md"
+  cp "$EVAL_FIXTURE/approvals/c3.json" "$EVAL_TASK_DIR/approvals/c3.json"
+
+  if sh "$PLANGATE_BIN" eval "$EVAL_TASK_NAME" --no-write >/dev/null 2>&1; then
+    printf '[PASS] eval: sample task → exit 0 (no blockers)\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] eval: sample task — expected exit 0\n'
+    fail=$((fail + 1))
+  fi
+
+  out=$(sh "$PLANGATE_BIN" eval "$EVAL_TASK_NAME" --no-write 2>&1 || true)
+  case "$out" in
+    *"AC coverage"*)
+      printf '[PASS] eval: stdout contains AC coverage line\n'
+      pass=$((pass + 1))
+      ;;
+    *)
+      printf '[FAIL] eval: stdout missing AC coverage line\n'
+      fail=$((fail + 1))
+      ;;
+  esac
+
+  if sh "$PLANGATE_BIN" eval 2>&1 | grep -q 'Usage'; then
+    printf '[PASS] eval: no args emits Usage text\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] eval: usage text missing\n'
+    fail=$((fail + 1))
+  fi
+
+  cleanup_eval
+  trap - EXIT INT TERM
+else
+  printf '[SKIP] eval-runner suite — jsonschema not installed\n'
+fi

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 # PlanGate CLI test suite
 # Usage: sh tests/run-tests.sh
+#
+# 構成:
+#   - 本体（base tests）: 下記 TA-01 / TA-02 / TA-03 + plangate validate --dir
+#   - 拡張テスト: tests/extras/*.sh を順次 source（Issue #170 で導入）
+#     新規テストブロック追加時は tests/extras/ にファイルを置くこと。
+#     詳細は tests/extras/README.md 参照。
 
 set -eu
 
 PLANGATE_BIN="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/bin/plangate"
 FIXTURES_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/fixtures"
+EXTRAS_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/extras"
 
 pass=0
 fail=0
@@ -114,135 +121,16 @@ if [ "${created_gate_test:-0}" -eq 1 ]; then
 fi
 rm -rf "$TMPDIR_TASK"
 
-printf '\n=== TA-04: check-pr-issue-link.sh ===\n'
-
-PR_LINK_SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/scripts/check-pr-issue-link.sh"
-PR_LINK_FIXTURES="$FIXTURES_DIR/check-pr-issue-link"
-
-run_pr_link_fixture() {
-  fixture_dir=$1
-  expected=$2
-  label=$3
-  out=$(sh "$PR_LINK_SCRIPT" \
-    --body-file "$fixture_dir/body.txt" \
-    --labels-file "$fixture_dir/labels.txt" \
-    --changed-files "$fixture_dir/changed-files.txt" 2>&1) || {
-    printf '[FAIL] %s — script exited non-zero: %s\n' "$label" "$out"
-    fail=$((fail + 1))
-    return
-  }
-  case "$out" in
-    "$expected"*)
-      printf '[PASS] %s — got %s\n' "$label" "$expected"
-      pass=$((pass + 1))
-      ;;
-    *)
-      printf '[FAIL] %s — expected prefix %s, got: %s\n' "$label" "$expected" "$out"
-      fail=$((fail + 1))
-      ;;
-  esac
-}
-
-run_pr_link_fixture "$PR_LINK_FIXTURES/pass" "PASS" "pass: closes #N present"
-run_pr_link_fixture "$PR_LINK_FIXTURES/warn" "WARN" "warn: no closing keyword"
-run_pr_link_fixture "$PR_LINK_FIXTURES/skip-label" "SKIP" "skip-label: documentation label"
-run_pr_link_fixture "$PR_LINK_FIXTURES/skip-marker" "SKIP" "skip-marker: HTML comment marker"
-
-printf '\n=== TA-05: validate-schemas (Issue #158) ===\n'
-
-if python3 -c 'import jsonschema' >/dev/null 2>&1; then
-  SCHEMA_FIXTURES="$FIXTURES_DIR/schema-validate"
-
-  if sh "$PLANGATE_BIN" validate-schemas "$SCHEMA_FIXTURES/valid/c3.json" >/dev/null 2>&1; then
-    printf '[PASS] valid/c3.json passes c3-approval schema\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] valid/c3.json — expected PASS\n'
-    fail=$((fail + 1))
-  fi
-
-  if ! sh "$PLANGATE_BIN" validate-schemas "$SCHEMA_FIXTURES/invalid/c3.json" >/dev/null 2>&1; then
-    printf '[PASS] invalid/c3.json fails c3-approval schema (exit non-zero)\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] invalid/c3.json — expected FAIL\n'
-    fail=$((fail + 1))
-  fi
-
-  if sh "$PLANGATE_BIN" validate-schemas 2>&1 | grep -q 'Usage'; then
-    printf '[PASS] validate-schemas: no args emits Usage text\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] validate-schemas: usage text missing\n'
-    fail=$((fail + 1))
-  fi
-else
-  printf '[SKIP] validate-schemas suite — jsonschema package not installed (CI will install it)\n'
-fi
-
-printf '\n=== TA-06: hooks (Issue #157) ===\n'
-
-HOOK_TESTS_SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/hooks/run-tests.sh"
-if [ -f "$HOOK_TESTS_SCRIPT" ]; then
-  # 子テストの結果を取り込む（自前で pass/fail カウンタを進める）
-  if sh "$HOOK_TESTS_SCRIPT" >/dev/null 2>&1; then
-    printf '[PASS] tests/hooks/run-tests.sh — all hook unit tests\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] tests/hooks/run-tests.sh — see "sh tests/hooks/run-tests.sh" output\n'
-    fail=$((fail + 1))
-  fi
-else
-  printf '[SKIP] tests/hooks/run-tests.sh not found\n'
-fi
-
-printf '\n=== TA-07: eval-runner (Issue #156) ===\n'
-
-if python3 -c 'import jsonschema' >/dev/null 2>&1; then
-  EVAL_FIXTURE="$FIXTURES_DIR/eval-runner/sample-task"
-  EVAL_TASK_NAME="TASK-9990"
-  EVAL_TASK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/docs/working/$EVAL_TASK_NAME"
-
-  cleanup_eval() { rm -rf "$EVAL_TASK_DIR"; }
-  trap cleanup_eval EXIT INT TERM
-
-  cleanup_eval
-  mkdir -p "$EVAL_TASK_DIR/approvals"
-  cp "$EVAL_FIXTURE/handoff.md" "$EVAL_TASK_DIR/handoff.md"
-  cp "$EVAL_FIXTURE/approvals/c3.json" "$EVAL_TASK_DIR/approvals/c3.json"
-
-  if sh "$PLANGATE_BIN" eval "$EVAL_TASK_NAME" --no-write >/dev/null 2>&1; then
-    printf '[PASS] eval: sample task → exit 0 (no blockers)\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] eval: sample task — expected exit 0\n'
-    fail=$((fail + 1))
-  fi
-
-  out=$(sh "$PLANGATE_BIN" eval "$EVAL_TASK_NAME" --no-write 2>&1 || true)
-  case "$out" in
-    *"AC coverage"*)
-      printf '[PASS] eval: stdout contains AC coverage line\n'
-      pass=$((pass + 1))
-      ;;
-    *)
-      printf '[FAIL] eval: stdout missing AC coverage line\n'
-      fail=$((fail + 1))
-      ;;
-  esac
-
-  if sh "$PLANGATE_BIN" eval 2>&1 | grep -q 'Usage'; then
-    printf '[PASS] eval: no args emits Usage text\n'
-    pass=$((pass + 1))
-  else
-    printf '[FAIL] eval: usage text missing\n'
-    fail=$((fail + 1))
-  fi
-
-  cleanup_eval
-  trap - EXIT INT TERM
-else
-  printf '[SKIP] eval-runner suite — jsonschema not installed\n'
+# ── Extras: tests/extras/*.sh を順番に source（Issue #170）─────────────────────
+# 新規 TA-NN を追加するときは tests/extras/ にファイルを置くだけでよい。
+# 本体（このファイル）の編集は不要 → PBI 連続実装時の衝突を回避。
+if [ -d "$EXTRAS_DIR" ]; then
+  for extra in "$EXTRAS_DIR"/ta-*.sh; do
+    # POSIX glob: マッチ無しのときリテラル文字列が返るため存在チェック
+    [ -f "$extra" ] || continue
+    # shellcheck source=/dev/null
+    . "$extra"
+  done
 fi
 
 printf '\n'


### PR DESCRIPTION
## Summary

retrospective 2026-05-01 P-2 / Try T-4 への対応。5 PBI 連続実装で `tests/run-tests.sh` 末尾領域コンフリクトが 3 PR で発生した問題を **構造的に解消**。

## Changes

- `tests/extras/ta-{04,05,06,07}-*.sh`: 既存 TA-04〜07 を 4 ファイルに分離（内容は無変更）
- `tests/extras/README.md`: 命名規約 / source 規約 / 新規追加手順 / 例を明文化
- `tests/run-tests.sh`: base test（TA-01〜03）+ extras loader にスリム化（末尾で `for extra in "$EXTRAS_DIR"/ta-*.sh; do . "$extra"; done`）
- 21 件 PASS 維持（loader 経由）
- 新規 TA-NN 追加時は `tests/extras/` にファイルを置くだけで完結 → 本体編集不要 = 衝突源根絶

## Test plan

- [x] `sh tests/run-tests.sh` → `Results: 21 passed, 0 failed`
- [x] `tests/extras/` 配下に 4 ファイル + README 配置
- [x] run-tests.sh から TA-04〜07 削除、loader が代替
- [ ] CI 緑確認

## Linked Issue

closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)