### PR TITLE
feat(observability): v8.6.0 workflow 統合 + observability (改善 PR6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,17 @@
 - 共有スキル: `.agents/skills/`（Codex CLI と共用）
 - ワークフロー詳細: [`docs/ai-driven-development.md`](docs/ai-driven-development.md) / Orchestrator: [`docs/orchestrator-mode.md`](docs/orchestrator-mode.md)
 
+## v8.6.0 Metrics & Governance（最新リリース機能）
+
+- **Metrics v1**: [`docs/ai/metrics.md`](docs/ai/metrics.md) — `bin/plangate metrics <TASK> --collect|--report|--validate`
+- **Privacy**: [`docs/ai/metrics-privacy.md`](docs/ai/metrics-privacy.md) — §3 Allowed / §4 Forbidden、4 層強制（gitignore + Hook EH-8 + schema additionalProperties:false + CI workflow）
+- **Issue / Label / Milestone Governance**: [`docs/ai/issue-governance.md`](docs/ai/issue-governance.md) — 必須セクション、4 軸 label taxonomy、roadmap PBI 作成 checklist
+- **Baseline**: [`docs/ai/eval-baselines/2026-05-04-baseline.{md,json}`](docs/ai/eval-baselines/) + [`schemas/eval-baseline.schema.json`](schemas/eval-baseline.schema.json) + `scripts/baseline-snapshot.py`
+- **Hook EH-8**: [`scripts/hooks/check-metrics-privacy.sh`](scripts/hooks/check-metrics-privacy.sh) — staging に events.ndjson / Forbidden field を検出
+- **Health check**: `bin/plangate doctor` に v8.6.0 セクション（schema 存在 / scripts 存在 / events.ndjson gitignore / EH-8 executable 等を 12 項目検査）
+- **Roadmap**: [`docs/ai/harness-improvement-roadmap.md`](docs/ai/harness-improvement-roadmap.md) — Phase 0/1 + Governance Done、Phase 2-6 Open
+- **Templates**: [`docs/working/templates/handoff.md`](docs/working/templates/handoff.md) §7 / [`docs/working/templates/current-state.md`](docs/working/templates/current-state.md) で metrics スナップショットを記載可能（任意）
+
 <language>Japanese</language>
 <character_code>UTF-8</character_code>
 <law>

--- a/docs/ai/metrics.md
+++ b/docs/ai/metrics.md
@@ -87,6 +87,26 @@ echo '{"schema_version":"1.0","ts":"2026-05-04T07:00:00Z","task_id":"TASK-0061",
 
 git が無い / commit が見つからない場合は silent に skip。
 
+### 3.5 mode 別集計（v8.6.0 PR6 / H-3）
+
+`bin/plangate metrics --report --aggregate` または `--report --json` の出力に `By mode` セクション / `by_mode` フィールドが追加される。
+
+- TASK ごとに plan_generated event の `mode` を解決して、各 mode の C-3 / V-1 / C-4 verdict と hook violation を別々に集計
+- V-1 PASS rate (%) も自動計算
+- harness 変更が mode 別にどう効いたかを比較可能（後続 PBI-HI-002 / #196 Eval expansion でフル活用予定）
+
+出力例（aggregate text）：
+
+```text
+## By mode (H-3)
+- **light**: V-1 12/14 PASS (85.71%) / C-3 APPROVED=10 / hook_violations=2
+- **standard**: V-1 5/5 PASS (100.0%) / C-3 APPROVED=5 / hook_violations=0
+```
+
+### 3.6 整合性検証（v8.6.0 PR5 / H-1）
+
+`bin/plangate metrics --validate` で `events.ndjson` 全行を `plangate-event.schema.json` で validate。違反は line:reason 形式で最大 20 件報告、exit 1。jsonschema 未導入時は SKIP（exit 0）。
+
 ## 4. Privacy
 
 [`metrics-privacy.md`](./metrics-privacy.md) 準拠。`metrics_collector.py` は §3 (Allowed) のフィールドのみ emit する。

--- a/docs/working/TASK-0059/eval-result.json
+++ b/docs/working/TASK-0059/eval-result.json
@@ -1,6 +1,6 @@
 {
   "task_id": "TASK-0059",
-  "evaluated_at": "2026-05-06T09:17:22Z",
+  "evaluated_at": "2026-05-06T09:34:17Z",
   "evaluator_version": "1.2.0",
   "schema_compliance": {
     "json_files_validated": 0,

--- a/docs/working/TASK-0059/eval-result.md
+++ b/docs/working/TASK-0059/eval-result.md
@@ -1,6 +1,6 @@
 # Eval Result: TASK-0059
 
-> Evaluated at: 2026-05-06T09:17:22Z
+> Evaluated at: 2026-05-06T09:34:17Z
 > Runner version: 1.2.0
 
 ## サマリ

--- a/docs/working/TASK-0067/handoff.md
+++ b/docs/working/TASK-0067/handoff.md
@@ -1,0 +1,64 @@
+# Handoff: TASK-0067 (v8.6.0 改善 PR6 / workflow 統合 + observability)
+
+## 1. 要件適合確認結果
+
+| AC | 検証 | 判定 |
+|----|------|------|
+| AC-01 handoff §7 Metrics summary | template に「7. Metrics summary（v8.6.0+、任意）」追加 | ✅ PASS |
+| AC-02 current-state Metrics スナップショット | 「## Metrics スナップショット（v8.6.0+、任意）」節追加 | ✅ PASS |
+| AC-03 reporter text by_mode | `--aggregate` 出力に「By mode (H-3)」節を確認 | ✅ PASS |
+| AC-04 reporter json by_mode | `--json --aggregate` 出力に `by_mode` キー含む | ✅ PASS |
+| AC-05 collector mode regex 強化 | TASK-0059 / 0061 で `mode=light` を抽出 | ✅ PASS |
+| AC-06 CLAUDE.md v8.6.0 section | 「v8.6.0 Metrics & Governance」セクション追加 + 8 リンク | ✅ PASS |
+| AC-07 metrics.md 加筆 | §3.5 mode 別集計 / §3.6 整合性検証を追記 | ✅ PASS |
+| AC-08 ta-09 +2 cases | 46 → **48 PASS** (H-3 text / H-3 json) | ✅ PASS |
+| AC-09 既存 regress なし | tests/hooks 48 PASS / 既存 21 cases PASS 維持 | ✅ PASS |
+
+**全 9/9 PASS**
+
+## 2. 既知課題
+
+なし。
+
+## 3. V2 候補
+
+- handoff §7 を `bin/plangate metrics --report --markdown-section` 等で自動挿入
+- current-state を session start / end hook で metrics スナップショットを自動更新
+- by_mode に approval_discipline / verification_honesty 等の eval 観点を追加（PBI-HI-002 / #196 と連動）
+- CLAUDE.md v8.6.0 セクションの自動同期（リリース毎に更新）
+
+## 4. 妥協点
+
+- reporter の by_mode は **TASK ID → mode を index 化** してから集計するため、plan_generated event が無い old TASK は集計対象外（mode 不明）
+- collector の mode regex は 3 形式（`**モード**` / `## Mode 判定` / `## Mode` 直下）に対応。それ以外は最初の light/standard/...キーワードで fallback
+- handoff §7 / current-state Metrics 節は任意。強制ではない（既存運用と互換）
+
+## 5. 引き継ぎ文書
+
+修正:
+- `scripts/metrics_reporter.py`:
+  - `summarize()` に `by_mode` bucket（C-3 / V-1 / C-4 / hook_violations）と V-1 PASS rate (%)
+  - TASK ID → mode index による正確な mode 解決
+  - `render_text()` に「## By mode (H-3)」節
+- `scripts/metrics_collector.py`:
+  - mode regex を 3 形式対応 + fallback で強化（後方互換維持）
+  - `ev["mode"]` を lowercase 化
+- `docs/working/templates/handoff.md`: §7 Metrics summary 追加
+- `docs/working/templates/current-state.md`: Metrics スナップショット節追加
+- `CLAUDE.md`: v8.6.0 Metrics & Governance セクション（8 リンク）
+- `docs/ai/metrics.md`: §3.5 mode 別集計 / §3.6 整合性検証
+- `tests/extras/ta-09-metrics.sh`: +2 cases (H-3 text / H-3 json)
+
+新規:
+- `docs/working/TASK-0067/{pbi-input,plan,test-cases,handoff}.md`
+
+## 6. テスト結果サマリ
+
+- `tests/run-tests.sh`: **48 PASS** (46 → 48)
+- `tests/hooks/run-tests.sh`: **48 PASS** (regression 0)
+- 動作確認:
+  - TASK-0059 / 0061 collect → mode=light が events.ndjson に記録
+  - `--report --aggregate` → "By mode (H-3)" + V-1 PASS rate (%)
+  - `--report --aggregate --json` → `summary.by_mode` キー
+  - `bin/plangate doctor` → v8.6.0 セクション全 PASS
+- 影響範囲: opt-in 拡張のみ（既存挙動 0 影響、template は任意項目、reporter 既存 fields は維持）

--- a/docs/working/TASK-0067/pbi-input.md
+++ b/docs/working/TASK-0067/pbi-input.md
@@ -1,0 +1,24 @@
+# PBI INPUT PACKAGE: TASK-0067 (v8.6.0 改善 PR6)
+
+## Why
+PR1〜PR5 で privacy / metrics 自動化 / baseline / 整合性検査を整えたが、ワークフロー成果物（handoff / current-state）と AI agent 入口（CLAUDE.md）への組込みが不足。さらに reporter は集計を mode 別に分けないため、harness 変更を mode で比較するのが手動だった。
+
+## What
+- F-1: handoff template に「7. Metrics summary」セクション追加（任意項目）
+- F-2: current-state template に metrics サブセクション追加
+- H-3: metrics_reporter.py の summary に by_mode (TASK の mode を解決して C-3/V-1/C-4/hook を mode 別集計、V-1 PASS rate %)
+- H-3 prerequisite: metrics_collector.py の mode regex 強化（"## Mode 判定" / "## Mode\nlight" 形式に対応）
+- I-1: CLAUDE.md に v8.6.0 機能サマリ追加（metrics / privacy / governance / baseline / hook EH-8 / doctor / templates）
+
+## Mode
+high-risk（reporter ロジック追加 + collector regex 改善 + テンプレ + CLAUDE.md）
+
+## AC
+- [ ] handoff template に §7 Metrics summary
+- [ ] current-state template に Metrics スナップショット節
+- [ ] reporter --aggregate text に By mode (H-3) 節
+- [ ] reporter --json で by_mode キー
+- [ ] collector が "## Mode 判定" / "## Mode\nlight" 形式で mode 抽出
+- [ ] CLAUDE.md に v8.6.0 機能サマリリンク
+- [ ] tests/extras/ta-09 +2 cases (H-3 text / H-3 json)
+- [ ] 既存テスト 0 件 regress

--- a/docs/working/TASK-0067/plan.md
+++ b/docs/working/TASK-0067/plan.md
@@ -1,0 +1,30 @@
+# EXECUTION PLAN: TASK-0067
+
+## Goal
+v8.6.0 機能をワークフロー成果物 + reporter + AI agent 入口に統合。
+
+## Mode
+high-risk
+
+## Approach
+1. metrics_reporter.py summarize() に task_to_mode index と by_mode bucket
+2. render_text() に By mode 節
+3. metrics_collector.py mode regex 強化（後方互換、3 形式対応）
+4. handoff template §7 / current-state template §Metrics スナップショット
+5. CLAUDE.md v8.6.0 セクション
+6. metrics.md §3.5 / §3.6 加筆
+7. ta-09 +2 cases
+
+## Files
+- scripts/metrics_reporter.py (修正)
+- scripts/metrics_collector.py (修正)
+- docs/working/templates/handoff.md (修正)
+- docs/working/templates/current-state.md (修正)
+- CLAUDE.md (修正)
+- docs/ai/metrics.md (修正)
+- tests/extras/ta-09-metrics.sh (修正)
+- docs/working/TASK-0067/* (新規)
+
+## Test
+- 自動: tests/run-tests.sh 46 → 48
+- 手動: --aggregate text + --json で by_mode 確認

--- a/docs/working/TASK-0067/test-cases.md
+++ b/docs/working/TASK-0067/test-cases.md
@@ -1,0 +1,13 @@
+# TEST CASES: TASK-0067
+
+| ID | AC | 検証 |
+|----|----|------|
+| TC-01 | handoff template §7 | grep "Metrics summary" docs/working/templates/handoff.md |
+| TC-02 | current-state template | grep "Metrics スナップショット" docs/working/templates/current-state.md |
+| TC-03 | reporter text by_mode | --aggregate 出力に "By mode (H-3)" |
+| TC-04 | reporter json by_mode | --json 出力に "by_mode" キー |
+| TC-05 | collector mode regex | TASK-0059 / 0061 で mode=light が抽出される |
+| TC-06 | CLAUDE.md v8.6.0 section | grep "v8.6.0 Metrics & Governance" CLAUDE.md |
+| TC-07 | metrics.md 加筆 | §3.5 §3.6 存在 |
+| TC-08 | tests +2 cases | ta-09 で H-3 text / H-3 json |
+| TC-09 | 既存 regress | tests/run-tests.sh 46 → 48 |

--- a/docs/working/templates/current-state.md
+++ b/docs/working/templates/current-state.md
@@ -24,3 +24,22 @@
 ## 計画からの乖離
 
 {なし / あれば要約。例: "T-4 で正規表現を変更（decision-log参照）"}
+
+## Metrics スナップショット（v8.6.0+、任意）
+
+> opt-in。取得していない場合は省略してよい。privacy: §3 Allowed のみ。
+
+```text
+bin/plangate metrics TASK-XXXX --report
+```
+
+直近の取得値（必要に応じてセッション開始時 / 終了時に上書き）:
+
+- events: {N}
+- mode: {ultra-light / light / standard / high-risk / critical}
+- C-3 verdict: {APPROVED / CONDITIONAL / REJECTED / 未到達}
+- V-1 verdict: {PASS / FAIL / WARN / 未実施}
+- hook violations: {N}（種別: {EH-N: block/warn ×N}）
+- 直近の events.ndjson 行数: {N}（`wc -l docs/working/_metrics/events.ndjson`）
+
+参照: [docs/ai/metrics.md](../../ai/metrics.md)

--- a/docs/working/templates/handoff.md
+++ b/docs/working/templates/handoff.md
@@ -94,6 +94,24 @@ v1_release: <コミット SHA or タグ>
 
 **FAIL / SKIP の詳細**: <FAIL の理由、SKIP の根拠>
 
+## 7. Metrics summary（v8.6.0+、任意）
+
+`bin/plangate metrics TASK-XXXX --collect && bin/plangate metrics TASK-XXXX --report` の結果を貼り付ける。
+opt-in: 取得していない場合は「該当なし」と記載するか節ごと省略してよい。privacy: §3 Allowed のみで構成され、ファイルパス / コマンド出力 / プロンプトは含まれない（[`docs/ai/metrics-privacy.md`](../../ai/metrics-privacy.md)）。
+
+| 観点 | 値 |
+|------|-----|
+| events | <N> |
+| modes | <例: light×1> |
+| C-3 | APPROVED=<N> / CONDITIONAL=<N> / REJECTED=<N> |
+| V-1 | PASS=<N> / FAIL=<N> / WARN=<N> |
+| C-4 | APPROVED=<N> / REQUEST_CHANGES=<N> / REJECTED=<N> |
+| hook violations | <N>（種別: <例: EH-2 block ×1>）|
+| fix_loop_max | <N> |
+| baseline 比較（任意） | <improved / unchanged / regressed + 観点>|
+
+参照: [`docs/ai/metrics.md`](../../ai/metrics.md) / [`docs/ai/eval-baselines/`](../../ai/eval-baselines/)
+
 ---
 
 ## 使い方

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -107,12 +107,23 @@ def derive_events(task_dir: Path, task_id: str) -> list[dict]:
         ev = base_event(task_id, "plan_generated", file_mtime_iso(plan)) | {"phase": "B"}
         ev["plan_hash"] = "sha256:" + sha256_hex(plan.read_bytes())
         # mode detection from plan.md (light/standard/high-risk/critical)
+        # v8.6.0 PR6 (H-3 prerequisite): tolerate multiple plan.md formats
+        plan_text = plan.read_text(errors="ignore")
+        mode_keywords = "(ultra-light|light|standard|high-risk|critical)"
         mode_match = re.search(
-            r"\*\*モード\*\*[^\n]*?(ultra-light|light|standard|high-risk|critical)",
-            plan.read_text(errors="ignore"),
+            rf"(?:\*\*モード\*\*|\*\*Mode\*\*|モード\s*判定|##?\s*Mode|最終判定)[^\n]{{0,200}}?{mode_keywords}",
+            plan_text,
+            re.IGNORECASE | re.MULTILINE,
         )
+        if mode_match is None:
+            # Fallback: 単独行 "Mode\nlight" や "## Mode\nlight" の形式
+            mode_match = re.search(
+                rf"^##?\s*Mode[^\n]*\n[^\n]*?{mode_keywords}",
+                plan_text,
+                re.IGNORECASE | re.MULTILINE,
+            )
         if mode_match:
-            ev["mode"] = mode_match.group(1)
+            ev["mode"] = mode_match.group(1).lower()
         events.append(ev)
 
     # 3. c3_decided — from approvals/c3.json if present

--- a/scripts/metrics_reporter.py
+++ b/scripts/metrics_reporter.py
@@ -45,7 +45,11 @@ def filter_task(events: list[dict], task_id: str) -> list[dict]:
 
 
 def summarize(events: list[dict]) -> dict:
-    """Compute summary counters for the given event slice."""
+    """Compute summary counters for the given event slice.
+
+    H-3 (v8.6.0 PR6): includes per-mode V-1 / C-3 PASS rates and per-mode
+    hook violation counts to make harness changes evaluable by mode.
+    """
     summary: dict = {
         "event_count": len(events),
         "events_by_type": dict(Counter(ev.get("event", "?") for ev in events)),
@@ -53,16 +57,43 @@ def summarize(events: list[dict]) -> dict:
             "total": 0,
             "by_hook_id": {},
             "by_result": {},
+            "by_mode": {},
         },
         "c3": {"APPROVED": 0, "CONDITIONAL": 0, "REJECTED": 0},
         "c4": {"APPROVED": 0, "REQUEST_CHANGES": 0, "REJECTED": 0},
         "v1": {"PASS": 0, "FAIL": 0, "WARN": 0},
         "fix_loop_max": 0,
         "modes": {},
+        # H-3: TASK ごとの mode を解決した上で gate verdict を mode 別に集計
+        "by_mode": {},
     }
+
+    # First pass: TASK ID → mode を index 化（plan_generated に mode が記録される）
+    task_to_mode: dict[str, str] = {}
+    for ev in events:
+        if ev.get("event") == "plan_generated" and ev.get("mode"):
+            task_to_mode[ev.get("task_id", "")] = ev["mode"]
+
+    def bump_mode_bucket(mode: str, key: str, sub: str) -> None:
+        if not mode:
+            return
+        bucket = summary["by_mode"].setdefault(
+            mode,
+            {
+                "c3": {"APPROVED": 0, "CONDITIONAL": 0, "REJECTED": 0},
+                "v1": {"PASS": 0, "FAIL": 0, "WARN": 0},
+                "c4": {"APPROVED": 0, "REQUEST_CHANGES": 0, "REJECTED": 0},
+                "hook_violations": 0,
+            },
+        )
+        if key == "hook_violations":
+            bucket["hook_violations"] += 1
+        elif sub in bucket.get(key, {}):
+            bucket[key][sub] += 1
 
     for ev in events:
         event_type = ev.get("event")
+        ev_mode = task_to_mode.get(ev.get("task_id", ""))
 
         if event_type == "hook_violation":
             summary["hook_violations"]["total"] += 1
@@ -74,18 +105,26 @@ def summarize(events: list[dict]) -> dict:
             summary["hook_violations"]["by_result"][hresult] = (
                 summary["hook_violations"]["by_result"].get(hresult, 0) + 1
             )
+            if ev_mode:
+                summary["hook_violations"]["by_mode"][ev_mode] = (
+                    summary["hook_violations"]["by_mode"].get(ev_mode, 0) + 1
+                )
+                bump_mode_bucket(ev_mode, "hook_violations", "")
         elif event_type == "c3_decided":
             v = ev.get("verdict", "?")
             if v in summary["c3"]:
                 summary["c3"][v] += 1
+            bump_mode_bucket(ev_mode, "c3", v)
         elif event_type == "c4_decided":
             v = ev.get("verdict", "?")
             if v in summary["c4"]:
                 summary["c4"][v] += 1
+            bump_mode_bucket(ev_mode, "c4", v)
         elif event_type == "v1_completed":
             v = ev.get("verdict", "?")
             if v in summary["v1"]:
                 summary["v1"][v] += 1
+            bump_mode_bucket(ev_mode, "v1", v)
         elif event_type == "fix_loop_incremented":
             count = ev.get("fix_loop_count", 0)
             if isinstance(count, int) and count > summary["fix_loop_max"]:
@@ -94,6 +133,13 @@ def summarize(events: list[dict]) -> dict:
             mode = ev.get("mode")
             if mode:
                 summary["modes"][mode] = summary["modes"].get(mode, 0) + 1
+
+    # H-3: per-mode pass rates (helps interpret the by_mode buckets)
+    for mode, bucket in summary["by_mode"].items():
+        v1 = bucket["v1"]
+        v1_total = sum(v1.values())
+        if v1_total > 0:
+            bucket["v1_pass_rate_pct"] = round(100.0 * v1["PASS"] / v1_total, 2)
 
     return summary
 
@@ -127,6 +173,23 @@ def render_text(task_id: str | None, summary: dict) -> str:
     lines.append(f"- C-4: {summary['c4']}")
     if summary["fix_loop_max"] > 0:
         lines.append(f"- fix_loop_max: {summary['fix_loop_max']}")
+
+    # H-3 (v8.6.0 PR6): per-mode breakdown
+    if summary.get("by_mode"):
+        lines.append("")
+        lines.append("## By mode (H-3)")
+        for mode, bucket in sorted(summary["by_mode"].items()):
+            v1 = bucket.get("v1", {})
+            c3 = bucket.get("c3", {})
+            v1_total = sum(v1.values())
+            v1_pass_rate = bucket.get("v1_pass_rate_pct")
+            line = f"- **{mode}**: V-1 {v1.get('PASS', 0)}/{v1_total} PASS"
+            if v1_pass_rate is not None:
+                line += f" ({v1_pass_rate}%)"
+            line += f" / C-3 APPROVED={c3.get('APPROVED', 0)}"
+            line += f" / hook_violations={bucket.get('hook_violations', 0)}"
+            lines.append(line)
+
     return "\n".join(lines)
 
 

--- a/tests/extras/ta-09-metrics.sh
+++ b/tests/extras/ta-09-metrics.sh
@@ -352,6 +352,26 @@ else
   fail=$((fail + 1))
 fi
 
+# Test (H-3, v8.6.0 PR6): aggregate report shows per-mode breakdown
+out=$(sh "$PLANGATE_BIN" metrics --report --aggregate --events-log "$METRICS_LOG" 2>&1)
+if printf '%s' "$out" | grep -q "By mode (H-3)"; then
+  printf '[PASS] metrics (H-3): aggregate report includes by-mode section\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics (H-3): by-mode section missing\n'
+  fail=$((fail + 1))
+fi
+
+# Test (H-3): JSON output contains by_mode key
+if sh "$PLANGATE_BIN" metrics --report --aggregate --json --events-log "$METRICS_LOG" 2>/dev/null \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); assert "by_mode" in d["summary"]' 2>/dev/null; then
+  printf '[PASS] metrics (H-3): --json output includes by_mode\n'
+  pass=$((pass + 1))
+else
+  printf '[FAIL] metrics (H-3): by_mode not in JSON\n'
+  fail=$((fail + 1))
+fi
+
 # Test 18 (C-3): baseline-snapshot.py --dry-run produces schema-valid output for real TASKs
 if python3 -c 'import jsonschema' >/dev/null 2>&1; then
   snapshot_script="$METRICS_REPO_ROOT/scripts/baseline-snapshot.py"


### PR DESCRIPTION
## Summary

PR1〜PR5 で整えた v8.6.0 機能を、ワークフロー成果物（handoff / current-state）と AI agent 入口（CLAUDE.md）に統合。さらに metrics reporter に mode 別集計を追加し、harness 変更を mode で比較可能にする。

## Added

### H-3: \`metrics_reporter.py\` に by_mode 集計

- TASK ID → mode を plan_generated event から index 化
- C-3 / V-1 / C-4 / hook_violations を mode 別 bucket
- V-1 PASS rate (%) を自動計算
- text 出力に「## By mode (H-3)」節、JSON に \`summary.by_mode\` キー

### H-3 prerequisite: collector mode regex 強化

3 形式対応（\`**モード**\` / \`## Mode 判定\` / \`## Mode\\nlight\`）+ fallback。後方互換維持。lowercase 正規化。

### F-1: handoff template §7

「7. Metrics summary（v8.6.0+、任意）」を追加。events / modes / C-3 / V-1 / C-4 / hook violations / fix_loop_max / baseline 比較 の 8 行表。

### F-2: current-state template Metrics スナップショット

opt-in。session 内の \`metrics --report\` 直近値を記録。

### I-1: CLAUDE.md v8.6.0 Metrics & Governance セクション

AI agent 入口に 8 リンク追加。

### docs/ai/metrics.md

§3.5 mode 別集計、§3.6 整合性検証 を追記。

## Tests

- tests/run-tests.sh: **48 PASS** (46 → 48、+2 cases for H-3 text/json)
- tests/hooks/run-tests.sh: 48 PASS (regression 0)

## Mode

high-risk（reporter ロジック追加 + collector regex + テンプレ + CLAUDE.md、ただし opt-in / 後方互換維持）

## V2 候補

- handoff §7 を \`metrics --report --markdown-section\` で自動挿入
- current-state を session hook で自動更新
- by_mode に approval_discipline / verification_honesty 等を追加（#196 連動）

## Roadmap

これで v8.6.0 範囲改善 6 PR が完走:
- PR1 (#215): privacy 強化 + governance 完結
- PR2 (#216): 利用者向けドキュメント強化
- PR3 (#217): metrics 自動化進化
- PR4 (#218): baseline 正式化
- PR5 (#219): 整合性検査強化
- PR6 (本 PR): workflow 統合 + observability