### PR TITLE
feat(#203): Tool Error Taxonomy and Recovery Policy / PBI-HI-010 / TASK-0093

### DIFF
--- a/docs/ai/core-contract.md
+++ b/docs/ai/core-contract.md
@@ -137,8 +137,10 @@ exec 前に停止 or 明示降格する:
 |----------|------|-----------------|
 | `delegation_unavailable` | サブエージェント起動（`Agent`/`Task`）が利用不可、**または判定不能**（両者を同一扱い＝安全側に倒す。判定不能で委譲を試みると再びデッドロックし得る） | exec router が **direct-implementer-mode** へ自動移行（人間介入不要・正規フロー）。conductor は委譲可能時のみ起動されるため Iron Law と衝突しない |
 
-> 正本 taxonomy は #203 で一元化予定。本表は field 恒常 bug（#237/#238/#239）
-> を待たせないための最小定義。
+> **正本 taxonomy は [`tool-error-taxonomy.md`](./tool-error-taxonomy.md)
+> （#203 / TASK-0093）に一元化済**。本表は exec router 直結の
+> `delegation_unavailable` 最小定義のみ残す（重複定義しない）。全 category /
+> recovery policy / severity / classification は正本を参照。
 
 ## 6. Available evidence
 

--- a/docs/ai/metrics.md
+++ b/docs/ai/metrics.md
@@ -98,10 +98,6 @@ git が無い / commit が見つからない場合は silent に skip。
 出力例（aggregate text）：
 
 ```text
-## By mode (H-3)
-- **light**: V-1 12/14 PASS (85.71%) / C-3 APPROVED=10 / hook_violations=2
-- **standard**: V-1 5/5 PASS (100.0%) / C-3 APPROVED=5 / hook_violations=0
-```
 
 ### 3.6 整合性検証（v8.6.0 PR5 / H-1）
 
@@ -140,6 +136,25 @@ bin/plangate doctor --json
 ```
 
 CI 統合用。v8.6.0 metrics & privacy セクション 16 check の結果を JSON で返す。`failures > 0` で exit 1。
+
+### 3.8 tool_error の記録方針（#203 PBI-HI-010）
+
+ツール失敗は `tool_error` event（schema 1.1 additive）として記録する。
+category は [tool-error-taxonomy.md](./tool-error-taxonomy.md) §2 の enum
+（`tool_error_category`）。Privacy（[metrics-privacy.md](./metrics-privacy.md)
+§4）に従い **message / stack trace / command output は emit しない**
+（`tool_error_category` と `tool_name` / `phase` のみ）。`unknown_tool_error`
+は harness improvement backlog 還流の入力（taxonomy §6）。
+
+```sh
+echo '{"schema_version":"1.1","ts":"2026-05-17T00:00:00Z","task_id":"TASK-XXXX","event":"tool_error","tool_error_category":"edit_patch_failure","tool_name":"Edit","phase":"D"}' \
+  >> "$EVENTS_LOG"
+```
+
+## By mode (H-3)
+- **light**: V-1 12/14 PASS (85.71%) / C-3 APPROVED=10 / hook_violations=2
+- **standard**: V-1 5/5 PASS (100.0%) / C-3 APPROVED=5 / hook_violations=0
+```
 
 ## 4. Privacy
 
@@ -214,7 +229,6 @@ baseline と metrics summary を組み合わせると、改善前後の差分が
 - [schemas/plangate-event.schema.json](../../schemas/plangate-event.schema.json)
 - [scripts/hooks/check-metrics-privacy.sh](../../scripts/hooks/check-metrics-privacy.sh) — EH-8 privacy 強制 hook
 - [examples/sample-task/metrics-events.ndjson](../../examples/sample-task/metrics-events.ndjson) / [metrics-summary.md](../../examples/sample-task/metrics-summary.md) — 利用例
-
 
 ## Trace Timeline v1（experimental / #229 PBI-HI-013・v8.7.0）
 

--- a/docs/ai/model-profiles.md
+++ b/docs/ai/model-profiles.md
@@ -85,6 +85,22 @@ interface-preflight.md で合意した値域:
 | `normal` | 標準検証 | なし |
 | `strict` | 厳格検証 | PBI-116-06 `docs/ai/hook-enforcement.md` で定義（最低 3 件） |
 
+## 8-bis. retry_strategy（Tool Error Taxonomy 接続 / #203）
+
+retryable な tool error（[tool-error-taxonomy.md](./tool-error-taxonomy.md) §4）
+の自動再試行方針。profile 別に値を持てる（未定義時は保守的既定）。
+
+| キー | 意味 | 既定（未定義時）|
+|------|------|----------------|
+| `max_retries` | retryable の自動再試行上限。超過で soft_warning 降格 | `1` |
+| `backoff` | `provider_timeout` 等の待機方針（none/linear/exponential）| `none` |
+
+- どの category が retry 対象かは [tool-error-taxonomy.md](./tool-error-taxonomy.md)
+  §2/§3 が正本。本節は **回数・待機の値域**のみを定義（責務分離）。
+- `release_blocker` 分類（schema_validation/missing_context/stale_contract）は
+  **retry しない**（max_retries に関わらず即停止）。
+- profile 拡張・値変更は §10 の方針（別 PBI / eval 根拠）に従う。
+
 ## 9. critical mode 禁止の運用
 
 `gpt-5_mini` は `disallowed_modes: [critical]` を持つ。これにより:

--- a/docs/ai/tool-error-taxonomy.md
+++ b/docs/ai/tool-error-taxonomy.md
@@ -1,0 +1,139 @@
+# Tool Error Taxonomy and Recovery Policy（正本）
+
+> PlanGate runtime / tool 実行におけるツール失敗の **分類・severity・回復
+> ポリシー・計測** の正本。Model Profile v2 の `retry_strategy` と Metrics v1
+> の `tool_error` event に接続する。
+> 関連: [#203](https://github.com/s977043/plangate/issues/203)（PBI-HI-010）/
+> TASK-0093 / [`core-contract.md`](./core-contract.md) §5 Error taxonomy /
+> [`model-profiles.md`](./model-profiles.md) / [`metrics.md`](./metrics.md) /
+> [`../../schemas/plangate-event.schema.json`](../../schemas/plangate-event.schema.json) /
+> [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md)
+
+## 1. 目的
+
+ツール失敗を「一時的失敗」で片付けず、**分類 → 回復 → 計測** できるように
+する。失敗種別ごとに適切な回復方法（retry / 文脈補完 / 停止 / backlog 還流）
+が異なるため、category を正規化し recovery policy を固定する。
+
+> 本正本は [core-contract.md](./core-contract.md) §5 の最小 Error taxonomy
+> （`delegation_unavailable`）を **一元化**する（core-contract は本正本を
+> 参照。重複定義しない）。C-3 / C-4 ゲートは緩和しない（Non-goal）。
+
+## 2. Error categories（一覧）
+
+| Category | 定義 / 例 | severity | classification |
+|----------|----------|----------|----------------|
+| `edit_patch_failure` | patch が適用できない（hunk 不一致 等）| minor | **retryable** |
+| `edit_replace_failure` | string replace 対象が見つからない / 非一意 | minor | **retryable** |
+| `test_command_failure` | test / lint / build が失敗 | major | **soft_warning**（実装欠陥なら blocker）|
+| `provider_timeout` | provider / CLI が timeout | minor | **retryable** |
+| `schema_validation_failure` | artifact / event schema 違反 | major | **release_blocker** |
+| `missing_context` | 必要な plan / test-cases / c3.json が無い | major | **release_blocker** |
+| `permission_denied` | file / command / connector 権限不足 | major | **soft_warning**（人間判断要）|
+| `stale_contract` | stale plan / stale c3 / stale plan_hash | critical | **release_blocker** |
+| `delegation_unavailable` | サブエージェント起動不可、または判定不能 | minor | **retryable\***（\*retry ではなく topology fallback: direct-implementer-mode へ自動移行。回数 retry はしない）|
+| `unknown_tool_error` | 未分類エラー | major | **soft_warning** → backlog 還流（§5）|
+
+> severity は [review-principles.md](../../.claude/rules/review-principles.md) §3
+> の 4 段階に整合。classification は回復戦略の決定軸（§3）。
+
+## 3. Recovery policy（category 別）
+
+| Category | recovery policy |
+|----------|-----------------|
+| `edit_patch_failure` | 最新内容を再読込し patch 再生成 → 最大 N 回 retry（`retry_strategy`）。N 超過で soft_warning 化し人間へ |
+| `edit_replace_failure` | 対象の一意化（文脈拡張）後 retry。非一意が解消不能なら停止し人間確認 |
+| `test_command_failure` | 失敗ログを読み原因修正 → 再実行。実装欠陥起因なら fix loop（V-1）へ。回数上限超過は EHS-3 escalation |
+| `provider_timeout` | backoff 付き retry（`retry_strategy` の max_retries / backoff）。上限超過で soft_warning、別 provider/profile 検討は人間判断 |
+| `schema_validation_failure` | **retry しない**。artifact/event を schema 準拠に修正してから再実行（release blocker）|
+| `missing_context` | **retry しない**。plan/test-cases/c3.json を生成・取得（正規フロー）後に再開（release blocker）|
+| `permission_denied` | **retry しない**。Human-owned 操作（[responsibility-classes.md](../../.claude/rules/responsibility-classes.md)）。人間へ escalate |
+| `stale_contract` | **retry しない**。再承認（c3.json plan_hash 更新）または revert（EH-3）。critical |
+| `delegation_unavailable` | exec router が direct-implementer-mode へ自動移行（人間介入不要・正規フロー、core-contract §5）|
+| `unknown_tool_error` | 1 回のみ保守的 retry 可。解消しなければ §5 で backlog 還流（分類拡充）|
+
+## 4. release blocker / soft warning / retryable の境界
+
+| classification | 意味 | フロー影響 |
+|----------------|------|-----------|
+| **retryable** | 自動 retry で回復見込みあり | `retry_strategy` に従い自動再試行。上限超過で soft_warning へ降格 |
+| **soft_warning** | 自動回復不可だが即時停止不要 | 記録し継続。人間が後追い確認（handoff 既知課題へ）|
+| **release_blocker** | 続行不可・成果物不整合リスク | 即停止。修正後に再開（C-3/C-4 は緩和しない）|
+
+- retryable が `retry_strategy.max_retries` を超過したら **soft_warning** に
+  降格して記録（無限 retry 禁止）。
+- **軸の区別（重要）**: 本 taxonomy の `release_blocker` は *tool error
+  category* の分類。[eval-runner.md](./eval-runner.md) の
+  `release_blocker_violations`（[eval-result.schema.json](../../schemas/eval-result.schema.json)
+  enum: `scope_discipline`/`approval_discipline`/`verification_honesty`/
+  `format_adherence`）は *評価 aspect* の別軸であり、**同一視しない**
+  （tool error category 名を eval-result にそのまま入れない）。両者の対応:
+
+  | tool error category（本 §2）| 概念的に対応する eval aspect |
+  |------------------------------|----------------------------|
+  | `schema_validation_failure` | `format_adherence`（成果物整形・schema 準拠）|
+  | `missing_context` | `approval_discipline`（plan/c3 前提欠落）|
+  | `stale_contract` | `approval_discipline`（stale c3/plan_hash）|
+
+  対応は *概念マッピング* であり機械的等価ではない（記録は別 event:
+  tool_error は events、release_blocker_violations は eval-result）。
+
+## 5. Metrics 記録方針（Metrics v1 接続）
+
+ツール失敗は `tool_error` event として記録する（[metrics.md](./metrics.md)）。
+[`schemas/plangate-event.schema.json`](../../schemas/plangate-event.schema.json)
+に **additive**（schema_version 1.1）で追加:
+
+- `event: "tool_error"`（enum 追加）
+- `tool_error_category`（本 §2 の enum）
+- 既存 `tool_name` / `phase` / `mode` を併用
+
+Privacy: [metrics-privacy.md](./metrics-privacy.md) §4 に従い、message /
+stack trace / command output は emit しない（category と tool_name のみ）。
+
+```json
+{"schema_version":"1.1","ts":"2026-05-17T00:00:00Z","task_id":"TASK-XXXX",
+ "event":"tool_error","tool_error_category":"edit_patch_failure",
+ "tool_name":"Edit","phase":"D"}
+```
+
+## 6. unknown error の backlog 還流（運用）
+
+`unknown_tool_error` は **harness improvement backlog へ戻す**:
+
+1. `tool_error_category=unknown_tool_error` で event 記録（message なし）。
+2. handoff.md「既知課題」に「未分類ツールエラー（再現条件の範囲で）」を記載。
+3. retrospective / [#200 Reporting](./harness-improvement-roadmap.md) で集計し、
+   頻出パターンを §2 の新規 category として **EPIC #193 配下の PBI 化**。
+4. 新 category 追加は本正本の改訂（versioning は
+   [versioning-stability-policy.md](./versioning-stability-policy.md) §2.1
+   enum 追加＝ minor、必須化は major）。
+
+これにより未分類が放置されず分類体系が継続改善される。
+
+## 7. Model Profile v2 接続
+
+各 retryable category の retry は Model Profile の `retry_strategy`
+（[model-profiles.md](./model-profiles.md) §retry_strategy 接続）に従う:
+
+- `max_retries`: retryable の自動再試行上限（超過で soft_warning 降格）
+- `backoff`: `provider_timeout` 等の待機方針
+- profile 未定義時は保守的既定（max_retries=1）。
+
+> retry_strategy の値域・既定の正本は model-profiles.md。本正本は
+> 「どの category が retry 対象か」を定義し、回数/待機は profile に委譲。
+
+## 8. Non-goals
+
+- provider runtime の全面実装 / 全 provider のエラー形式対応
+- 自動修復の完全実装 / 外部監視システム連携
+- C-3 / C-4 ゲートの緩和
+
+## 9. 関連
+
+- [`core-contract.md`](./core-contract.md) §5 — delegation_unavailable 最小定義（本正本へ集約）
+- [`model-profiles.md`](./model-profiles.md) — retry_strategy 値域
+- [`metrics.md`](./metrics.md) — tool_error event 収集
+- [`schemas/plangate-event.schema.json`](../../schemas/plangate-event.schema.json) — event schema（additive 1.1）
+- [`.claude/rules/review-principles.md`](../../.claude/rules/review-principles.md) §3 — severity 4 段階
+- [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) — backlog 還流先

--- a/docs/working/TASK-0093/INDEX.md
+++ b/docs/working/TASK-0093/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0093 INDEX
+
+> 生成日: 2026-05-17
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0093/approvals/c3.json
+++ b/docs/working/TASK-0093/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0093",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T14:36:54Z",
+  "plan_hash": "sha256:f56eb0b0a82ae3316a52149adde46f20737c36182c3e8001427ebea840ab6553"
+}

--- a/docs/working/TASK-0093/current-state.md
+++ b/docs/working/TASK-0093/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0093 現在状態
+
+> 更新日: 2026-05-17
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0093/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0093 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0093/handoff.md
+++ b/docs/working/TASK-0093/handoff.md
@@ -1,0 +1,32 @@
+# Handoff — TASK-0093 / #203 PBI-HI-010 Tool Error Taxonomy and Recovery Policy
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 tool-error-taxonomy.md 存在 | PASS |
+| AC2 category 一覧（10）| PASS |
+| AC3 category 別 recovery policy | PASS |
+| AC4 release blocker/soft warning/retryable 境界 | PASS |
+| AC5 Model Profile v2 retry_strategy 接続 | PASS |
+| AC6 Metrics v1 event schema 記録方針（schema additive + 機械検証）| PASS (V-3 MJ-1 反映) |
+| AC7 unknown→harness backlog 還流運用 | PASS |
+V-1 全 PASS。V-3（Codex）critical 0 / major 2 / minor 3 → 全反映・回帰 PASS。
+## 2. 既知課題
+- tool_error event の自動 emit 実装は別 PBI（本 PBI は taxonomy + schema +
+  記録方針まで。runtime 実装は Non-goal）。
+- delegation_unavailable は分類上 retryable* だが実体は topology fallback
+  （回数 retry はしない・注記済）。
+## 3. V2 候補
+- metrics_collector.py に tool_error 自動導出（hook-events/エラーログから）。
+- retry_strategy を model-profiles.yaml に実値域として追加（#197 連携）。
+- unknown_tool_error 集計の #200 Reporting 連携で新 category PBI 化の自動提案。
+## 4. 妥協点
+- schema は additive のみ（tool_error 専用 conditional + schema_version 1.1
+  固定）。runtime 自動 emit・自動修復は実装せず方針定義に留める（Non-goal）。
+## 5. 引き継ぎ
+#203 を standard で実装。tool-error-taxonomy.md 正本（10 category/severity/
+recovery/classification/metrics/backlog/profile 接続）、plangate-event.schema
+additive（tool_error + tool_error_category + conditional）、core-contract §5
+集約・model-profiles §8-bis・metrics §3.8 接続。V-3 で schema conditional /
+別軸明記 / fallback 注記 / 採番を修正。これで v8.7.0 残: #204 PlanGateBench Fixture。
+## 6. テスト結果
+V-1: AC1-7 + E1-E3 全 PASS。V-3 反映後 schema 正/異常/非破壊を jsonschema 機械確認。

--- a/docs/working/TASK-0093/pbi-input.md
+++ b/docs/working/TASK-0093/pbi-input.md
@@ -1,0 +1,30 @@
+# PBI INPUT — TASK-0093 / #203 PBI-HI-010 Tool Error Taxonomy and Recovery Policy
+
+## Context / Why
+ツール失敗を一時失敗で片付けず分類・回復・計測可能にする。失敗種別ごとに
+回復方法が異なるため category を正規化し recovery policy を固定、Model Profile
+v2 retry_strategy と Metrics v1 tool_error event に接続する。
+
+## What
+- In: docs/ai/tool-error-taxonomy.md（正本）/ schemas/plangate-event.schema.json
+  （additive: tool_error event + tool_error_category）/ core-contract.md §5 集約 /
+  model-profiles.md retry_strategy 接続 / metrics.md tool_error 記録
+- Out: provider runtime 全面実装 / 全 provider エラー形式 / 自動修復完全実装 /
+  外部監視連携 / C-3・C-4 緩和
+
+## 受入基準（#203）
+- AC1: tool-error-taxonomy.md が存在
+- AC2: tool error category 一覧化
+- AC3: category ごと recovery policy 定義
+- AC4: release blocker/soft warning/retryable の区別定義
+- AC5: Model Profile v2 retry_strategy と接続
+- AC6: Metrics v1 event schema に記録できる方針
+- AC7: unknown error を harness improvement backlog に戻す運用定義
+
+## Notes
+core-contract.md §5（delegation_unavailable 最小定義）を本正本に集約（参照化）。
+schema は 1.1 additive（既存 event 非破壊）。Privacy: message/stack 非 emit。
+
+## Estimation
+Risks: schema 破壊（緩和: additive enum 追加・既存 event validate 確認）/
+core-contract 二重定義（緩和: 参照化）/ Unknowns: なし

--- a/docs/working/TASK-0093/plan.md
+++ b/docs/working/TASK-0093/plan.md
@@ -1,0 +1,53 @@
+# EXECUTION PLAN — TASK-0093 / #203 PBI-HI-010
+
+## Goal
+Tool Error Taxonomy と Recovery Policy を正本化し、Model Profile v2
+retry_strategy / Metrics v1 tool_error event に接続する。
+
+## Constraints / Non-goals
+- provider runtime 全面実装 / 全 provider エラー形式 / 自動修復完全実装 /
+  外部監視連携 / C-3・C-4 ゲート緩和 はしない。
+- schema は additive のみ（既存 event / schema_version を破壊しない）。
+- core-contract.md §5 を再定義せず本正本へ集約（参照化）。
+
+## Approach Overview
+tool-error-taxonomy.md 正本（category/severity/recovery/classification/
+metrics/backlog/profile 接続）→ schema additive（tool_error event +
+tool_error_category, 1.1）→ core-contract §5 参照化 → model-profiles
+§8-bis retry_strategy → metrics §3.5 tool_error 記録。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | tool-error-taxonomy.md 正本 | agent | 中 | 🚩 AC1-4,AC7 |
+| S2 | plangate-event.schema.json additive | agent | 中 | 🚩 AC6 非破壊 |
+| S3 | core-contract/model-profiles/metrics 接続 | agent | 中 | 🚩 AC5/AC6 |
+
+## Files / Components to Touch
+- docs/ai/tool-error-taxonomy.md（新規・正本）
+- schemas/plangate-event.schema.json（additive）
+- docs/ai/core-contract.md（§5 参照化）
+- docs/ai/model-profiles.md（§8-bis retry_strategy）
+- docs/ai/metrics.md（§3.5 tool_error）
+
+## Testing Strategy
+- Verification: AC1-7 を grep 構造突合 + tool_error event を jsonschema
+  validate + 既存 event 非破壊 validate（schema_version 1.0/1.1）。
+- Unit/E2E: 該当なし（定義 + schema additive、runtime 実装なし）。
+
+## Risks & Mitigations
+- schema 破壊 → additive enum/optional のみ、新旧 event を jsonschema 検証
+- core-contract 二重定義 → §5 を正本参照に置換、最小定義のみ残置
+- 承認境界誤解 → Non-goal で C-3/C-4 緩和なしを明記
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 5 → 中
+- 受入基準数: 7 → 中
+- 変更種別: feat（正本 + schema additive + 多正本接続）→ 中
+- リスク: 中（共有 schema への additive・回帰注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0093/review-external.md
+++ b/docs/working/TASK-0093/review-external.md
@@ -1,0 +1,18 @@
+# V-3 外部レビュー（Codex）— TASK-0093 / #203
+
+## 結果サマリ
+critical: 0 / major: 2 / minor: 3 / info: 4（初回 NOT APPROVE → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | schema に tool_error の conditional 無く category 欠落 event が valid | allOf に `if event==tool_error then required:[tool_error_category, schema_version], schema_version const 1.1` を additive 追加。jsonschema で欠落/1.0 が REJECT、正常/既存1.0 が PASS を確認 |
+| MJ-2 | major | taxonomy の release_blocker と eval-result release_blocker_violations(enum 別) を整合と誤記 | 「別軸（tool error category vs 評価 aspect）・同一視しない」明記 + 概念対応表追加（機械的等価でない旨） |
+| mn-1 | minor | schema_version 1.0 でも tool_error 許容で版境界曖昧 | MJ-1 conditional で schema_version const 1.1 固定（解消）|
+| mn-2 | minor | delegation_unavailable が retryable だが実体は topology fallback | classification に `retryable*` + 「retry でなく topology fallback・回数 retry しない」注記 |
+| mn-3 | minor | metrics.md §3.5 が既存 mode別集計と重複 | tool_error を §3.8（末尾・mode別集計/整合性/機械可読化の後）へ正規配置、3.x 一意化 |
+| info×4 | info | enum/additionalProperties 非矛盾 / 既存 conditional 非干渉 / Privacy 一貫 / 責務分離 OK | 対応不要 |
+
+## 判定
+major 2 / minor 3 を全反映。critical 0。回帰 V-1 全 PASS・schema 正/異常/非破壊
+を jsonschema で機械確認・metrics 採番一意化。

--- a/docs/working/TASK-0093/review-self.md
+++ b/docs/working/TASK-0093/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0093
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-7 ↔ S1-S3 ↔ T1-T7 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | runtime全面/全provider/自動修復/外部監視/ゲート緩和 Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | grep + jsonschema validate（新旧 event）|
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | schema 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T7 ↔ AC1-7 |
+| C1-TC-02 Edge網羅 | PASS | E1 schema非破壊 / E2 集約 / E3 Non-goal |
+| C1-TC-03 自動化可否 | PASS | grep/jsonschema 自動 |
+| C1-INT-01 schema整合 | PASS | additive 1.1（既存 event 非破壊・jsonschema 確認）|
+| C1-INT-02 正本集約 | PASS | core-contract §5 を本正本へ参照化（重複なし）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0093/test-cases.md
+++ b/docs/working/TASK-0093/test-cases.md
@@ -1,0 +1,14 @@
+# テストケース — TASK-0093 / #203
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | docs/ai/tool-error-taxonomy.md 存在 | ファイル存在 |
+| T2 | AC2 | 9 category（edit_patch_failure…unknown_tool_error）一覧 | 構造突合 |
+| T3 | AC3 | §3 Recovery policy に category 別ポリシー | 構造突合 |
+| T4 | AC4 | retryable/soft_warning/release_blocker 境界表 | 構造突合 |
+| T5 | AC5 | tool-error-taxonomy §7 + model-profiles §8-bis retry_strategy 接続 | 構造突合 |
+| T6 | AC6 | schema に tool_error event + tool_error_category（jsonschema validate）+ metrics §3.5 | 機械検証 |
+| T7 | AC7 | §6 unknown→backlog 還流（EPIC #193 PBI 化）運用 | 構造突合 |
+## Edge
+- E1: schema additive 非破壊（既存 hook_violation event が 1.0 で valid のまま）
+- E2: core-contract §5 が正本参照化（重複定義なし）
+- E3: Non-goal C-3/C-4 緩和なし明記

--- a/docs/working/TASK-0093/todo.md
+++ b/docs/working/TASK-0093/todo.md
@@ -1,0 +1,13 @@
+# TODO — TASK-0093 / #203
+## 🤖 Agent
+- [x] 準備: #203本文・既存 schema/core-contract/model-profiles/metrics 確認
+- [x] S1 tool-error-taxonomy.md 正本（🚩AC1-4,AC7）
+- [x] S2 schema additive（🚩AC6 非破壊）
+- [x] S3 core-contract/model-profiles/metrics 接続（🚩AC5/AC6）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/schemas/plangate-event.schema.json
+++ b/schemas/plangate-event.schema.json
@@ -18,7 +18,7 @@
         "1.0",
         "1.1"
       ],
-      "description": "PlanGate event schema version (1.0 baseline / 1.1 additive: gate_id, parent_event_id, phase WF/handoff — experimental, #229 PBI-HI-013)"
+      "description": "PlanGate event schema version (1.0 baseline / 1.1 additive: gate_id, parent_event_id, phase WF/handoff — experimental, #229 PBI-HI-013) / 1.1 additive: tool_error event + tool_error_category (#203 PBI-HI-010)"
     },
     "ts": {
       "type": "string",
@@ -43,8 +43,10 @@
         "external_review_completed",
         "pr_created",
         "c4_decided",
-        "handoff_completed"
-      ]
+        "handoff_completed",
+        "tool_error"
+      ],
+      "description": ""
     },
     "phase": {
       "type": "string",
@@ -162,6 +164,22 @@
       "description": "Causal link to a prior event id (1.1 optional / experimental #229). Privacy(#202): 識別子のみ・slash/空白/自由文不可",
       "pattern": "^[A-Za-z0-9._:-]{1,64}$",
       "maxLength": 64
+    },
+    "tool_error_category": {
+      "type": "string",
+      "enum": [
+        "edit_patch_failure",
+        "edit_replace_failure",
+        "test_command_failure",
+        "provider_timeout",
+        "schema_validation_failure",
+        "missing_context",
+        "permission_denied",
+        "stale_contract",
+        "delegation_unavailable",
+        "unknown_tool_error"
+      ],
+      "description": "tool error category (1.1 additive, #203 PBI-HI-010). 正本: docs/ai/tool-error-taxonomy.md"
     }
   },
   "allOf": [
@@ -248,6 +266,29 @@
       "then": {
         "required": [
           "fix_loop_count"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "tool_error"
+          }
+        },
+        "required": [
+          "event"
+        ]
+      },
+      "then": {
+        "properties": {
+          "schema_version": {
+            "const": "1.1"
+          }
+        },
+        "required": [
+          "tool_error_category",
+          "schema_version"
         ]
       }
     }


### PR DESCRIPTION
## 概要
#203 を standard で実装。ツール失敗を分類・回復・計測できる正本を新規作成し、Model Profile v2 retry_strategy / Metrics v1 tool_error event に接続。

## 変更
- **新規** `docs/ai/tool-error-taxonomy.md`（正本・~140行）: 10 error category / severity / category 別 recovery policy / retryable・soft_warning・release_blocker 境界 / Metrics 記録方針（Privacy: message/stack 非 emit）/ unknown→harness backlog 還流（EPIC #193 PBI 化）/ Model Profile v2 retry_strategy 接続
- `schemas/plangate-event.schema.json`: `tool_error` event + `tool_error_category` を **1.1 additive** + conditional（event==tool_error → category 必須 & schema_version const 1.1）。既存 1.0 event 非破壊を jsonschema で機械確認
- `docs/ai/core-contract.md` §5: 本正本へ集約（参照化・delegation_unavailable 最小定義のみ残置）
- `docs/ai/model-profiles.md` §8-bis retry_strategy 接続 / `docs/ai/metrics.md` §3.8 tool_error 記録方針

## V-1 / V-3
- V-1: AC1-7 + E1-E3 全 PASS（grep + jsonschema 正/異常/非破壊機械検証）
- V-3（Codex）: critical 0 / major 2 / minor 3 → **全反映**（schema conditional / eval-runner と別軸明記+対応表 / schema_version 1.1 固定 / delegation_unavailable=topology fallback 注記 / metrics 採番一意化）、回帰 PASS

## Non-goals 遵守
provider runtime 全面実装 / 全 provider エラー形式 / 自動修復完全実装 / 外部監視連携 / C-3・C-4 緩和 — いずれも未実施

## Mode
standard（feat・正本 + schema additive + 多正本接続）

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)