### PR TITLE
feat(env): gh CLI active account 自動固定 shim (#171)

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,10 +1,21 @@
 {
-  "_comment_": "PlanGate Hook enforcement (Issue #157 / TASK-0048) — opt-in 設定例",
-  "_usage_": "本ファイルは example。実 .claude/settings.json にコピーして適用する。default は warning モード（continue:true）。PLANGATE_HOOK_STRICT=1 で block モード、PLANGATE_BYPASS_HOOK=1 で常時 pass。",
+  "_comment_": "PlanGate hooks 設定例 — opt-in",
+  "_usage_": "本ファイルは example。実 .claude/settings.json にコピーして適用する。",
   "hooks": {
+    "SessionStart": [
+      {
+        "_comment_": "Issue #171: gh CLI active account を s977043 に固定（plangate 用）。PLANGATE_GH_USER で他 user に override 可能。失敗しても session は継続（exit code は無視される）。",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ${CLAUDE_PROJECT_DIR}/scripts/gh-pin-account.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
-        "_comment_": "Hook EH-2: plan / C-3 承認なしで Edit / Write を実行しようとした場合に warning（strict 時 block）。PLANGATE_HOOK_TASK 環境変数で対象 TASK を明示する必要あり。未明示時は skip（false-positive 防止）。",
+        "_comment_": "Hook EH-2: plan / C-3 承認なしで Edit / Write を実行しようとした場合に warning（strict 時 block）。PLANGATE_HOOK_TASK 環境変数で対象 TASK を明示する必要あり。未明示時は skip（false-positive 防止）。default は warning モード（continue:true）、PLANGATE_HOOK_STRICT=1 で block、PLANGATE_BYPASS_HOOK=1 で常時 pass。",
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/docs/working/TASK-0052/handoff.md
+++ b/docs/working/TASK-0052/handoff.md
@@ -1,0 +1,81 @@
+---
+task_id: TASK-0052
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-05-01
+author: qa-reviewer
+v1_release: ""
+related_issue: 171
+---
+
+# Handoff: TASK-0052 / Issue #171 — gh CLI active account 自動固定 shim
+
+## 1. 要件適合確認結果
+
+| AC | 判定 | 根拠 |
+|----|------|------|
+| AC-1: 冪等性 | PASS | 2 回実行で問題なし、結果一致 |
+| AC-2: already pinned 検出 | PASS | `gh api user --jq .login` で現在 user 取得、一致時に "already pinned" |
+| AC-3: switched 通知 | PASS | 別 user → `gh auth switch -u $DESIRED_USER` 成功時 "switched to" |
+| AC-4: 不在 user で exit 1 | PASS | `gh auth status` に該当 user がなければ "not in gh auth status" + exit 1 |
+| AC-5: gh 不在で exit 1 | PASS | `command -v gh` で検出、stderr "not installed" |
+| AC-6: SessionStart hook 登録 | PASS | `.claude/settings.example.json` に SessionStart entry |
+
+**総合**: **6 / 6 PASS**
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 |
+|------|---------|------|
+| `gh api user` が API rate limit で失敗する可能性 | minor | accepted（fallback あり）|
+| 切替後すぐの API 呼び出しは時々遅延 | info | accepted（運用で気にならないレベル）|
+| 上流 gh CLI の自動切替バグの根本解消はしていない | info | accepted（workaround アプローチ）|
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 優先度 |
+|--------|------|--------|
+| Codex / Gemini 用の同等 hook 提供 | クロスツール対応 | Low |
+| gh CLI 上流バグの調査 + report | 根本解消 | Low |
+| direnv / mise との統合 | 自動化深化 | Low |
+
+## 4. 妥協点
+
+| 選択 | 諦めた代替 | 理由 |
+|------|-----------|------|
+| `.claude/settings.example.json` opt-in | 実 `.claude/settings.json` 直接登録 | 開発者環境の差異を尊重、自動適用しない |
+| `gh api user` で active 取得 | `gh auth status` のみ解析 | API call なら確実、parse の脆さ回避 |
+| デフォルト `s977043` ハードコード | repo config から動的取得 | git remote URL から取得は複雑、env override で十分 |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+plangate での作業中に gh CLI active account が想定外に kominem-unilabo へ切り戻る現象（retrospective 2026-05-01 P-1、本セッションで 4 回以上発生）への workaround。`scripts/gh-pin-account.sh` で現在 user を確認し、必要時のみ `s977043` に切替。SessionStart hook として `.claude/settings.example.json` に opt-in 登録。
+
+主要成果:
+- `scripts/gh-pin-account.sh`（POSIX sh、冪等、`PLANGATE_GH_USER` で override 可能）
+- `.claude/settings.example.json` に SessionStart hook 追加
+
+### 触れないでほしいファイル
+
+- `scripts/gh-pin-account.sh` の `gh api user` fallback 順序: 環境差異対応で重要
+
+### 次に手を入れるなら
+
+- 実 `.claude/settings.json` への登録は開発者の手動 opt-in
+- 他 fork の開発者は `PLANGATE_GH_USER` を export してから session 開始
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP |
+|---------|------|------|-----------|
+| Manual smoke | 4 | 4 | 0 / 0 |
+
+検証コマンド:
+```sh
+sh scripts/gh-pin-account.sh                                # already pinned / switched
+PLANGATE_GH_USER=non-existent sh scripts/gh-pin-account.sh  # exit 1
+grep -E '"SessionStart"' .claude/settings.example.json      # match
+```

--- a/docs/working/TASK-0052/pbi-input.md
+++ b/docs/working/TASK-0052/pbi-input.md
@@ -1,0 +1,29 @@
+# PBI INPUT PACKAGE: TASK-0052 / Issue #171
+
+> Source: [#171 gh CLI active account 自動固定 shim](https://github.com/s977043/plangate/issues/171)
+> Mode: **light**
+
+## Context / Why
+
+retrospective 2026-04-30 T-5 / 2026-05-01 P-1。plangate での作業中に gh CLI の active account が `kominem-unilabo` へ勝手に切り戻る現象が頻発。本セッションだけで 4 回以上、共有 mutation が `does not have the correct permissions` で失敗 → 手動 `gh auth switch` 必要。
+
+## What
+
+### In scope
+- `scripts/gh-pin-account.sh`: 現在 user チェック + 必要時のみ `gh auth switch` 実行
+- 環境変数 `PLANGATE_GH_USER` で username override（デフォルト `s977043`）
+- `.claude/settings.example.json` の SessionStart hook に追加（opt-in）
+- 不在 / 切替失敗時の明確なエラーメッセージ
+
+### Out of scope
+- Claude Code 以外の AI（Codex / Gemini）連携
+- gh CLI 自体のバグ修正（上流 issue 領域）
+
+## Acceptance Criteria
+
+- AC-1: `sh scripts/gh-pin-account.sh` が冪等（複数回実行しても問題なし）
+- AC-2: 既に正しい user 時は `already pinned` と出力 + exit 0
+- AC-3: 別 user 時は切り替え + `switched to` と出力 + exit 0
+- AC-4: 該当 user が logged-in でない時は `not in gh auth status` と stderr + exit 1
+- AC-5: `gh` 不在時は `not installed` と stderr + exit 1
+- AC-6: `.claude/settings.example.json` に SessionStart hook が登録されている

--- a/docs/working/TASK-0052/plan.md
+++ b/docs/working/TASK-0052/plan.md
@@ -1,0 +1,40 @@
+# EXECUTION PLAN: TASK-0052 / Issue #171
+
+> Mode: **light**
+
+## Goal
+
+plangate 作業時に gh CLI active account を `s977043` に自動固定する shim を提供。SessionStart hook + 単発実行 CLI の両方を opt-in で利用可能にする。
+
+## Approach
+
+1. `scripts/gh-pin-account.sh`: POSIX sh、`gh api user --jq .login` で現在 user 取得、`gh auth switch` 実行
+2. `.claude/settings.example.json` の `hooks.SessionStart` に登録（opt-in）
+3. 環境変数 `PLANGATE_GH_USER` でデフォルト `s977043` を override 可能（他 user で plangate fork した場合等）
+4. 失敗時は exit 1〜2 で診断可能、session 継続性を妨げない
+
+## 変更ファイル
+
+| ファイル | 種別 |
+|---------|------|
+| `scripts/gh-pin-account.sh` | 新規 |
+| `.claude/settings.example.json` | 編集（SessionStart hook 追加）|
+| `docs/working/TASK-0052/*` | 新規 |
+
+## Mode判定
+
+light（環境改善、CI 影響なし、既存挙動への副作用ゼロ）
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|----------|
+| `gh api user` が一時的に失敗 | fallback で `gh auth status` 解析、それでも取れなければ強制 switch |
+| 別 user で fork したい開発者が困る | `PLANGATE_GH_USER` 環境変数で override 可能 |
+| SessionStart hook が誤動作で session 阻害 | hook の exit code は Claude Code 側で warning 扱い（block しない）、shim も exit 1 程度で session 継続 |
+
+## 確認方法
+
+- `sh scripts/gh-pin-account.sh` を 2 回実行 → 1 回目「switched」or「already」、2 回目「already pinned」
+- `PLANGATE_GH_USER=nonexistent sh scripts/gh-pin-account.sh` → exit 1, "not in gh auth status"
+- `.claude/settings.example.json` に SessionStart hook が含まれている

--- a/docs/working/TASK-0052/test-cases.md
+++ b/docs/working/TASK-0052/test-cases.md
@@ -1,0 +1,27 @@
+# TEST CASES: TASK-0052 / Issue #171
+
+| AC | TC | 検証 |
+|----|----|------|
+| AC-1〜AC-3 | TC-1 | 連続実行で idempotent |
+| AC-4 | TC-2 | 不在 user で exit 1 |
+| AC-5 | TC-3 | gh 不在シミュレーション（PATH 制限） |
+| AC-6 | TC-4 | settings.example に SessionStart 登録 |
+
+## TC-1
+```sh
+sh scripts/gh-pin-account.sh; echo "exit=$?"
+sh scripts/gh-pin-account.sh; echo "exit=$?"
+# 期待: 両方 exit=0、2 回目は "already pinned"
+```
+
+## TC-2
+```sh
+PLANGATE_GH_USER=non-existent-user sh scripts/gh-pin-account.sh; echo "exit=$?"
+# 期待: exit=1、stderr に "not in gh auth status"
+```
+
+## TC-4
+```sh
+grep -E '"SessionStart"' .claude/settings.example.json
+grep -E "gh-pin-account.sh" .claude/settings.example.json
+```

--- a/docs/working/TASK-0052/todo.md
+++ b/docs/working/TASK-0052/todo.md
@@ -1,0 +1,12 @@
+# EXECUTION TODO: TASK-0052 / Issue #171
+
+> Mode: **light**
+
+- [x] PBI INPUT
+- [x] plan + test-cases
+- [x] scripts/gh-pin-account.sh 実装
+- [x] .claude/settings.example.json に SessionStart hook 追加
+- [x] 動作確認（idempotent / 不在 user / 既に切替済）
+- [x] handoff.md
+- [x] commit + push + PR
+- [ ] CI 緑確認 → C-4

--- a/scripts/gh-pin-account.sh
+++ b/scripts/gh-pin-account.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# gh-pin-account.sh — plangate 作業時に gh CLI active account を s977043 に固定
+#
+# 背景: retrospective 2026-05-01 P-1 — plangate での作業中に gh CLI の active
+# account が想定外に kominem-unilabo へ切り戻る現象（本セッションで 4 回以上発生）。
+# 共有 mutation（pr merge / pr comment / issue create）が 403 で失敗する原因。
+#
+# Usage:
+#   sh scripts/gh-pin-account.sh                      # デフォルト: s977043
+#   PLANGATE_GH_USER=other-user sh scripts/gh-pin-account.sh
+#
+# Exit code:
+#   0  正しいユーザーに切り替え済み（または既に正しい状態）
+#   1  gh CLI 不在 / 該当ユーザーが logged-in に存在しない
+#   2  切り替え試行が失敗（権限エラー等）
+#
+# Issue #171 / TASK-0052
+
+set -eu
+
+DESIRED_USER=${PLANGATE_GH_USER:-s977043}
+
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'gh-pin-account: gh CLI not installed, skipping\n' >&2
+  exit 1
+fi
+
+# 現在の active account を取得（gh CLI バージョン差異を考慮した複数戦略）
+current=$(gh api user --jq .login 2>/dev/null || true)
+if [ -z "$current" ]; then
+  # Fallback: gh auth status から抽出
+  current=$(gh auth status 2>&1 | grep -B1 "Active account: true" | grep -oE "account [^ ]+" | awk '{print $2}' | head -1 || true)
+fi
+
+if [ "$current" = "$DESIRED_USER" ]; then
+  printf 'gh-pin-account: already pinned to %s\n' "$DESIRED_USER"
+  exit 0
+fi
+
+# 該当ユーザーが logged-in 一覧にあるか確認
+if ! gh auth status 2>&1 | grep -q "account $DESIRED_USER"; then
+  printf 'gh-pin-account: %s is not in `gh auth status` (run: gh auth login -u %s)\n' "$DESIRED_USER" "$DESIRED_USER" >&2
+  exit 1
+fi
+
+# 切り替え実行
+if gh auth switch -u "$DESIRED_USER" >/dev/null 2>&1; then
+  printf 'gh-pin-account: switched to %s\n' "$DESIRED_USER"
+  exit 0
+fi
+
+printf 'gh-pin-account: failed to switch to %s\n' "$DESIRED_USER" >&2
+exit 2


### PR DESCRIPTION
## Summary

retrospective 2026-05-01 P-1 / Try T-5 への対応。plangate 作業中に gh CLI active account が `kominem-unilabo` へ勝手に切り戻る現象（本セッションで 4 回以上発生）の workaround。

## Changes

- `scripts/gh-pin-account.sh`（新規）: POSIX sh、冪等、`gh api user --jq .login` で現在 user 確認 + 必要時のみ `gh auth switch -u $DESIRED` 実行
- 環境変数 `PLANGATE_GH_USER` でデフォルト `s977043` を override 可能（fork 開発者対応）
- `.claude/settings.example.json` に SessionStart hook 追加（opt-in）

## Test plan

- [x] `sh scripts/gh-pin-account.sh` を 2 回実行 → idempotent（"already pinned"）
- [x] `PLANGATE_GH_USER=non-existent sh scripts/gh-pin-account.sh` → exit 1, "not in gh auth status"
- [x] `.claude/settings.example.json` に `SessionStart` + `gh-pin-account.sh` の登録確認
- [ ] CI 緑確認

## 既知制限

- 上流 gh CLI の自動切戻バグの根本解消はしていない（workaround アプローチ）
- 実 `.claude/settings.json` への登録は手動 opt-in（自動適用はしない）

## Linked Issue

closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)