### PR TITLE
feat(#213): Lightweight Plan Quality Checks / PBI-PQ-001 / TASK-0091

### DIFF
--- a/.claude/skills/plan-quality-check/SKILL.md
+++ b/.claude/skills/plan-quality-check/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: plan-quality-check
+description: "計画の不足情報・リスク・暗黙の前提・完了条件・次アクションを軽量に構造化抽出する。Use when: 計画の品質を実装前に確認したい時、Missing Items / Risks / Assumptions / Done Criteria を JSON 化したい時、重い Gate を使わず計画健全性を素早く見える化したい時。"
+---
+
+# Plan Quality Check
+
+計画文書（目的・スコープ・成功条件・完了条件）を読み、品質を構造化して
+返す軽量 Check の Skill。重い Gate / Agent orchestration / PR review /
+QA automation には依存しない（手動実行可能・補助情報）。
+
+## カテゴリ
+
+Design
+
+## 想定 Phase
+
+計画レビュー前後の軽量確認（計画作成直後・実装着手前）
+
+## 役割
+
+3 種の Check を単独または統合（combined）で実行する:
+
+| Check | 目的 | 主出力 |
+| --- | --- | --- |
+| `plan_check` | 目的・対象・成功条件・スコープの明確さを確認 | score / missing_items / summary |
+| `risk_check` | 失敗要因・依存関係・未決事項・暗黙の前提を確認 | risks / assumptions / next_actions |
+| `done_check` | 完了条件・検証方法・リリース後確認を確認 | done_criteria / validation_notes |
+
+## 入力
+
+- 計画文書（目的 / スコープ / 受入基準 / 完了条件を含むテキスト）
+- 任意: 確認したい Check 種別（plan_check / risk_check / done_check / combined）
+
+## 出力
+
+- 結果 JSON（`score`, `decision`, `summary`, `missing_items`, `risks`,
+  `assumptions`, `done_criteria`, `next_actions`, 任意 `score_breakdown`,
+  `validation_notes`）
+- 出力構造はリポジトリ側スキーマ（`schemas/plan-quality-check.schema.json`）
+  に準拠させる
+- 自由文サマリも併記してよいが、機械処理対象は JSON とする
+
+## Plan Health Score の考え方
+
+0-100。最小内訳: goal_clarity / scope_defined / success_metric /
+risks_identified / done_criteria_defined。閾値で助言的に
+`ready` / `needs_clarification` / `insufficient` を返す。
+
+## 制約
+
+- 本 Check の `decision` は **助言**であり、人間承認・ゲート判定の
+  代替にしない。
+- 重い自動実行（PR review / browser QA / pair-agent）を呼び出さない。
+- 不足が判定不能なときは安全側（より低い score / needs_clarification）。

--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -6,12 +6,14 @@ on:
       - 'docs/working/**/*.json'
       - 'schemas/**/*.json'
       - 'scripts/validate-schemas.py'
+      - 'scripts/schema_mapping.py'
       - '.github/workflows/schema-validate.yml'
   push:
     branches: [main]
     paths:
       - 'schemas/**/*.json'
       - 'scripts/validate-schemas.py'
+      - 'scripts/schema_mapping.py'
 
 permissions:
   contents: read
@@ -32,6 +34,21 @@ jobs:
 
       - name: Install jsonschema
         run: pip install 'jsonschema>=4,<5'
+
+      - name: Validate schema files and mapping integrity
+        run: |
+          set -eu
+          for f in schemas/*.json; do python3 -m json.tool "$f" >/dev/null; done
+          python3 - <<'PYCHK'
+          import sys, pathlib
+          sys.path.insert(0, "scripts")
+          import schema_mapping as m
+          miss = [v for v in m.FILENAME_TO_SCHEMA.values()
+                  if not (pathlib.Path(m.SCHEMAS_DIR) / v).exists()]
+          if miss:
+              sys.exit("missing schema targets: %s" % miss)
+          print("schema files + schema_mapping integrity OK")
+          PYCHK
 
       - name: Determine changed JSON files
         id: changed

--- a/bin/plangate
+++ b/bin/plangate
@@ -127,6 +127,7 @@ cmd_help() {
     "  validate-schemas <args>        Validate JSON artifacts against schemas/ (Issue #158)" \
     "  eval <TASK-XXXX> [--baseline]  Run 8-aspect eval (Issue #156)" \
     "  metrics <TASK-XXXX> [--collect|--report] Collect/report workflow metrics (Issue #195)" \
+    "  plan-check <TASK-XXXX> [--init|--validate]  Lightweight plan quality check (#213)" \
     "  review <TASK-XXXX> [--phase]   Run external AI review (c2/v3)" \
     "  exec <TASK-XXXX> [--mode]      Dispatch implementation agent (after C-3)" \
     "  abort <TASK-XXXX> [--reason]   Record abort event in run.ndjson" \
@@ -1168,6 +1169,88 @@ cmd_resume() {
   cmd_status "$task_id" 2>/dev/null | grep -E 'Current:|Next:' || true
 }
 
+cmd_plan_check() {
+  # Lightweight Plan Quality Check（手動実行・heavy Gate 非依存 / #213）
+  # 正本: docs/ai/plan-quality-checks.md
+  # Usage:
+  #   plangate plan-check <TASK-XXXX> --init   雛形 plan-quality-check.json 生成
+  #   plangate plan-check <TASK-XXXX> --validate  schema 検証
+  if [ $# -lt 1 ]; then
+    printf 'Usage: plangate plan-check <TASK-XXXX> [--init|--validate]\n' >&2
+    return 1
+  fi
+  task_id=$1
+  shift
+  plangate_validate_task_id "$task_id"
+  plangate_require_task_dir "$task_id"
+  pqc_file="$plangate_working_dir/$task_id/plan-quality-check.json"
+  action=${1:---init}
+  case "$action" in
+    --init)
+      if [ -f "$pqc_file" ]; then
+        printf '[plan-check] exists (not overwritten): %s\n' "$pqc_file"
+        return 0
+      fi
+      cat > "$pqc_file" <<'PQC'
+{
+  "check_type": "combined",
+  "score": 0,
+  "decision": "insufficient",
+  "summary": "TODO: 計画品質サマリを記述（plan_check/risk_check/done_check）",
+  "score_breakdown": {
+    "goal_clarity": 0,
+    "scope_defined": 0,
+    "success_metric": 0,
+    "risks_identified": 0,
+    "done_criteria_defined": 0
+  },
+  "missing_items": [],
+  "risks": [],
+  "assumptions": [],
+  "done_criteria": [],
+  "next_actions": []
+}
+PQC
+      printf '[plan-check] template created: %s\n' "$pqc_file"
+      printf '  Fill in via plan-quality-check skill, then: plangate plan-check %s --validate\n' "$task_id"
+      return 0
+      ;;
+    --validate)
+      if [ ! -f "$pqc_file" ]; then
+        printf '[plan-check] not found: %s (run --init first)\n' "$pqc_file" >&2
+        return 2
+      fi
+      schema="$plangate_root/schemas/plan-quality-check.schema.json"
+      vs="$plangate_root/scripts/validate-schemas.py"
+      if [ -f "$vs" ]; then
+        python3 "$vs" "$pqc_file"
+        return $?
+      fi
+      python3 - "$pqc_file" "$schema" <<'PYV'
+import json,sys
+doc=json.load(open(sys.argv[1])); sch=json.load(open(sys.argv[2]))
+try:
+    import jsonschema
+    jsonschema.validate(doc,sch)
+    print("[plan-check] VALID:", sys.argv[1])
+except ImportError:
+    req=sch.get("required",[])
+    miss=[k for k in req if k not in doc]
+    print("[plan-check] %s (jsonschema absent; required check)" %
+          ("VALID" if not miss else "INVALID missing=%s"%miss))
+    sys.exit(0 if not miss else 1)
+except Exception as e:
+    print("[plan-check] INVALID:", e); sys.exit(1)
+PYV
+      return $?
+      ;;
+    *)
+      printf 'Usage: plangate plan-check <TASK-XXXX> [--init|--validate]\n' >&2
+      return 1
+      ;;
+  esac
+}
+
 cmd_review() {
   if [ $# -eq 0 ]; then
     printf 'Usage: plangate review <TASK-XXXX> [--phase c2|v3] [--file <path>]\n' >&2
@@ -1316,6 +1399,7 @@ case "$command" in
   validate-schemas) cmd_validate_schemas "$@" ;;
   eval)        cmd_eval "$@" ;;
   metrics)     cmd_metrics "$@" ;;
+  plan-check)  cmd_plan_check "$@" ;;
   review)      cmd_review "$@" ;;
   exec)        cmd_exec "$@" ;;
   abort)       cmd_abort "$@" ;;

--- a/docs/ai/plan-quality-checks.md
+++ b/docs/ai/plan-quality-checks.md
@@ -1,0 +1,136 @@
+# Lightweight Plan Quality Checks（正本）
+
+> 計画品質を実装前に軽量に構造化する **正本**。重い Gate / Agent
+> orchestration / PR review / QA automation を導入せず、手動実行可能な
+> 補助 Check として計画の不足・リスク・前提・完了条件・次アクションを
+> 抽出する。
+> 関連: [#213](https://github.com/s977043/plangate/issues/213)（PBI-PQ-001）/
+> [#53](https://github.com/s977043/plangate/issues/53) / TASK-0091 /
+> [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) §10 /
+> [`.claude/skills/plan-quality-check/SKILL.md`](../../.claude/skills/plan-quality-check/SKILL.md) /
+> [`../../schemas/plan-quality-check.schema.json`](../../schemas/plan-quality-check.schema.json)
+
+## 1. 目的と位置づけ
+
+PlanGate の初期価値は重い自動実行基盤ではなく **計画品質を上げること**に
+ある。`gstack` 的な AI 開発ワークフロー（slash command / agent
+orchestration / PR review / QA automation / browser daemon）を直接移植
+すると重くなる。本機能は **`gstack` を参考思想に留め直接移植しない**方針で、
+軽量な Plan Quality Layer のみを定義する。
+
+> 本 Check の判定は **助言（advisory）**であり、C-3/C-4 等の人間承認・
+> ゲート判定を**代替しない**（[review-principles.md](../../.claude/rules/review-principles.md)
+> の承認境界・[responsibility-classes.md](../../.claude/rules/responsibility-classes.md)
+> の Human-owned 境界は不変）。
+
+## 2. Check 種別と責務
+
+| Check | 責務（何を確認するか） | 主出力フィールド |
+|-------|----------------------|----------------|
+| `plan_check` | 計画の **目的・対象・成功条件・スコープ** が明確か | `score` / `missing_items` / `summary` |
+| `risk_check` | **失敗要因・依存関係・未決事項・暗黙の前提** が洗い出されているか | `risks` / `assumptions` / `next_actions` |
+| `done_check` | **完了条件・検証方法・リリース後確認** が定義されているか | `done_criteria` / `validation_notes` |
+| `combined` | 上記 3 種を統合した 1 結果 | 全フィールド |
+
+各 Check は単独でも `combined` でも実行できる。
+
+## 3. 出力構造
+
+出力は [`schemas/plan-quality-check.schema.json`](../../schemas/plan-quality-check.schema.json)
+準拠の JSON。自由文サマリ（`summary`）も持つが、機械処理対象は JSON とする
+（AI 出力を自由文だけにしない＝ AC4）。
+
+| フィールド | 内容 |
+|-----------|------|
+| `check_type` | plan_check / risk_check / done_check / combined |
+| `score` | Plan Health Score（0-100、§4）|
+| `decision` | ready / needs_clarification / insufficient（助言） |
+| `summary` | 1 行サマリ |
+| `score_breakdown` | Score 最小内訳（§4、任意） |
+| `missing_items[]` | `field` / `severity`(critical/major/minor/info) / `message` |
+| `risks[]` | `severity`(high/medium/low) / `title` / `recommendation` |
+| `assumptions[]` | `title` / `confidence`(high/medium/low) / `validation_method` |
+| `done_criteria[]` | 完了条件の配列 |
+| `validation_notes` | 検証方法・リリース後確認のメモ |
+| `next_actions[]` | `title` / `type`(clarify/investigate/decide/implement/verify) |
+
+### 出力例
+
+```json
+{
+  "check_type": "combined",
+  "score": 76,
+  "decision": "needs_clarification",
+  "summary": "目的は明確だが、成功指標と完了条件が不足している。",
+  "missing_items": [
+    { "field": "success_metric", "severity": "major",
+      "message": "成功指標が測定可能ではない。" }
+  ],
+  "risks": [
+    { "severity": "high", "title": "通知対象条件が曖昧",
+      "recommendation": "何日前から通知対象にするか定義する。" }
+  ],
+  "assumptions": [
+    { "title": "契約更新日が既存DBに存在する", "confidence": "medium",
+      "validation_method": "DBスキーマを確認する。" }
+  ],
+  "done_criteria": [
+    "通知対象ユーザーに契約更新通知が届く",
+    "通知対象が0件でもエラーにならない"
+  ],
+  "next_actions": [ { "title": "成功指標を定義する", "type": "clarify" } ]
+}
+```
+
+## 4. Plan Health Score（最小内訳）
+
+`score`（0-100）は以下の最小 5 軸の平均（各 0-100、等加重）。実装側で
+重みを調整してよいが、軸は固定（二重定義防止）:
+
+| 軸 | 評価対象 |
+|----|---------|
+| `goal_clarity` | 目的・狙いが一意に読めるか |
+| `scope_defined` | In/Out スコープが切られているか |
+| `success_metric` | 成功条件が測定可能か |
+| `risks_identified` | リスク・依存・前提が洗い出されているか |
+| `done_criteria_defined` | 完了条件・検証方法が定義されているか |
+
+### decision 閾値（助言）
+
+| score | decision | 意味 |
+|-------|----------|------|
+| 85-100 | `ready` | 計画品質は十分（人間最終判断は別） |
+| 60-84 | `needs_clarification` | 重要な不足あり。`next_actions` を解消推奨 |
+| 0-59 | `insufficient` | 計画として未成熟。再構造化推奨 |
+
+> 判定不能 / 根拠不足のときは **安全側**（より低い score・
+> `needs_clarification` 以下）に倒す。
+
+## 5. 実行と保存
+
+- **手動実行**: `bin/plangate plan-check <TASK-XXXX> --init` で
+  `docs/working/TASK-XXXX/plan-quality-check.json` の雛形を生成し、
+  AI / 人間が内容を埋める。`--validate` でスキーマ検証する。
+  重い Gate / Agent を起動しない（AC: heavy 非依存・手動実行可能）。
+- **Plan 状態としての保存**: 結果は
+  `docs/working/TASK-XXXX/plan-quality-check.json` に保存し、計画の
+  状態の一部として扱う（[working-context.md](../../.claude/rules/working-context.md)
+  の TASK 作業コンテキストに同居）。`status.md` / `current-state.md`
+  から参照してよい（任意）。
+- 将来、Gate / Review / QA / Release 判定へ拡張する **土台**とする
+  （本 PBI は定義と軽量実行まで。heavy 拡張は別 PBI・Non-goal）。
+
+## 6. Non-goals（本 PBI で実装しない）
+
+- `gstack` の slash command / workflow をそのまま取り込むこと
+- browser daemon / ngrok / pair-agent / PR review automation /
+  QA automation（Playwright）/ Release Gate / Security Gate の実装
+- AI 判定を人間承認の代替にすること（承認境界不変）
+
+## 7. 関連
+
+- [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) §10 — Lightweight Plan Quality Checks
+- [`.claude/skills/plan-quality-check/SKILL.md`](../../.claude/skills/plan-quality-check/SKILL.md) — 再利用 Skill 定義
+- [`schemas/plan-quality-check.schema.json`](../../schemas/plan-quality-check.schema.json) — 出力スキーマ
+- [`.claude/rules/review-principles.md`](../../.claude/rules/review-principles.md) — 承認境界（不変）
+- [`.claude/rules/responsibility-classes.md`](../../.claude/rules/responsibility-classes.md) — Human-owned 境界

--- a/docs/working/TASK-0091/INDEX.md
+++ b/docs/working/TASK-0091/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0091 INDEX
+
+> 生成日: 2026-05-17
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0091/approvals/c3.json
+++ b/docs/working/TASK-0091/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0091",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T14:18:03Z",
+  "plan_hash": "sha256:1a21ccdb0323c1d8489d81b258a45c638c3598fd28ab89f7ed0331a08ee28fd0"
+}

--- a/docs/working/TASK-0091/current-state.md
+++ b/docs/working/TASK-0091/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0091 現在状態
+
+> 更新日: 2026-05-17
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0091/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0091 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0091/handoff.md
+++ b/docs/working/TASK-0091/handoff.md
@@ -1,0 +1,31 @@
+# Handoff — TASK-0091 / #213 PBI-PQ-001 Lightweight Plan Quality Checks
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 Plan/Risk/Done Check 責務文書化 | PASS (T1) |
+| AC2 出力構造定義（missing/risks/assumptions/done/next）| PASS (T2) |
+| AC3 Plan Health Score 最小内訳 | PASS (T3, V-3 mn-2 で required 化) |
+| AC4 AI 出力が JSON として扱える | PASS (T4) |
+| AC5 軽量 Check 手動実行 | PASS (T5, CLI --init/--validate) |
+| AC6 Plan 状態として保存方針 | PASS (T6) |
+| AC7 heavy Gate/PR review/browser QA 非依存 | PASS (T7) |
+| AC8 gstack 参考思想留め・直接移植しない | PASS (T8) |
+V-1 全 PASS。V-3（Codex）critical 0 / major 3 / minor 2 → 全反映・回帰 PASS。
+## 2. 既知課題
+- CLI は scaffold(--init)/validate(--validate) のみ。AI による自動 Check 生成は
+  skill 経由の手動運用（heavy 化回避のため意図的）。
+## 3. V2 候補
+- `plan-check` の AI 自動生成モード（skill 連携・opt-in、heavy 化に注意）。
+- status.md/current-state.md からの plan-quality-check.json 自動参照表示。
+- Gate/Review/QA/Release 判定への拡張（本 PBI は土台のみ・Non-goal）。
+## 4. 妥協点
+- CLI に AI 実行を内蔵しない（軽量・heavy Gate 非依存の AC 優先）。判定は助言で
+  人間承認の代替にしない（承認境界不変）。
+## 5. 引き継ぎ
+#213 を standard で実装。schema + skill(Rule2準拠) + 正本 doc + 軽量 CLI
+(plan-check --init/--validate) + schema_mapping 登録。V-3 で enum 統一/雛形
+decision 整合/CI schema 健全性検証ステップ/Rule2 gate名除去/score_breakdown
+required を修正。次は #196 Harness Eval expansion。
+## 6. テスト結果
+V-1: T1-T8 + E1/E2 全 PASS。V-3 反映後回帰全 PASS。CLI --validate PASS・
+workflow step 実機シミュレーション成功。

--- a/docs/working/TASK-0091/pbi-input.md
+++ b/docs/working/TASK-0091/pbi-input.md
@@ -1,0 +1,30 @@
+# PBI INPUT — TASK-0091 / #213 PBI-PQ-001 Lightweight Plan Quality Checks
+
+## Context / Why
+gstack 的な重い AI ワークフローを直接移植せず、PlanGate の初期価値「計画品質」
+を軽量に構造化する。計画の不足・リスク・前提・完了条件・次アクションを
+JSON で抽出し、将来の Gate/Review/QA/Release 拡張の土台にする。
+
+## What
+- In: schemas/plan-quality-check.schema.json / .claude/skills/plan-quality-check/SKILL.md /
+  docs/ai/plan-quality-checks.md（正本）/ bin/plangate plan-check 軽量サブコマンド
+- Out: gstack slash command 移植 / browser daemon / PR review automation /
+  QA automation / Release・Security Gate / AI 判定の人間承認代替
+
+## 受入基準（#213）
+- AC1: Plan/Risk/Done Check の責務が文書化
+- AC2: Missing Items/Risks/Assumptions/Done Criteria/Next Actions の出力構造定義
+- AC3: Plan Health Score の最小内訳定義
+- AC4: AI 出力が自由文だけでなく JSON として扱える
+- AC5: 軽量 Check は手動実行できる
+- AC6: Check 結果を Plan の状態として保存できる方針
+- AC7: heavy Gate/PR review/browser QA に依存しない
+- AC8: gstack は参考思想に留め直接移植しない方針が明記
+
+## Notes
+skill は Rule 2 準拠（案件固有名なし）。decision は助言で承認境界不変。
+schema は issue 提案構造に準拠。CLI は --init/--validate のみ（AI 非起動）。
+
+## Estimation
+Risks: skill への案件固有混入（緩和: Rule 2 機械検出）/ CLI が重くなる
+（緩和: scaffold+validate のみ）/ Unknowns: なし

--- a/docs/working/TASK-0091/plan.md
+++ b/docs/working/TASK-0091/plan.md
@@ -1,0 +1,50 @@
+# EXECUTION PLAN — TASK-0091 / #213 PBI-PQ-001
+
+## Goal
+軽量 Plan Quality Layer（plan/risk/done check + Health Score + JSON 出力 +
+手動実行 + Plan 状態保存）を定義し、将来拡張の土台を作る。
+
+## Constraints / Non-goals
+- heavy Gate/Agent/PR review/QA automation/browser daemon を導入しない。
+- gstack 直接移植しない（参考思想のみ）。AI 判定は人間承認の代替にしない。
+- CLI は scaffold(--init)/validate(--validate) のみ（AI 実行を内蔵しない）。
+
+## Approach Overview
+schema（出力構造正規化）→ skill（再利用 Check 観点・Rule 2 準拠）→
+doc 正本（責務/Score/保存方針/Non-goals）→ bin/plangate 軽量サブコマンド。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | plan-quality-check.schema.json | agent | 中 | 🚩 AC2/AC4 |
+| S2 | .claude/skills/plan-quality-check/SKILL.md | agent | 低 | 🚩 AC1 Rule2 |
+| S3 | docs/ai/plan-quality-checks.md 正本 | agent | 中 | 🚩 AC1/3/6/8 |
+| S4 | bin/plangate plan-check（--init/--validate）| agent | 中 | 🚩 AC5/7 |
+
+## Files / Components to Touch
+- schemas/plan-quality-check.schema.json（新規）
+- .claude/skills/plan-quality-check/SKILL.md（新規）
+- docs/ai/plan-quality-checks.md（新規・正本）
+- bin/plangate（cmd_plan_check + dispatch + help）
+
+## Testing Strategy
+- Verification: AC1-8 を grep 構造突合 + schema json.load + CLI smoke
+  （--init で雛形→--validate で schema 検証、sh -n 構文）。
+- Unit/E2E: 該当なし（定義 + 軽量 scaffold、AI 実行系なし）。
+
+## Risks & Mitigations
+- skill 案件固有混入 → Rule 2 機械検出（grep）で 0 件確認
+- CLI 肥大化 → --init/--validate に限定、AI 起動を内蔵しない
+- 承認境界誤解 → doc/schema/skill すべてに「decision は助言」明記
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 4 → 中
+- 受入基準数: 8 → 中
+- 変更種別: feat（schema+skill+doc+CLI 新規）→ 中
+- リスク: 中（CLI 追加・将来拡張土台・承認境界整合）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0091/review-external.md
+++ b/docs/working/TASK-0091/review-external.md
@@ -1,0 +1,18 @@
+# V-3 外部レビュー（Codex）— TASK-0091 / #213
+
+## 結果サマリ
+critical: 0 / major: 3 / minor: 2 / info: 3（初回 NOT APPROVE → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | skill 入力種別 `plan/risk/done/combined` が schema enum `*_check` と不一致（利用者が enum 違反 JSON を生成）| skill を `plan_check/risk_check/done_check/combined` に統一 |
+| MJ-2 | major | CLI --init 雛形が score:0 なのに decision:needs_clarification（doc 閾値 0-59=insufficient と意味論不整合・誤状態が schema 通過）| 雛形 decision を `insufficient` に修正 |
+| MJ-3 | major | schema-validate.yml が schemas/** trigger でも docs/working/*.json しか検証せず、schema/mapping 単独破損を skip。schema_mapping.py が trigger 外 | trigger に scripts/schema_mapping.py 追加 + 「schema files and mapping integrity」ステップ追加（全 schema json.tool + schema_mapping import + 参照先存在検証）。ローカル実機シミュレーション成功 |
+| mn-1 | minor | skill 想定 Phase に `C-3` 固有 gate 名（Rule 2 違反）| gate 名除去「計画レビュー前後の軽量確認（計画作成直後・実装着手前）」、Rule 2 機械検出 0 件 |
+| mn-2 | minor | score_breakdown が部分内訳も valid（doc は「軸固定」）| score_breakdown.required に 5 軸追加（任意フィールドだが存在時は完全性要求）|
+| info×3 | info | CLI heavy 非起動・sh -n OK / 承認境界一貫 / gstack Non-goal 明記 — 問題なし | 対応不要 |
+
+## 判定
+major 3 / minor 2 を全反映。critical 0。回帰 V-1 全 PASS・CLI --validate PASS・
+workflow ステップ実機シミュレーション成功・Rule 2 機械検出 0 件・schema valid。

--- a/docs/working/TASK-0091/review-self.md
+++ b/docs/working/TASK-0091/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0091
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-8 ↔ S1-S4 ↔ T1-T8 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | gstack移植/browser/PR/QA/Gate を Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | grep + json.load + CLI smoke + sh -n |
+| C1-PLAN-05 WB Output | PASS | S1-S4 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | schema/CLI 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S4 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T8 ↔ AC1-8 |
+| C1-TC-02 Edge網羅 | PASS | E1 Rule2 / E2 承認境界不変 |
+| C1-TC-03 自動化可否 | PASS | 全件 grep/機械検証 |
+| C1-INT-01 承認境界整合 | PASS | decision=助言、review-principles/responsibility-classes 不変 |
+| C1-INT-02 Rule整合 | PASS | skill Rule2 準拠（機械検出 0 件）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0091/test-cases.md
+++ b/docs/working/TASK-0091/test-cases.md
@@ -1,0 +1,14 @@
+# テストケース — TASK-0091 / #213
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | doc に plan_check/risk_check/done_check 責務表 + skill に同表 | 構造突合 |
+| T2 | AC2 | schema に missing_items/risks/assumptions/done_criteria/next_actions 定義 | 構造突合 |
+| T3 | AC3 | doc に Plan Health Score 最小内訳5軸 + schema score_breakdown | 構造突合 |
+| T4 | AC4 | schema が JSON 妥当 + check_type/score/decision/summary required | 機械検証 |
+| T5 | AC5 | bin/plangate plan-check --init/--validate が手動実行可（smoke）| 機械検証 |
+| T6 | AC6 | doc に「Plan 状態として保存」方針（plan-quality-check.json）| 構造突合 |
+| T7 | AC7 | doc/skill に heavy Gate/PR review/browser QA 非依存明記 + CLI が AI 非起動 | 構造突合 |
+| T8 | AC8 | doc に gstack 参考思想留め・直接移植しない明記 | 構造突合 |
+## Edge
+- E1: skill が Rule 2 準拠（TASK-/PlanGate/特定FW 名なし）
+- E2: decision は助言で人間承認の代替にしない（schema description + doc）

--- a/docs/working/TASK-0091/todo.md
+++ b/docs/working/TASK-0091/todo.md
@@ -1,0 +1,14 @@
+# TODO — TASK-0091 / #213
+## 🤖 Agent
+- [x] 準備: #213本文・bin/plangate構造・skill規約確認
+- [x] S1 schema（🚩AC2/AC4）
+- [x] S2 skill（🚩AC1 Rule2）
+- [x] S3 doc正本（🚩AC1/3/6/8）
+- [x] S4 CLI plan-check（🚩AC5/7）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/schemas/plan-quality-check.schema.json
+++ b/schemas/plan-quality-check.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/s977043/plangate/schemas/plan-quality-check.schema.json",
+  "title": "Plan Quality Check Result",
+  "description": "Lightweight Plan Quality Check 出力（plan_check / risk_check / done_check 統合）。正本: docs/ai/plan-quality-checks.md (#213 / PBI-PQ-001)。AI 判定は人間承認の代替ではない（補助情報）。",
+  "type": "object",
+  "required": [
+    "check_type",
+    "score",
+    "decision",
+    "summary"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "check_type": {
+      "type": "string",
+      "enum": [
+        "plan_check",
+        "risk_check",
+        "done_check",
+        "combined"
+      ],
+      "description": "実行した Check 種別。combined は 3 種を統合した結果"
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Plan Health Score（0-100）。内訳は docs/ai/plan-quality-checks.md §Plan Health Score"
+    },
+    "decision": {
+      "type": "string",
+      "enum": [
+        "ready",
+        "needs_clarification",
+        "insufficient"
+      ],
+      "description": "score 閾値に基づく助言的判定（ゲート判定・承認の代替ではない）"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024
+    },
+    "score_breakdown": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Plan Health Score の最小内訳（各 0-100）",
+      "properties": {
+        "goal_clarity": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "scope_defined": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "success_metric": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "risks_identified": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "done_criteria_defined": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "required": [
+        "goal_clarity",
+        "scope_defined",
+        "success_metric",
+        "risks_identified",
+        "done_criteria_defined"
+      ]
+    },
+    "missing_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "field",
+          "severity",
+          "message"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "major",
+              "minor",
+              "info"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          }
+        }
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          "recommendation": {
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "confidence"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "validation_method": {
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      }
+    },
+    "done_criteria": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512
+      }
+    },
+    "validation_notes": {
+      "type": "string",
+      "maxLength": 1024
+    },
+    "next_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "type"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "clarify",
+              "investigate",
+              "decide",
+              "implement",
+              "verify"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/schema_mapping.py
+++ b/scripts/schema_mapping.py
@@ -38,6 +38,7 @@ FILENAME_TO_SCHEMA: dict[str, str] = {
     # NDJSON である plangate-event.schema.json は本マッピングに含めない
     # （append-only NDJSON は plangate metrics --validate で検査する設計）
     "2026-05-04-baseline.json": "eval-baseline.schema.json",
+    "plan-quality-check.json": "plan-quality-check.schema.json",
 }
 
 


### PR DESCRIPTION
## 概要
#213 を standard で実装。gstack を参考思想に留め直接移植せず、計画品質を実装前に軽量構造化する Plan Quality Layer を定義（将来 Gate/Review/QA/Release 拡張の土台）。

## 変更
- **新規** `schemas/plan-quality-check.schema.json` — plan/risk/done check 統合出力（score/decision/summary/missing_items/risks/assumptions/done_criteria/next_actions、draft-07・additionalProperties:false）
- **新規** `.claude/skills/plan-quality-check/SKILL.md` — 再利用 Check 観点（Rule 2 準拠・案件固有名なし）
- **新規** `docs/ai/plan-quality-checks.md`（正本）— 3 Check 責務 / Plan Health Score 最小5軸 / decision 閾値（助言・承認境界不変）/ Plan 状態保存方針 / Non-goals
- `bin/plangate` — `plan-check <TASK> --init|--validate` 軽量サブコマンド（scaffold + schema 検証のみ・AI/heavy Gate 非起動）
- `scripts/schema_mapping.py` — plan-quality-check.json マッピング登録
- `.github/workflows/schema-validate.yml` — schema_mapping.py を trigger 追加 + schema/mapping 健全性検証ステップ（V-3 MJ-3）

## V-1 / V-3
- V-1: AC1-8（T1-T8）+ E1/E2 全 PASS（grep + schema json.load + CLI smoke + sh -n）
- V-3（Codex）: critical 0 / major 3 / minor 2 → **全反映**（skill enum 統一 / 雛形 decision 整合 / CI schema 健全性ステップ / Rule2 gate名除去 / score_breakdown required）、回帰全 PASS・CI ステップ実機シミュレーション成功

## Non-goals 遵守
gstack slash command 移植 / browser daemon / PR review・QA automation / Release・Security Gate / AI 判定の人間承認代替 — いずれも未実装（明記）

## Mode
standard（feat・schema+skill+doc+CLI 新規）

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)