### PR TITLE
fix(schemas): c3/c4 approval schema が _*アノテーションを許容 (#167)

### DIFF
--- a/docs/working/TASK-0053/handoff.md
+++ b/docs/working/TASK-0053/handoff.md
@@ -1,0 +1,78 @@
+---
+task_id: TASK-0053
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-05-01
+author: qa-reviewer
+v1_release: ""
+related_issue: 167
+---
+
+# Handoff: TASK-0053 / Issue #167 — c3.json schema 違反正規化（Option B）
+
+## 1. 要件適合確認結果
+
+| AC | 判定 | 根拠 |
+|----|------|------|
+| AC-1: 6 PBI で validate-schemas PASS | PASS | TASK-0039〜0044 全件 PASS（直接 `python3 -c` で確認、その後 `sh tests/run-tests.sh` 21 件 PASS）|
+| AC-2: eval で blocker 0 | PASS | 全 6 PBI で `Release Blocker 違反: なし（PASS）` |
+| AC-3: 既存 c3.json 無変更 | PASS | `git status` でも `docs/working/` に変更なし、schema 緩和のみで対応 |
+| AC-4: typo 拒否維持 | PASS | `^_` 接頭以外の未知 key は依然 `additionalProperties: false` で拒否 |
+| AC-5: tests 21 PASS | PASS | `Results: 21 passed, 0 failed` |
+
+**総合**: **5 / 5 PASS**
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 |
+|------|---------|------|
+| `^_` 接頭の慣例が schema-wide には未統一 | info | accepted（c3/c4 のみ修正、必要時に他 schema も追加）|
+| review-result.schema.json 等での同需要は未着手 | info | accepted（V2 候補）|
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 優先度 |
+|--------|------|--------|
+| 全 schema に `^_` patternProperties 統一 | annotation 文化の標準化 | Low |
+| `_review_summary` を正式 property として schema 化 | 構造化 + 可読性向上 | Low |
+
+## 4. 妥協点
+
+| 選択 | 諦めた代替 | 理由 |
+|------|-----------|------|
+| Option B（schema 緩和）| Option A（既存 c3.json 正規化）| 履歴汚染ゼロ、変更ファイル 2 件で完結、原則 backward-compatible |
+| `^_` プレフィクス限定 | 任意 additional property 許容 | typo 検出の厳しさ維持 |
+| c4-approval も予防修正 | c3 のみ修正 | 将来 c4-approval.json が運用始まったときに同問題を出さない |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+`bin/plangate eval` が PBI-116 配下 6 件で format adherence の release blocker を量産していた問題（retrospective 2026-05-01 P-3）を schema 緩和で解消。`patternProperties: { "^_": {} }` を c3 / c4 schema に追加し、`_review_summary` 等の human-readable annotation を許容。既存 c3.json を一切変更せず、変更ファイル 2 件で完結。
+
+### 触れないでほしいファイル
+
+- `schemas/c3-approval.schema.json` の `patternProperties.^_`: 緩和の核
+- 既存 `docs/working/TASK-0039〜0044/approvals/c3.json`: schema 緩和で適合化済、再正規化不要
+
+### 次に手を入れるなら
+
+- 新 schema 作成時は `_*` 慣例を念頭に `patternProperties` を初期から追加するか検討
+- アンチパターン: `additionalProperties: true` で全許容（typo 検出が効かなくなる）
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP |
+|---------|------|------|-----------|
+| 既存 PBI 突合 | 6 | 6 | 0 / 0 |
+| eval blocker 検査 | 6 | 6 | 0 / 0 |
+| Integration（tests/run-tests.sh）| 21 | 21 | 0 / 0 |
+
+検証コマンド:
+```sh
+sh tests/run-tests.sh                                                   # 21 PASS
+for t in TASK-0039 TASK-0040 TASK-0041 TASK-0042 TASK-0043 TASK-0044; do
+  python3 scripts/eval-runner.py $t --no-write | grep "Release Blocker"
+done                                                                     # 全件 "なし（PASS）"
+```

--- a/docs/working/TASK-0053/pbi-input.md
+++ b/docs/working/TASK-0053/pbi-input.md
@@ -1,0 +1,32 @@
+# PBI INPUT PACKAGE: TASK-0053 / Issue #167
+
+> Source: [#167 既存 PBI c3.json schema 違反正規化](https://github.com/s977043/plangate/issues/167)
+> Mode: **standard** → 実装で **light** に縮減（schema 緩和のみで完結）
+
+## Context / Why
+
+retrospective 2026-05-01 P-3 / Try T-1。#158（schema validate CI）/ #156（eval runner）を実装したところ、PBI-116 配下 6 件の `approvals/c3.json` が `c3-approval.schema.json` の `additionalProperties: false` 制約に違反していると判明（`_review_summary` `_schema_reference` `_note` 等の human-readable annotation が含まれる）。`bin/plangate eval` で format adherence の release blocker が量産されていた。
+
+## What
+
+### 採用方針: Option B（schema を緩める）
+
+`additionalProperties: false` を維持しつつ、`patternProperties: { "^_": {} }` を追加して **アンダースコア接頭の key だけを許容**。既存ファイルは無変更で schema 適合化、人間可読の annotation を保持できる。
+
+### In scope
+- `schemas/c3-approval.schema.json` に `patternProperties` 追加
+- `schemas/c4-approval.schema.json` に同等の修正（予防的、c4 ファイル不在でも将来対応）
+- 既存 6 件の c3.json が schema validate PASS
+- eval runner で blocker 0 確認
+
+### Out of scope
+- 他 schema（review-result / handoff-summary 等）の同等改修（必要時に別 PBI）
+- Option A（既存ファイル正規化）はリジェクト（手間 + 履歴汚染）
+
+## Acceptance Criteria
+
+- AC-1: 既存 6 件の c3.json が `bin/plangate validate-schemas TASK-XXXX` で PASS
+- AC-2: `bin/plangate eval TASK-XXXX` で format adherence の release blocker が 0
+- AC-3: 既存 review_summary 情報が失われていない（schema 緩和のみで既存ファイル無変更）
+- AC-4: schema 変更が `_*` 接頭以外の未知 key は引き続き拒否（厳しさ維持）
+- AC-5: tests/run-tests.sh 21 件 PASS 維持

--- a/docs/working/TASK-0053/plan.md
+++ b/docs/working/TASK-0053/plan.md
@@ -1,0 +1,43 @@
+# EXECUTION PLAN: TASK-0053 / Issue #167
+
+> Mode: **light**（当初 standard 想定だが Option B 採用で 2 ファイル変更のみ）
+
+## Goal
+
+`patternProperties: { "^_": {} }` を c3 / c4 schema に追加。既存 c3.json を **無変更** のまま schema 適合化し、人間可読 annotation（`_review_summary` 等）の保持と機械検証を両立。
+
+## Approach
+
+JSON Schema の標準機能 `patternProperties` を活用:
+- `properties` で定義した key と `patternProperties` にマッチする key 以外は `additionalProperties: false` で拒否
+- `^_` プレフィクスの key は内容自由（schema `{}` = anything）
+
+これにより:
+- 既存 c3.json の `_review_summary` `_schema_reference` `_note` が許容される
+- typo（例: `c3_statu` を `c3_status` の typo として書いた）は引き続き拒否される
+- 厳しさは維持しつつ、annotation 文化を許容
+
+## 変更ファイル
+
+| ファイル | 種別 |
+|---------|------|
+| `schemas/c3-approval.schema.json` | 編集（`patternProperties` 追加）|
+| `schemas/c4-approval.schema.json` | 編集（同等の予防修正）|
+| `docs/working/TASK-0053/*` | 新規 |
+
+## Mode判定
+
+light（schema 2 ファイル + 既存ファイル無変更、後方互換維持、リスク極低）
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|----------|
+| `_*` プレフィクスの誤用（typo を許容してしまう）| `^_` で頭文字限定、既存 annotation 文化に沿うパターンのみ許容 |
+| 他 schema との不整合 | c3 / c4 のみ修正、他 schema は影響受けず |
+
+## 確認方法
+
+- 全 6 PBI で `bin/plangate validate-schemas TASK-XXXX` が PASS
+- 全 6 PBI で `bin/plangate eval TASK-XXXX --no-write` が `Release Blocker 違反: なし（PASS）`
+- `sh tests/run-tests.sh` → 21 PASS

--- a/docs/working/TASK-0053/test-cases.md
+++ b/docs/working/TASK-0053/test-cases.md
@@ -1,0 +1,31 @@
+# TEST CASES: TASK-0053 / Issue #167
+
+| AC | TC | 検証 |
+|----|----|------|
+| AC-1 | TC-1 | 6 PBI で validate-schemas PASS |
+| AC-2 | TC-2 | 6 PBI で eval blocker 0 |
+| AC-3 | TC-3 | 既存 c3.json 無変更（git diff で確認）|
+| AC-4 | TC-4 | typo（`c3_statu`）が依然として拒否される |
+| AC-5 | TC-5 | tests/run-tests.sh 21 PASS |
+
+## TC-1
+```sh
+for t in TASK-0039 TASK-0040 TASK-0041 TASK-0042 TASK-0043 TASK-0044; do
+  sh bin/plangate validate-schemas $t/approvals/c3.json && echo "$t: OK"
+done
+```
+
+## TC-2
+```sh
+for t in TASK-0039 TASK-0040 TASK-0041 TASK-0042 TASK-0043 TASK-0044; do
+  python3 scripts/eval-runner.py $t --no-write 2>&1 | grep -A2 "Release Blocker" | grep "なし"
+done
+# 期待: 6 行ヒット
+```
+
+## TC-4
+```sh
+echo '{"task_id":"TASK-0001","phase":"C-3","c3_statu":"APPROVED","approved_by":"x","approved_at":"2026-01-01T00:00:00Z","plan_hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}' > /tmp/typo-c3.json
+sh bin/plangate validate-schemas /tmp/typo-c3.json
+# 期待: FAIL (c3_status missing + c3_statu unknown)
+```

--- a/docs/working/TASK-0053/todo.md
+++ b/docs/working/TASK-0053/todo.md
@@ -1,0 +1,14 @@
+# EXECUTION TODO: TASK-0053 / Issue #167
+
+> Mode: **light**
+
+- [x] PBI INPUT
+- [x] plan + test-cases
+- [x] schemas/c3-approval.schema.json: patternProperties 追加
+- [x] schemas/c4-approval.schema.json: 同等の予防修正
+- [x] 既存 6 PBI で validate-schemas PASS 確認
+- [x] 既存 6 PBI で eval blocker 0 確認
+- [x] tests/run-tests.sh 21 PASS 維持
+- [x] handoff.md
+- [x] commit + push + PR
+- [ ] CI 緑確認 → C-4

--- a/schemas/c3-approval.schema.json
+++ b/schemas/c3-approval.schema.json
@@ -41,6 +41,11 @@
       "description": "Required when c3_status is REJECTED"
     }
   },
+  "patternProperties": {
+    "^_": {
+      "description": "Underscore-prefixed keys are reserved for human-readable annotations (e.g. _review_summary, _schema_reference, _note). They are ignored by machine validation but preserved in the file. Issue #167 / TASK-0053."
+    }
+  },
   "allOf": [
     {
       "if": {

--- a/schemas/c4-approval.schema.json
+++ b/schemas/c4-approval.schema.json
@@ -34,5 +34,10 @@
       "description": "HEAD commit SHA of the merged PR"
     }
   },
+  "patternProperties": {
+    "^_": {
+      "description": "Underscore-prefixed keys are reserved for human-readable annotations. Ignored by machine validation. Issue #167 / TASK-0053."
+    }
+  },
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

retrospective 2026-05-01 P-3 / Try T-1 への対応。PBI-116 配下 6 件の `approvals/c3.json` が schema 違反していた問題を **Option B（schema 緩和）** で解消。

## Changes

- `schemas/c3-approval.schema.json`: `patternProperties: { "^_": {} }` を追加
- `schemas/c4-approval.schema.json`: 同等の予防修正
- 既存 c3.json は **無変更**（履歴汚染ゼロ）
- typo 等の未知 key は依然 `additionalProperties: false` で拒否（厳しさ維持）

## Test plan

- [x] PBI-116 配下 6 件すべてが `validate-schemas` で PASS（TASK-0039〜0044）
- [x] `bin/plangate eval TASK-XXXX --no-write` で全件 `Release Blocker: なし（PASS）`
- [x] `sh tests/run-tests.sh` → 21 PASS
- [ ] CI 緑確認

## Why Option B (schema 緩和) over Option A (既存ファイル正規化)

- 履歴汚染ゼロ（既存 c3.json を 1 文字も変更しない）
- 6 個別ファイル編集 vs 2 schema 編集 → 工数比較
- `_review_summary` 等の human-readable annotation は今後も書き続けられる文化

## Linked Issue

closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)