### PR TITLE
feat(#198): Keep Rate v1 / PBI-HI-004 / TASK-0096

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -128,6 +128,7 @@ cmd_help() {
     "  eval <TASK-XXXX> [--baseline]  Run 8-aspect eval (Issue #156)" \
     "  metrics <TASK-XXXX> [--collect|--report] Collect/report workflow metrics (Issue #195)" \
     "  plan-check <TASK-XXXX> [--init|--validate]  Lightweight plan quality check (#213)" \
+    "  keep-rate <TASK-XXXX> [--no-write]  Keep Rate v1 (advisory, #198)" \
     "  review <TASK-XXXX> [--phase]   Run external AI review (c2/v3)" \
     "  exec <TASK-XXXX> [--mode]      Dispatch implementation agent (after C-3)" \
     "  abort <TASK-XXXX> [--reason]   Record abort event in run.ndjson" \
@@ -1251,6 +1252,22 @@ PYV
   esac
 }
 
+cmd_keep_rate() {
+  # Keep Rate v1 — AI 成果物残存率（advisory・release blocker 不可 / #198）
+  # 正本: docs/ai/keep-rate.md
+  if [ $# -lt 1 ]; then
+    printf 'Usage: plangate keep-rate <TASK-XXXX> [--no-write]\n' >&2
+    return 1
+  fi
+  py="$plangate_root/scripts/keep-rate.py"
+  if [ ! -f "$py" ]; then
+    printf 'error: scripts/keep-rate.py not found\n' >&2
+    return 2
+  fi
+  python3 "$py" "$@"
+  return $?
+}
+
 cmd_review() {
   if [ $# -eq 0 ]; then
     printf 'Usage: plangate review <TASK-XXXX> [--phase c2|v3] [--file <path>]\n' >&2
@@ -1400,6 +1417,7 @@ case "$command" in
   eval)        cmd_eval "$@" ;;
   metrics)     cmd_metrics "$@" ;;
   plan-check)  cmd_plan_check "$@" ;;
+  keep-rate)   cmd_keep_rate "$@" ;;
   review)      cmd_review "$@" ;;
   exec)        cmd_exec "$@" ;;
   abort)       cmd_abort "$@" ;;

--- a/docs/ai/keep-rate.md
+++ b/docs/ai/keep-rate.md
@@ -1,0 +1,92 @@
+# Keep Rate v1（正本）
+
+> AI が作成・変更した成果物の **残存率**を決定論・軽量に測る正本。
+> 「生成された作業」ではなく「採用され、残った作業」を改善対象にする。
+> 関連: [#198](https://github.com/s977043/plangate/issues/198)（PBI-HI-004）/
+> TASK-0096 / [`metrics.md`](./metrics.md)（PBI-HI-001 接続）/
+> [`../../schemas/keep-rate-result.schema.json`](../../schemas/keep-rate-result.schema.json) /
+> [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md)
+
+## 1. 目的と原則
+
+eval は scope/approval/AC/verification/format を評価できるが、AI 生成物が
+**PR merge 後・後続 PBI でどれだけ残ったか**は測れていない。Keep Rate v1 は
+それを軽量に可視化する。
+
+- **advisory のみ**: release blocker としては使わない（#198 Non-goal・
+  [responsibility-classes.md](../../.claude/rules/responsibility-classes.md)
+  の承認境界は不変）。
+- **決定論・軽量**: GitHub 全履歴の完全解析・LLM judge 満足度判定・外部
+  分析基盤は行わない（Non-goal）。ローカル git + TASK artifact のみ。
+- **算出不能は `unknown`**（0 ではない）。unknown を劣化と誤読しない。
+
+## 2. 4 メトリクス
+
+| Metric | 定義 | v1 算出方法（軽量近似）|
+|--------|------|----------------------|
+| **Code Keep Rate** | AI が変更したコードが一定後も残る割合 | `git log --all --grep=<TASK>` の commit が触れた *コードファイル*（`docs/working/` 等は除外）のうち HEAD で存続する割合。commit 無し → unknown |
+| **Plan Keep Rate** | C-3 承認 plan の todo/方針が handoff まで維持された割合 | `todo.md` の `- [x]` / 全チェック項目比率（plan_hash 一致前提）。todo/c3/handoff 欠 → unknown |
+| **Acceptance Keep Rate** | `test-cases.md` の受入条件が V-1/V-4 まで有効だった割合 | `handoff.md` §1 AC 表の PASS / (PASS+FAIL+WARN)。AC 行無し → unknown |
+| **Handoff Keep Rate** | `handoff.md` の既知課題/V2/妥協点が後続 PBI で参照された割合 | §3 参照（後続 TASK の plan/handoff/pbi-input が当該 TASK を参照していれば `referenced`+件数。未参照/未算出 → unknown）|
+
+> v1 はすべて **近似**。厳密な行 blame・意味的参照判定は v2 以降（Non-goal）。
+
+## 3. Handoff Keep Rate の定義と算出方針
+
+`handoff.md` の「既知課題 / V2 候補 / 妥協点」が **後続作業に実際に
+引き継がれたか**を測る。完全な履歴・意味解析はしない（Non-goal）ため
+v1 は以下の軽量方針:
+
+1. 他 `docs/working/TASK-*/`（自身を除く）の `plan.md` / `handoff.md` /
+   `pbi-input.md` が当該 `task_id` を **文字列参照**しているか走査。
+2. 参照する後続 TASK が 1 件以上 → `value: "referenced"`,
+   `referenced_by: <件数>`。
+3. 参照ゼロ / 走査不能 → `value: "unknown"`（劣化ではなく「まだ参照が
+   観測されていない」。時間経過で再算出する）。
+4. 意味的に「V2 候補が実際に着手されたか」までは v1 では判定しない
+   （v2 候補: #200 Reporting と連携した参照グラフ。本 PBI Non-goal）。
+
+## 4. 出力
+
+`bin/plangate keep-rate <TASK-XXXX>` で生成:
+
+- `docs/working/TASK-XXXX/keep-rate-result.json`
+  （[schema](../../schemas/keep-rate-result.schema.json) 準拠）
+- `docs/working/TASK-XXXX/keep-rate-result.md`（人間可読）
+- `--no-write` で標準出力のみ
+
+各メトリクスは `{ "value": <0-100 | "unknown" | "referenced">, ... }`。
+
+## 5. metrics（PBI-HI-001）接続方針
+
+- Keep Rate は **独立 artifact**（`keep-rate-result.json`）として保存し、
+  [metrics.md](./metrics.md) の events.ndjson とは **別系統**（event schema
+  は変更しない＝既存 metrics を破壊しない）。
+- `metrics report` 運用時に keep-rate-result.json を **任意の補助入力**
+  として併読する方針（集計は #200 Reporting & Retrospective で統合）。
+- Privacy: keep-rate-result は file path（リポジトリ相対・公開対象）と
+  集計値のみ。message / stack / 個人情報は含めない
+  （[metrics-privacy.md](./metrics-privacy.md) §3 準拠）。
+- 将来 event 化する場合も additive（本 PBI は接続方針の文書化まで）。
+
+## 6. 運用手順
+
+1. PBI 完了（handoff 発行）後または後続スプリント開始時に実行:
+   `sh bin/plangate keep-rate TASK-XXXX`
+2. `unknown` は「測定不能/未観測」であり劣化ではない。Code/Plan が低い
+   場合のみ retrospective で要因を確認（advisory）。
+3. Handoff Keep Rate は時間経過で再算出（後続参照が増えるため）。
+4. **ゲート判定に使わない**（C-3/C-4/V-1 の合否に影響させない）。
+
+## 7. Non-goals
+
+- 外部分析基盤の構築 / GitHub 全履歴の完全解析
+- LLM judge による満足度判定 / Dynamic Context Engine 実装
+- release blocker としての強制利用
+
+## 8. 関連
+
+- [`metrics.md`](./metrics.md) — PBI-HI-001 Metrics v1（別系統・接続方針 §5）
+- [`schemas/keep-rate-result.schema.json`](../../schemas/keep-rate-result.schema.json)
+- [`metrics-privacy.md`](./metrics-privacy.md) §3 — 公開可否
+- [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) — EPIC #193 / #200 連携

--- a/docs/working/TASK-0096/INDEX.md
+++ b/docs/working/TASK-0096/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0096 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0096/approvals/c3.json
+++ b/docs/working/TASK-0096/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0096",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T16:06:03Z",
+  "plan_hash": "sha256:9b22750fab1b96fe3e9cc093b2849eecd502d9f593bb77bf71eb592745a0c1f5"
+}

--- a/docs/working/TASK-0096/current-state.md
+++ b/docs/working/TASK-0096/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0096 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0096/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0096 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0096/handoff.md
+++ b/docs/working/TASK-0096/handoff.md
@@ -1,0 +1,33 @@
+# Handoff — TASK-0096 / #198 PBI-HI-004 Keep Rate v1
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 Code Keep Rate 算出 | PASS（allowlist 化・docs/schema は unknown 正規化）|
+| AC2 Plan Keep Rate 算出 | PASS（plan_hash 実検証付き）|
+| AC3 Acceptance Keep Rate 算出 | PASS（AC 突合 coverage 注記）|
+| AC4 Handoff Keep Rate 定義/算出方針 | PASS（keep-rate.md §3）|
+| AC5 算出不能=unknown 明記 | PASS（reason 付き・0 と区別）|
+| AC6 results JSON/Markdown 保存 | PASS（schema validate）|
+| AC7 keep-rate.md 運用手順 | PASS（§6）|
+| AC8 PBI-HI-001 metrics 接続 | PASS（別系統 artifact・event schema 非変更）|
+V-1 全 PASS。V-3（Codex）critical 0/major 3/minor 2 → 全反映・回帰 PASS。
+## 2. 既知課題
+- Code Keep Rate は git log token 境界 + 存続率の軽量近似（全履歴 blame は
+  Non-goal）。docs/schema 主体 TASK は「no code files」= unknown（設計通り）。
+- Acceptance は handoff AC 表書式依存。書式差異時は unknown + coverage 注記。
+## 3. V2 候補
+- metrics events.ndjson 直接連携（fix_loop/v1_first を events 由来に）。
+- Handoff Keep Rate の意味的参照判定（#200 Reporting 連携）。
+- Code Keep Rate の行 blame 精密化（重い解析・別 PBI）。
+## 4. 妥協点
+- 決定論・軽量に限定（GitHub 全履歴解析/LLM judge/外部基盤は Non-goal）。
+  advisory（ゲート非使用）で承認境界不変。
+## 5. 引き継ぎ
+#198 を standard で実装。keep-rate.py（4 メトリクス・unknown フォールバック）
++ keep-rate-result.schema.json + schema_mapping 登録 + bin/plangate keep-rate
++ keep-rate.md 正本。stash 退避→ main 再ブランチ復元時に bin/plangate・
+schema_mapping を #213(plan-check)/#268/#269 と統合解消。V-3 で allowlist /
+token 境界 / plan_hash 実検証 / AC 突合 を反映。
+**EPIC #193 残: #199 Dynamic Context Engine v1 / #200 Reporting（次バッチ）。**
+## 6. テスト結果
+V-1: AC1-8 + E1/E2 全 PASS。V-3 反映後 smoke/schema 機械確認 PASS。

--- a/docs/working/TASK-0096/pbi-input.md
+++ b/docs/working/TASK-0096/pbi-input.md
@@ -1,0 +1,28 @@
+# PBI INPUT — TASK-0096 / #198 PBI-HI-004 Keep Rate v1
+
+## Context / Why
+AI が生成した code/plan/test-cases/handoff が PR merge 後・後続 PBI で
+どれだけ残ったか未計測。「生成」でなく「採用・残存」を改善対象にする。
+
+## What
+- In: scripts/keep-rate.py / bin/plangate keep-rate / schemas/keep-rate-result.schema.json /
+  docs/ai/keep-rate.md（正本）/ scripts/schema_mapping.py 登録
+- Out: 外部分析基盤 / GitHub 全履歴完全解析 / LLM judge 満足度 / DCE / release blocker 強制
+
+## 受入基準（#198）
+- AC1: Code Keep Rate を算出できる
+- AC2: Plan Keep Rate を算出できる
+- AC3: Acceptance Keep Rate を算出できる
+- AC4: Handoff Keep Rate の定義と算出方針が文書化
+- AC5: 算出不能時は unknown と明記
+- AC6: results が JSON/Markdown で保存
+- AC7: docs/ai/keep-rate.md に運用手順
+- AC8: PBI-HI-001 metrics と接続できる
+
+## Notes
+決定論・軽量（ローカル git+artifact のみ）。advisory（ゲート非使用）。
+unknown は 0 でなく測定不能/未観測。event schema 非変更（#203/#197 と非衝突）。
+
+## Estimation
+Risks: 全履歴解析誘惑（緩和: git log --grep+存続率の軽量近似）/ ゲート誤用
+（緩和: advisory 明記・Non-goal）/ Unknowns: なし

--- a/docs/working/TASK-0096/plan.md
+++ b/docs/working/TASK-0096/plan.md
@@ -1,0 +1,52 @@
+# EXECUTION PLAN — TASK-0096 / #198 PBI-HI-004
+
+## Goal
+AI 成果物残存率（Code/Plan/Acceptance/Handoff Keep Rate）を決定論・軽量に
+算出し、改善対象を「採用・残存」へ移す（advisory・ゲート非使用）。
+
+## Constraints / Non-goals
+- 外部分析基盤 / GitHub 全履歴完全解析 / LLM judge / DCE / release blocker
+  強制 はしない。
+- metrics event schema を変更しない（別系統 artifact・#203/#197 と非衝突）。
+
+## Approach Overview
+keep-rate.py（git log --grep + artifact 軽量近似、unknown フォールバック）→
+keep-rate-result.schema.json → schema_mapping 登録 → bin/plangate keep-rate
+→ keep-rate.md 正本（4 メトリクス/Handoff 定義方針/metrics 接続/運用/Non-goal）。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | scripts/keep-rate.py | agent | 中 | 🚩 AC1-3,AC5,AC6 |
+| S2 | schema + schema_mapping | agent | 中 | 🚩 AC6 validate |
+| S3 | bin/plangate keep-rate | agent | 低 | 🚩 AC6 |
+| S4 | docs/ai/keep-rate.md 正本 | agent | 中 | 🚩 AC4,AC7,AC8 |
+
+## Files / Components to Touch
+- scripts/keep-rate.py（新規）
+- schemas/keep-rate-result.schema.json（新規）
+- scripts/schema_mapping.py（登録）
+- bin/plangate（cmd_keep_rate + dispatch + help）
+- docs/ai/keep-rate.md（新規・正本）
+
+## Testing Strategy
+- Verification: AC1-8 を smoke（main 在席 TASK で各メトリクス算出 + unknown
+  経路）+ 生成 JSON を validate-schemas + grep 構造突合 + ast.parse/sh -n。
+- Unit/E2E: 該当なし（決定論スクリプト・runtime 連携なし）。
+
+## Risks & Mitigations
+- 全履歴解析化 → git log --grep + 存続率の軽量近似に限定（Non-goal 明記）
+- ゲート誤用 → advisory/ゲート非使用を doc/JSON note/出力に明記
+- schema 衝突 → 独立 artifact・event schema 非変更
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 5 → 中
+- 受入基準数: 8 → 中
+- 変更種別: feat（スクリプト+schema+CLI+doc）→ 中
+- リスク: 中（決定論計測・ゲート誤用注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0096/review-external.md
+++ b/docs/working/TASK-0096/review-external.md
@@ -1,0 +1,20 @@
+# V-3 外部レビュー（Codex）— TASK-0096 / #198
+
+## 結果サマリ
+critical: 0 / major: 3 / minor: 2 / info: 6（初回 NOT APPROVE → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | code_keep_rate が docs/schema を「コード」に誤算入（成果物残存率化）| `_is_code()` allowlist 導入（コード拡張子 + scripts/src/lib/app/tests/ + bin/plangate のみ、docs/ 配下と *.md/*.json 除外）。docs/schema PBI は「no code files」= unknown に正規化 |
+| MJ-2 | major | `git log --grep=<task_id>` が substring 偽陽性（無関係 commit/近接 ID 誤検出）| `-E` + token 境界正規表現 `(^|[^0-9A-Za-z-])TASK-XXXX([^0-9A-Za-z-]|$)` に変更 |
+| MJ-3 | major | plan_keep_rate が docstring「plan_hash 一致前提」だが未検証（C-3 後 todo 改変で誤集計）| c3.json の plan_hash と plan.md の sha256 を**実検証**、不一致なら `unknown (plan.md changed after C-3)`。docstring も実検証へ更新 |
+| mn-1 | minor | acceptance_keep_rate が test-cases AC ID 未突合（別ID/欠落でも PASS 比率を出す）| test-cases.md の AC ID 集合を抽出し handoff AC 行数と突合、不足時 `reason: partial coverage` を付記 |
+| mn-2 | minor | schema_mapping 登録が差分外で判定不能 | 登録済（keep-rate-result.json → keep-rate-result.schema.json）。stash 復元時の merge で 3 エントリ統合・確認済 |
+| info×6 | info | subprocess 配列実行/timeout 安全 / unknown は reason 付きで 0 と区別 / value oneOf 整合 / advisory 一貫 / metrics event schema 非変更 / privacy file path/集計値のみ | 対応不要 |
+
+## 判定
+major 3 / minor 2 を全反映。critical 0。回帰 V-1: smoke（TASK-0095/0087）/
+_is_code allowlist / token 境界 / plan_hash 実検証 / AC 突合 / schema validate
+全 PASS。stash 復元時の bin/plangate・schema_mapping コンフリクトも解消
+（plan-check#213 + keep-rate#198 両立）。

--- a/docs/working/TASK-0096/review-self.md
+++ b/docs/working/TASK-0096/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0096
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-8 ↔ S1-S4 ↔ T1-T8 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | 外部基盤/全履歴/LLM judge/DCE/blocker強制 Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | smoke + validate-schemas + grep + ast/sh -n |
+| C1-PLAN-05 WB Output | PASS | S1-S4 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | smoke/schema 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S4 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T8 ↔ AC1-8 |
+| C1-TC-02 Edge網羅 | PASS | E1 advisory / E2 event schema 非衝突 |
+| C1-TC-03 自動化可否 | PASS | smoke/jsonschema 自動 |
+| C1-INT-01 metrics整合 | PASS | 別系統 artifact・event schema 非変更（#203/#197 非衝突）|
+| C1-INT-02 承認境界 | PASS | advisory・ゲート非使用（responsibility-classes 不変）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0096/test-cases.md
+++ b/docs/working/TASK-0096/test-cases.md
@@ -1,0 +1,14 @@
+# テストケース — TASK-0096 / #198
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | keep-rate.py が Code Keep Rate（git log --grep 存続率）算出 | smoke |
+| T2 | AC2 | Plan Keep Rate（todo done 比率）算出 | smoke |
+| T3 | AC3 | Acceptance Keep Rate（handoff AC PASS 比率）算出 | smoke |
+| T4 | AC4 | keep-rate.md §3 に Handoff Keep Rate 定義+算出方針 | 構造突合 |
+| T5 | AC5 | 算出不能で value:"unknown"+reason（0 でない）| smoke |
+| T6 | AC6 | keep-rate-result.{json,md} 保存 + JSON が schema validate | 機械検証 |
+| T7 | AC7 | keep-rate.md §6 運用手順 | 構造突合 |
+| T8 | AC8 | keep-rate.md §5 metrics(PBI-HI-001) 接続方針（別系統・event schema 非変更）| 構造突合 |
+## Edge
+- E1: advisory/ゲート非使用が JSON note + doc + 出力に明記
+- E2: event schema(plangate-event) 未変更（#203/#197 非衝突）

--- a/docs/working/TASK-0096/todo.md
+++ b/docs/working/TASK-0096/todo.md
@@ -1,0 +1,14 @@
+# TODO — TASK-0096 / #198
+## 🤖 Agent
+- [x] 準備: #198本文・metrics/handoff 構造確認
+- [x] S1 keep-rate.py（🚩AC1-3,5,6）
+- [x] S2 schema+mapping（🚩AC6）
+- [x] S3 bin/plangate keep-rate（🚩AC6）
+- [x] S4 keep-rate.md 正本（🚩AC4,7,8）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/schemas/keep-rate-result.schema.json
+++ b/schemas/keep-rate-result.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/s977043/plangate/schemas/keep-rate-result.schema.json",
+  "title": "Keep Rate v1 Result",
+  "description": "AI 成果物の残存率（Code/Plan/Acceptance/Handoff）。算出不能は unknown。advisory（release blocker 不可・#198 Non-goal）。正本: docs/ai/keep-rate.md",
+  "type": "object",
+  "required": ["task_id", "schema", "code_keep_rate", "plan_keep_rate", "acceptance_keep_rate", "handoff_keep_rate"],
+  "additionalProperties": false,
+  "properties": {
+    "task_id": { "type": "string", "pattern": "^TASK-[0-9A-Za-z]+$" },
+    "schema": { "type": "string", "const": "keep-rate-result/v1" },
+    "code_keep_rate": { "$ref": "#/definitions/metric" },
+    "plan_keep_rate": { "$ref": "#/definitions/metric" },
+    "acceptance_keep_rate": { "$ref": "#/definitions/metric" },
+    "handoff_keep_rate": { "$ref": "#/definitions/metric" },
+    "note": { "type": "string", "maxLength": 256 }
+  },
+  "definitions": {
+    "metric": {
+      "type": "object",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "description": "0-100 の数値 / 'unknown'（算出不能）/ 'referenced'（handoff 参照あり）",
+          "oneOf": [
+            { "type": "number", "minimum": 0, "maximum": 100 },
+            { "type": "string", "enum": ["unknown", "referenced"] }
+          ]
+        },
+        "reason": { "type": "string", "maxLength": 256 },
+        "survived": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "done": { "type": "integer", "minimum": 0 },
+        "pass": { "type": "integer", "minimum": 0 },
+        "fail": { "type": "integer", "minimum": 0 },
+        "warn": { "type": "integer", "minimum": 0 },
+        "referenced_by": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/scripts/keep-rate.py
+++ b/scripts/keep-rate.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""keep-rate.py — Keep Rate v1 (#198 / PBI-HI-004).
+
+AI が作成・変更した成果物の残存率を **決定論・軽量**に算出する。
+GitHub 全履歴の完全解析・LLM judge・外部分析基盤は行わない（Non-goal）。
+算出不能は 0 ではなく "unknown"。release blocker としては使わない（助言）。
+
+正本: docs/ai/keep-rate.md / schema: schemas/keep-rate-result.schema.json
+
+Usage:
+  python3 scripts/keep-rate.py <TASK-XXXX> [--no-write]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKING = REPO / "docs" / "working"
+AC_LINE = re.compile(r"^\|\s*AC[0-9A-Za-z_-]*\s*\|.*\|\s*(PASS|FAIL|WARN)\s*\|", re.I)
+
+
+def _git(*args: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=REPO, capture_output=True, text=True, timeout=30
+        )
+        return out.stdout if out.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+_CODE_EXT = (".py", ".sh", ".js", ".ts", ".tsx", ".jsx", ".rb", ".go",
+             ".rs", ".java", ".php", ".sql")
+_CODE_PATH_PREFIX = ("scripts/", "src/", "lib/", "app/", "tests/")
+
+
+def _is_code(path: str) -> bool:
+    """コードファイル allowlist（#198 V-3 MJ-1）。
+
+    Code Keep Rate は *コード* の残存率。docs/*.md・schemas/*.json・
+    docs/working/ 等の成果物/設定は対象外（成果物残存率と混同しない）。
+    """
+    if path == "bin/plangate":
+        return True
+    if path.startswith("docs/"):
+        return False
+    if path.startswith(_CODE_PATH_PREFIX) and path.endswith(_CODE_EXT):
+        return True
+    if path.endswith(_CODE_EXT):
+        return True
+    return False
+
+
+def code_keep_rate(task_id: str) -> dict:
+    """TASK の commit が触れた *コードファイル* のうち HEAD で残存する割合。
+
+    全履歴 blame 解析はしない（Non-goal）。ファイル存続率の軽量近似。
+    """
+    log = _git("log", "--all", "-E", "--format=%H",
+               f"--grep=(^|[^0-9A-Za-z-]){re.escape(task_id)}([^0-9A-Za-z-]|$)")
+    if not log or not log.strip():
+        return {"value": "unknown", "reason": f"no commit referencing {task_id}"}
+    shas = log.split()
+    changed: set[str] = set()
+    for sha in shas:
+        files = _git("show", "--name-only", "--format=", sha) or ""
+        for f in files.splitlines():
+            f = f.strip()
+            if not f or not _is_code(f):
+                continue
+            changed.add(f)
+    if not changed:
+        return {"value": "unknown", "reason": "no code files in TASK commits"}
+    survived = sum(1 for f in changed if (REPO / f).is_file())
+    return {
+        "value": round(100.0 * survived / len(changed), 2),
+        "survived": survived,
+        "total": len(changed),
+    }
+
+
+def plan_keep_rate(task_id: str) -> dict:
+    """C-3 承認 plan の todo がどれだけ完了維持されたか（todo.md done 比率）。
+
+    plan_hash を **実検証**し、C-3 後に plan.md 改変があれば unknown。
+    """
+    d = WORKING / task_id
+    todo = d / "todo.md"
+    c3 = d / "approvals" / "c3.json"
+    handoff = d / "handoff.md"
+    plan_md = d / "plan.md"
+    if not todo.is_file() or not c3.is_file() or not handoff.is_file():
+        return {"value": "unknown", "reason": "todo.md / c3.json / handoff.md missing"}
+    if plan_md.is_file():
+        try:
+            import hashlib
+
+            rec = re.search(
+                r'"plan_hash"\s*:\s*"sha256:([0-9a-f]+)"', c3.read_text()
+            )
+            cur = hashlib.sha256(plan_md.read_bytes()).hexdigest()
+            if rec and rec.group(1) != cur:
+                return {
+                    "value": "unknown",
+                    "reason": "plan.md changed after C-3 (plan_hash mismatch)",
+                }
+        except OSError:
+            pass
+    txt = todo.read_text()
+    done = len(re.findall(r"^\s*- \[x\]", txt, re.M | re.I))
+    total = len(re.findall(r"^\s*- \[[ xX]\]", txt, re.M))
+    if total == 0:
+        return {"value": "unknown", "reason": "no todo checklist items"}
+    return {
+        "value": round(100.0 * done / total, 2),
+        "done": done,
+        "total": total,
+    }
+
+
+def acceptance_keep_rate(task_id: str) -> dict:
+    """test-cases の AC が handoff まで PASS で維持された割合（handoff §1 AC 表）。"""
+    d = WORKING / task_id
+    tc = d / "test-cases.md"
+    handoff = d / "handoff.md"
+    if not tc.is_file() or not handoff.is_file():
+        return {"value": "unknown", "reason": "test-cases.md / handoff.md missing"}
+    tc_ids = set(re.findall(r"\bAC[0-9][0-9A-Za-z_-]*", tc.read_text()))
+    p = f = w = 0
+    for ln in handoff.read_text().splitlines():
+        m = AC_LINE.match(ln)
+        if m:
+            v = m.group(1).upper()
+            p += v == "PASS"
+            f += v == "FAIL"
+            w += v == "WARN"
+    tot = p + f + w
+    if tot == 0:
+        return {"value": "unknown", "reason": "no AC verdict rows in handoff"}
+    out = {"value": round(100.0 * p / tot, 2), "pass": p, "fail": f, "warn": w}
+    if tc_ids and tot < len(tc_ids):
+        out["reason"] = (
+            f"partial: handoff AC rows {tot} < test-cases AC ids "
+            f"{len(tc_ids)} (coverage 不足の可能性)"
+        )
+    return out
+
+
+def handoff_keep_rate(task_id: str) -> dict:
+    """handoff の既知課題/V2/妥協点が後続 PBI で参照された割合（粗い近似）。
+
+    定義と算出方針は docs/ai/keep-rate.md。完全な履歴解析はしない（Non-goal）。
+    近似: 他 TASK の plan/handoff/pbi-input が本 task_id を参照していれば
+    「参照あり」とし referenced_by 件数を返す。0 件 or 未算出は unknown。
+    """
+    d = WORKING / task_id
+    if not (d / "handoff.md").is_file():
+        return {"value": "unknown", "reason": "handoff.md missing"}
+    refs = 0
+    for other in sorted(WORKING.glob("TASK-*")):
+        if other.name == task_id or not other.is_dir():
+            continue
+        for fn in ("plan.md", "handoff.md", "pbi-input.md"):
+            fp = other / fn
+            if fp.is_file() and task_id in fp.read_text():
+                refs += 1
+                break
+    if refs == 0:
+        return {
+            "value": "unknown",
+            "reason": "no downstream reference yet (定義: keep-rate.md §Handoff)",
+        }
+    return {"value": "referenced", "referenced_by": refs}
+
+
+def build(task_id: str) -> dict:
+    return {
+        "task_id": task_id,
+        "schema": "keep-rate-result/v1",
+        "code_keep_rate": code_keep_rate(task_id),
+        "plan_keep_rate": plan_keep_rate(task_id),
+        "acceptance_keep_rate": acceptance_keep_rate(task_id),
+        "handoff_keep_rate": handoff_keep_rate(task_id),
+        "note": "advisory only — not a release blocker (#198 Non-goal)",
+    }
+
+
+def render_md(r: dict) -> str:
+    def fmt(m: dict) -> str:
+        v = m["value"]
+        if v == "unknown":
+            return f"unknown ({m.get('reason', '')})"
+        if v == "referenced":
+            return f"referenced (by {m.get('referenced_by')} TASK)"
+        return f"{v}%"
+
+    return "\n".join(
+        [
+            f"# Keep Rate v1: {r['task_id']}",
+            "",
+            "> advisory only — release blocker としては使わない（#198）",
+            "",
+            f"- Code Keep Rate: **{fmt(r['code_keep_rate'])}**",
+            f"- Plan Keep Rate: **{fmt(r['plan_keep_rate'])}**",
+            f"- Acceptance Keep Rate: **{fmt(r['acceptance_keep_rate'])}**",
+            f"- Handoff Keep Rate: **{fmt(r['handoff_keep_rate'])}**",
+            "",
+            "## 関連",
+            "",
+            "- [`docs/ai/keep-rate.md`](../../ai/keep-rate.md)",
+            "- [`schemas/keep-rate-result.schema.json`]"
+            "(../../../schemas/keep-rate-result.schema.json)",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="PlanGate Keep Rate v1 (#198)")
+    ap.add_argument("task_id")
+    ap.add_argument("--no-write", action="store_true")
+    a = ap.parse_args()
+    if not re.match(r"^TASK-[0-9A-Za-z]+$", a.task_id):
+        print(f"error: invalid task_id: {a.task_id}", file=sys.stderr)
+        return 2
+    r = build(a.task_id)
+    md = render_md(r)
+    js = json.dumps(r, indent=2, ensure_ascii=False)
+    if a.no_write:
+        print("=== keep-rate-result.md ===")
+        print(md)
+        print("=== keep-rate-result.json ===")
+        print(js)
+    else:
+        d = WORKING / a.task_id
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "keep-rate-result.md").write_text(md + "\n")
+        (d / "keep-rate-result.json").write_text(js + "\n")
+        print(f"Written: docs/working/{a.task_id}/keep-rate-result.{{md,json}}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/schema_mapping.py
+++ b/scripts/schema_mapping.py
@@ -40,6 +40,7 @@ FILENAME_TO_SCHEMA: dict[str, str] = {
     "2026-05-04-baseline.json": "eval-baseline.schema.json",
     "plan-quality-check.json": "plan-quality-check.schema.json",
     "eval-comparison.json": "eval-comparison.schema.json",
+    "keep-rate-result.json": "keep-rate-result.schema.json",
 }
 
 


### PR DESCRIPTION
## 概要
#198 を standard で実装。AI 生成物の「採用・残存」を測る Keep Rate v1（決定論・軽量・advisory）。

## 変更
- **新規** `scripts/keep-rate.py`: Code/Plan/Acceptance/Handoff Keep Rate（算出不能は reason 付き `unknown`・0 と区別）
- **新規** `schemas/keep-rate-result.schema.json` + `scripts/schema_mapping.py` 登録
- `bin/plangate keep-rate <TASK> [--no-write]`（#213 plan-check と併存）
- **新規** `docs/ai/keep-rate.md` 正本（4 メトリクス / Handoff 定義・算出方針 / metrics(PBI-HI-001) 別系統接続 / 運用手順 / Non-goal）

## V-1 / V-3
- V-1: AC1-8 + E1/E2 全 PASS（smoke + schema validate + grep）
- V-3（Codex）: critical 0 / major 3 / minor 2 → **全反映**
  - MJ-1 `_is_code` allowlist（Code Keep Rate に docs/schema 誤算入を除去）
  - MJ-2 `git log` token 境界正規表現（substring 偽陽性除去）
  - MJ-3 plan_hash 実検証（C-3 後 plan.md 改変→unknown）
  - mn-1 test-cases AC ID 突合（coverage 不足を reason 注記）

## 設計
advisory のみ（release blocker 不可・ゲート非使用・承認境界不変）。metrics event schema は**変更しない**（別系統 artifact＝#203/#197 と非衝突）。GitHub 全履歴解析/LLM judge/外部基盤は Non-goal。

## 補足
stash 退避→最新 main 再ブランチ復元時に bin/plangate・schema_mapping のコンフリクトを #213(plan-check)/#268/#269 と統合解消（純 additive・既存機能非破壊を diff 検証済）。

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)