### PR TITLE
feat(#196): Eval comparison for harness changes / PBI-HI-002 / TASK-0092

### DIFF
--- a/docs/ai/eval-comparison-template.md
+++ b/docs/ai/eval-comparison-template.md
@@ -85,6 +85,31 @@
 - **保留 (WARN)**: latency / cost が baseline +50% 超過だが accuracy 大幅改善
 - **却下 (release blocker)**: scope discipline FAIL or verification honesty FAIL or schema 準拠率 < 95%
 
+## ハーネス変更比較（自動 / #196 PBI-HI-002）
+
+`bin/plangate eval --harness-compare` で PBI-HI-000 baseline と target TASK
+群（3 件以上）を自動比較する。出力 `eval-comparison.{md,json}` は
+[`schemas/eval-comparison.schema.json`](../../schemas/eval-comparison.schema.json)
+準拠。
+
+| 項目 | 内容 |
+|------|------|
+| harness_metadata | profile / prompt_rev / workflow_rev（変更単位の記録）|
+| baseline | PBI-HI-000（#194）の baseline JSON（baseline_id / release / aggregate）|
+| target | 代表 TASK 3 件以上の aggregate（AC% / pass rate / blocker total）|
+| delta | ac_coverage_avg / release_blocker_total / release_blocker_status |
+| release_blocker_summary | target で blocker を出した TASK と aspect の明示 |
+| per-target metrics | latency / fix_loop / hook_violation / v1_first_pass / blockers |
+
+採用判断: `release_blocker_status == "regressed"` でリリース停止（exit 1）。
+それ以外は WARN 記録 + retrospective。**AI 判定は人間承認の代替ではない**。
+
+### PBI-HI-000 baseline との接続
+
+`--baseline-file` 既定は `docs/ai/eval-baselines/2026-05-04-baseline.json`
+（PBI-HI-000 / #194 / v8.5.0）。新 baseline 確立時は同パス命名規約で追加し
+`--baseline-file` で切替える（[`eval-baseline-procedure.md`](./eval-baseline-procedure.md)）。
+
 ## eval 実行手順
 
 1. baseline 取得（変更前の同条件で 8 観点測定、最低 3 PBI）

--- a/docs/ai/eval-runner.md
+++ b/docs/ai/eval-runner.md
@@ -85,6 +85,32 @@ sh bin/plangate eval TASK-0050 --baseline TASK-0046
 #   ac_coverage_delta_percent / format_adherence_delta_percent / release_blocker_status
 ```
 
+### ハーネス変更比較（#196 / PBI-HI-002）
+
+profile / prompt / workflow 変更を PBI-HI-000 baseline と比較し、release
+blocker を明示する。新 LLM judge は導入しない（既存 8 観点を再利用）。
+
+```sh
+sh bin/plangate eval --harness-compare \
+  --targets TASK-AAAA,TASK-BBBB,TASK-CCCC \
+  --baseline-file docs/ai/eval-baselines/2026-05-04-baseline.json \
+  --profile gpt-5_5_pro --prompt-rev v8.7 --workflow-rev wf-v5
+# → docs/working/TASK-AAAA/eval-comparison.{md,json} を生成
+#   harness_metadata（profile/prompt_rev/workflow_rev）を記録
+#   baseline aggregate vs target aggregate の delta + release blocker 明示
+#   per-target に latency / fix_loop / hook_violation / v1_first_pass を併記
+```
+
+- `--targets` は代表 TASK を **3 件以上**推奨（baseline と同条件）。
+- baseline は **PBI-HI-000 / #194**（`docs/ai/eval-baselines/*baseline.json`）
+  に接続。`--baseline-file` で切替可能。
+- `release_blocker_status` が `regressed` のとき exit 1（採用判断のゲート材料。
+  人間承認の代替ではない）。
+- 出力は [`schemas/eval-comparison.schema.json`](../../schemas/eval-comparison.schema.json)
+  準拠（`plangate validate-schemas` で機械検証可能）。
+- 測定不能な latency / fix_loop / v1_first_pass は `n/a`
+  （Non-goal: 全 provider session log parser 非対応）。
+
 ### dry-run（出力せず確認）
 
 ```sh

--- a/docs/working/TASK-0092/INDEX.md
+++ b/docs/working/TASK-0092/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0092 INDEX
+
+> 生成日: 2026-05-17
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0092/approvals/c3.json
+++ b/docs/working/TASK-0092/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0092",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T14:29:53Z",
+  "plan_hash": "sha256:e3824a6291185d58426d0adabda5f9912e01c5e6a4244c2a6788390b7d1f80c4"
+}

--- a/docs/working/TASK-0092/current-state.md
+++ b/docs/working/TASK-0092/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0092 現在状態
+
+> 更新日: 2026-05-17
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0092/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0092 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0092/handoff.md
+++ b/docs/working/TASK-0092/handoff.md
@@ -1,0 +1,31 @@
+# Handoff — TASK-0092 / #196 PBI-HI-002 Eval comparison for harness changes
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 baseline↔target 比較結果 | PASS (T1) |
+| AC2 release blocker 明示 | PASS (T2) |
+| AC3 latency/cost/hook/V-1 first/fix loop 比較対象 | PASS (T3) |
+| AC4 profile/prompt/workflow metadata 記録 | PASS (T4) |
+| AC5 代表 TASK 3 件以上 | PASS (T5) |
+| AC6 eval-runner.md 運用手順追記 | PASS (T6) |
+| AC7 PBI-HI-000 baseline 接続 | PASS (T7) |
+V-1 全 PASS（E1 既存非破壊・E2 schema PASS 含む）。V-3（Codex）critical/major 0・
+minor 2 → 全反映・APPROVE。
+## 2. 既知課題
+- latency/fix_loop/v1_first_pass は測定基盤が無い TASK で `n/a`（Non-goal: 全
+  provider session log parser 非対応）。--session-log / metrics 連携時に充実。
+- hook_violation は監査ログ依存（ログ未生成 TASK は n/a）。
+## 3. V2 候補
+- metrics events.ndjson との直接連携（fix_loop/v1_first_pass を events から）。
+- 複数 baseline 系列の時系列比較（#200 Reporting & Retrospective と連携）。
+- release gate への自動接続（regressed で CI block、人間承認は維持）。
+## 4. 妥協点
+- additive 設計（--harness-compare 独立 early-return）で既存 eval を一切変更
+  しない方針を優先（judge 非新設・Non-goal 遵守）。測定不能値は n/a 許容。
+## 5. 引き継ぎ
+#196 を standard で実装。eval-runner.py に harness_compare を additive 追加
+（--dogfood と同型 early-return）、eval-comparison.schema.json + mapping +
+docs 2 件運用手順 + PBI-HI-000 接続。V-3 で空 targets 弾き / hook token 境界
+一致を反映。これで v8.7.0 残: #203 Tool Error Taxonomy / #204 PlanGateBench Fixture。
+## 6. テスト結果
+V-1: T1-T7 + E1/E2 全 PASS。V-3 APPROVE・minor 2 反映後回帰全 PASS。

--- a/docs/working/TASK-0092/pbi-input.md
+++ b/docs/working/TASK-0092/pbi-input.md
@@ -1,0 +1,29 @@
+# PBI INPUT — TASK-0092 / #196 PBI-HI-002 Eval comparison for harness changes
+
+## Context / Why
+profile/prompt/workflow 変更の採用を「感覚」でなく eval 比較で判断するため、
+PBI-HI-000 baseline と PBI-HI-001 metrics を踏まえ、ハーネス変更前後比較を
+eval-runner で扱えるようにする。
+
+## What
+- In: scripts/eval-runner.py（additive --harness-compare）/ schemas/eval-comparison.schema.json /
+  scripts/schema_mapping.py 登録 / docs/ai/eval-runner.md / docs/ai/eval-comparison-template.md /
+  bin/plangate（cmd_eval 素通しで対応済）
+- Out: 新 LLM judge / 外部ダッシュボード / 全 provider session log parser / Keep Rate / Dynamic Context
+
+## 受入基準（#196）
+- AC1: baseline と target の比較結果が出せる
+- AC2: release blocker が比較結果に明示される
+- AC3: latency/cost/hook violation/V-1 first pass/fix loop count が比較対象に含まれる
+- AC4: profile/prompt/workflow 変更の metadata を記録できる
+- AC5: 代表 TASK 3 件以上で比較できる
+- AC6: docs/ai/eval-runner.md に運用手順が追記されている
+- AC7: PBI-HI-000 の baseline と接続できる
+
+## Notes
+既存 8 観点・build_eval_result を再利用（judge 非新設）。--harness-compare は
+--dogfood と同じ additive 独立 early-return（既存挙動不変）。測定不能メトリクスは n/a。
+
+## Estimation
+Risks: 既存 eval パス破壊（緩和: additive early-return・既存テスト不変）/
+Unknowns: なし / Assumptions: baseline JSON は PBI-HI-000 形式

--- a/docs/working/TASK-0092/plan.md
+++ b/docs/working/TASK-0092/plan.md
@@ -1,0 +1,52 @@
+# EXECUTION PLAN — TASK-0092 / #196 PBI-HI-002
+
+## Goal
+ハーネス変更（profile/prompt/workflow）を PBI-HI-000 baseline と比較し
+release blocker を明示する eval 比較を additive に追加する。
+
+## Constraints / Non-goals
+- 新 LLM judge を導入しない（既存 8 観点再利用）。
+- 外部ダッシュボード / 全 provider session log parser / Keep Rate /
+  Dynamic Context は実装しない。
+- 既存 eval / --baseline / --dogfood の挙動を変更しない（additive のみ）。
+
+## Approach Overview
+eval-runner.py に _task_summary/harness_compare/render_harness_compare_md を
+追加し、main() に --harness-compare 独立 early-return（--dogfood と同型）。
+新 schema eval-comparison.schema.json + schema_mapping 登録。docs 2 件に
+運用手順 + PBI-HI-000 接続を追記。CLI は cmd_eval 素通しで対応。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | eval-runner.py additive harness_compare | agent | 中 | 🚩 AC1-5 |
+| S2 | eval-comparison.schema.json + mapping | agent | 中 | 🚩 AC2 schema validate |
+| S3 | eval-runner.md / eval-comparison-template.md 追記 | agent | 低 | 🚩 AC6/7 |
+
+## Files / Components to Touch
+- scripts/eval-runner.py（additive）
+- schemas/eval-comparison.schema.json（新規）
+- scripts/schema_mapping.py（登録）
+- docs/ai/eval-runner.md / docs/ai/eval-comparison-template.md（追記）
+
+## Testing Strategy
+- Verification: AC1-7 を smoke（代表 TASK 3 件で --harness-compare 実行）+
+  生成 JSON を validate-schemas + grep 構造突合 + ast.parse 構文。
+- Unit/E2E: 既存 eval 非破壊を smoke（通常 eval が従来どおり動くか）。
+
+## Risks & Mitigations
+- 既存 eval 破壊 → additive early-return、task_id を nargs="?" にしつつ
+  非 harness-compare 経路の必須チェック維持
+- judge 改変誤解 → build_eval_result 再利用、Non-goal 明記
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 5 → 中
+- 受入基準数: 7 → 中
+- 変更種別: feat（eval 比較 additive 拡張）→ 中
+- リスク: 中（既存 eval 基盤への additive・回帰注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0092/review-external.md
+++ b/docs/working/TASK-0092/review-external.md
@@ -1,0 +1,15 @@
+# V-3 外部レビュー（Codex）— TASK-0092 / #196
+
+## 結果サマリ
+critical: 0 / major: 0 / minor: 2 / info: 5 — **APPROVE**
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| mn-1 | minor | `--targets ","` 等で strip 後空配列のまま比較が誤生成（improved 判定）| strip 後 targets 空なら `return 2`（誤生成防止）|
+| mn-2 | minor | hook violation 集計が task_id 部分一致（ログ拡張時に別フィールド誤検出）| task token 境界正規表現 `(^|[^A-Za-z0-9-])TASK-…([^A-Za-z0-9-]|$)` で照合 |
+| info×5 | info | nargs="?" 後方互換 / baseline aggregate キー整合(.get で KeyError なし) / 生成 JSON schema PASS / 新 judge 非導入 / render 改行正常 — 問題なし | 対応不要 |
+
+## 判定
+APPROVE。minor 2 件は堅牢化のため全反映。回帰: 空 targets → exit 2 / 通常 eval /
+--baseline / --dogfood / harness-compare すべて非破壊（task_count=3）。

--- a/docs/working/TASK-0092/review-self.md
+++ b/docs/working/TASK-0092/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0092
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-7 ↔ S1-S3 ↔ T1-T7 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | judge新設/dashboard/parser/KeepRate/DCE を Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | smoke + validate-schemas + grep + ast.parse |
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | smoke/schema 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T7 ↔ AC1-7 |
+| C1-TC-02 Edge網羅 | PASS | E1 既存非破壊 / E2 schema validate |
+| C1-TC-03 自動化可否 | PASS | 全件 smoke/機械検証 |
+| C1-INT-01 既存基盤整合 | PASS | additive early-return、build_eval_result 再利用 |
+| C1-INT-02 baseline 接続 | PASS | PBI-HI-000 既定 + template 接続記載 |
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0092/test-cases.md
+++ b/docs/working/TASK-0092/test-cases.md
@@ -1,0 +1,13 @@
+# テストケース — TASK-0092 / #196
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | --harness-compare で baseline↔target 比較 MD/JSON 生成 | smoke |
+| T2 | AC2 | 出力に release_blocker_summary + delta.release_blocker_status | 構造突合 |
+| T3 | AC3 | per-target に latency_cost/fix_loop_count/hook_violation_count/v1_first_pass | 構造突合 |
+| T4 | AC4 | harness_metadata に profile/prompt_rev/workflow_rev | 構造突合 |
+| T5 | AC5 | 代表 TASK 3 件（TASK-0087/0088/0089）で task_count=3 | smoke |
+| T6 | AC6 | eval-runner.md に「ハーネス変更比較」運用手順 | 構造突合 |
+| T7 | AC7 | baseline-file 既定が PBI-HI-000 baseline + template に接続記載 | 構造突合 |
+## Edge
+- E1: 既存 eval（通常/--baseline/--dogfood）非破壊（ast.parse + 通常 eval smoke）
+- E2: 生成 eval-comparison.json が schema validate PASS

--- a/docs/working/TASK-0092/todo.md
+++ b/docs/working/TASK-0092/todo.md
@@ -1,0 +1,13 @@
+# TODO — TASK-0092 / #196
+## 🤖 Agent
+- [x] 準備: #196本文・既存 eval-runner/schema/baseline 構造確認
+- [x] S1 eval-runner.py additive harness_compare（🚩AC1-5）
+- [x] S2 schema + mapping（🚩AC2）
+- [x] S3 docs 追記（🚩AC6/7）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/schemas/eval-comparison.schema.json
+++ b/schemas/eval-comparison.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/s977043/plangate/schemas/eval-comparison.schema.json",
+  "title": "Eval Harness Comparison Result",
+  "description": "ハーネス変更前後比較（baseline vs target TASK set）。正本: docs/ai/eval-runner.md / docs/ai/eval-comparison-template.md (#196 / PBI-HI-002)。新 LLM judge は導入しない。",
+  "type": "object",
+  "required": ["comparison_type", "evaluated_at", "harness_metadata", "baseline", "target", "delta"],
+  "additionalProperties": false,
+  "properties": {
+    "comparison_type": { "type": "string", "enum": ["harness_change"] },
+    "evaluated_at": { "type": "string" },
+    "harness_metadata": {
+      "type": "object",
+      "required": ["profile", "prompt_rev", "workflow_rev"],
+      "additionalProperties": false,
+      "properties": {
+        "profile": { "type": "string" },
+        "prompt_rev": { "type": "string" },
+        "workflow_rev": { "type": "string" }
+      }
+    },
+    "baseline": {
+      "type": "object",
+      "required": ["baseline_id", "aggregate"],
+      "additionalProperties": true,
+      "properties": {
+        "baseline_id": { "type": ["string", "null"] },
+        "release": { "type": ["string", "null"] },
+        "file": { "type": "string" },
+        "aggregate": { "type": "object" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "required": ["task_count", "task_ids", "ac_coverage_avg_pct", "release_blocker_total", "tasks"],
+      "additionalProperties": true,
+      "properties": {
+        "task_count": { "type": "integer", "minimum": 0 },
+        "task_ids": { "type": "array", "items": { "type": "string" } },
+        "ac_coverage_avg_pct": { "type": "number" },
+        "format_adherence_pass_rate_pct": { "type": "number" },
+        "scope_discipline_pass_rate_pct": { "type": "number" },
+        "verification_honesty_pass_rate_pct": { "type": "number" },
+        "stop_behavior_pass_rate_pct": { "type": "number" },
+        "release_blocker_total": { "type": "integer", "minimum": 0 },
+        "tasks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["task_id", "ac_coverage_pct", "release_blocker_count"],
+            "additionalProperties": true,
+            "properties": {
+              "task_id": { "type": "string" },
+              "ac_coverage_pct": { "type": "number" },
+              "latency_cost": { "type": ["string", "number"] },
+              "fix_loop_count": { "type": ["string", "integer"] },
+              "hook_violation_count": { "type": ["string", "integer"] },
+              "v1_first_pass": { "type": "string" },
+              "release_blocker_count": { "type": "integer", "minimum": 0 },
+              "release_blocker_aspects": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "delta": {
+      "type": "object",
+      "required": ["ac_coverage_avg_pct", "release_blocker_total", "release_blocker_status"],
+      "additionalProperties": false,
+      "properties": {
+        "ac_coverage_avg_pct": { "type": "number" },
+        "release_blocker_total": { "type": "integer" },
+        "release_blocker_status": { "type": "string", "enum": ["unchanged", "improved", "regressed"] }
+      }
+    },
+    "release_blocker_summary": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["task_id", "count", "aspects"],
+        "additionalProperties": false,
+        "properties": {
+          "task_id": { "type": "string" },
+          "count": { "type": "integer", "minimum": 0 },
+          "aspects": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -25,6 +25,7 @@ Exit code:
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import re
 import sys
@@ -324,6 +325,218 @@ def render_markdown(result: dict) -> str:
 
 
 
+def _task_summary(task_id: str) -> dict:
+    """対象 TASK の eval-result を baseline task 形状に正規化（#196）。
+
+    既存 build_eval_result を再利用。latency/cost/fix_loop/hook_violation/
+    v1_first_pass は測定不能なら "n/a"（Non-goal: 全 provider parser 非対応）。
+    """
+    res_path = WORKING_DIR / task_id / "eval-result.json"
+    if res_path.is_file():
+        r = json.loads(res_path.read_text())
+    else:
+        r = build_eval_result(task_id, profile=None)
+    rb = r.get("release_blocker_violations", [])
+    # hook violation: 監査ログから当該 TASK の VIOLATION 行数（あれば）
+    hv = "n/a"
+    hlog = WORKING_DIR / "_audit" / "hook-events.log"
+    if hlog.is_file():
+        try:
+            tok = re.compile(
+                r"(^|[^A-Za-z0-9-])" + re.escape(task_id) + r"([^A-Za-z0-9-]|$)"
+            )
+            n = sum(
+                1 for ln in hlog.read_text().splitlines()
+                if "VIOLATION" in ln and tok.search(ln)
+            )
+            hv = n
+        except OSError:
+            hv = "n/a"
+    # fix loop / v1 first pass: status.md ヒューリスティック（測定不能なら n/a）
+    fix_loop = "n/a"
+    v1_first = "n/a"
+    st = WORKING_DIR / task_id / "status.md"
+    if st.is_file():
+        txt = st.read_text()
+        m = re.findall(r"fix[ _-]?loop[^0-9]*([0-9]+)", txt, re.IGNORECASE)
+        if m:
+            fix_loop = max(int(x) for x in m)
+        if re.search(r"V-1[^\n]*(PASS|first[ _-]?pass)", txt, re.IGNORECASE):
+            v1_first = "pass"
+    return {
+        "task_id": task_id,
+        "ac_coverage_pct": r["ac_coverage"]["rate_percent"],
+        "approval_discipline": r["approval_discipline"]["decision"],
+        "format_adherence": r["format_adherence"]["decision"],
+        "scope_discipline": r["scope_discipline"]["decision"],
+        "verification_honesty": r["verification_honesty"]["decision"],
+        "stop_behavior": r["stop_behavior"]["decision"],
+        "tool_overuse": r["tool_overuse"]["decision"],
+        "latency_cost": r["latency_cost"].get("decision", "n/a"),
+        "fix_loop_count": fix_loop,
+        "hook_violation_count": hv,
+        "v1_first_pass": v1_first,
+        "release_blocker_count": len(rb),
+        "release_blocker_aspects": sorted({v["aspect"] for v in rb}),
+    }
+
+
+def harness_compare(
+    targets: list[str],
+    baseline_file: str,
+    profile: str | None,
+    prompt_rev: str | None,
+    workflow_rev: str | None,
+) -> dict:
+    """ハーネス変更前後比較（#196 / PBI-HI-002）。
+
+    baseline（PBI-HI-000 baseline JSON）の aggregate と target TASK 群の
+    aggregate を比較し、release blocker を明示する。新 LLM judge は導入しない。
+    """
+    bpath = Path(baseline_file)
+    if not bpath.is_file():
+        raise SystemExit(f"baseline file not found: {baseline_file}")
+    base = json.loads(bpath.read_text())
+    bagg = base.get("aggregate", {})
+
+    tsum = [_task_summary(t) for t in targets]
+    n = len(tsum)
+    ac_avg = round(sum(t["ac_coverage_pct"] for t in tsum) / n, 2) if n else 0.0
+
+    def _pass_rate(field: str) -> float:
+        if not n:
+            return 0.0
+        return round(
+            100.0 * sum(1 for t in tsum if t[field] == "PASS") / n, 2
+        )
+
+    tgt_blockers = sum(t["release_blocker_count"] for t in tsum)
+    base_blockers = bagg.get("release_blocker_total", 0)
+    if tgt_blockers > base_blockers:
+        rb_status = "regressed"
+    elif tgt_blockers < base_blockers:
+        rb_status = "improved"
+    else:
+        rb_status = "unchanged"
+
+    return {
+        "comparison_type": "harness_change",
+        "evaluated_at": _dt.datetime.now(_dt.timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "harness_metadata": {
+            "profile": profile or "unspecified",
+            "prompt_rev": prompt_rev or "unspecified",
+            "workflow_rev": workflow_rev or "unspecified",
+        },
+        "baseline": {
+            "baseline_id": base.get("baseline_id"),
+            "release": base.get("release"),
+            "file": str(bpath),
+            "aggregate": bagg,
+        },
+        "target": {
+            "task_count": n,
+            "task_ids": targets,
+            "ac_coverage_avg_pct": ac_avg,
+            "format_adherence_pass_rate_pct": _pass_rate("format_adherence"),
+            "scope_discipline_pass_rate_pct": _pass_rate("scope_discipline"),
+            "verification_honesty_pass_rate_pct": _pass_rate(
+                "verification_honesty"
+            ),
+            "stop_behavior_pass_rate_pct": _pass_rate("stop_behavior"),
+            "release_blocker_total": tgt_blockers,
+            "tasks": tsum,
+        },
+        "delta": {
+            "ac_coverage_avg_pct": round(
+                ac_avg - bagg.get("ac_coverage_avg_pct", 0.0), 2
+            ),
+            "release_blocker_total": tgt_blockers - base_blockers,
+            "release_blocker_status": rb_status,
+        },
+        "release_blocker_summary": [
+            {
+                "task_id": t["task_id"],
+                "count": t["release_blocker_count"],
+                "aspects": t["release_blocker_aspects"],
+            }
+            for t in tsum
+            if t["release_blocker_count"] > 0
+        ],
+    }
+
+
+def render_harness_compare_md(c: dict) -> str:
+    d = c["delta"]
+    b = c["baseline"]
+    t = c["target"]
+    hm = c["harness_metadata"]
+    lines = [
+        "# Eval Harness Comparison",
+        "",
+        f"> Evaluated at: {c['evaluated_at']}  (#196 / PBI-HI-002)",
+        "",
+        "## Harness metadata",
+        "",
+        f"- profile: `{hm['profile']}`",
+        f"- prompt_rev: `{hm['prompt_rev']}`",
+        f"- workflow_rev: `{hm['workflow_rev']}`",
+        "",
+        "## 比較サマリ",
+        "",
+        f"- Baseline: `{b['baseline_id']}` ({b['release']}) — {b['file']}",
+        f"- Target: {t['task_count']} TASK ({', '.join(t['task_ids'])})",
+        f"- AC coverage avg: {b['aggregate'].get('ac_coverage_avg_pct', 0.0)}%"
+        f" → {t['ac_coverage_avg_pct']}% "
+        f"(**{d['ac_coverage_avg_pct']:+.2f}%**)",
+        f"- Release blocker total: {b['aggregate'].get('release_blocker_total', 0)}"
+        f" → {t['release_blocker_total']} "
+        f"(**{d['release_blocker_total']:+d}**, "
+        f"status: **{d['release_blocker_status']}**)",
+        "",
+        "## Release blocker（明示）",
+        "",
+    ]
+    if c["release_blocker_summary"]:
+        for r in c["release_blocker_summary"]:
+            lines.append(
+                f"- **{r['task_id']}**: {r['count']} "
+                f"({', '.join(r['aspects']) or 'n/a'})"
+            )
+    else:
+        lines.append("- なし（target に release blocker なし）")
+    lines.extend([
+        "",
+        "## 比較対象メトリクス（per target TASK）",
+        "",
+        "| TASK | AC% | format | scope | verif | stop | latency | "
+        "fix_loop | hook_viol | v1_first | blockers |",
+        "|------|-----|--------|-------|-------|------|---------|"
+        "----------|-----------|----------|----------|",
+    ])
+    for ts in t["tasks"]:
+        lines.append(
+            f"| {ts['task_id']} | {ts['ac_coverage_pct']} | "
+            f"{ts['format_adherence']} | {ts['scope_discipline']} | "
+            f"{ts['verification_honesty']} | {ts['stop_behavior']} | "
+            f"{ts['latency_cost']} | {ts['fix_loop_count']} | "
+            f"{ts['hook_violation_count']} | {ts['v1_first_pass']} | "
+            f"{ts['release_blocker_count']} |"
+        )
+    lines.extend([
+        "",
+        "## 関連",
+        "",
+        "- [`docs/ai/eval-runner.md`](../ai/eval-runner.md) §harness-compare",
+        "- [`docs/ai/eval-comparison-template.md`](../ai/eval-comparison-template.md)",
+        "- [`schemas/eval-comparison.schema.json`]"
+        "(../../schemas/eval-comparison.schema.json)",
+        "- baseline: PBI-HI-000 / #194",
+        "",
+    ])
+    return "\n".join(lines)
+
+
 def dogfood_eval(task_id: str) -> dict:
     """#231 Dogfooding Eval v1: 5 項目の決定論構造判定 + rationale.
 
@@ -453,18 +666,51 @@ def render_dogfood_md(r: dict) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="PlanGate eval runner (Issue #156)")
-    parser.add_argument("task_id", help="Target TASK-XXXX")
+    parser.add_argument("task_id", nargs="?", help="Target TASK-XXXX (not required with --harness-compare)")
     parser.add_argument("--baseline", help="Baseline TASK-YYYY for comparison")
     parser.add_argument("--profile", help="Model profile key (recorded in output)")
     parser.add_argument("--no-write", action="store_true", help="Print to stdout instead of writing files")
     parser.add_argument("--dogfood", action="store_true", help="[#231] Dogfooding Eval v1: 5-item deterministic structural eval -> eval-dogfood.md")
+    parser.add_argument("--harness-compare", action="store_true", help="[#196] Harness change comparison (baseline vs target TASK set)")
+    parser.add_argument("--targets", help="[#196] Comma-separated target TASK ids (>=3 recommended)")
+    parser.add_argument("--baseline-file", default="docs/ai/eval-baselines/2026-05-04-baseline.json", help="[#196] PBI-HI-000 baseline JSON path")
+    parser.add_argument("--prompt-rev", help="[#196] Prompt assembly revision label (recorded)")
+    parser.add_argument("--workflow-rev", help="[#196] Workflow revision label (recorded)")
     parser.add_argument(
         "--session-log",
         help="Path to codex session log (NDJSON) for latency / token metrics (Issue #168)",
     )
     args = parser.parse_args()
 
-    if not re.match(r"^TASK-[0-9A-Za-z]+$", args.task_id):
+    if args.harness_compare:
+        if not args.targets:
+            print("error: --harness-compare requires --targets T1,T2,T3", file=sys.stderr)
+            return 2
+        targets = [x.strip() for x in args.targets.split(",") if x.strip()]
+        if not targets:
+            print("error: --targets is empty after parsing", file=sys.stderr)
+            return 2
+        for t in targets:
+            if not re.match(r"^TASK-[0-9A-Za-z]+$", t):
+                print(f"error: invalid target task_id: {t}", file=sys.stderr)
+                return 2
+        c = harness_compare(targets, args.baseline_file, args.profile, args.prompt_rev, args.workflow_rev)
+        cmd = render_harness_compare_md(c)
+        cjs = json.dumps(c, indent=2, ensure_ascii=False)
+        if args.no_write:
+            print("=== eval-comparison.md ===")
+            print(cmd)
+            print("=== eval-comparison.json ===")
+            print(cjs)
+        else:
+            outdir = WORKING_DIR / targets[0]
+            outdir.mkdir(parents=True, exist_ok=True)
+            (outdir / "eval-comparison.md").write_text(cmd + "\n")
+            (outdir / "eval-comparison.json").write_text(cjs + "\n")
+            print(f"Written: docs/working/{targets[0]}/eval-comparison.{{md,json}}")
+        return 1 if c["delta"]["release_blocker_status"] == "regressed" else 0
+
+    if not args.task_id or not re.match(r"^TASK-[0-9A-Za-z]+$", args.task_id):
         print(f"error: invalid task_id: {args.task_id}", file=sys.stderr)
         return 2
 

--- a/scripts/schema_mapping.py
+++ b/scripts/schema_mapping.py
@@ -38,6 +38,7 @@ FILENAME_TO_SCHEMA: dict[str, str] = {
     # NDJSON である plangate-event.schema.json は本マッピングに含めない
     # （append-only NDJSON は plangate metrics --validate で検査する設計）
     "2026-05-04-baseline.json": "eval-baseline.schema.json",
+    "eval-comparison.json": "eval-comparison.schema.json",
 }
 
 


### PR DESCRIPTION
## 概要
#196 を standard で実装。profile/prompt/workflow 変更の採用を eval 比較で判断できるよう、PBI-HI-000 baseline ↔ target TASK 群の比較を **additive** に追加（新 LLM judge 非導入・既存 8 観点再利用）。

## 変更
- `scripts/eval-runner.py`: `_task_summary` / `harness_compare` / `render_harness_compare_md` + main() に `--harness-compare`（`--dogfood` と同型の独立 early-return・既存挙動不変、task_id を nargs="?" 化しつつ非該当経路の必須検証は維持）
- **新規** `schemas/eval-comparison.schema.json`（draft-07・additionalProperties:false）+ `scripts/schema_mapping.py` 登録
- `docs/ai/eval-runner.md` §ハーネス変更比較（運用手順）/ `docs/ai/eval-comparison-template.md` §ハーネス変更比較(自動) + PBI-HI-000 baseline 接続
- harness_metadata（profile/prompt_rev/workflow_rev）記録 / baseline↔target delta + release blocker 明示 / per-target に latency・fix_loop・hook_violation・v1_first_pass 併記（測定不能は n/a）

## V-1 / V-3
- V-1: AC1-7（T1-T7）+ E1 既存非破壊（通常/--baseline/--dogfood rc=0）+ E2 schema validate 全 PASS
- V-3（Codex）: critical 0 / major 0 / minor 2 → **APPROVE**。minor 2（空 targets 弾き / hook violation task token 境界一致）全反映、回帰 PASS

## Non-goals 遵守
新 LLM judge / 外部ダッシュボード / 全 provider session log parser / Keep Rate / Dynamic Context — いずれも未実装

## Mode
standard（feat・eval 基盤 additive 拡張）

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)