### PR TITLE
feat(governance): Issue / Label / Milestone Governance (#201, PBI-HI-007)

### DIFF
--- a/.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml
+++ b/.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml
@@ -1,0 +1,78 @@
+name: PlanGate roadmap task (PBI)
+description: Roadmap PBI for harness improvement / governance / workflow scope.
+title: "PBI-XX-NNN: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Roadmap PBI 用テンプレートです。本テンプレートは [docs/ai/issue-governance.md](../../docs/ai/issue-governance.md) §2 の必須セクションを強制します。
+        EPIC が紐付く場合は冒頭の Parent EPIC 欄に EPIC 番号を入れてください。
+  - type: input
+    id: parent-epic
+    attributes:
+      label: Parent EPIC / Roadmap
+      description: 親 EPIC / ロードマップ doc / 関連 PR
+      placeholder: "Parent EPIC: #193 / Roadmap doc: docs/ai/harness-improvement-roadmap.md"
+    validations:
+      required: true
+  - type: input
+    id: planned-milestone
+    attributes:
+      label: Planned milestone
+      description: 紐付け予定の milestone（GitHub 上に存在しない場合は先に作成）
+      placeholder: "v8.6.0"
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: この PBI が必要な背景・問題・コスト
+      placeholder: 現状なぜこれが必要か、放置した場合のコスト
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What (Scope / Out-of-scope / Suggested files)
+      description: in scope / out of scope / suggested files / suggested outputs
+      placeholder: |
+        ### Scope
+        - ...
+
+        ### Suggested files
+        ```text
+        path/to/file.md
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: 機械的に検証可能なチェックリスト
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: 明示的にやらないこと
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: input
+    id: labels
+    attributes:
+      label: Labels (kind + priority [+ area])
+      description: docs/ai/issue-governance.md §3 の taxonomy に沿う
+      placeholder: "enhancement, priority:P0, area:metrics"
+    validations:
+      required: true

--- a/docs/ai/issue-governance.md
+++ b/docs/ai/issue-governance.md
@@ -1,0 +1,158 @@
+# Issue / Label / Milestone Governance
+
+> **Status**: v1
+> **Review cadence**: Monthly
+> **Owner**: Governance / Maintainer
+> **Related**: [EPIC #193](https://github.com/s977043/plangate/issues/193) / [pages/guides/governance/documentation-management.md](../../pages/guides/governance/documentation-management.md)
+
+## 1. 目的
+
+PlanGate の Issue 運用 (Issue 必須セクション / Label taxonomy / Milestone mapping) を正本化する。
+
+ドキュメント配置・更新ルールは [`pages/guides/governance/documentation-management.md`](../../pages/guides/governance/documentation-management.md) が正本。本ドキュメントは **Issue / Label / Milestone 側** を扱う。
+
+## 2. Issue required sections
+
+すべての PlanGate roadmap issue は以下のセクションを持つ。
+
+| Section | Purpose |
+|---------|---------|
+| **Why** | この Issue が必要な背景・問題・コスト |
+| **What** | scope / out-of-scope / suggested files / suggested outputs |
+| **Acceptance Criteria** | チェック可能な完了条件（チェックボックス箇条書き）|
+| **Non-goals** | 明示的にやらないこと、誤解防止 |
+| **Labels** | 付与するラベル一覧 |
+| **Milestone** | 紐付ける milestone |
+| **Parent EPIC / Roadmap** | 親 EPIC / ロードマップ doc / 関連 PR の引用 |
+
+軽微な bug / typo は `bug_report.yml` / `feature_request.yml` テンプレートで OK。Roadmap PBI は `plangate-roadmap-task.yml` を使う。
+
+## 3. Label taxonomy
+
+PlanGate ラベルは 4 軸で分類する。複数軸を組み合わせて付与する。
+
+### 3.1 kind（必須、1 件のみ）
+
+| Label | 用途 |
+|-------|-----|
+| `enhancement` | 新規機能追加・改善 |
+| `bug` | 不具合修正 |
+| `documentation` | ドキュメント変更が主体 |
+| `governance` | 運用ルール・ガバナンス変更 |
+| `refactor` | 振る舞いを変えないリファクタリング |
+| `security` | セキュリティ関連 |
+
+### 3.2 area（任意、複数可）
+
+| Label | 用途 |
+|-------|-----|
+| `area:cli` | bin/plangate 関連 |
+| `area:hooks` | scripts/hooks/ 関連 |
+| `area:eval` | eval-runner / eval-cases 関連 |
+| `area:schema` | schemas/ 関連 |
+| `area:workflow` | docs/workflows/ 関連 |
+| `area:metrics` | metrics 関連 |
+| `area:docs` | 公開 docs / pages 関連 |
+
+### 3.3 priority（必須、1 件のみ）
+
+| Label | 用途 |
+|-------|-----|
+| `priority:P0` | 直近 milestone の必須項目 |
+| `priority:P1` | 次 milestone 候補 |
+| `priority:P2` | 中期計画 |
+| `priority:P3` | 着手未定 |
+
+### 3.4 status（任意、状態遷移で更新）
+
+| Label | 用途 |
+|-------|-----|
+| `status:blocked` | 他 Issue / 外部要因で着手不可 |
+| `status:in-progress` | 着手中 |
+| `status:needs-review` | レビュー待ち |
+| `status:wontfix` | 対応しない判断 |
+
+> **note**: 既存 Issue にこれらのラベルが未付与でも、新規 Issue 作成時から徹底する。一括 backfill は scope 外（Non-goals）。
+
+## 4. Milestone mapping
+
+### 4.1 命名規則
+
+`vMAJOR.MINOR.PATCH` の semver。次期予定 milestone は EPIC で先に作成する。
+
+### 4.2 紐付けルール
+
+- **EPIC**: 紐付ける PBI 群と同じ milestone を持たせる（or なし）
+- **PBI**: 必ず 1 件の milestone を持つ
+- **bug / hotfix**: 該当する直近 milestone を付与
+- **推測禁止**: GitHub に該当 milestone が存在しない場合、先に作成する。番号を推測して紐付けてはならない（[EPIC #193 policy](https://github.com/s977043/plangate/issues/193) を踏襲）
+
+### 4.3 milestone 移動
+
+milestone をまたいで移動する場合（次期へ繰越など）は、Issue コメントに **理由 + 移動日** を残す。
+
+## 5. Roadmap issue creation checklist
+
+新しい roadmap PBI を作成するときに通すチェックリスト。
+
+```text
+- [ ] Title が `PBI-HI-NNN: <短い説明>` などロードマップ規約に沿っている
+- [ ] Why / What / Acceptance Criteria / Non-goals が揃っている
+- [ ] Suggested files / outputs が記載されている
+- [ ] Parent EPIC / Roadmap doc / Related PR が冒頭で引用されている
+- [ ] Labels (kind + priority、必要なら area) が付与されている
+- [ ] Milestone が EPIC の表に従って付与されている
+- [ ] 該当 milestone が GitHub 上に存在する（なければ先に作成）
+- [ ] Acceptance Criteria は AI / human が機械的に検証できる粒度になっている
+- [ ] EPIC の child policy / scope と矛盾していない
+- [ ] documentation-management.md の Directory policy と矛盾していない
+```
+
+## 6. Issue template policy
+
+GitHub Issue テンプレートは `.github/ISSUE_TEMPLATE/` 配下に置く。
+
+| Template | 用途 |
+|----------|-----|
+| `bug_report.yml` | バグ報告 |
+| `feature_request.yml` | 軽量な機能要望 |
+| `plangate-roadmap-task.yml` | EPIC #193 等の roadmap PBI |
+| `config.yml` | テンプレート選択画面の設定 |
+
+`plangate-roadmap-task.yml` は Section 2 / 5 を強制するために事前にスキャフォールドを提供する（Why / What / AC / Non-goals / Labels / Milestone を必須入力）。
+
+## 7. EPIC governance
+
+EPIC issue は以下を満たす。
+
+- 親 EPIC 自身に milestone を付ける（最終リリース予定の milestone でもよい）
+- Roadmap to milestones 表で「Issue ↔ Milestone ↔ Priority」を一覧化する
+- Milestone policy を本文中で明記し、不在時の作成順序を指示する
+- 子 PBI 作成後、EPIC 本体の表を最新化する
+
+## 8. 既存 Issue への適用
+
+このガバナンスは新規 Issue 作成時から適用する。既存 Issue について：
+
+- **milestone 不整合**は気付き次第訂正する（今回 #194〜#204 一括訂正がその例）
+- **label 不足**は次回更新ついでに backfill。一括対応は scope 外
+- **必須セクション欠落**は再ファイリング不要、引き続き運用する
+
+## 9. PR と Issue の連動
+
+- 1 PBI = 1 PR が原則。複数 PR に分割する場合は EPIC 側で分割理由を残す
+- PR 本文で `closes #N` / `fixes #N` / `resolves #N` のいずれかを書く（自動 close 対象）
+- doc-only PR は `documentation` ラベルを付ければ issue-link チェックを skip 可能（PR `<!-- skip-issue-link-check -->` でも可）
+
+## 10. Non-goals
+
+- すべての既存 Issue を一括で本ガバナンスへ整合させること
+- GitHub Projects / 自動ラベリング bot の導入
+- release automation の実装
+- 全 PR への必須 reviewer 強制
+
+## 11. 関連
+
+- [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193)
+- [pages/guides/governance/documentation-management.md](../../pages/guides/governance/documentation-management.md)（Doc 配置 / 更新ルール正本）
+- [.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml](../../.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml)

--- a/docs/working/TASK-0059/handoff.md
+++ b/docs/working/TASK-0059/handoff.md
@@ -1,0 +1,55 @@
+# Handoff: TASK-0059 (PBI-HI-007 / Issue #201)
+
+## 1. 要件適合確認結果
+
+| AC | 検証 | 判定 |
+|----|------|------|
+| AC-01 governance ドキュメント存在 | docs/ai/issue-governance.md + pages/guides/governance/documentation-management.md | ✅ PASS |
+| AC-02 Why/What/AC/Non-goals 定義 | issue-governance.md §2 (4セクション) | ✅ PASS |
+| AC-03 label taxonomy | issue-governance.md §3 (kind/area/priority/status) | ✅ PASS |
+| AC-04 milestone mapping 正本 | issue-governance.md §4 (推測禁止条項含む) | ✅ PASS |
+| AC-05 roadmap checklist | issue-governance.md §5 (10 項目チェック) | ✅ PASS |
+| AC-06 pages/docs 責務分離 | documentation-management.md §2 | ✅ PASS（既存）|
+| AC-07 公開説明は pages/ | documentation-management.md §3 | ✅ PASS（既存）|
+| AC-08 sidebars.js 管理方針 | documentation-management.md §6 | ✅ PASS（既存）|
+| AC-09 user-facing 変更時 doc update | documentation-management.md §4 | ✅ PASS（既存）|
+| AC-10 PR checklist | documentation-management.md §4.3 | ✅ PASS（既存）|
+| AC-11 status/cadence/owner policy | documentation-management.md §4.5-4.7 | ✅ PASS（既存）|
+| AC-12 source of truth rules | documentation-management.md §5 | ✅ PASS（既存）|
+| AC-13 deprecated/removal rules | documentation-management.md §9 | ✅ PASS（既存）|
+| AC-14 EPIC #193 child policy 整合 | issue-governance.md §4.2 で #193 引用、矛盾なし | ✅ PASS |
+| AC-15 Issue テンプレート方針 | .github/ISSUE_TEMPLATE/plangate-roadmap-task.yml + governance §6 言及 | ✅ PASS |
+
+**全 15/15 PASS**
+
+## 2. 既知課題
+
+なし。
+
+## 3. V2 候補
+
+- 既存 Issue への label backfill（一括対応）
+- `priority:` ラベルが GitHub 上に未作成 → 必要時に作成（自動作成は scope 外）
+- GitHub Projects 連携による進捗可視化
+- 自動ラベリング bot
+
+## 4. 妥協点
+
+- Issue テンプレートは `.yml` 1 件のみ（複雑な validation は GitHub Issue Forms の制約上限定的）
+- 既存 Issue (EPIC #193 配下 11 件) の本文書式の遡及修正はしない（運用負荷回避）
+
+## 5. 引き継ぎ文書
+
+新規ファイル 2 件 + 既存 1 件への参照追記。
+
+- 新規: `docs/ai/issue-governance.md`（Issue / Label / Milestone 運用の正本）
+- 新規: `.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml`（roadmap PBI 用 GitHub Issue Form）
+- 追記: `pages/guides/governance/documentation-management.md` 冒頭に Related 欄追加（doc / issue 正本の役割分離を明記）
+
+documentation-management.md（PR #205 でマージ済み）が doc 配置・更新ルール側を、issue-governance.md が issue 運用側を担う 2 ファイル体制となる。
+
+## 6. テスト結果サマリ
+
+- L-0 markdown lint: CI で確認予定
+- V-1 受入基準照合: 全 15 AC PASS（自己検証）
+- 影響範囲: docs only、runtime 変更なし

--- a/docs/working/TASK-0059/pbi-input.md
+++ b/docs/working/TASK-0059/pbi-input.md
@@ -1,0 +1,33 @@
+# PBI INPUT PACKAGE: TASK-0059 (PBI-HI-007 / Issue #201)
+
+## Context / Why
+
+Harness Improvement Roadmap (EPIC #193) の Issue 群を継続的に運用するため、Issue / Label / Milestone 運用を標準化する。今回の milestone 整列対応 (v8.6.0/v8.7.0/v8.8.0/v8.9.0 一括訂正) で、運用ルールが暗黙のままだと再発することが判明した。
+
+## What
+
+### In scope
+- Issue 必須セクション (Why / What / AC / Non-goals) を正本化
+- Label taxonomy（kind / area / priority / status）を定義
+- Milestone mapping policy を定義（推測禁止、EPIC で固定）
+- Roadmap issue 作成チェックリストを提供
+- GitHub Issue テンプレートを追加（PlanGate Roadmap Task 用）
+- 既存 `pages/guides/governance/documentation-management.md` に Issue governance への参照を追加
+
+### Out of scope
+- すべての既存 Issue の即時修正
+- 自動ラベリング bot
+- GitHub Projects 導入
+- release automation
+
+## Acceptance Criteria（Issue #201 から転記）
+
+15 項目。issue-governance.md と既存 documentation-management.md の組合せで充足する。
+
+## Mode 判定
+
+**light** — documentation 系 PBI（変更ファイル 3-4 件、既存テンプレ拡張中心、リスク低）。
+
+## Plan/Test cases
+
+簡易版で進める（light モード）。

--- a/docs/working/TASK-0059/plan.md
+++ b/docs/working/TASK-0059/plan.md
@@ -1,0 +1,36 @@
+# EXECUTION PLAN: TASK-0059 (PBI-HI-007)
+
+## Goal
+
+Issue / Label / Milestone Governance を文書化し、再発防止と運用標準化を実現する。
+
+## Mode 判定
+
+- 変更ファイル数: 3 → light
+- 受入基準数: 15 → standard 寄り
+- 変更種別: doc 追加 → light
+- リスク: 低 → light
+- **最終判定**: light（doc only）
+
+## Approach
+
+1. `docs/ai/issue-governance.md` を新規作成（Issue 運用の正本）
+2. `.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml` を新規作成
+3. `pages/guides/governance/documentation-management.md` に Issue governance への参照追加
+
+## Files to Touch
+
+| File | Action |
+|------|--------|
+| `docs/ai/issue-governance.md` | 新規 |
+| `.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml` | 新規 |
+| `pages/guides/governance/documentation-management.md` | 参照追記 |
+
+## Testing Strategy
+
+- L-0: markdown lint（CI）
+- V-1: 受入基準 15 項目突合（test-cases.md と照合）
+
+## Risks
+
+- 既存 EPIC #193 の child issue policy との矛盾 → 引用して整合性担保

--- a/docs/working/TASK-0059/test-cases.md
+++ b/docs/working/TASK-0059/test-cases.md
@@ -1,0 +1,19 @@
+# TEST CASES: TASK-0059 (PBI-HI-007)
+
+| ID | AC | 検証方法 | 期待結果 |
+|----|-----|---------|---------|
+| TC-01 | governance ドキュメント存在 | `ls docs/ai/issue-governance.md` または `pages/guides/governance/documentation-management.md` | 1 件以上存在 |
+| TC-02 | Issue 必須セクション定義 | `grep "Why\|What\|Acceptance Criteria\|Non-goals" docs/ai/issue-governance.md` | 4 セクション言及 |
+| TC-03 | label taxonomy 定義 | issue-governance.md に label セクションあり | PASS |
+| TC-04 | milestone mapping 正本 | issue-governance.md に milestone policy あり | PASS |
+| TC-05 | roadmap issue 作成 checklist | issue-governance.md に checklist あり | PASS |
+| TC-06 | pages/docs 責務分離 | documentation-management.md 第2章に既存 | PASS（既存）|
+| TC-07 | 公開説明は pages/ | documentation-management.md 第3章 | PASS（既存）|
+| TC-08 | sidebars.js 管理方針 | documentation-management.md 第6章 | PASS（既存）|
+| TC-09 | user-facing 変更時 doc update | documentation-management.md 第4章 | PASS（既存）|
+| TC-10 | PR checklist | documentation-management.md 4.3 節 | PASS（既存）|
+| TC-11 | status / cadence / owner policy | documentation-management.md 4.5-4.7 節 | PASS（既存）|
+| TC-12 | source of truth rules | documentation-management.md 第5章 | PASS（既存）|
+| TC-13 | deprecated / removal rules | documentation-management.md 第9章 | PASS（既存）|
+| TC-14 | EPIC #193 child policy と矛盾していない | issue-governance.md で #193 を引用 | PASS |
+| TC-15 | Issue テンプレート方針 | `.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml` 存在 + governance doc で言及 | PASS |

--- a/pages/guides/governance/documentation-management.md
+++ b/pages/guides/governance/documentation-management.md
@@ -3,6 +3,7 @@
 > **Status**: v0
 > **Review cadence**: Monthly
 > **Reference**: River-Reviewer documentation structure
+> **Related**: [docs/ai/issue-governance.md](../../../docs/ai/issue-governance.md) — Issue / Label / Milestone Governance（本ドキュメントは Doc 配置・更新ルール側、Issue 運用側は別正本）
 
 ## 1. 目的
 


### PR DESCRIPTION
## Summary

Issue 運用ルール（Issue 必須セクション / Label taxonomy / Milestone mapping / Roadmap checklist）と Issue テンプレートを整備する。

## Why

EPIC #193 の milestone 整列対応で、運用ルールが暗黙のままだと再発することが判明した。`pages/guides/governance/documentation-management.md` (PR #205) は doc 配置・更新ルール側を担う。本 PR で **Issue 運用側** を 2 ファイル体制で正本化する。

## Added

- \`docs/ai/issue-governance.md\` — Issue / Label / Milestone Governance の正本
  - §2 Issue 必須セクション
  - §3 Label taxonomy (kind / area / priority / status)
  - §4 Milestone mapping (推測禁止条項を明文化)
  - §5 Roadmap issue creation checklist (10 項目)
  - §6 Issue template policy
  - §7 EPIC governance
- \`.github/ISSUE_TEMPLATE/plangate-roadmap-task.yml\` — roadmap PBI 用 GitHub Issue Form
- \`docs/working/TASK-0059/\` — 作業コンテキスト + handoff

## Modified

- \`pages/guides/governance/documentation-management.md\` 冒頭に \`Related: docs/ai/issue-governance.md\` を追記（2 ファイル体制の役割分離を明示）

## Acceptance Criteria

15 項目全 PASS（handoff.md §1）。

## Mode

light (documentation only)

closes #201