### PR TITLE
fix(codex): 不正な sandbox_mode "workspace-read" を "read-only" に修正

### DIFF
--- a/.codex/agents/acceptance_tester.toml
+++ b/.codex/agents/acceptance_tester.toml
@@ -3,7 +3,7 @@
 name = "acceptance_tester"
 description = "PlanGate V-1 受け入れ検査。test-cases.md の完了条件を機械的に突合し PASS/FAIL を判定する"
 
-sandbox_mode = "workspace-read"
+sandbox_mode = "read-only"
 model_reasoning_effort = "high"
 
 developer_instructions = """

--- a/.codex/agents/agile_coach.toml
+++ b/.codex/agents/agile_coach.toml
@@ -3,7 +3,7 @@
 name = "agile_coach"
 description = "アジャイル思考の補助線、アウトカム志向への補正、仮説検証設計、フィードバック設計、継続改善の仕組み化を担当する"
 
-sandbox_mode = "workspace-read"
+sandbox_mode = "read-only"
 model_reasoning_effort = "high"
 
 developer_instructions = """
@@ -13,7 +13,7 @@ developer_instructions = """
 - アウトカム志向: 成果物ではなく成果（ユーザー価値）を測る
 - 仮説検証: 改善は仮説→実験→計測のサイクルで回す
 - フィードバック設計: 振返りから具体的な改善アクションを生成する
-- `workspace-read` は repo 内のドキュメント・設定ファイル参照のために使う
+- `read-only` で repo 内のドキュメント・設定ファイルを参照する（書き込み不可）
 
 スタック: Scrum / Kanban / PlanGate v5-v6
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。

--- a/.codex/agents/research_analyst.toml
+++ b/.codex/agents/research_analyst.toml
@@ -3,7 +3,7 @@
 name = "research_analyst"
 description = "技術調査・実現可能性分析。plan 前の外部 API・ライブラリ評価、技術選定を担当する"
 
-sandbox_mode = "workspace-read"
+sandbox_mode = "read-only"
 model_reasoning_effort = "high"
 
 developer_instructions = """

--- a/.codex/agents/retrospective_analyst.toml
+++ b/.codex/agents/retrospective_analyst.toml
@@ -3,7 +3,7 @@
 name = "retrospective_analyst"
 description = "exec 完了後の振り返りデータ分析。計画精度・プロセス改善点を抽出し改善提案を行う"
 
-sandbox_mode = "workspace-read"
+sandbox_mode = "read-only"
 model_reasoning_effort = "high"
 
 developer_instructions = """

--- a/.codex/agents/scrum_master.toml
+++ b/.codex/agents/scrum_master.toml
@@ -3,7 +3,7 @@
 name = "scrum_master"
 description = "Sprint Planning、Daily Scrum、Sprint Review、Retrospective の論点整理、停滞可視化、impediment管理、改善アクション追跡を担当する"
 
-sandbox_mode = "workspace-read"
+sandbox_mode = "read-only"
 model_reasoning_effort = "high"
 
 developer_instructions = """
@@ -14,7 +14,7 @@ developer_instructions = """
 - Daily Scrum: 停滞の早期発見と impediment の可視化
 - Sprint Review: フィードバック収集と次スプリントへの反映
 - Retrospective: 改善実験の設計とアクション追跡
-- `workspace-read` は repo 内のドキュメント・設定ファイル参照のために使う
+- `read-only` で repo 内のドキュメント・設定ファイルを参照する（書き込み不可）
 
 スタック: Scrum Guide 2020 / PlanGate v5-v6
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。


### PR DESCRIPTION
## 背景

TASK-0069 振り返りの P4 外部レビュー時、Codex CLI 起動が失敗。原因は5つの `.codex/agents/*.toml` が `sandbox_mode = "workspace-read"`（Codex CLI 非対応の不正値）を持っていたこと。Codex は `read-only` / `workspace-write` / `danger-full-access` のみ受理する。

## 変更

- `acceptance_tester` / `agile_coach` / `research_analyst` / `retrospective_analyst` / `scrum_master` の `sandbox_mode` を `read-only` に修正
- agile_coach / scrum_master の説明文中の `workspace-read` 言及も整合修正

## 影響

- Codex マルチエージェント（PlanGate V-3 外部レビュー）が再び機能する
- 挙動変更は read-only エージェントの sandbox 値正常化のみ。権限は据え置き（読み取り専用）

## 検証

- `grep -rl workspace-read .codex/agents/*.toml` → 残存なし
- 全 sandbox_mode が有効3値のいずれか

🤖 Generated with [Claude Code](https://claude.com/claude-code)