### PR TITLE
docs(tests): tests/extras/ README に set -e 互換書法を追記

### DIFF
--- a/tests/extras/README.md
+++ b/tests/extras/README.md
@@ -45,8 +45,53 @@ else
 fi
 ```
 
+## set -e 互換書法（retrospective 2026-05-01 s3 P-1 対応）
+
+extras は run-tests.sh の `set -eu` 環境下で source される。**コマンド置換の中で非ゼロ終了を許容したい場合**は exit code を明示捕捉する必要がある。
+
+### NG（早期終了する）
+
+```sh
+out=$(python3 myscript.py 2>&1)        # ← myscript.py が exit 1 すると set -e で run-tests.sh 全体が止まる
+case "$out" in *"OK"*) ... ;; esac
+```
+
+### OK（exit code を捕捉）
+
+```sh
+out=$(python3 myscript.py 2>&1) && rc=0 || rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q OK; then
+  printf '[PASS] ...\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] ... (rc=%d)\n' "$rc"
+  fail=$((fail + 1))
+fi
+```
+
+### trap は使わない
+
+EXIT/INT/TERM trap は extras 間で互いに上書きし合い、set -e との組み合わせで予測しにくい挙動になる（s3 retrospective で実害発生）。**fixture の cleanup は trap ではなく直接 `rm -rf` で行う**。
+
+```sh
+# OK: trap なし、明示的な前後 cleanup
+TMP_DIR="$(...)"
+rm -rf "$TMP_DIR"     # 念のため事前削除
+mkdir -p "$TMP_DIR"
+# ... テスト本体 ...
+rm -rf "$TMP_DIR"     # 後片付け（このブロック内で完結）
+```
+
+### 関数定義の namespace
+
+extras はすべて同一 shell プロセスで source されるため、関数名の衝突に注意:
+
+- 各 extras 固有のヘルパは `_taN_helper_name()` のように `_taN_` プレフィクスを推奨
+- `assert_pass` / `assert_fail` は run-tests.sh 提供で再定義不要
+
 ## 関連
 
 - 親 issue: [#170](https://github.com/s977043/plangate/issues/170)
 - TASK: `docs/working/TASK-0050/`
 - retrospective: `docs/working/retrospective-2026-05-01.md` § P-2 / T-4
+- set -e 書法ガイド追加: `docs/working/retrospective-2026-05-01-s3.md` § P-1 / T-2


### PR DESCRIPTION
## Summary

retrospective 2026-05-01 s3 **P-1 / Try T-2** への対応。s3 セッションで TA-08 が早期終了した原因（trap + command substitution × set -e の干渉）を踏まえ、新 extras 追加時のアンチパターンと推奨書法を README に明記。

## Changes

- **NG / OK の対比例**を追加（command substitution の exit code 捕捉）
- **trap 不使用 + 直接 rm cleanup**
- 関数名 namespace（`_taN_` プレフィクス推奨）
- 関連リンクに s3 retrospective を追加

## Test plan

- [x] `sh tests/run-tests.sh` → 24 PASS