### PR TITLE
docs(#225): バージョニング安定性ポリシー正本化 / TASK-0087

### DIFF
--- a/docs/ai/versioning-stability-policy.md
+++ b/docs/ai/versioning-stability-policy.md
@@ -1,0 +1,170 @@
+# バージョニング安定性ポリシー（正本）
+
+> PlanGate のバージョニングと互換性の **正本**。導入側が「このバージョンに
+> 上げて安全か」を CHANGELOG だけで判断できることを目的とする。
+> 関連: [#225](https://github.com/s977043/plangate/issues/225) / TASK-0087 /
+> [`oss-governance.md`](../oss-governance.md) / [`CHANGELOG.md`](../../CHANGELOG.md)
+
+## 1. 目的と背景
+
+PlanGate は高頻度リリース（v8.1.0 -> v8.6.0 を 8 日間で 5 メジャー）を行う。
+20 個の JSON Schema・11 の enforcement hook・5 つの workflow mode が相互依存
+するため、1 変更の波及範囲が広い。本ポリシーは **何が breaking change か** を
+定義し、**コンポーネント別の安定性レベル** を宣言し、**CHANGELOG 影響度タグ**
+を標準化し、**安定版運用方針** を定める。
+
+SemVer（`MAJOR.MINOR.PATCH`）を採用する。release-please の conventional
+commits 自動採番を維持しつつ、本ポリシーで **消費側互換性の判定軸** を補う。
+
+## 2. Breaking Change 定義
+
+「導入側の既存運用が、無変更では壊れる変更」を **major** とする。以下は
+コンポーネント別の正規化された判定表。**判定に迷う場合は安全側（より高い
+severity）に倒す**。
+
+### 2.1 JSON Schema（`schemas/*.json`）
+
+| 変更 | severity | 理由 |
+|------|----------|------|
+| 必須フィールドの追加 | **major** | 既存データが invalid 化 |
+| フィールド型の変更 / 制約強化（pattern, enum 削減, maxLength 短縮） | **major** | 既存データが invalid 化 |
+| オプショナルフィールドの追加 | minor | 既存データは valid のまま |
+| enum 値の追加（`additionalProperties:false` を維持） | minor | 既存データは valid のまま |
+| フィールド削除 | **major** | 参照側が壊れる |
+| description / title のみ変更 | patch | 振る舞い不変 |
+
+> `additionalProperties:false` の Schema に enum 追加するのは minor だが、
+> **その値を必須化・既定化する変更は major**（消費側が新値を扱えない）。
+
+### 2.2 Enforcement Hook（`scripts/hooks/*` / EH-x）
+
+| 変更 | severity | 理由 |
+|------|----------|------|
+| 既定挙動の変更（warning -> block、SKIP -> BLOCK 等） | **major** | 既存フローが停止し得る |
+| 新規 hook の追加（既定 OFF / opt-in） | minor | 明示有効化まで影響なし |
+| 新規 hook の追加（既定 ON / 強制） | **major** | 既存フローが停止し得る |
+| block 条件の緩和（block -> warning） | minor | 既存フローは止まらなくなる |
+| 監査ログ形式の変更（消費側パーサあり） | **major** | ログ解析が壊れる |
+| メッセージ文言のみ変更 | patch | 振る舞い不変 |
+
+### 2.3 Workflow / Mode（`docs/workflows/*` / mode 定義）
+
+| 変更 | severity | 理由 |
+|------|----------|------|
+| 必須フェーズの追加 / 削除 | **major** | 完了条件が変わる |
+| ゲート（C-3/C-4/V-1）の必須化 | **major** | 通過条件が変わる |
+| オプショナルフェーズの追加 / 削除 | minor | 既定フローは不変 |
+| mode 判定閾値の変更（同 mode に収まる範囲） | minor | 大半の PBI は不変 |
+| mode 判定閾値の変更（既存 PBI の mode が上がる） | **major** | 適用フェーズが増える |
+| `lite_eligible` 安全側不変条件の緩和 | **major** | ゲート強度低下（緩和不可・[`mode-classification.md`](../../.claude/rules/mode-classification.md) 調整ガイド3 で固定） |
+
+### 2.4 CLI（`bin/plangate`）
+
+| 変更 | severity | 理由 |
+|------|----------|------|
+| サブコマンドの削除 / リネーム | **major** | 既存スクリプトが壊れる |
+| 引数・フラグの削除 / 意味変更 | **major** | 既存呼び出しが壊れる |
+| 必須引数の追加 | **major** | 既存呼び出しが壊れる |
+| 新規サブコマンド / オプショナルフラグの追加 | minor | 既存呼び出しは不変 |
+| 出力フォーマット変更（消費側パーサあり: `--json` 等） | **major** | パイプライン破壊 |
+| 人間向け出力文言のみ変更 | patch | 機械可読部不変 |
+
+## 3. 安定性レベル
+
+各コンポーネントは以下 3 段階のいずれかを宣言する。レベルは
+**API 契約の強度** であり、品質・テスト網羅度とは独立。
+
+| レベル | 契約 | 変更時の扱い |
+|--------|------|-------------|
+| **Stable** | breaking change は major のみ・移行ガイド必須 | 2 章を厳格適用 |
+| **Beta** | breaking change を minor で許容（CHANGELOG 明記必須） | 影響度タグで通知 |
+| **Experimental** | 予告なく変更可・本番依存非推奨 | 互換保証なし |
+
+### 3.1 コンポーネント別宣言
+
+| コンポーネント | レベル | 備考 |
+|---------------|--------|------|
+| JSON Schema（`schemas/*.json`） | **Stable** | 消費側がデータ検証に使用 |
+| Hook enforcement model（EH-x / EHS-x の契約） | **Stable** | フロー停止に直結 |
+| CLI core subcommands（`init` / `doctor` / `version` / `metrics`） | **Stable** | スクリプト依存対象 |
+| Workflow / Gate モデル（C-3/C-4/V-1、5 mode） | **Stable** | 運用契約の中核 |
+| Plugin mode（`plugin/plangate/`） | **Beta** | #224 で成熟化進行中 |
+| Metrics v1（events / collector / reporter） | **Beta** | schema_version で additive 進化 |
+| Eval framework（eval-runner / dogfooding eval） | **Beta** | 観点・項目は追加進化 |
+| Dynamic Context Engine（#199） | **Experimental** | 未確定 |
+| Model Profile v2（#197） | **Experimental** | 未確定 |
+
+> レベル変更（例: Beta -> Stable 昇格）は **CHANGELOG に `[STABILITY]`
+> として明記**し、昇格後は 2 章を厳格適用する。降格（Stable -> Beta）は
+> 原則行わない（行う場合は major + 移行ガイド必須）。
+
+## 4. CHANGELOG 影響度タグ
+
+CHANGELOG.md の各エントリ先頭に、導入側影響度を表すタグを付与する。
+**1 エントリに最も重いタグ 1 つ**を付ける（複数該当時は上から優先）。
+
+| タグ | 意味 | 導入側のアクション |
+|------|------|------------------|
+| `[BREAKING]` | 2 章の major に該当 | 移行作業が必須。移行ガイドへのリンクを併記 |
+| `[MIGRATION REQUIRED]` | 互換だが設定・データ移行が必要 | 指示に従い移行（無変更だと degrade） |
+| `[STABILITY]` | 安定性レベルの変更（3.1） | 依存方針の再確認 |
+| `[SAFE UPDATE]` | 後方互換・無変更で安全 | そのまま更新可 |
+| `[INTERNAL]` | 消費側に影響しない内部変更 | アクション不要 |
+
+記載例:
+
+```markdown
+### Changed
+- `[BREAKING]` `schemas/plangate-event.schema.json`: `gate_id` を必須化
+  （移行: [versioning-stability-policy.md](docs/ai/versioning-stability-policy.md#5-移行ガイド)）
+- `[SAFE UPDATE]` `schemas/plangate-event.schema.json`: `parent_event_id`
+  をオプショナル追加（既存 events は無変更で valid）
+```
+
+> release-please は conventional commits からバージョンを採番する。
+> `feat!:` / `BREAKING CHANGE:` フッタを付けた commit が major を駆動する。
+> 本タグは **CHANGELOG 上の人間可読な影響度通知** であり、採番ロジックとは
+> 独立に常に付与する（採番が minor でも `[MIGRATION REQUIRED]` はあり得る）。
+
+## 5. 移行ガイド
+
+`[BREAKING]` / `[MIGRATION REQUIRED]` を含むリリースは、CHANGELOG の
+当該エントリから移行手順へのリンクを必須とする。移行手順は最低限:
+
+1. **何が変わったか**（before -> after の具体例）
+2. **影響を受ける条件**（どの利用形態が壊れるか）
+3. **移行手順**（コマンド / 設定変更 / データ変換）
+4. **移行しない場合の挙動**（degrade or 停止）
+
+配置: 大規模移行は `docs/migration/<version>.md`、小規模は CHANGELOG
+エントリ内に直接記載してよい。
+
+## 6. 安定版（LTS）運用方針
+
+高頻度リリースと並行し、以下を提供する:
+
+- **最新安定版ポインタ**: `main` の最新タグを常に「推奨導入版」とする。
+  Plugin 消費側は 3.1 Stable コンポーネントについて、同一 major 内で
+  互換が保たれることを期待してよい。
+- **LTS ブランチ**: 当面は **採用なし**（単一 active line を維持）。
+  外部採用が増え、複数 major の並行保守需要が顕在化した時点で
+  `release/vN.x` ブランチを切る。判断トリガと運用は #224 Plugin 成熟化の
+  バージョン同期機構（release archive 方式）と合わせて再評価する。
+- **非互換の予告**: Stable コンポーネントの major 変更は、可能な限り
+  1 リリース前に CHANGELOG の `### Deprecated` で予告する。
+
+## 7. 適用と検証
+
+- 本ポリシーは **リリース PR 作成時**（release-manager / V-4）に適用する。
+- CHANGELOG 影響度タグの付与漏れは C-4 レビュー観点に含める。
+- 2 章の severity 判定が分かれる場合、**安全側（高い severity）を採用**し、
+  判断を CHANGELOG エントリまたは PR に明記する（トレーサビリティ）。
+
+## 8. 関連
+
+- [`oss-governance.md`](../oss-governance.md) — OSS 運用ガバナンス全体
+- [`CHANGELOG.md`](../../CHANGELOG.md) — リリース履歴（本ポリシーのタグ適用先）
+- [`issue-governance.md`](./issue-governance.md) — Issue / Label / Milestone
+- [`.claude/rules/mode-classification.md`](../../.claude/rules/mode-classification.md) — 5 mode / lite_eligible
+- [#224](https://github.com/s977043/plangate/issues/224) — Plugin 成熟化（バージョン同期機構）
+- [#226](https://github.com/s977043/plangate/issues/226) — 段階的導入ガイド

--- a/docs/oss-governance.md
+++ b/docs/oss-governance.md
@@ -132,6 +132,14 @@ GitHub Discussions は有効化済みであることを確認した（2026-04-27
 | 活用事例・ショーケース | Discussions — Show and tell |
 | セキュリティ懸念 | Private vulnerability reporting |
 
+## バージョニング / 互換性
+
+リリースの互換性判定・安定性レベル・CHANGELOG 影響度タグの正本は
+[`docs/ai/versioning-stability-policy.md`](ai/versioning-stability-policy.md)。
+導入側が「このバージョンに上げて安全か」を CHANGELOG だけで判断できる
+ことを目的とし、Schema / Hook / Workflow / CLI 別の Breaking Change 定義と
+コンポーネント別 Stable / Beta / Experimental 宣言を提供する。
+
 ## Deferred Decisions
 
 各項目の判断状況を記録する（2026-04-27 更新）。

--- a/docs/working/TASK-0087/INDEX.md
+++ b/docs/working/TASK-0087/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0087 INDEX
+
+> 生成日: 2026-05-17
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0087/approvals/c3.json
+++ b/docs/working/TASK-0087/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0087",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T13:11:39Z",
+  "plan_hash": "sha256:f4ff663c33ac8e135fd14f1e941200d3fa01ac80eec9e0be9fc6264783984b81"
+}

--- a/docs/working/TASK-0087/current-state.md
+++ b/docs/working/TASK-0087/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0087 現在状態
+
+> 更新日: 2026-05-17
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0087/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0087 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0087/handoff.md
+++ b/docs/working/TASK-0087/handoff.md
@@ -1,0 +1,34 @@
+# Handoff — TASK-0087 / #225 バージョニング安定性ポリシー明文化
+
+## 1. 要件適合確認結果
+| AC | 内容 | 判定 |
+|----|------|------|
+| AC1 | Schema/Hook/Workflow/CLI 別 Breaking Change 定義 | PASS (T1) |
+| AC2 | コンポーネント別 Stable/Beta/Experimental 宣言 | PASS (T2) |
+| AC3 | CHANGELOG 影響度タグ + 記載例 | PASS (T3) |
+| AC4 | 安定版（LTS）運用方針 | PASS (T4) |
+| AC5 | oss-governance.md から到達 | PASS (T5) |
+V-1: 全 PASS（light のため V-3 スキップ）。
+
+## 2. 既知課題
+- CHANGELOG 既存エントリへの遡及タグ付けは未実施（Out of scope）。
+- 影響度タグの CI 強制（付与漏れ検出 lint）は未実装。
+
+## 3. V2 候補
+- 次回リリース PR から影響度タグ運用を実適用し、付与漏れ検出を CI 化。
+- #224 release archive 方式確定時に §6 LTS 方針を再評価・具体化。
+- release-please 設定と `feat!:` 運用ガイドの整合明文化。
+
+## 4. 妥協点
+- LTS ブランチは「当面採用なし」に留めた（単一 active line 維持）。複数 major
+  並行保守の需要が顕在化していない現状でブランチ運用コストを避けるため。
+
+## 5. 引き継ぎ文書
+#225 を docs only / light で実装。正本 `docs/ai/versioning-stability-policy.md`
+を新規作成し Breaking Change 定義（4 コンポーネント）・安定性レベル宣言・
+CHANGELOG 影響度タグ・移行ガイド要件・LTS 方針を規定。`oss-governance.md`
+に参照節を追加。release-please 採番ロジック・CI 強制は変更せず後続 PBI。
+次は #226 段階的導入ガイド。
+
+## 6. テスト結果サマリ
+T1-T5 + E1 すべて PASS（grep 構造突合）。c3.json schema required/plan_hash OK。

--- a/docs/working/TASK-0087/pbi-input.md
+++ b/docs/working/TASK-0087/pbi-input.md
@@ -1,0 +1,24 @@
+# PBI INPUT PACKAGE — TASK-0087 / #225 バージョニング安定性ポリシー明文化
+
+## Context / Why
+PlanGate は高頻度リリース（8 日で v8.1.0→v8.6.0）。20 Schema / 11 Hook / 5 mode
+が相互依存し波及が広いが、何が breaking change かの定義がなく、導入側が
+バージョンアップの安全性を CHANGELOG だけで判断できない。
+
+## What (Scope)
+- In scope: `docs/ai/versioning-stability-policy.md`（正本・新規）+ `oss-governance.md` から参照リンク
+- Out of scope: release-please 設定変更 / CHANGELOG 既存エントリの遡及タグ付け / LTS ブランチの実切り出し / CI 強制（後続）
+
+## 受入基準
+- AC1: Schema / Hook / Workflow / CLI 別の Breaking Change 定義（major/minor/patch）が表で示される
+- AC2: コンポーネント別 Stable / Beta / Experimental 宣言がある
+- AC3: CHANGELOG 影響度タグ（[BREAKING]/[MIGRATION REQUIRED]/[STABILITY]/[SAFE UPDATE]/[INTERNAL]）と記載例がある
+- AC4: 安定版（LTS）運用方針が明記される（当面 LTS なし + トリガ）
+- AC5: oss-governance.md から本ポリシーへ到達できる
+
+## Notes from Refinement
+- #225 提案の severity 表を踏襲。判定不明時は安全側（高 severity）固定。
+- #224（release archive 方式）と LTS 判断を将来連携。
+
+## Estimation Evidence
+- Risks: 既存運用との齟齬（緩和: 既存 mode-classification 固定条項を参照） / Unknowns: なし / Assumptions: docs のみで CI 強制は後続 PBI

--- a/docs/working/TASK-0087/plan.md
+++ b/docs/working/TASK-0087/plan.md
@@ -1,0 +1,43 @@
+# EXECUTION PLAN — TASK-0087 / #225
+
+## Goal
+バージョニング安定性ポリシーを正本化し、導入側が CHANGELOG だけで
+アップグレード安全性を判断できる基盤を docs として提供する。
+
+## Constraints / Non-goals
+- docs のみ。release-please 採番ロジック・CI 強制は変更しない（後続）。
+- 既存正本（mode-classification の lite_eligible 固定条項）と矛盾させない。
+
+## Approach Overview
+新規正本 `docs/ai/versioning-stability-policy.md` を作成。Breaking Change
+定義（Schema/Hook/Workflow/CLI）・安定性レベル宣言・CHANGELOG 影響度タグ・
+移行ガイド要件・LTS 方針を記載。`oss-governance.md` から参照リンクを追加。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | versioning-stability-policy.md 作成 | agent | 低 | 🚩 AC1-4 充足確認 |
+| S2 | oss-governance.md に参照節追加 | agent | 低 | 🚩 AC5 リンク到達確認 |
+
+## Files / Components to Touch
+- `docs/ai/versioning-stability-policy.md`（新規）
+- `docs/oss-governance.md`（参照節追加）
+
+## Testing Strategy
+Verification: 受入基準 5 件を test-cases.md で文書構造突合（grep）。Unit/E2E: 該当なし（docs）。
+
+## Risks & Mitigations
+- 既存運用との齟齬 → 既存正本を参照し緩和不可条項を明記
+- タグ運用の形骸化 → §7 で C-4 観点・安全側採用を規定
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: light
+**判定根拠**:
+- 変更ファイル数: 2 → 低
+- 受入基準数: 5 → 中
+- 変更種別: docs 新規 + 参照追加 → 低
+- リスク: 低（docs のみ・実行系不変）
+- **最終判定**: light（docs only・実行コード非変更のため受入基準数より実リスクを優先）

--- a/docs/working/TASK-0087/review-self.md
+++ b/docs/working/TASK-0087/review-self.md
@@ -1,0 +1,13 @@
+# C-1 セルフレビュー（light 簡易 / Plan 7 項目）— TASK-0087
+
+| ID | 項目 | 判定 | 根拠 |
+|----|------|------|------|
+| C1-PLAN-01 | 受入基準網羅性 | PASS | AC1-5 を S1/S2 と test-cases T1-T5 に 1:1 紐付け |
+| C1-PLAN-02 | Unknowns 処理 | PASS | Unknowns なし。LTS 実切り出しは Non-goal 明記 |
+| C1-PLAN-03 | スコープ制御 | PASS | docs のみ。release-please/CI 強制を Out of scope 明記 |
+| C1-PLAN-04 | テスト戦略 | PASS | docs のため構造突合（grep）で検証可能と定義 |
+| C1-PLAN-05 | Work Breakdown Output | PASS | S1/S2 に Output と 🚩 を明記 |
+| C1-PLAN-06 | 依存関係 | PASS | C-3→exec、C-1 簡易（light）依存を todo に明記 |
+| C1-PLAN-07 | 動作検証自動化 | PASS | grep ベース突合で自動確認可能 |
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0087/test-cases.md
+++ b/docs/working/TASK-0087/test-cases.md
@@ -1,0 +1,12 @@
+# テストケース定義 — TASK-0087 / #225
+
+| ID | 受入基準 | 入力 | 期待 | 種別 |
+|----|---------|------|------|------|
+| T1 | AC1 | versioning-stability-policy.md | "2.1 JSON Schema"/"2.2 Enforcement Hook"/"2.3 Workflow"/"2.4 CLI" 各表に major/minor 行が存在 | 構造突合 |
+| T2 | AC2 | 同上 | "3.1 コンポーネント別宣言" に Stable/Beta/Experimental 各 1 行以上 | 構造突合 |
+| T3 | AC3 | 同上 | "[BREAKING]"/"[MIGRATION REQUIRED]"/"[STABILITY]"/"[SAFE UPDATE]"/"[INTERNAL]" 全タグ + 記載例コードブロック | 構造突合 |
+| T4 | AC4 | 同上 | "6. 安定版（LTS）運用方針" に「当面は 採用なし」と再評価トリガ記載 | 構造突合 |
+| T5 | AC5 | oss-governance.md | "versioning-stability-policy" へのリンクが存在 | 構造突合 |
+
+## Edge
+- E1: 相対リンク `../oss-governance.md` / `ai/versioning-stability-policy.md` が実在パスを指す

--- a/docs/working/TASK-0087/todo.md
+++ b/docs/working/TASK-0087/todo.md
@@ -1,0 +1,15 @@
+# EXECUTION TODO — TASK-0087 / #225
+
+## 🤖 Agent
+- [x] 準備: #225 本文・既存 docs/CHANGELOG/release 構成確認
+- [x] 実装 S1: versioning-stability-policy.md 作成（🚩 AC1-4）
+- [x] 実装 S2: oss-governance.md 参照節追加（🚩 AC5）
+- [ ] 検証: V-1 受け入れ検査（test-cases 全件突合）
+- [ ] 完了: handoff.md 作成
+
+## 👤 Human
+- [ ] C-3: 計画差分確認（light 簡易）
+- [ ] C-4: PR レビュー / マージ
+
+## ⚠️ 依存
+- C-3 APPROVED 後に exec（本 PBI は docs のため C-1 簡易 7 項目）


### PR DESCRIPTION
## 概要
#225 を docs only / light で実装。導入側が「このバージョンに上げて安全か」を CHANGELOG だけで判断できる正本を新規作成。

## 変更
- **新規** `docs/ai/versioning-stability-policy.md`（正本・170行）
  - §2 Breaking Change 定義: Schema / Hook / Workflow / CLI 別 major/minor/patch 表
  - §3 安定性レベル: コンポーネント別 Stable / Beta / Experimental 宣言
  - §4 CHANGELOG 影響度タグ: `[BREAKING]`/`[MIGRATION REQUIRED]`/`[STABILITY]`/`[SAFE UPDATE]`/`[INTERNAL]` + 記載例
  - §5 移行ガイド要件 / §6 LTS 運用方針（当面採用なし + 再評価トリガ）/ §7 適用と検証
- `docs/oss-governance.md`: 「バージョニング / 互換性」参照節を追加

## V-1
T1-T5 + E1 すべて PASS（grep 構造突合）。light のため V-3 スキップ。

## Mode
light（docs only・実行コード非変更）

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)