### PR TITLE
feat(metrics): Metrics v1 を実装 (#195, PBI-HI-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ docs/working/_audit/hook-events.log
 .claude/scheduled_tasks.lock
 scripts/__pycache__/
 scripts/parsers/__pycache__/
+
+# PlanGate Metrics v1 (Issue #195) — local artifact, never commit
+# privacy: docs/ai/metrics-privacy.md §8
+docs/working/_metrics/events.ndjson

--- a/bin/plangate
+++ b/bin/plangate
@@ -125,6 +125,7 @@ cmd_help() {
     "  validate <TASK-XXXX> [--mode]  Verify artifacts and plan_hash integrity" \
     "  validate-schemas <args>        Validate JSON artifacts against schemas/ (Issue #158)" \
     "  eval <TASK-XXXX> [--baseline]  Run 8-aspect eval (Issue #156)" \
+    "  metrics <TASK-XXXX> [--collect|--report] Collect/report workflow metrics (Issue #195)" \
     "  review <TASK-XXXX> [--phase]   Run external AI review (c2/v3)" \
     "  exec <TASK-XXXX> [--mode]      Dispatch implementation agent (after C-3)" \
     "  abort <TASK-XXXX> [--reason]   Record abort event in run.ndjson" \
@@ -545,6 +546,69 @@ cmd_eval() {
   return $?
 }
 
+cmd_metrics() {
+  # Collect / report PlanGate workflow metrics for a TASK.
+  # Issue #195 / PBI-HI-001 (Metrics v1)
+  if [ $# -eq 0 ]; then
+    printf 'Usage: plangate metrics <TASK-XXXX> [--collect|--report] [--aggregate] [--json]\n' >&2
+    printf '  --collect     Append metrics events to docs/working/_metrics/events.ndjson (default if no flag)\n' >&2
+    printf '  --report      Print summary instead of appending\n' >&2
+    printf '  --aggregate   Aggregate across all TASKs (--report only)\n' >&2
+    printf '  --json        JSON output (--report only)\n' >&2
+    return 1
+  fi
+
+  collector="$plangate_root/scripts/metrics_collector.py"
+  reporter="$plangate_root/scripts/metrics_reporter.py"
+  if [ ! -f "$collector" ] || [ ! -f "$reporter" ]; then
+    printf 'error: metrics scripts not found under scripts/\n' >&2
+    return 2
+  fi
+
+  mode="collect"
+  passthrough=""
+  task_id=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --collect) mode="collect" ;;
+      --report) mode="report" ;;
+      --aggregate) passthrough="$passthrough --aggregate" ;;
+      --json) passthrough="$passthrough --json" ;;
+      --dry-run) passthrough="$passthrough --dry-run" ;;
+      --events-log)
+        shift
+        passthrough="$passthrough --events-log $1"
+        ;;
+      TASK-*) task_id="$1" ;;
+      *)
+        printf 'Unknown metrics arg: %s\n' "$1" >&2
+        return 2
+        ;;
+    esac
+    shift
+  done
+
+  if [ "$mode" = "collect" ]; then
+    if [ -z "$task_id" ]; then
+      printf 'metrics --collect requires TASK-XXXX\n' >&2
+      return 2
+    fi
+    # shellcheck disable=SC2086
+    python3 "$collector" "$task_id" $passthrough
+    return $?
+  fi
+
+  # report
+  if [ -n "$task_id" ]; then
+    # shellcheck disable=SC2086
+    python3 "$reporter" "$task_id" $passthrough
+  else
+    # shellcheck disable=SC2086
+    python3 "$reporter" $passthrough
+  fi
+  return $?
+}
+
 cmd_abort() {
   if [ $# -eq 0 ]; then
     printf 'Usage: plangate abort <TASK-XXXX> [--reason "..."]\n' >&2
@@ -809,6 +873,7 @@ case "$command" in
   validate)    cmd_validate "$@" ;;
   validate-schemas) cmd_validate_schemas "$@" ;;
   eval)        cmd_eval "$@" ;;
+  metrics)     cmd_metrics "$@" ;;
   review)      cmd_review "$@" ;;
   exec)        cmd_exec "$@" ;;
   abort)       cmd_abort "$@" ;;

--- a/docs/ai/metrics.md
+++ b/docs/ai/metrics.md
@@ -1,0 +1,143 @@
+# Metrics v1 — Operational Guide
+
+> **Status**: v1
+> **Review cadence**: On change
+> **Owner**: Engineering / Governance
+> **Issue**: [#195 PBI-HI-001](https://github.com/s977043/plangate/issues/195)
+> **Related**: [docs/ai/metrics-privacy.md](./metrics-privacy.md), [docs/ai/eval-baselines/2026-05-04-baseline.md](./eval-baselines/2026-05-04-baseline.md)
+
+## 1. 目的
+
+PlanGate workflow event を構造化 metrics として保存・集計可能にする。Hook violation / C-3 / V-1 / C-4 の最小集計から始め、後続の Eval expansion (#196) / Model Profile v2 (#197) / Keep Rate (#198) / Dynamic Context Engine (#199) の効果測定基盤として機能させる。
+
+**opt-in**: 既存 workflow を壊さず、`bin/plangate metrics` を呼んだときのみ動く。
+
+## 2. 構成
+
+| ファイル | 役割 |
+|---------|------|
+| `schemas/plangate-event.schema.json` | event の JSON Schema |
+| `scripts/metrics_collector.py` | TASK ディレクトリから event を導出して NDJSON へ append |
+| `scripts/metrics_reporter.py` | events.ndjson から TASK 別 / aggregate summary を生成 |
+| `bin/plangate metrics` | 上記のラッパ CLI |
+| `docs/working/_metrics/events.ndjson` | append-only metrics log（**.gitignore 対象、commit 禁止**）|
+
+## 3. 使い方
+
+### 3.1 Collect（TASK の現在状態から event を導出）
+
+```bash
+bin/plangate metrics TASK-0061 --collect
+```
+
+実行内容: `docs/working/TASK-0061/` の以下ファイル群を読み、event を抽出して `docs/working/_metrics/events.ndjson` に append する。
+
+| 対象ファイル | 導出 event |
+|------------|----------|
+| `pbi-input.md` | `task_initialized` |
+| `plan.md` | `plan_generated` (plan_hash 含む、mode 自動検出) |
+| `approvals/c3.json` | `c3_decided` (verdict: APPROVED/CONDITIONAL/REJECTED) |
+| `evidence/` | `exec_started` (最初の evidence 作成時刻) |
+| `handoff.md` | `v1_completed` (AC PASS/FAIL カウント) + `handoff_completed` |
+| `review-external.md` | `external_review_completed` |
+
+**dry-run** で append 前に内容確認:
+
+```bash
+bin/plangate metrics TASK-0061 --collect --dry-run
+```
+
+### 3.2 Report（summary 表示）
+
+```bash
+# TASK 単位
+bin/plangate metrics TASK-0061 --report
+
+# 全 TASK 集約
+bin/plangate metrics --report --aggregate
+
+# JSON 出力（baseline 比較用）
+bin/plangate metrics TASK-0061 --report --json
+```
+
+### 3.3 hook violation の手動記録
+
+PBI-HI-001 では hook 側からの自動 emit は **scope 外**。手動で append する場合は schema 準拠 NDJSON を append する：
+
+```bash
+echo '{"schema_version":"1.0","ts":"2026-05-04T07:00:00Z","task_id":"TASK-0061","event":"hook_violation","hook_id":"EH-1","hook_result":"block"}' \
+  >> docs/working/_metrics/events.ndjson
+```
+
+自動 emit は v8.7+ 候補（hook 側修正が必要、scope 外）。
+
+## 4. Privacy
+
+[`metrics-privacy.md`](./metrics-privacy.md) 準拠。`metrics_collector.py` は §3 (Allowed) のフィールドのみ emit する。
+
+| 保存される | 例 |
+|-----------|-----|
+| event 種別、phase、mode | `task_initialized`, `B`, `light` |
+| TASK ID | `TASK-0061` |
+| plan_hash | `sha256:...` (内容そのものは保存しない) |
+| AC count | `ac_total: 6, ac_pass: 6, ac_fail: 0` |
+| verdict | `APPROVED`, `PASS`, `FAIL`, `WARN` |
+| timestamp | UTC ISO 8601 |
+
+| 保存されない | 理由 |
+|-------------|-----|
+| ファイルパス、ファイル名 | privacy §4 Forbidden |
+| stack trace、command output | 同上 |
+| user prompt、handoff 本文 | 同上 |
+| provider raw response | 同上 |
+
+`docs/working/_metrics/events.ndjson` は **.gitignore で除外**。commit されない。
+
+## 5. Schema 検証
+
+```bash
+python3 -c "import json,jsonschema,sys; \
+  schema=json.load(open('schemas/plangate-event.schema.json')); \
+  events=[json.loads(l) for l in open('docs/working/_metrics/events.ndjson') if l.strip()]; \
+  [jsonschema.validate(e,schema) for e in events]; \
+  print(f'{len(events)} events valid')"
+```
+
+## 6. Baseline 比較
+
+[`docs/ai/eval-baselines/2026-05-04-baseline.json`](./eval-baselines/2026-05-04-baseline.json) と互換のフィールド命名:
+
+| baseline.json | metrics summary |
+|--------------|-----------------|
+| `tasks[].ac_coverage_pct` | `summary.v1` から算出 (PASS/FAIL/WARN ratio) |
+| `tasks[].approval_discipline` | `summary.c3` の APPROVED 有無 |
+| `aggregate.release_blocker_total` | hook_violations.total + c3 REJECTED + v1 FAIL |
+
+baseline と metrics summary を組み合わせると、改善前後の差分が機械比較可能。
+
+## 7. Non-goals (Metrics v1)
+
+- ダッシュボード UI（v2+ 候補）
+- LLM judge による満足度判定
+- Keep Rate 算出（PBI-HI-004 / #198）
+- Dynamic Context Engine（PBI-HI-005 / #199）
+- 外部 DB（DataDog 等）への保存
+- Hook 側からの自動 emit（v8.7+ 候補、scope 外）
+- 暗号化ストレージ
+
+## 8. 後続改善の接続点
+
+| Roadmap | metrics v1 への接続 |
+|--------|-------------------|
+| **#196 Eval expansion** | `summary.v1` / `summary.hook_violations` を mode 別に判定 |
+| **#197 Model Profile v2** | event に `model_profile` 追加で profile 別比較 |
+| **#198 Keep Rate v1** | `plan_hash` 履歴と handoff 後の差分で算出 |
+| **#199 Dynamic Context** | `task_initialized` 時に context manifest 識別子を記録 |
+
+## 9. 関連
+
+- [Issue #195 PBI-HI-001 Metrics v1](https://github.com/s977043/plangate/issues/195)
+- [docs/ai/metrics-privacy.md](./metrics-privacy.md)
+- [docs/ai/eval-baselines/2026-05-04-baseline.md](./eval-baselines/2026-05-04-baseline.md)
+- [docs/ai/harness-improvement-roadmap.md](./harness-improvement-roadmap.md)
+- [schemas/plangate-event.schema.json](../../schemas/plangate-event.schema.json)

--- a/docs/working/TASK-0062/handoff.md
+++ b/docs/working/TASK-0062/handoff.md
@@ -1,0 +1,74 @@
+# Handoff: TASK-0062 (PBI-HI-001 / Issue #195 / Metrics v1)
+
+## 1. 要件適合確認結果
+
+| AC | 検証 | 判定 |
+|----|------|------|
+| AC-01 plangate-event.schema.json 存在 | `schemas/plangate-event.schema.json` (110+ 行、11 events) | ✅ PASS |
+| AC-02 events.ndjson に append-only 記録 | TASK-0059 で 0 → 4 行に増加（`docs/working/_metrics/events.ndjson`）| ✅ PASS |
+| AC-03 `bin/plangate metrics <TASK>` で summary 出力 | `--report` で TASK-0059 summary 表示確認 | ✅ PASS |
+| AC-04 hook violation / C-3 / V-1 / C-4 最低集計 | reporter 出力に C-3 dict / V-1 dict / C-4 dict / hook_violations 含む | ✅ PASS |
+| AC-05 既存 workflow 不影響（opt-in） | tests/run-tests.sh 32/32 PASS、CLI 既存サブコマンド全動作 | ✅ PASS |
+| AC-06 docs/ai/metrics.md 運用手順 | 9 章構成、CLI 使用例 / privacy / schema 検証 / baseline 比較 | ✅ PASS |
+| AC-07 PBI-HI-000 baseline と比較可能 | metrics.md §6 で `2026-05-04-baseline.json` とのフィールドマッピング提供 | ✅ PASS |
+
+**全 7/7 PASS**
+
+### 追加検証
+- **TC-A schema validation**: jsonschema で全 event 検証 → ta-09 で確認
+- **TC-B privacy**: collector が emit するフィールドは §3 Allowed のみ。file path / stack trace / prompt は schema 上に定義しないため emit 不能
+- **TC-C gitignore**: `docs/working/_metrics/events.ndjson` が git check-ignore で除外確認
+
+## 2. 既知課題
+
+- **hook 自動 emit は scope 外**: 現状は手動で append（doc に記載済）。v8.7+ で hook 側を改修する候補
+- **pr_created / c4_decided は collector 未実装**: TASK ディレクトリだけでは推測困難、GitHub API 連携が必要 → v2 候補
+- **fix_loop_count の自動カウント未実装**: 現状は手動 append のみ → v2 候補
+
+## 3. V2 候補
+
+- Hook 側からの自動 emit (#195 完了後の v8.7+)
+- GitHub API 経由で pr_created / c4_decided を取得
+- ダッシュボード UI（明示的 Non-goal）
+- LLM judge による満足度判定
+- Keep Rate (#198) / Dynamic Context (#199) との接続
+- 外部 DB 連携（明示的 Non-goal）
+
+## 4. 妥協点
+
+- **Collector が emit する events は 6 種類**: 11 events 中 task_initialized / plan_generated / c3_decided / exec_started / v1_completed / handoff_completed / external_review_completed の 7 events を自動導出（pr_created / c4_decided / hook_violation / fix_loop_incremented は手動 append または v2）
+  - 理由: TASK ディレクトリ内の artifact から決定論的に推測できる範囲を優先。Issue #195 の AC-04「最低限集計」は満たしつつ、過剰実装を避けた
+- **AC count は handoff.md の絵文字マーカー (✅/❌/⚠️) ベース**: 絵文字テンプレートに依存するが、handoff template が確定しているため安定
+- **schema validation は ta-09 内**: CI 統合は run-tests.sh 経由で実施
+
+## 5. 引き継ぎ文書
+
+新規ファイル 7 件 + 修正 2 件:
+
+**新規:**
+- `schemas/plangate-event.schema.json` — JSON Schema（11 events、conditional required）
+- `scripts/metrics_collector.py` — TASK → NDJSON 抽出
+- `scripts/metrics_reporter.py` — NDJSON → summary
+- `docs/ai/metrics.md` — 運用 guide
+- `tests/extras/ta-09-metrics.sh` — 8 test cases
+- `docs/working/_metrics/.gitkeep` — placeholder
+- `docs/working/TASK-0062/` — PBI artifacts (4 files)
+
+**修正:**
+- `bin/plangate` — `cmd_metrics` 関数追加 + dispatcher + help text
+- `.gitignore` — `docs/working/_metrics/events.ndjson` 除外
+
+PBI-HI-001 完了により、v8.6.0 milestone の P0 4 件全て完走（#194, #201, #202, #195）。後続 EPIC #193 改善で本 metrics を実利用シグナルとして活用。
+
+## 6. テスト結果サマリ
+
+- L-0 markdown lint: CI で確認
+- V-1 受入基準照合: 7/7 PASS（TC-A/B/C 補助検証含めて 10/10 PASS）
+- 自動テスト: `sh tests/run-tests.sh` → 32/32 PASS（ta-09 で 8 cases 含む）
+- 手動動作確認:
+  - `bin/plangate metrics TASK-0059 --collect` → 4 events emit
+  - `bin/plangate metrics TASK-0059 --report` → summary 表示
+  - `bin/plangate metrics --report --aggregate` → 集約表示
+  - `bin/plangate metrics --report --json` → JSON 出力
+  - `git check-ignore docs/working/_metrics/events.ndjson` → ignored
+- 影響範囲: opt-in CLI 拡張のみ、既存 workflow / tests 影響なし

--- a/docs/working/TASK-0062/pbi-input.md
+++ b/docs/working/TASK-0062/pbi-input.md
@@ -1,0 +1,22 @@
+# PBI INPUT PACKAGE: TASK-0062 (PBI-HI-001 / Issue #195)
+
+## Why
+EPIC #193 後続改善 (Eval expansion / Model Profile v2 / Keep Rate / Dynamic Context Engine) を比較で判断するため、PlanGate workflow event を構造化 metrics として保存・集計可能にする。
+
+## What
+In scope:
+- plangate-event.schema.json
+- metrics_collector.py（TASK 配下から event 導出 + NDJSON append）
+- metrics_reporter.py（events.ndjson から TASK / aggregate summary）
+- bin/plangate metrics サブコマンド
+- .gitignore で events.ndjson 除外（privacy §8）
+- docs/ai/metrics.md 運用手順
+- tests/extras/ta-09-metrics.sh smoke test
+
+Out: ダッシュボード、LLM judge、Keep Rate、Dynamic Context、外部DB、hook 自動 emit (v8.7+)
+
+## Mode
+high-risk（コード追加 + schema + CLI + tests + 既存 .gitignore 修正）
+
+## AC
+Issue #195 の 7 項目

--- a/docs/working/TASK-0062/plan.md
+++ b/docs/working/TASK-0062/plan.md
@@ -1,0 +1,56 @@
+# EXECUTION PLAN: TASK-0062 (PBI-HI-001 Metrics v1)
+
+## Goal
+Metrics v1 を opt-in で実装し、後続 EPIC #193 改善の効果測定基盤を提供する。
+
+## Mode 判定
+- 変更ファイル数: 9 → high-risk
+- 受入基準数: 7 → standard寄り
+- 変更種別: 機能追加 (CLI / schema / scripts / tests) → high-risk
+- リスク: 中（既存挙動 opt-in、CLI 表面拡張のみ）
+- **最終判定**: **high-risk**（mode-classification 表通り）
+
+## Approach
+
+### コンポーネント
+1. JSON Schema (`schemas/plangate-event.schema.json`)
+   - 11 event types (issue #195 表通り)
+   - privacy: §3 Allowed のみ、§4 Forbidden は schema にも生やさない
+   - conditional required (c3/c4/v1/hook/fix_loop)
+2. Collector (`scripts/metrics_collector.py`)
+   - TASK ディレクトリ → event NDJSON
+   - dry-run / events-log オーバーライド対応
+   - mode 自動検出 (plan.md から regex)
+   - ✅PASS/❌FAIL/⚠️WARN マーカーから AC count
+3. Reporter (`scripts/metrics_reporter.py`)
+   - --task / --aggregate / --json
+   - hook violation / C-3 / V-1 / C-4 / fix_loop_max を集計
+4. CLI wrapper (`bin/plangate metrics`)
+   - --collect (default) / --report / --aggregate / --json / --events-log
+5. .gitignore 追記 (privacy §8 準拠)
+6. doc (`docs/ai/metrics.md`)
+7. test (`tests/extras/ta-09-metrics.sh`、8 テストケース)
+
+## Files
+| File | 種別 |
+|------|-----|
+| schemas/plangate-event.schema.json | 新規 |
+| scripts/metrics_collector.py | 新規 |
+| scripts/metrics_reporter.py | 新規 |
+| bin/plangate | 修正 (cmd_metrics 追加 + dispatcher + help) |
+| .gitignore | 修正 (events.ndjson 除外) |
+| docs/ai/metrics.md | 新規 |
+| tests/extras/ta-09-metrics.sh | 新規 |
+| docs/working/_metrics/.gitkeep | 新規 (placeholder) |
+| docs/working/TASK-0062/* | 新規 (PBI artifacts) |
+
+## Testing
+- L-0: markdown lint, shellcheck
+- V-1: 受入基準 7 項目
+- 自動: tests/run-tests.sh で 32/32 PASS（ta-09: 8 cases 含む）
+- Schema validation: jsonschema による全 event 検証
+
+## Risks
+- (低) bin/plangate の既存 dispatcher 修正で他コマンドに影響 → 既存テスト全 PASS で確認
+- (低) 既存 .gitignore 修正で他ファイルに影響 → 末尾追加のみ
+- (低) python 3.10+ syntax (dict union `|`) → 既存 eval-runner.py が同 syntax を採用済み、host check 済み

--- a/docs/working/TASK-0062/test-cases.md
+++ b/docs/working/TASK-0062/test-cases.md
@@ -1,0 +1,14 @@
+# TEST CASES: TASK-0062 (PBI-HI-001 Metrics v1)
+
+| ID | AC (Issue #195) | 検証 | 期待 |
+|----|----------------|------|------|
+| TC-01 | schema 存在 | `ls schemas/plangate-event.schema.json` | exists |
+| TC-02 | append-only NDJSON 記録 | `bin/plangate metrics TASK-XXXX --collect` 後に events.ndjson に追記 | 行数増加 |
+| TC-03 | TASK summary CLI | `bin/plangate metrics TASK-XXXX --report` | summary 表示 |
+| TC-04 | hook violation / C-3 / V-1 / C-4 集計 | reporter 出力に各カウント | reported |
+| TC-05 | 既存 workflow 不影響 | `tests/run-tests.sh` 全 PASS | PASS |
+| TC-06 | 運用手順 doc | `ls docs/ai/metrics.md` + 内容に CLI 使用例 + privacy 言及 | exists |
+| TC-07 | baseline 互換 | metrics.md §6 で 2026-05-04-baseline.json とのマッピング表 | exists |
+| TC-A | schema validation | jsonschema で events.ndjson 全行検証 | 全件 valid |
+| TC-B | privacy 準拠 | events.ndjson に file path / stack trace / prompt が含まれない | unwritten |
+| TC-C | gitignore | `git check-ignore docs/working/_metrics/events.ndjson` → 除外 | ignored |

--- a/docs/working/_metrics/.gitkeep
+++ b/docs/working/_metrics/.gitkeep
@@ -1,0 +1,2 @@
+# このディレクトリは metrics v1 (PBI-HI-001 / #195) で使用されます。
+# events.ndjson は .gitignore で除外されます (privacy policy / docs/ai/metrics-privacy.md §8)。

--- a/schemas/plangate-event.schema.json
+++ b/schemas/plangate-event.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/s977043/plangate/schemas/plangate-event.schema.json",
+  "title": "PlanGate Workflow Event (Metrics v1)",
+  "description": "Single NDJSON event emitted by metrics-collector. Privacy: docs/ai/metrics-privacy.md §3 Allowed only — file paths, stack traces, command output, raw prompts MUST NOT appear (§4 Forbidden).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ts", "task_id", "event", "schema_version"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "PlanGate event schema version"
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp"
+    },
+    "task_id": {
+      "type": "string",
+      "pattern": "^TASK-[0-9]{4}$",
+      "description": "TASK 連番のみ。内容を含むメタデータは保存しない"
+    },
+    "event": {
+      "type": "string",
+      "enum": [
+        "task_initialized",
+        "plan_generated",
+        "c3_decided",
+        "exec_started",
+        "hook_violation",
+        "v1_completed",
+        "fix_loop_incremented",
+        "external_review_completed",
+        "pr_created",
+        "c4_decided",
+        "handoff_completed"
+      ]
+    },
+    "phase": {
+      "type": "string",
+      "enum": ["A", "B", "C-1", "C-2", "C-3", "D", "L-0", "V-1", "V-2", "V-3", "V-4", "PR", "C-4"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["ultra-light", "light", "standard", "high-risk", "critical"]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["APPROVED", "CONDITIONAL", "REJECTED", "PASS", "FAIL", "WARN", "REQUEST_CHANGES"]
+    },
+    "hook_id": {
+      "type": "string",
+      "pattern": "^(EH|EHS)-[0-9]+$",
+      "description": "EH-N or EHS-N 固定 enum パターン"
+    },
+    "hook_result": {
+      "type": "string",
+      "enum": ["pass", "block", "warn"]
+    },
+    "fix_loop_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "ac_total": { "type": "integer", "minimum": 0 },
+    "ac_pass": { "type": "integer", "minimum": 0 },
+    "ac_fail": { "type": "integer", "minimum": 0 },
+    "ac_warn": { "type": "integer", "minimum": 0 },
+    "plan_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "model_profile": {
+      "type": "string",
+      "description": "固定 enum: 内部で再定義 (provider+model_family レベル、API key 等は含まない)"
+    },
+    "tool_name": {
+      "type": "string",
+      "description": "固定 enum: Edit/Bash/Read/Grep/Write 等のツール名のみ"
+    },
+    "tool_call_count": { "type": "integer", "minimum": 0 },
+    "by": {
+      "type": "string",
+      "description": "agent / human の識別子（人名・社名は不可）"
+    },
+    "pr_number": { "type": "integer", "minimum": 1 }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "event": { "const": "c3_decided" } }, "required": ["event"] },
+      "then": { "required": ["verdict"] }
+    },
+    {
+      "if": { "properties": { "event": { "const": "c4_decided" } }, "required": ["event"] },
+      "then": { "required": ["verdict"] }
+    },
+    {
+      "if": { "properties": { "event": { "const": "hook_violation" } }, "required": ["event"] },
+      "then": { "required": ["hook_id", "hook_result"] }
+    },
+    {
+      "if": { "properties": { "event": { "const": "v1_completed" } }, "required": ["event"] },
+      "then": { "required": ["verdict"] }
+    },
+    {
+      "if": { "properties": { "event": { "const": "fix_loop_incremented" } }, "required": ["event"] },
+      "then": { "required": ["fix_loop_count"] }
+    }
+  ]
+}

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+PlanGate Metrics Collector v1 (Issue #195 / PBI-HI-001).
+
+Reads workflow artifacts from docs/working/<TASK-XXXX>/ and appends
+metrics events to docs/working/_metrics/events.ndjson.
+
+Privacy: only emits fields allowed by docs/ai/metrics-privacy.md §3.
+File paths, stack traces, command output, and raw prompts MUST NOT
+appear in emitted events (§4 Forbidden).
+
+Usage:
+    python3 scripts/metrics_collector.py TASK-XXXX [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKING_DIR = REPO_ROOT / "docs" / "working"
+METRICS_DIR = WORKING_DIR / "_metrics"
+EVENTS_LOG = METRICS_DIR / "events.ndjson"
+SCHEMA_VERSION = "1.0"
+
+TASK_ID_RE = re.compile(r"^TASK-[0-9]{4}$")
+HOOK_ID_RE = re.compile(r"\b(EH|EHS)-[0-9]+\b")
+
+
+def utc_now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def file_mtime_iso(path: Path) -> str:
+    ts = datetime.datetime.fromtimestamp(path.stat().st_mtime, tz=datetime.timezone.utc)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def base_event(task_id: str, event: str, ts: str | None = None) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ts": ts or utc_now_iso(),
+        "task_id": task_id,
+        "event": event,
+    }
+
+
+def derive_events(task_dir: Path, task_id: str) -> list[dict]:
+    """Derive metrics events from TASK artifacts.
+
+    Each event satisfies plangate-event.schema.json. Privacy-sensitive
+    fields (file paths, stdout, prompts, etc.) are NEVER emitted —
+    only the allowed scalar fields from §3 of metrics-privacy.md.
+    """
+    events: list[dict] = []
+
+    # 1. task_initialized — derived from pbi-input.md mtime
+    pbi = task_dir / "pbi-input.md"
+    if pbi.is_file():
+        events.append(
+            base_event(task_id, "task_initialized", file_mtime_iso(pbi)) | {"phase": "A"}
+        )
+
+    # 2. plan_generated — when plan.md & todo.md & test-cases.md all exist
+    plan = task_dir / "plan.md"
+    todo = task_dir / "todo.md"
+    test_cases = task_dir / "test-cases.md"
+    if plan.is_file():
+        ev = base_event(task_id, "plan_generated", file_mtime_iso(plan)) | {"phase": "B"}
+        ev["plan_hash"] = "sha256:" + sha256_hex(plan.read_bytes())
+        # mode detection from plan.md (light/standard/high-risk/critical)
+        mode_match = re.search(
+            r"\*\*モード\*\*[^\n]*?(ultra-light|light|standard|high-risk|critical)",
+            plan.read_text(errors="ignore"),
+        )
+        if mode_match:
+            ev["mode"] = mode_match.group(1)
+        events.append(ev)
+
+    # 3. c3_decided — from approvals/c3.json if present
+    c3 = task_dir / "approvals" / "c3.json"
+    if c3.is_file():
+        try:
+            data = json.loads(c3.read_text())
+            verdict = str(data.get("decision", "")).upper()
+            if verdict in {"APPROVED", "CONDITIONAL", "REJECTED"}:
+                events.append(
+                    base_event(task_id, "c3_decided", file_mtime_iso(c3))
+                    | {"phase": "C-3", "verdict": verdict}
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # 4. exec_started — derived from any file under TASK-XXXX/evidence/ or todo.md modification
+    evidence_dir = task_dir / "evidence"
+    if evidence_dir.is_dir() and any(evidence_dir.iterdir()):
+        first_evidence = min(evidence_dir.rglob("*"), key=lambda p: p.stat().st_mtime, default=None)
+        if first_evidence and first_evidence.is_file():
+            events.append(
+                base_event(task_id, "exec_started", file_mtime_iso(first_evidence))
+                | {"phase": "D"}
+            )
+
+    # 5. v1_completed — from handoff.md (assumes V-1 PASS recorded inside handoff)
+    handoff = task_dir / "handoff.md"
+    if handoff.is_file():
+        text = handoff.read_text(errors="ignore")
+        # Count AC PASS / FAIL from "✅ PASS" / "❌ FAIL" markers (privacy-safe: counts only)
+        ac_pass = len(re.findall(r"✅\s*PASS", text))
+        ac_fail = len(re.findall(r"❌\s*FAIL", text))
+        ac_warn = len(re.findall(r"⚠️\s*WARN", text))
+        ac_total = ac_pass + ac_fail + ac_warn
+        verdict = "PASS" if ac_fail == 0 and ac_total > 0 else "FAIL" if ac_fail > 0 else "WARN"
+        ev = base_event(task_id, "v1_completed", file_mtime_iso(handoff)) | {
+            "phase": "V-1",
+            "verdict": verdict,
+        }
+        if ac_total > 0:
+            ev.update({"ac_total": ac_total, "ac_pass": ac_pass, "ac_fail": ac_fail})
+            if ac_warn > 0:
+                ev["ac_warn"] = ac_warn
+        events.append(ev)
+
+        # 6. handoff_completed
+        events.append(
+            base_event(task_id, "handoff_completed", file_mtime_iso(handoff))
+            | {"phase": "V-1"}
+        )
+
+    # 7. external_review_completed — from review-external.md presence
+    review_ext = task_dir / "review-external.md"
+    if review_ext.is_file():
+        events.append(
+            base_event(task_id, "external_review_completed", file_mtime_iso(review_ext))
+            | {"phase": "V-3"}
+        )
+
+    return events
+
+
+def append_events(events: list[dict], events_log: Path = EVENTS_LOG) -> None:
+    events_log.parent.mkdir(parents=True, exist_ok=True)
+    with events_log.open("a", encoding="utf-8") as fp:
+        for ev in events:
+            fp.write(json.dumps(ev, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("task_id", help="Target TASK-XXXX")
+    parser.add_argument("--dry-run", action="store_true", help="Print events without appending")
+    parser.add_argument(
+        "--events-log",
+        default=str(EVENTS_LOG),
+        help="Override events log path (default: docs/working/_metrics/events.ndjson)",
+    )
+    args = parser.parse_args(argv)
+
+    if not TASK_ID_RE.match(args.task_id):
+        print(f"Invalid task_id format: {args.task_id} (expected TASK-XXXX)", file=sys.stderr)
+        return 2
+
+    task_dir = WORKING_DIR / args.task_id
+    if not task_dir.is_dir():
+        print(f"TASK directory not found: {task_dir}", file=sys.stderr)
+        return 2
+
+    events = derive_events(task_dir, args.task_id)
+
+    if args.dry_run:
+        for ev in events:
+            print(json.dumps(ev, ensure_ascii=False, sort_keys=True))
+        return 0
+
+    target_log = Path(args.events_log)
+    if not target_log.is_absolute():
+        target_log = REPO_ROOT / target_log
+    append_events(events, target_log)
+    try:
+        display = target_log.relative_to(REPO_ROOT)
+    except ValueError:
+        display = target_log
+    print(f"Appended {len(events)} events to {display}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/metrics_reporter.py
+++ b/scripts/metrics_reporter.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+PlanGate Metrics Reporter v1 (Issue #195 / PBI-HI-001).
+
+Reads docs/working/_metrics/events.ndjson and prints a TASK-level
+or aggregate summary covering hook violations / C-3 / V-1 / C-4.
+
+Privacy: only reads the allowed §3 fields. No file paths, stack
+traces, command outputs are dereferenced (per metrics-privacy.md).
+
+Usage:
+    python3 scripts/metrics_reporter.py TASK-XXXX
+    python3 scripts/metrics_reporter.py --aggregate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_EVENTS_LOG = REPO_ROOT / "docs" / "working" / "_metrics" / "events.ndjson"
+
+
+def load_events(events_log: Path) -> list[dict]:
+    if not events_log.is_file():
+        return []
+    out = []
+    for line in events_log.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def filter_task(events: list[dict], task_id: str) -> list[dict]:
+    return [ev for ev in events if ev.get("task_id") == task_id]
+
+
+def summarize(events: list[dict]) -> dict:
+    """Compute summary counters for the given event slice."""
+    summary: dict = {
+        "event_count": len(events),
+        "events_by_type": dict(Counter(ev.get("event", "?") for ev in events)),
+        "hook_violations": {
+            "total": 0,
+            "by_hook_id": {},
+            "by_result": {},
+        },
+        "c3": {"APPROVED": 0, "CONDITIONAL": 0, "REJECTED": 0},
+        "c4": {"APPROVED": 0, "REQUEST_CHANGES": 0, "REJECTED": 0},
+        "v1": {"PASS": 0, "FAIL": 0, "WARN": 0},
+        "fix_loop_max": 0,
+        "modes": {},
+    }
+
+    for ev in events:
+        event_type = ev.get("event")
+
+        if event_type == "hook_violation":
+            summary["hook_violations"]["total"] += 1
+            hid = ev.get("hook_id", "?")
+            hresult = ev.get("hook_result", "?")
+            summary["hook_violations"]["by_hook_id"][hid] = (
+                summary["hook_violations"]["by_hook_id"].get(hid, 0) + 1
+            )
+            summary["hook_violations"]["by_result"][hresult] = (
+                summary["hook_violations"]["by_result"].get(hresult, 0) + 1
+            )
+        elif event_type == "c3_decided":
+            v = ev.get("verdict", "?")
+            if v in summary["c3"]:
+                summary["c3"][v] += 1
+        elif event_type == "c4_decided":
+            v = ev.get("verdict", "?")
+            if v in summary["c4"]:
+                summary["c4"][v] += 1
+        elif event_type == "v1_completed":
+            v = ev.get("verdict", "?")
+            if v in summary["v1"]:
+                summary["v1"][v] += 1
+        elif event_type == "fix_loop_incremented":
+            count = ev.get("fix_loop_count", 0)
+            if isinstance(count, int) and count > summary["fix_loop_max"]:
+                summary["fix_loop_max"] = count
+        elif event_type == "plan_generated":
+            mode = ev.get("mode")
+            if mode:
+                summary["modes"][mode] = summary["modes"].get(mode, 0) + 1
+
+    return summary
+
+
+def render_text(task_id: str | None, summary: dict) -> str:
+    title = f"# Metrics summary: {task_id}" if task_id else "# Metrics summary: aggregate"
+    lines = [title, ""]
+    lines.append(f"- events: {summary['event_count']}")
+    lines.append("- events by type:")
+    for k, v in sorted(summary["events_by_type"].items()):
+        lines.append(f"    - {k}: {v}")
+    if summary["modes"]:
+        lines.append(f"- modes: {summary['modes']}")
+    lines.append("")
+
+    lines.append("## Hook violations")
+    lines.append(f"- total: {summary['hook_violations']['total']}")
+    if summary["hook_violations"]["by_hook_id"]:
+        lines.append("- by hook_id:")
+        for k, v in sorted(summary["hook_violations"]["by_hook_id"].items()):
+            lines.append(f"    - {k}: {v}")
+    if summary["hook_violations"]["by_result"]:
+        lines.append("- by result:")
+        for k, v in sorted(summary["hook_violations"]["by_result"].items()):
+            lines.append(f"    - {k}: {v}")
+    lines.append("")
+
+    lines.append("## Gate decisions")
+    lines.append(f"- C-3: {summary['c3']}")
+    lines.append(f"- V-1: {summary['v1']}")
+    lines.append(f"- C-4: {summary['c4']}")
+    if summary["fix_loop_max"] > 0:
+        lines.append(f"- fix_loop_max: {summary['fix_loop_max']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("task_id", nargs="?", help="Target TASK-XXXX (omit with --aggregate)")
+    parser.add_argument("--aggregate", action="store_true", help="Aggregate across all TASKs")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    parser.add_argument(
+        "--events-log",
+        default=str(DEFAULT_EVENTS_LOG),
+        help="Path to events.ndjson (default: docs/working/_metrics/events.ndjson)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.task_id and not args.aggregate:
+        parser.error("either task_id or --aggregate is required")
+
+    events_log = Path(args.events_log)
+    if not events_log.is_absolute():
+        events_log = REPO_ROOT / events_log
+    all_events = load_events(events_log)
+
+    if args.aggregate:
+        target_events = all_events
+        task_id_label = None
+    else:
+        target_events = filter_task(all_events, args.task_id)
+        task_id_label = args.task_id
+
+    summary = summarize(target_events)
+    if args.json:
+        out = {"task_id": task_id_label, "summary": summary}
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(task_id_label, summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/extras/ta-09-metrics.sh
+++ b/tests/extras/ta-09-metrics.sh
@@ -1,0 +1,132 @@
+# tests/extras/ta-09-metrics.sh
+# Sourced by tests/run-tests.sh
+# Issue #195 / PBI-HI-001 (Metrics v1)
+
+printf '\n=== TA-09: metrics (Issue #195) ===\n'
+
+METRICS_TASK_NAME="TASK-9991"
+METRICS_TASK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/docs/working/$METRICS_TASK_NAME"
+METRICS_LOG="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/.tmp-metrics-events.ndjson"
+
+cleanup_metrics() {
+  rm -rf "$METRICS_TASK_DIR"
+  rm -f "$METRICS_LOG"
+}
+trap cleanup_metrics EXIT INT TERM
+
+cleanup_metrics
+mkdir -p "$METRICS_TASK_DIR/approvals" "$METRICS_TASK_DIR/evidence"
+
+# Minimal fixture
+cat > "$METRICS_TASK_DIR/pbi-input.md" <<'PBI'
+# pbi-input
+PBI
+
+cat > "$METRICS_TASK_DIR/plan.md" <<'PLAN'
+# plan
+**モード**: light
+PLAN
+
+cat > "$METRICS_TASK_DIR/handoff.md" <<'HANDOFF'
+# Handoff: TASK-9991
+
+## 1. 要件適合確認結果
+| AC | 結果 |
+|----|------|
+| AC-01 | ✅ PASS |
+| AC-02 | ✅ PASS |
+| AC-03 | ✅ PASS |
+HANDOFF
+
+cat > "$METRICS_TASK_DIR/approvals/c3.json" <<'C3'
+{"task_id":"TASK-9991","decision":"APPROVED"}
+C3
+
+# Test 1: collect (default mode, append)
+if sh "$PLANGATE_BIN" metrics "$METRICS_TASK_NAME" --collect --events-log "$METRICS_LOG" >/dev/null 2>&1 && [ -s "$METRICS_LOG" ]; then
+  printf '[PASS] metrics: collect appended events to events.ndjson\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: collect failed or events.ndjson empty\n'
+  fail=$((fail + 1))
+fi
+
+# Test 2: each line is valid JSON
+if [ -s "$METRICS_LOG" ] && python3 -c "import json,sys; [json.loads(l) for l in open('$METRICS_LOG') if l.strip()]" 2>/dev/null; then
+  printf '[PASS] metrics: events.ndjson lines are valid JSON\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: events.ndjson contains invalid JSON\n'
+  fail=$((fail + 1))
+fi
+
+# Test 3: schema validation (if jsonschema available)
+if python3 -c 'import jsonschema' >/dev/null 2>&1 && [ -s "$METRICS_LOG" ]; then
+  schema_path="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/schemas/plangate-event.schema.json"
+  if python3 -c "
+import json, jsonschema, sys
+schema = json.load(open('$schema_path'))
+events = [json.loads(l) for l in open('$METRICS_LOG') if l.strip()]
+for ev in events:
+    jsonschema.validate(ev, schema)
+sys.exit(0)
+" 2>/dev/null; then
+    printf '[PASS] metrics: events conform to plangate-event.schema.json\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] metrics: schema validation failed\n'
+    fail=$((fail + 1))
+  fi
+else
+  printf '[SKIP] metrics: jsonschema not available, schema validation skipped\n'
+fi
+
+# Test 4: c3_decided event with verdict APPROVED
+if grep -q '"event": "c3_decided"' "$METRICS_LOG" 2>/dev/null && grep -q '"verdict": "APPROVED"' "$METRICS_LOG" 2>/dev/null; then
+  printf '[PASS] metrics: c3_decided event with APPROVED verdict emitted\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: c3_decided / verdict APPROVED missing\n'
+  fail=$((fail + 1))
+fi
+
+# Test 5: v1_completed with PASS verdict (3 ✅ PASS markers in handoff)
+if grep -q '"event": "v1_completed"' "$METRICS_LOG" 2>/dev/null; then
+  if grep -E '"verdict": "PASS"' "$METRICS_LOG" >/dev/null; then
+    printf '[PASS] metrics: v1_completed with PASS verdict (AC counts derived)\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] metrics: v1_completed has unexpected verdict\n'
+    fail=$((fail + 1))
+  fi
+else
+  printf '[FAIL] metrics: v1_completed event missing\n'
+  fail=$((fail + 1))
+fi
+
+# Test 6: report --json works
+if sh "$PLANGATE_BIN" metrics "$METRICS_TASK_NAME" --report --json --events-log "$METRICS_LOG" 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["summary"]["c3"]["APPROVED"] >= 1' 2>/dev/null; then
+  printf '[PASS] metrics: report --json shows c3 APPROVED count\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: report --json output incorrect\n'
+  fail=$((fail + 1))
+fi
+
+# Test 7: aggregate report
+if sh "$PLANGATE_BIN" metrics --report --aggregate --events-log "$METRICS_LOG" 2>&1 | grep -q 'aggregate'; then
+  printf '[PASS] metrics: --aggregate report works\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: --aggregate report failed\n'
+  fail=$((fail + 1))
+fi
+
+# Test 8: usage on no args
+if sh "$PLANGATE_BIN" metrics 2>&1 | grep -q 'Usage'; then
+  printf '[PASS] metrics: usage shown on no args\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics: usage not shown on no args\n'
+  fail=$((fail + 1))
+fi


### PR DESCRIPTION
## Summary

PlanGate workflow event を構造化 metrics として保存・集計可能にする。Metrics v1 (PBI-HI-001 / #195) で v8.6.0 milestone を完成させる。

## Why

EPIC #193 後続改善（#196 Eval expansion / #197 Model Profile v2 / #198 Keep Rate / #199 Dynamic Context）の効果測定基盤として、実利用シグナルを構造化保存できるようにする。本 PR で v8.6.0 P0 4 件すべて完走。

## Added

- \`schemas/plangate-event.schema.json\` — 11 events、conditional required（c3/c4/v1/hook/fix_loop）、privacy §3 Allowed のみ
- \`scripts/metrics_collector.py\` — TASK ディレクトリから 6 events 自動導出 + NDJSON append
- \`scripts/metrics_reporter.py\` — TASK / aggregate summary、--json 対応
- \`docs/ai/metrics.md\` — 9 章運用ガイド（CLI / privacy / schema / baseline 比較）
- \`tests/extras/ta-09-metrics.sh\` — 8 test cases (schema validation 含む)

## Modified

- \`bin/plangate\` — metrics サブコマンド追加
- \`.gitignore\` — events.ndjson 除外（privacy §8）

## Acceptance Criteria

7/7 PASS + 補助 3/3 PASS（handoff.md §1）。

## Tests

tests/run-tests.sh: 24 → **32 PASS**（ta-09 で 8 件追加、既存 0 件 regress）

## Roadmap

本 PR で **v8.6.0 milestone P0 4 件完走**:
- #194 Baseline alignment (PR #208)
- #201 Issue/Label/Milestone Governance (PR #206)
- #202 Metrics Privacy Policy (PR #207)
- **#195 Metrics v1**（本 PR）

closes #195