### PR TITLE
docs: retrospective 2026-05-01 (s5) — doc-audit 完了 + 同日 8 セッション総括

### DIFF
--- a/docs/working/retrospective-2026-05-01-s5.md
+++ b/docs/working/retrospective-2026-05-01-s5.md
@@ -1,0 +1,177 @@
+# 振り返り 2026-05-01 (s5): doc-audit 2026-05-01 + 同日 8 セッション総括
+
+> 対象 PR: [#188](https://github.com/s977043/PlanGate/pull/188)
+> Audit doc: [`docs/working/_audit/2026-05-01-doc-audit.md`](_audit/2026-05-01-doc-audit.md)
+> 期間: 2026-05-01（同日 8 セッション目、Auto Mode）
+> ステータス: **本日のセッション群を最終クローズ**
+
+## サマリ
+
+v8.5.0 リリース完了後の自然な follow-up として **5 観点並列ドキュメント監査** を実施し、Critical 1 + Major 3 を一括修正（残 Minor 7 は本振り返りで継承）。同日 s1〜s5 の 8 セッションで PlanGate を **v8.3.0 → v8.4.0 → v8.5.0 + ドキュメント品質再担保** まで進めて完了。
+
+| 指標 | 値（s5 単独）| 値（s1〜s5 累計）|
+|------|----------|----------------|
+| 完了 PBI | 1（doc-audit 2026-05-01）| **17 件**（TASK-0045〜0058 + retro × 5）|
+| マージ PR | 1（#188）| **28 件**（#161〜#188）|
+| Critical 解消 | 1（V4-C-1 _prompts/README）| — |
+| Major 解消 | 3（V1-M-1, V1-M-2, V4-M-1）| — |
+| **Audit** | doc-audit 2026-05-01 完了 | doc-audit 2026-04-28 → **doc-audit 2026-05-01** |
+| **release** | — | v8.3.0 → v8.4.0 → **v8.5.0** |
+
+## 対応マッピング（s5）
+
+| 区分 | 内容 | 成果物 |
+|------|------|------|
+| Phase A | 5 観点（V1〜V5）並列読取専用監査 | `docs/working/_audit/2026-05-01-doc-audit.md` |
+| Phase B | Critical 1 + Major 3 修正 | PR #188 |
+| 継承 | Minor 7 件は次セッション or 個別判断へ | 本 retrospective に列挙 |
+
+## Keep（うまくいったこと）
+
+### K-1. 過去 doc-audit パターンの忠実な再現
+
+2026-04-28 の doc-audit と同じ「Phase A 読取専用 → punch list → Phase B 修正」パターンを踏襲。**4 並列 Explore agent + 5 観点（V1〜V5）** という分割設計が機能し、20 分程度で全体監査が完了。事前パターンを持っていることで意思決定コストが極小化された。
+
+### K-2. 観点 V2 / V5 で「完全一致」が確認できた価値
+
+実装 ↔ ドキュメント整合性（V2）と テンプレ ↔ 実 PBI 整合性（V5）が **完全整合**。これは v8.4.0 / v8.5.0 リリース時に `bin/plangate validate-schemas` / hook tests / handoff Rule 5 を機械的に維持した結果。**「品質を測れる仕組みがあると、品質が維持される」** という Goodhart の法則の正の側面が観測できた。
+
+### K-3. 過去 audit からの大幅改善（Critical 4→1, Major 4→3）
+
+- 2026-04-28: Critical 4 / Major 4 / Minor 4 / Info 3
+- 2026-05-01: Critical **1** / Major **3** / Minor 7 / Info 多数
+
+軽微な改善範囲（Minor 7）は増えたが、**重大な不整合は減少**。日々の retrospective Try → V2 候補 → 実装 → 解消サイクルが「致命的な不整合の蓄積」を防いだ。
+
+### K-4. Auto Mode + B 承認 1 回で自律実行が完結
+
+Phase A は読取専用なので承認なし、Phase B 開始時に「A / B / C」選択肢提示 → 「B」承認 → 自律実行。中断や追加確認なし、約 25 分で PR #188 マージまで完了。**Auto Mode の運用テンプレが定着** している実証。
+
+### K-5. 本日 8 セッションで「3 連続リリース + 監査」を達成
+
+s1: v8.3 後続 5 PBI → s2: V2 候補 4 件 → s3: #168 + v8.4.0 → s4: #169 EPIC + v8.5.0 → s5: doc-audit。**1 日で Spec → Implementation → Hook 完成 → Quality Audit** のフルサイクルを回した。retrospective 累積 5 ファイルで knowledge transfer も担保。
+
+## Problem（課題・反省）
+
+### P-1. retrospective が 5 ファイルに分裂してメンテ負荷増
+
+s1 / s2 / s3 / s4 / s5 で個別 retrospective を作成。Cross-reference は維持したが、**「同日のセッション群を 1 ファイルにまとめる」** か **「セッション横断の hub doc を作る」** かの設計判断が未着手。次回同様の長セッションでは事前に方針決定したい。
+
+**対策**: V2 候補として「retrospective batched フロー」を提案（s4 retrospective Try T-6 と同方向）。
+
+### P-2. doc-audit Minor 7 件を継承する形になった
+
+Phase B では Critical + Major のみ対応、Minor 7 件は本 retrospective に列挙して継承。これ自体は scope discipline として正しいが、**Minor が時間経過で「気づいた時には Major」に昇格するリスク** がある。
+
+**対策**: 次回監査（v8.6.0 リリース後 or 定期）で Minor 7 件を再評価、その時点で対応 / 却下を判断する仕組み化。
+
+### P-3. _prompts/ の古い review-{NNNN}.md の整理判断は先送り
+
+V4-C-1 で `README.md` を新設して **扱いを明記**したが、実際の整理（legacy/ への移動 or 削除）は実施せず。「保持」を選んだのは保守的判断だが、これが正しいかは運用知見不足。
+
+**対策**: 次回 review プロンプト改訂時に判断、もしくは半年後の定期整理で legacy/ 化を検討。
+
+### P-4. v8.3 互換手動セクション（V4-m-2）の対応保留
+
+`eval-baseline-procedure.md` の「v8.3 互換の手動手順（参考）」セクションが空のまま残置。Step 9 の v8.3 表記は更新したが、セクション自体は埋めるか削除するかの判断保留。Minor 扱いだが Minor 7 件のうち 1 件として残った。
+
+**対策**: 次回監査で「内容なしセクションは削除」「内容ありなら埋める」のルール化。
+
+## Try（次にやること）
+
+### T-1. 残 Minor 7 件のトリアージ会議
+
+| ID | 内容 | 推奨 |
+|----|------|------|
+| V1-m-1 | CHANGELOG v8.5.0 注釈 | スキップ（CHANGELOG は git log で十分）|
+| V3-m-1, V3-m-2 | retrospective ディレクトリリンク明示化 | スキップ（GitHub native 機能で十分）|
+| V4-m-1 | handoff template 役割分担セクション整合 | 次回 PBI で実 handoff vs テンプレ比較時に判断 |
+| V4-m-2 | eval-baseline-procedure 空セクション処理 | 次回 v8.6 タイミングで内容追加 or 削除 |
+| V5-m-1 | retrospective 個数標準化 | 次回 retrospective 起票時にテンプレ整備 |
+| V5-m-2 | INDEX.md template 別検査 | 別 audit セッションで実施 |
+
+優先度: **Low 全件**。即着手の必要性なし、運用の自然な機会で対応。
+
+### T-2. retrospective batched フローの設計
+
+P-1 への対応。Option:
+- **Option A**: 同日セッション群を 1 ファイルに集約（s1〜s5 を 1 つの `retrospective-2026-05-01.md` に統合）
+- **Option B**: セッション横断 hub `retrospective-INDEX.md` を作って各 session retro へリンク
+- **Option C**: 現状維持（個別 retro）+ 次回 retrospective テンプレに「同日連続セッションの場合の規約」を明記
+
+優先度: Medium。次回長セッションで再現する前に決めたい。
+
+### T-3. v8.6.0 milestone 候補の事前選定
+
+v8.5.0 までで Open Issue 0、Open PR 0、ガバナンス層・実装層ともに完全 clean。次の milestone は user 判断（新規要求 / V2 候補からの選定）に依存するが、本日積み上げた V2 候補 7 件（CHANGELOG v8.5.0 § Next EPIC 候補）を **優先度付きリスト** として残しておく。
+
+優先度: 自動的に発生（次セッション）。
+
+### T-4. 定期監査ルーチン化
+
+doc-audit を 2 回（2026-04-28 / 2026-05-01）実施し、パターンが定着。**release ごとに doc-audit を実施する運用** を CHANGELOG / release flow に組み込みたい。
+
+具体案:
+- release PR の test plan に「doc-audit 実施を記録」を追加
+- `scripts/doc-audit.sh`（CLI 化）を別 PBI で検討（V2 候補）
+
+優先度: Low、定着確認後の自然な延長。
+
+## メトリクス
+
+| 指標 | s5 単独 | 同日累計（s1〜s5）|
+|------|--------|----------------|
+| 計画 PR 数 | 1 | 28 |
+| 計画外 PR | 0 | 0 |
+| マージコンフリクト | 0 件 | 5 件（s1 で 3、tests/extras/ 効果で s2〜s8 ゼロ）|
+| handoff 必須 6 要素完備率 | n/a（doc audit、PBI 形式ではない）| **15/15 = 100%**（s1〜s4 累計）|
+| ローカル test PASS 率 | 24/24 = 100% | 24/24 = 100% |
+| Hook 単体 test PASS 率 | 42/42 = 100% | 42/42 = 100% |
+| CI 緑率 | 1/1 = 100% | **28/28 = 100%** |
+| Issue auto-close 率 | n/a | 12/12 = 100% |
+| **Audit 結果** | **Critical 1 + Major 3 解消** | doc-audit 2026-04-28 → **2026-05-01** |
+| **release** | — | v8.3.0 → v8.4.0 → **v8.5.0** |
+
+## 関連リンク
+
+- 親 retrospective: [`retrospective-2026-05-01.md`](retrospective-2026-05-01.md) / [`-s2.md`](retrospective-2026-05-01-s2.md) / [`-s3.md`](retrospective-2026-05-01-s3.md) / [`-s4.md`](retrospective-2026-05-01-s4.md)
+- マージ済 PR: #188（doc-audit Phase B）
+- Audit doc: [`docs/working/_audit/2026-05-01-doc-audit.md`](_audit/2026-05-01-doc-audit.md)
+- v8.5.0 リリース: <https://github.com/s977043/PlanGate/releases/tag/v8.5.0>
+
+## 同日 8 セッションの全体像
+
+| Session | 主題 | PR | 主要成果 |
+|---------|------|-----|--------|
+| s1 | v8.3 後続 5 PBI 並走 | #161〜#166 | 5 PR + retro |
+| s2 | V2 候補 4 件解消 | #173〜#177 | 4 PR + retro |
+| s3 | #168 完走 + v8.4.0 リリース | #178〜#180 | 3 PR + tag |
+| s4 | #169 EPIC 完走 + v8.5.0 リリース | #181〜#187 | 7 PR + tag |
+| **s5** | **doc-audit 2026-05-01** | **#188** | **Phase A + B 完了** |
+| **計** | — | **28 PR** | **2 release + 1 audit + 5 retro** |
+
+### 累計達成事項（v8.3 → v8.5）
+
+| カテゴリ | 値 |
+|---------|---|
+| マージ PR | **28 件** |
+| Issue closed | 12 件 |
+| 完走 PBI | 17 件 |
+| 新 release | **2 連続**（v8.4.0 + v8.5.0）|
+| 新 hook | **10/10**（EH-1〜EH-7 + EHS-1〜EHS-3）|
+| 新 CI | 2（schema-validate / check-pr-issue-link）|
+| 新 CLI | 2（validate-schemas / eval）|
+| ローカル test | 10 → 24 + hook 42 = **計 66 件 PASS** |
+| Audit | doc-audit 2026-05-01 完了（Critical 1 + Major 3 解消、過去比 -75%）|
+
+PlanGate v8.5.0 で **「自動化基盤の完成」+ 「ドキュメント品質再担保」** に到達。本日のセッション群を完全に終了する。
+
+## セッション終了の宣言
+
+- ✅ 全 8 セッションのマージ・タグ・Release・Audit 完了
+- ✅ Open Issue / Open PR ともに **0 件**
+- ✅ main は clean state、CI 緑率 100%
+- ✅ retrospective 累積 5 ファイルで knowledge transfer 担保
+- ✅ V2 候補は CHANGELOG v8.5.0 § Next EPIC 候補 + 本 retrospective Try T-1 にリスト化済
+
+次の起点は user の判断（新規要求 / 残 V2 候補からの選定 / 定期監査）に委ねる。


### PR DESCRIPTION
## Summary

v8.5.0 リリース後の **doc-audit を Phase A + B で完了**させ、本日のセッション群を最終クローズ。

## Sections
- Keep 5 / Problem 4 / Try 4
- メトリクス（s5 単独 + s1〜s5 累計）
- 同日 8 セッションの全体像（v8.3.0 → v8.4.0 → v8.5.0 + audit）
- セッション終了の宣言

## 同日累計（s1〜s5、8 セッション）

| 指標 | 値 |
|------|---|
| マージ PR | **28 件**（#161〜#188）|
| Issue closed | 12 件 |
| 完走 PBI | 17 件 |
| **release** | v8.3.0 → **v8.4.0 → v8.5.0** |
| **新 hook** | **10/10 完成** |
| **Audit** | doc-audit 2026-05-01 完了 |

## 本 PR
振り返り文書のみ。closes は付けない。**本セッション最終 PR**。