### PR TITLE
feat(#197): Model Profile v2 / PBI-HI-003 / TASK-0095

### DIFF
--- a/docs/ai/model-profiles.md
+++ b/docs/ai/model-profiles.md
@@ -1,6 +1,8 @@
 # PlanGate Model Profiles — 仕様 + マトリクス
 
-> **Status**: v1（PBI-116-02 で初版確立、Phase 2 / PBI-116）
+> **Status**: v2（#197 / PBI-HI-003 で edit_interface_preference / retry_strategy /
+> context_acquisition / provider_capabilities / telemetry_tags を追加。v1 は
+> 後方互換維持＝schema `version` は 1/2 両対応）
 > 本体定義: [`docs/ai/model-profiles.yaml`](./model-profiles.yaml)
 > Schema: [`schemas/model-profile.schema.json`](../../schemas/model-profile.schema.json)
 > Interface preflight: [`docs/working/PBI-116/interface-preflight.md`](../working/PBI-116/interface-preflight.md)
@@ -84,6 +86,56 @@ interface-preflight.md で合意した値域:
 | `lenient` | 軽い検証 | なし |
 | `normal` | 標準検証 | なし |
 | `strict` | 厳格検証 | PBI-116-06 `docs/ai/hook-enforcement.md` で定義（最低 3 件） |
+
+## 8-bis. v2 拡張フィールド（#197 / PBI-HI-003）
+
+モデル差分をプロンプト全文 fork ではなく Model Profile に閉じ込めるための
+v2 追加（すべて任意フィールド・既存 v1 profile は無変更で valid）。
+
+| フィールド | 内容 | 値域 |
+|-----------|------|------|
+| `edit_interface_preference` | モデルが得意な編集形式 | `primary`/`fallback` ∈ {patch, string_replace, full_file}（primary 必須）|
+| `retry_strategy` | 失敗時の回復方針・回数・待機 | `on_edit_failure`{reread_then_retry_small_diff,retry_same,escalate} / `on_test_failure`{inspect_error_then_fix,retry_same,escalate} / `max_retries` 0-10 / `backoff`{none,linear,exponential} |
+| `context_acquisition` | 初期コンテキスト取得戦略 | `strategy`{dynamic_first,eager,lazy}（必須）/ `initial_context_budget`{compact,standard,expanded} |
+| `provider_capabilities` | provider 機能可否（判定根拠）| `supports_patch` / `supports_string_replace` / `supports_parallel_subagents`（bool）|
+| `telemetry_tags` | 公開安全な provider/世代ラベル | `provider` ∈ {openai, anthropic, claude_code, codex, unknown} / `generation` ∈ {gpt-5.5, gpt-5.5-pro, gpt-5-mini, legacy, unknown}（**固定 enum・free-form 不可**。鍵/アカウントID/社内モデル名を構造排除＝metrics-privacy §4/§5.4）|
+
+### retry_strategy と Tool Error Taxonomy の責務分離
+
+- **どの category が retry 対象か** は [tool-error-taxonomy.md](./tool-error-taxonomy.md)
+  （#203）が正本（**PR #269 提供。未マージ時は前方参照**）。
+- 本 `retry_strategy` は **回数（max_retries）・待機（backoff）・方針**のみを
+  profile 別に定義（二重定義しない）。`release_blocker` 分類
+  （schema_validation / missing_context / stale_contract）は max_retries に
+  関わらず **retry しない**（taxonomy §4）。
+- `max_retries` 未指定時は保守的既定 **1**。
+- **`on_*: escalate` のとき `max_retries` は適用しない**（即エスカレーション。
+  `legacy_or_unknown` は `escalate` + `max_retries: 0` で安全側を明示）。
+
+### telemetry_tags の registry（privacy）
+
+`provider` / `generation` は **固定 enum registry**（schema `enum`）。
+free-form を許さないことで [metrics-privacy.md](./metrics-privacy.md) §4 の
+鍵 / アカウント ID / 社内モデル名混入を構造的に排除する。新 provider /
+世代の追加は本 schema の enum 追加（versioning-stability-policy §2.1 =
+minor・additive）として行い、free-form 化はしない。
+
+### context_acquisition の位置づけ
+
+`strategy` は将来の Dynamic Context Engine（[#199](https://github.com/s977043/plangate/issues/199)）
+の **判定根拠**であり、本 PBI では DCE 実装はしない（Non-goal）。
+
+### 移行と後方互換
+
+- 既存 4 profile を v2 へ移行済（`docs/ai/model-profiles.yaml` version: 2）。
+- `legacy_or_unknown` fallback は維持（安全側: escalate / lazy / patch 非対応）。
+- schema `version` は **1/2 両対応**（v1 設定は無変更で valid＝
+  [versioning-stability-policy.md](./versioning-stability-policy.md) §2.1
+  オプショナル追加 = minor）。
+- **Core Contract / Gate / Artifact schema はモデル別に変更しない**（v2 でも不変）。
+- v1→v2 の比較は [#196](https://github.com/s977043/plangate/issues/196)
+  eval comparison（`--harness-compare`、**PR #268 提供・前方参照**）で
+  v1 baseline と対比可能（profile を harness_metadata に記録）。
 
 ## 9. critical mode 禁止の運用
 

--- a/docs/ai/model-profiles.yaml
+++ b/docs/ai/model-profiles.yaml
@@ -1,4 +1,4 @@
-# PlanGate Model Profiles v1
+# PlanGate Model Profiles v2 (#197 / PBI-HI-003)
 #
 # Schema: schemas/model-profile.schema.json
 # Companion doc: docs/ai/model-profiles.md
@@ -6,9 +6,11 @@
 #
 # Core Contract / Gate / Artifact schema はモデル別に変更しない。
 # 本ファイルは「reasoning effort / verbosity / context budget / tool policy / validation bias / adapter」
-# のモデル差分のみを表現する薄い設定層。
+# に加え v2 で「edit_interface_preference / retry_strategy / context_acquisition /
+# provider_capabilities / telemetry_tags」のモデル差分のみを表現する薄い設定層。
+# Core Contract / Gate / Artifact schema はモデル別に変更しない（v2 でも不変）。
 
-version: 1
+version: 2
 
 defaults:
   structured_outputs: true
@@ -36,6 +38,24 @@ models:
     tool_policy: allowed_tools_by_phase
     validation_bias: normal
     adapter: outcome_first
+    edit_interface_preference:
+      primary: patch
+      fallback: string_replace
+    retry_strategy:
+      on_edit_failure: reread_then_retry_small_diff
+      on_test_failure: inspect_error_then_fix
+      max_retries: 2
+      backoff: linear
+    context_acquisition:
+      strategy: dynamic_first
+      initial_context_budget: standard
+    provider_capabilities:
+      supports_patch: true
+      supports_string_replace: true
+      supports_parallel_subagents: false
+    telemetry_tags:
+      provider: openai
+      generation: gpt-5.5
 
   # 強力推論モデル。high_risk / critical で本領発揮。
   gpt-5_5_pro:
@@ -58,6 +78,24 @@ models:
     tool_policy: expanded
     validation_bias: strict
     adapter: outcome_first_strict
+    edit_interface_preference:
+      primary: patch
+      fallback: string_replace
+    retry_strategy:
+      on_edit_failure: reread_then_retry_small_diff
+      on_test_failure: inspect_error_then_fix
+      max_retries: 3
+      backoff: exponential
+    context_acquisition:
+      strategy: dynamic_first
+      initial_context_budget: expanded
+    provider_capabilities:
+      supports_patch: true
+      supports_string_replace: true
+      supports_parallel_subagents: false
+    telemetry_tags:
+      provider: openai
+      generation: gpt-5.5-pro
 
   # 高速軽量モデル。critical mode は disallow。
   gpt-5_mini:
@@ -80,6 +118,24 @@ models:
     validation_bias: lenient
     adapter: explicit_short
     disallowed_modes: [critical]
+    edit_interface_preference:
+      primary: string_replace
+      fallback: patch
+    retry_strategy:
+      on_edit_failure: retry_same
+      on_test_failure: inspect_error_then_fix
+      max_retries: 1
+      backoff: none
+    context_acquisition:
+      strategy: eager
+      initial_context_budget: compact
+    provider_capabilities:
+      supports_patch: true
+      supports_string_replace: true
+      supports_parallel_subagents: false
+    telemetry_tags:
+      provider: openai
+      generation: gpt-5-mini
 
   # フォールバック（未知モデル / レガシー）。安全側に倒す。
   legacy_or_unknown:
@@ -101,3 +157,20 @@ models:
     tool_policy: allowed_tools_by_phase
     validation_bias: normal
     adapter: legacy_or_unknown
+    edit_interface_preference:
+      primary: string_replace
+    retry_strategy:
+      on_edit_failure: escalate
+      on_test_failure: escalate
+      max_retries: 0
+      backoff: none
+    context_acquisition:
+      strategy: lazy
+      initial_context_budget: standard
+    provider_capabilities:
+      supports_patch: false
+      supports_string_replace: true
+      supports_parallel_subagents: false
+    telemetry_tags:
+      provider: unknown
+      generation: legacy

--- a/docs/working/TASK-0095/INDEX.md
+++ b/docs/working/TASK-0095/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0095 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0095/approvals/c3.json
+++ b/docs/working/TASK-0095/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0095",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T15:58:22Z",
+  "plan_hash": "sha256:1f5630a055e2143c51c27a1dfd380bcce94ec24950634dfd9780645e75f1e7dd"
+}

--- a/docs/working/TASK-0095/current-state.md
+++ b/docs/working/TASK-0095/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0095 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0095/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0095 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0095/handoff.md
+++ b/docs/working/TASK-0095/handoff.md
@@ -1,0 +1,33 @@
+# Handoff — TASK-0095 / #197 PBI-HI-003 Model Profile v2
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 edit_interface_preference schema 化 | PASS |
+| AC2 retry_strategy schema 化 | PASS |
+| AC3 context_acquisition schema 化 | PASS |
+| AC4 provider_capabilities schema 化 | PASS |
+| AC5 既存 profile v2 移行 | PASS |
+| AC6 legacy_or_unknown fallback 維持 | PASS（escalate/lazy/patch非対応/max_retries:0）|
+| AC7 Core Contract/Gate/Artifact schema 不変明記 | PASS（yaml+md）|
+| AC8 #196 eval comparison で v1 baseline 比較 | PASS（前方参照明記）|
+V-1 全 PASS（v1 後方互換含む）。V-3（Codex）critical 0/major 1/minor 2 → 全反映。
+## 2. 既知課題
+- **前方参照依存**: retry 対象 category 正本 = #203/PR #269、v1↔v2 比較 CLI =
+  #196/PR #268。推奨マージ順: PR #268・#269 → 本 PR（未マージでも schema/yaml/
+  doc は単独有効、CLI/category 正本連携のみ従属）。
+- runtime での profile 適用（edit_interface 切替・retry 実行）は別 PBI（本 PBI
+  は schema/設定/doc の判定根拠まで）。
+## 3. V2 候補
+- runtime で edit_interface_preference / retry_strategy を実行（provider adapter）。
+- telemetry_tags を metrics events に接続（#198 Keep Rate / #200 Reporting）。
+- 新 provider/世代の enum 追加（additive・別 PBI）。
+## 4. 妥協点
+- telemetry を free-form でなく固定 enum registry に（privacy 構造排除を優先・
+  拡張は schema 改訂 additive）。runtime 実装は Non-goal で判定根拠に留める。
+## 5. 引き継ぎ
+#197 を standard で実装。model-profile.schema v2（version enum[1,2]+5 optional）、
+model-profiles.yaml v2 移行（4 profile・legacy 安全側）、md §8-bis v2 doc。
+V-3 で telemetry enum 化 / yaml コメント所属 / legacy max_retries:0 を修正。
+次は #198 Keep Rate v1。
+## 6. テスト結果
+V-1: AC1-8 + E1/E2 全 PASS。V-3 反映後 v2/v1 jsonschema 機械確認 PASS。

--- a/docs/working/TASK-0095/pbi-input.md
+++ b/docs/working/TASK-0095/pbi-input.md
@@ -1,0 +1,31 @@
+# PBI INPUT — TASK-0095 / #197 PBI-HI-003 Model Profile v2
+
+## Context / Why
+Core Contract/Gate/Artifact schema はモデル非依存だが、編集形式の得手不得手・
+失敗回復方針・provider capability はモデル別。差分をプロンプト全文 fork でなく
+Model Profile v2 に閉じ込め、provider/model 別実行スタイルを選択可能にする。
+
+## What
+- In: schemas/model-profile.schema.json（v2 additive）/ docs/ai/model-profiles.yaml
+  （v2 移行）/ docs/ai/model-profiles.md（v2 doc）
+- Out: モデル別プロンプト全文 fork / provider runtime 全面刷新 / Cursor/Gemini/
+  OpenCode 完全実装 / Dynamic Context Engine 実装 / Keep Rate 算出
+
+## 受入基準（#197）
+- AC1: edit_interface_preference が schema 化
+- AC2: retry_strategy が schema 化
+- AC3: context_acquisition が schema 化
+- AC4: provider_capabilities が schema 化
+- AC5: 既存 profile が v2 に移行
+- AC6: legacy_or_unknown fallback 維持
+- AC7: Core Contract/Gate/Artifact schema をモデル別に変更しない明記
+- AC8: PBI-HI-002(#196) eval comparison で v1 baseline と比較できる
+
+## Notes
+新 5 フィールドは optional・version enum[1,2]＝v1 後方互換。retry_strategy の
+category 正本は #203(PR#269 前方参照)。#196(PR#268) で v1↔v2 比較。telemetry_tags
+は privacy §4 準拠（鍵/秘匿不可）。
+
+## Estimation
+Risks: schema v1 破壊（緩和: optional+version enum・v1 validate 確認）/
+#203/#196 前方参照（緩和: 依存・マージ順明記）/ Unknowns: なし

--- a/docs/working/TASK-0095/plan.md
+++ b/docs/working/TASK-0095/plan.md
@@ -1,0 +1,50 @@
+# EXECUTION PLAN — TASK-0095 / #197 PBI-HI-003
+
+## Goal
+Model Profile を v2 に拡張し、モデル別実行特性（編集形式/回復/文脈取得/
+capability/telemetry）を表現可能にする（v1 後方互換維持）。
+
+## Constraints / Non-goals
+- プロンプト全文 fork / provider runtime 全面刷新 / Cursor等完全実装 /
+  Dynamic Context Engine 実装 / Keep Rate 算出 はしない。
+- Core Contract/Gate/Artifact schema をモデル別に変更しない（不変）。
+- schema は additive（version enum[1,2]・新フィールド optional）。
+
+## Approach Overview
+schema $defs/profile に 5 optional フィールド追加 + version enum[1,2] →
+model-profiles.yaml 4 profile を v2 移行（legacy_or_unknown 安全側維持）→
+model-profiles.md §8-bis v2 doc（#203 retry 責務分離・#196 比較を前方参照明記）。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | model-profile.schema.json v2 additive | agent | 中 | 🚩 AC1-4 |
+| S2 | model-profiles.yaml v2 移行 | agent | 中 | 🚩 AC5/6 |
+| S3 | model-profiles.md §8-bis v2 doc | agent | 低 | 🚩 AC7/8 |
+
+## Files / Components to Touch
+- schemas/model-profile.schema.json（additive）
+- docs/ai/model-profiles.yaml（v2 移行）
+- docs/ai/model-profiles.md（§8-bis）
+
+## Testing Strategy
+- Verification: AC1-8 を schema json.load + jsonschema validate（v2 yaml /
+  v1 後方互換）+ grep 構造突合。
+- Unit/E2E: 該当なし（schema/設定/doc、runtime 非実装）。
+
+## Risks & Mitigations
+- v1 破壊 → optional + version enum[1,2]、v1 最小 profile を jsonschema 確認
+- #203/#196 前方参照 → 依存・推奨マージ順を doc に明記
+- telemetry privacy → pattern 制約 + §4 準拠注記
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 3 → 中
+- 受入基準数: 8 → 中
+- 変更種別: feat（schema v2 + 設定移行 + doc）→ 中
+- リスク: 中（共有 schema への version 拡張・後方互換注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0095/review-external.md
+++ b/docs/working/TASK-0095/review-external.md
@@ -1,0 +1,17 @@
+# V-3 外部レビュー（Codex）— TASK-0095 / #197
+
+## 結果サマリ
+critical: 0 / major: 1 / minor: 2 / info: 4（初回 REQUEST CHANGES → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | telemetry_tags が free-form pattern で metrics-privacy §4（鍵/アカウントID/社内モデル名）を排除できない | provider/generation を**固定 enum** 化（provider:{openai,anthropic,claude_code,codex,unknown} / generation:{gpt-5.5,gpt-5.5-pro,gpt-5-mini,legacy,unknown}）。md に registry 節 + free-form 不可を明記。yaml 値は enum 適合 |
+| mn-1 | minor | yaml v2 ブロック挿入位置が次 profile 見出しコメントの後で所属誤認 | 再移行で末尾コメント行をスキップし profile 内末尾に挿入（comment→header→v1→v2 が profile 内に収まることを確認）|
+| mn-2 | minor | legacy_or_unknown が escalate なのに max_retries:1 で曖昧 | legacy max_retries:**0** に変更 + md に「on_*: escalate のとき max_retries 非適用」明記 |
+| info×4 | info | v1 後方互換 OK / retry 責務分離 OK（#203 前方参照明記必須＝明記済）/ Core Contract 不変 yaml・md 両方 / version enum[1,2]=minor 整合 | 対応不要 |
+
+## 判定
+major 1 / minor 2 を全反映。critical 0。回帰: v2 yaml jsonschema valid・
+v1 後方互換 valid・telemetry enum 適合・legacy 安全側明確化。
+#203(PR#269)/#196(PR#268) は前方参照（依存・推奨マージ順を md に明記）。

--- a/docs/working/TASK-0095/review-self.md
+++ b/docs/working/TASK-0095/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0095
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-8 ↔ S1-S3 ↔ T1-T8 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | fork/runtime刷新/完全実装/DCE/KeepRate を Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | jsonschema validate(v2/v1後方互換) + grep |
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3、#203/#196 前方参照明記 |
+| C1-PLAN-07 検証自動化 | PASS | schema 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T8 ↔ AC1-8 |
+| C1-TC-02 Edge網羅 | PASS | E1 v1後方互換 / E2 telemetry privacy |
+| C1-TC-03 自動化可否 | PASS | jsonschema/grep 自動 |
+| C1-INT-01 後方互換 | PASS | version enum[1,2]・新 optional・v1 validate 確認 |
+| C1-INT-02 責務分離 | PASS | retry 対象=#203正本 / 回数待機=profile（二重定義なし）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0095/test-cases.md
+++ b/docs/working/TASK-0095/test-cases.md
@@ -1,0 +1,14 @@
+# テストケース — TASK-0095 / #197
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | schema $defs/profile に edit_interface_preference | 機械検証 |
+| T2 | AC2 | schema に retry_strategy（on_edit/on_test/max_retries/backoff）| 機械検証 |
+| T3 | AC3 | schema に context_acquisition（strategy/initial_context_budget）| 機械検証 |
+| T4 | AC4 | schema に provider_capabilities（supports_*）| 機械検証 |
+| T5 | AC5 | yaml version:2 + 4 profile が v2 フィールド保持・jsonschema valid | 機械検証 |
+| T6 | AC6 | legacy_or_unknown が存在し安全側（escalate/lazy/patch非対応）| 構造突合 |
+| T7 | AC7 | yaml/md に Core Contract/Gate/Artifact schema 不変明記 | 構造突合 |
+| T8 | AC8 | md に #196 eval comparison で v1 baseline 比較（harness_metadata profile）記載 | 構造突合 |
+## Edge
+- E1: v1（version=1・v2フィールドなし最小 profile）が jsonschema valid（後方互換）
+- E2: telemetry_tags が pattern 制約（鍵/秘匿不可・privacy §4 注記）

--- a/docs/working/TASK-0095/todo.md
+++ b/docs/working/TASK-0095/todo.md
@@ -1,0 +1,14 @@
+# TODO — TASK-0095 / #197
+## 🤖 Agent
+- [x] 準備: #197本文・既存 schema/yaml/md 構造確認
+- [x] S1 schema v2 additive（🚩AC1-4）
+- [x] S2 yaml v2 移行（🚩AC5/6）
+- [x] S3 md §8-bis v2 doc（🚩AC7/8）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3
+- 前方参照: #203(PR#269 retry 正本) / #196(PR#268 v1↔v2比較)

--- a/schemas/model-profile.schema.json
+++ b/schemas/model-profile.schema.json
@@ -4,12 +4,18 @@
   "title": "PlanGate Model Profile",
   "description": "実行モデル別の reasoning effort / verbosity / context budget / tool policy / validation depth を表す薄い設定層。PlanGate Core はモデル非依存で維持し、本 schema 配下のプロファイルでモデル差分を吸収する。",
   "type": "object",
-  "required": ["version", "models"],
+  "required": [
+    "version",
+    "models"
+  ],
   "properties": {
     "version": {
       "type": "integer",
-      "const": 1,
-      "description": "本 schema のバージョン。後方互換破壊的変更時にインクリメント。"
+      "enum": [
+        1,
+        2
+      ],
+      "description": "schema バージョン。1=v1（既存・後方互換）/ 2=v2（#197: edit_interface_preference / retry_strategy / context_acquisition / provider_capabilities / telemetry_tags を追加）。1 は引き続き valid。"
     },
     "defaults": {
       "type": "object",
@@ -32,7 +38,9 @@
       "type": "object",
       "description": "プロファイル ID → 設定のマップ。",
       "minProperties": 1,
-      "additionalProperties": { "$ref": "#/$defs/profile" }
+      "additionalProperties": {
+        "$ref": "#/$defs/profile"
+      }
     }
   },
   "additionalProperties": false,
@@ -52,59 +60,115 @@
       "properties": {
         "family": {
           "type": "string",
-          "enum": ["gpt-5", "gpt-5-pro", "gpt-5-mini", "legacy"],
+          "enum": [
+            "gpt-5",
+            "gpt-5-pro",
+            "gpt-5-mini",
+            "legacy"
+          ],
           "description": "モデルファミリー識別子"
         },
         "role": {
           "type": "string",
-          "enum": ["default_reasoning", "advanced_reasoning", "fast_lightweight", "unknown"],
+          "enum": [
+            "default_reasoning",
+            "advanced_reasoning",
+            "fast_lightweight",
+            "unknown"
+          ],
           "description": "プロファイルが想定する役割"
         },
         "reasoning_effort_by_mode": {
           "type": "object",
           "description": "PlanGate 5 mode 別の推奨 reasoning effort",
-          "required": ["ultra_light", "light", "standard", "high_risk", "critical"],
+          "required": [
+            "ultra_light",
+            "light",
+            "standard",
+            "high_risk",
+            "critical"
+          ],
           "properties": {
-            "ultra_light": { "$ref": "#/$defs/effort_value" },
-            "light": { "$ref": "#/$defs/effort_value" },
-            "standard": { "$ref": "#/$defs/effort_value" },
-            "high_risk": { "$ref": "#/$defs/effort_value" },
-            "critical": { "$ref": "#/$defs/effort_value" }
+            "ultra_light": {
+              "$ref": "#/$defs/effort_value"
+            },
+            "light": {
+              "$ref": "#/$defs/effort_value"
+            },
+            "standard": {
+              "$ref": "#/$defs/effort_value"
+            },
+            "high_risk": {
+              "$ref": "#/$defs/effort_value"
+            },
+            "critical": {
+              "$ref": "#/$defs/effort_value"
+            }
           },
           "additionalProperties": false
         },
         "allowed_efforts": {
           "type": "array",
-          "items": { "$ref": "#/$defs/effort_enum" },
+          "items": {
+            "$ref": "#/$defs/effort_enum"
+          },
           "uniqueItems": true,
           "description": "プロファイルで許容される effort 値の集合（critical mode で xhigh も許容したい場合の構造化表現）"
         },
         "verbosity_by_phase": {
           "type": "object",
           "description": "phase 別の出力 verbosity",
-          "required": ["classify", "plan", "execute", "review", "handoff"],
+          "required": [
+            "classify",
+            "plan",
+            "execute",
+            "review",
+            "handoff"
+          ],
           "properties": {
-            "classify": { "$ref": "#/$defs/verbosity_value" },
-            "plan": { "$ref": "#/$defs/verbosity_value" },
-            "execute": { "$ref": "#/$defs/verbosity_value" },
-            "review": { "$ref": "#/$defs/verbosity_value" },
-            "handoff": { "$ref": "#/$defs/verbosity_value" }
+            "classify": {
+              "$ref": "#/$defs/verbosity_value"
+            },
+            "plan": {
+              "$ref": "#/$defs/verbosity_value"
+            },
+            "execute": {
+              "$ref": "#/$defs/verbosity_value"
+            },
+            "review": {
+              "$ref": "#/$defs/verbosity_value"
+            },
+            "handoff": {
+              "$ref": "#/$defs/verbosity_value"
+            }
           },
           "additionalProperties": false
         },
         "max_context_policy": {
           "type": "string",
-          "enum": ["compact", "standard", "expanded"],
+          "enum": [
+            "compact",
+            "standard",
+            "expanded"
+          ],
           "description": "context budget policy。compact=コスト優先 / standard=標準 / expanded=長文許容"
         },
         "tool_policy": {
           "type": "string",
-          "enum": ["narrow", "allowed_tools_by_phase", "expanded"],
+          "enum": [
+            "narrow",
+            "allowed_tools_by_phase",
+            "expanded"
+          ],
           "description": "interface-preflight.md で合意した tool_policy 値域。実 tool セット射影は PBI-116-06 の docs/ai/tool-policy.md に従う"
         },
         "validation_bias": {
           "type": "string",
-          "enum": ["lenient", "normal", "strict"],
+          "enum": [
+            "lenient",
+            "normal",
+            "strict"
+          ],
           "description": "interface-preflight.md で合意した validation_bias 値域。strict 時の追加 Hook 条件は PBI-116-06 の docs/ai/hook-enforcement.md に従う"
         },
         "structured_outputs": {
@@ -113,29 +177,185 @@
         },
         "adapter": {
           "type": "string",
-          "enum": ["outcome_first", "outcome_first_strict", "explicit_short", "legacy_or_unknown"],
+          "enum": [
+            "outcome_first",
+            "outcome_first_strict",
+            "explicit_short",
+            "legacy_or_unknown"
+          ],
           "description": "Prompt Assembly (PBI-116-03) で使用する adapter 種別"
         },
         "disallowed_modes": {
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["ultra_light", "light", "standard", "high_risk", "critical"]
+            "enum": [
+              "ultra_light",
+              "light",
+              "standard",
+              "high_risk",
+              "critical"
+            ]
           },
           "uniqueItems": true,
           "description": "本プロファイルで禁止する PlanGate mode（例: gpt-5_mini で critical を disallow）"
+        },
+        "edit_interface_preference": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "v2: モデルが得意な編集形式（PBI-HI-003 / #197）",
+          "required": [
+            "primary"
+          ],
+          "properties": {
+            "primary": {
+              "enum": [
+                "patch",
+                "string_replace",
+                "full_file"
+              ],
+              "type": "string"
+            },
+            "fallback": {
+              "enum": [
+                "patch",
+                "string_replace",
+                "full_file"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "retry_strategy": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "v2: 失敗時の回復方針。対象 category は docs/ai/tool-error-taxonomy.md(#203)が正本、本欄は方針/回数/待機（#197）",
+          "properties": {
+            "on_edit_failure": {
+              "enum": [
+                "reread_then_retry_small_diff",
+                "retry_same",
+                "escalate"
+              ],
+              "type": "string"
+            },
+            "on_test_failure": {
+              "enum": [
+                "inspect_error_then_fix",
+                "retry_same",
+                "escalate"
+              ],
+              "type": "string"
+            },
+            "max_retries": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10,
+              "description": "retryable の自動再試行上限（超過で soft_warning 降格）。未指定時は保守的既定 1（tool-error-taxonomy §7）"
+            },
+            "backoff": {
+              "enum": [
+                "none",
+                "linear",
+                "exponential"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "context_acquisition": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "v2: 初期コンテキスト取得戦略（Dynamic Context Engine #199 実装は別 PBI・Non-goal）",
+          "required": [
+            "strategy"
+          ],
+          "properties": {
+            "strategy": {
+              "enum": [
+                "dynamic_first",
+                "eager",
+                "lazy"
+              ],
+              "type": "string"
+            },
+            "initial_context_budget": {
+              "enum": [
+                "compact",
+                "standard",
+                "expanded"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "provider_capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "v2: provider の機能可否（判定根拠。runtime 実装は別 PBI）",
+          "properties": {
+            "supports_patch": {
+              "type": "boolean"
+            },
+            "supports_string_replace": {
+              "type": "boolean"
+            },
+            "supports_parallel_subagents": {
+              "type": "boolean"
+            }
+          }
+        },
+        "telemetry_tags": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "v2: 公開安全な provider/世代ラベル（固定 enum・free-form 不可。metrics-privacy §4: 鍵/アカウントID/社内モデル名は構造上排除）",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": [
+                "openai",
+                "anthropic",
+                "claude_code",
+                "codex",
+                "unknown"
+              ],
+              "description": "provider 種別（固定 enum・拡張は本 schema 改訂で additive）"
+            },
+            "generation": {
+              "type": "string",
+              "enum": [
+                "gpt-5.5",
+                "gpt-5.5-pro",
+                "gpt-5-mini",
+                "legacy",
+                "unknown"
+              ],
+              "description": "公開可能な世代ラベル（固定 enum registry。新世代追加は versioning-stability-policy §2.1 enum 追加=minor）"
+            }
+          }
         }
       },
       "additionalProperties": false
     },
     "effort_enum": {
       "type": "string",
-      "enum": ["low", "medium", "high", "xhigh"]
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "xhigh"
+      ]
     },
-    "effort_value": { "$ref": "#/$defs/effort_enum" },
+    "effort_value": {
+      "$ref": "#/$defs/effort_enum"
+    },
     "verbosity_value": {
       "type": "string",
-      "enum": ["low", "medium", "high"]
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
     }
   }
 }


### PR DESCRIPTION
## 概要
#197 を standard で実装。モデル別実行特性（編集形式/回復/文脈取得/capability/telemetry）を Model Profile v2 に閉じ込め、プロンプト全文 fork を回避（v1 後方互換維持）。

## 変更
- `schemas/model-profile.schema.json`: `version` const1→**enum[1,2]**（v1 維持）+ `$defs/profile` に 5 **optional** フィールド追加（required 不変＝既存 v1 profile は無変更で valid）
- `docs/ai/model-profiles.yaml`: 4 profile を **v2 移行**（version:2）。`legacy_or_unknown` は escalate / lazy / patch非対応 / max_retries:0 で安全側
- `docs/ai/model-profiles.md` §8-bis: v2 doc（retry 責務分離=#203正本/回数待機=profile、telemetry 固定 enum registry、#196 v1↔v2 比較、Core Contract/Gate/Artifact schema 不変）

## 前方参照依存（重要）
retry 対象 category 正本=**#203/PR #269**、v1↔v2 比較 CLI=**#196/PR #268**。推奨マージ順: PR #268・#269 → 本 PR（未マージでも schema/yaml/doc は単独有効）。

## V-1 / V-3
- V-1: AC1-8 + E1（v1 後方互換）/E2（telemetry pattern→enum）全 PASS（jsonschema 機械検証）
- V-3（Codex）: critical 0 / major 1 / minor 2 → **全反映**（telemetry 固定 enum 化で privacy §4 構造排除 / yaml v2 所属修正 / legacy max_retries:0）、回帰 PASS

## Non-goals 遵守
プロンプト全文 fork / provider runtime 全面刷新 / Cursor等完全実装 / Dynamic Context Engine / Keep Rate — いずれも未実装

## Mode
standard（feat・schema v2 additive + 設定移行 + doc）

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)