### PR TITLE
feat(#199): Dynamic Context Engine v1 / PBI-HI-005 / TASK-0097

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -128,6 +128,7 @@ cmd_help() {
     "  eval <TASK-XXXX> [--baseline]  Run 8-aspect eval (Issue #156)" \
     "  metrics <TASK-XXXX> [--collect|--report] Collect/report workflow metrics (Issue #195)" \
     "  plan-check <TASK-XXXX> [--init|--validate]  Lightweight plan quality check (#213)" \
+    "  context <TASK-XXXX> --phase <p> [--mode <m>] [--profile <k>]  Dynamic Context Engine v1 (opt-in, #199)" \
     "  review <TASK-XXXX> [--phase]   Run external AI review (c2/v3)" \
     "  exec <TASK-XXXX> [--mode]      Dispatch implementation agent (after C-3)" \
     "  abort <TASK-XXXX> [--reason]   Record abort event in run.ndjson" \
@@ -1251,6 +1252,22 @@ PYV
   esac
 }
 
+cmd_context() {
+  # Dynamic Context Engine v1 — phase/mode/profile 別 context 解決
+  # opt-in・advisory（C-3/C-4 緩和なし / #199）。正本: docs/ai/context-engine.md
+  if [ $# -lt 1 ]; then
+    printf 'Usage: plangate context <TASK-XXXX> --phase <p> [--mode <m>] [--profile <k>] [--no-write]\n' >&2
+    return 1
+  fi
+  py="$plangate_root/scripts/context-engine.py"
+  if [ ! -f "$py" ]; then
+    printf 'error: scripts/context-engine.py not found\n' >&2
+    return 2
+  fi
+  python3 "$py" "$@"
+  return $?
+}
+
 cmd_review() {
   if [ $# -eq 0 ]; then
     printf 'Usage: plangate review <TASK-XXXX> [--phase c2|v3] [--file <path>]\n' >&2
@@ -1400,6 +1417,7 @@ case "$command" in
   eval)        cmd_eval "$@" ;;
   metrics)     cmd_metrics "$@" ;;
   plan-check)  cmd_plan_check "$@" ;;
+  context)     cmd_context "$@" ;;
   review)      cmd_review "$@" ;;
   exec)        cmd_exec "$@" ;;
   abort)       cmd_abort "$@" ;;

--- a/docs/ai/context-engine.md
+++ b/docs/ai/context-engine.md
@@ -1,0 +1,114 @@
+# Dynamic Context Engine v1（正本）
+
+> phase / mode / model profile に応じて context を解決する正本。
+> **契約コンテキスト**（PBI / 承認済 plan / test-cases / c3.json）は固定し
+> 承認境界・監査可能性を保ち、**作業コンテキスト**は動的取得する。
+> **opt-in**（既存 workflow 非破壊）。Vector DB / embedding は使わない。
+> 関連: [#199](https://github.com/s977043/plangate/issues/199)（PBI-HI-005）/
+> TASK-0097 / [`prompt-assembly.md`](./prompt-assembly.md) /
+> [`hook-enforcement.md`](./hook-enforcement.md) EH-3 /
+> [`model-profiles.md`](./model-profiles.md) /
+> [`../../schemas/context-manifest.schema.json`](../../schemas/context-manifest.schema.json)
+
+## 1. 目的と原則
+
+高度モデル・複数 provider 対応には全情報の静的詰め込みではなく phase/mode/
+profile に応じた context 組み立てが要る。一方 PBI / C-3 承認 plan /
+test-cases / approval は **契約コンテキスト**として固定すべき（全部動的化は
+承認境界・監査可能性を弱める）。本エンジンは両者を分離する。
+
+- **opt-in**: 既存 workflow を変更しない（`bin/plangate context` を明示実行
+  したときだけ動作）。全 prompt の本エンジン移行はしない（Non-goal）。
+- **C-3 / C-4 を緩和しない**。本エンジンは advisory（gate ではない）。
+- **Vector DB / embedding search を導入しない**（Non-goal）。決定論的に
+  ファイル/コマンド記述子を解決するのみ。
+
+## 2. Context policy（分類）
+
+| Context type | 分類 | Handling |
+|--------------|------|----------|
+| PBI / approved plan / test-cases / c3.json | **contract** | 固定（承認境界・監査）。stale 検知時 invalidated |
+| git status / diff / recent files / test failure | **dynamic** | 作業コンテキストの**取得候補を列挙**（記述子のみ・実取得は呼び出し側が budget 内で実施）|
+| repo structure / coding rules | dynamic | 必要時取得（on_demand）|
+| 過去 handoff / 関連 PBI | dynamic | 必要時検索（on_demand。Vector でなく決定論走査）|
+
+`contract_context` は `present` / `missing` / `stale` を持ち、stale は
+`invalidated: true`。`dynamic_context` は `kind` / `source` / `when`
+（always / on_demand / on_failure）の **記述子のみ**（実取得は呼び出し側が
+budget 内で行う）。
+
+## 3. Context budget（mode / profile）
+
+mode により budget を適用（[model-profiles.md](./model-profiles.md) の
+`max_context_policy` と整合）:
+
+| mode | max_context_policy | dynamic_max_items |
+|------|--------------------|-------------------|
+| ultra_light | compact | 3 |
+| light | compact | 5 |
+| standard | standard | 10 |
+| high_risk | expanded | 16 |
+| critical | expanded | 24 |
+
+`--profile` 指定時は [model-profiles.yaml](./model-profiles.yaml) の当該
+profile `max_context_policy` を読み、**mode 由来と profile 由来の保守側**
+（compact<standard<expanded の小さい方）を採用する（profile 方針と矛盾
+させない / V-3 MJ-1）。PyYAML 不在・profile 未定義時は mode 由来のみ。
+
+## 4. stale plan / stale C-3 と Hook / validate の整合
+
+**EH-3（plan_hash 改竄検知）と矛盾しない**ことを保証する:
+
+- `c3.json` の `plan_hash` と `plan.md` の sha256 を照合。
+- 不一致＝ **stale**: 当該 `approved_plan` を `status:stale` /
+  `invalidated:true` とし、`stale_guard.plan_hash_match:false`、
+  CLI は **exit 1（advisory 警告）**。
+- これにより「C-3 承認後に改変された plan を contract として使う」ことを
+  構造的に防ぐ（[hook-enforcement.md](./hook-enforcement.md) EH-3 /
+  `plangate validate` と同方向。ゲートを置換せず補完）。
+- 本エンジンは Hook を**代替しない**。EH-3 が block、本エンジンは
+  context 解決時に同じ不整合を invalidated として可視化するだけ。
+
+## 5. Prompt Assembly との接続方針
+
+[prompt-assembly.md](./prompt-assembly.md) の 4 層
+（base_contract / phase_contract / risk_mode_contract / model_adapter）と
+**矛盾させない**:
+
+- `contract_context` は `base_contract` / `phase_contract` の **入力資産**
+  （PBI/plan/test-cases/c3）を指す。Prompt Assembly はこれを固定前提に
+  組み立てる（本エンジンは「何を contract として渡すか」を明示するだけで
+  プロンプト本文は生成しない）。
+- `dynamic_context` は phase/mode に応じ Prompt Assembly が **budget 内で
+  取り込む候補**。取り込み実装は Prompt Assembly 側（本 PBI は manifest
+  提供まで・全 prompt 移行は Non-goal）。
+- stale invalidated の contract は Prompt Assembly に渡す前に解消
+  （再承認 or revert）すべき（§4）。
+
+## 6. 使い方（opt-in）
+
+```sh
+sh bin/plangate context TASK-XXXX --phase execute --mode standard \\
+  --profile gpt-5_5
+# → docs/working/TASK-XXXX/context-manifest.{md,json} を生成
+#   contract（固定）/ dynamic（記述子）/ budget / stale_guard
+```
+
+- 明示実行時のみ動作（既存 workflow 非破壊・opt-in）。
+- 出力は [schema](../../schemas/context-manifest.schema.json) 準拠
+  （`plangate validate-schemas` で機械検証可）。
+- stale（plan_hash 不一致）検知時 exit 1（advisory。ゲートは EH-3 が担う）。
+
+## 7. Non-goals
+
+- Vector DB / embedding search の導入
+- すべての既存 prompt を context engine 経由へ移行すること
+- C-3 / C-4 gate の緩和 / Keep Rate の算出 / provider runtime の全面刷新
+
+## 8. 関連
+
+- [`prompt-assembly.md`](./prompt-assembly.md) — 4 層構造（接続方針 §5）
+- [`hook-enforcement.md`](./hook-enforcement.md) EH-3 — plan_hash（§4 整合）
+- [`model-profiles.md`](./model-profiles.md) — max_context_policy / context_acquisition
+- [`schemas/context-manifest.schema.json`](../../schemas/context-manifest.schema.json)
+- [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) — EPIC #193 Phase 5

--- a/docs/working/TASK-0097/INDEX.md
+++ b/docs/working/TASK-0097/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0097 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0097/approvals/c3.json
+++ b/docs/working/TASK-0097/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0097",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T21:10:08Z",
+  "plan_hash": "sha256:8e02aeb2701552ae0ce30ebb0a26f712f04c7f47fa8727f81969290132334405"
+}

--- a/docs/working/TASK-0097/current-state.md
+++ b/docs/working/TASK-0097/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0097 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0097/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0097 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0097/handoff.md
+++ b/docs/working/TASK-0097/handoff.md
@@ -1,0 +1,32 @@
+# Handoff — TASK-0097 / #199 PBI-HI-005 Dynamic Context Engine v1
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 context-manifest.schema.json 存在 | PASS |
+| AC2 contract/dynamic 分離 | PASS |
+| AC3 context --phase --profile で resolved 出力 | PASS |
+| AC4 mode/profile budget 適用 | PASS（V-3 MJ-1: profile 保守側解決）|
+| AC5 stale plan/c3 が Hook/validate と矛盾しない | PASS（plan_hash 実照合・抽出不可も invalidated・EH-3 補完/非代替）|
+| AC6 Prompt Assembly 接続方針記載 | PASS（context-engine.md §5）|
+| AC7 既存 workflow 非破壊 opt-in | PASS（明示 CLI のみ・diff context 追加のみ・keep-rate#198 非混入）|
+V-1 全 PASS。V-3（Codex）critical 0/major 2/minor 2 → 全反映・回帰 PASS。
+## 2. 既知課題
+- dynamic_context は記述子のみ（実取得は呼び出し側 / Prompt Assembly。Vector
+  /embedding は Non-goal）。
+- profile↔mode budget は保守側採用（v1 設計判断）。Model Profile v2
+  context_acquisition との精緻連携は将来（本 PBI は記録+保守側まで）。
+## 3. V2 候補
+- Prompt Assembly が dynamic_context を budget 内で実取得する実装。
+- context_acquisition（#197 v2）戦略との連動（dynamic_first 等）。
+- past_handoff/related_pbi の決定論索引精緻化（Vector 非導入のまま）。
+## 4. 妥協点
+- 決定論記述子に限定（Vector/embedding Non-goal）。opt-in・advisory で
+  EH-3/C-3/C-4 を代替しない（承認境界不変）。profile は保守側で安全側。
+## 5. 引き継ぎ
+#199 を standard で実装。context-manifest schema + context-engine.py
+（contract 固定+plan_hash 実照合 / dynamic 記述子 / mode×profile 保守側
+budget / stale→invalidated exit1）+ bin/plangate context（opt-in）+ 正本 doc。
+V-3 で profile 保守側解決 / plan_hash 抽出不可も invalidated / 文言・help を修正。
+**EPIC #193 残: #200 Reporting & Retrospective（v8.9.0・最後の1件）。**
+## 6. テスト結果
+V-1: AC1-7 + E1/E2 全 PASS。V-3 反映後 smoke/schema/plan_hash 機械確認 PASS。

--- a/docs/working/TASK-0097/pbi-input.md
+++ b/docs/working/TASK-0097/pbi-input.md
@@ -1,0 +1,29 @@
+# PBI INPUT — TASK-0097 / #199 PBI-HI-005 Dynamic Context Engine v1
+
+## Context / Why
+高度モデル・複数 provider 対応に phase/mode/profile 別 context 組み立てが要る
+が、PBI/C-3 承認 plan/test-cases/approval は契約コンテキストとして固定すべき。
+両者を分離し Prompt Assembly・EH-3 と矛盾しない Context Engine v1 を作る。
+
+## What
+- In: schemas/context-manifest.schema.json / scripts/context-engine.py /
+  bin/plangate context / docs/ai/context-engine.md（正本）/ schema_mapping 登録
+- Out: Vector DB/embedding / 全 prompt の engine 移行 / C-3・C-4 緩和 /
+  Keep Rate 算出 / provider runtime 全面刷新
+
+## 受入基準（#199）
+- AC1: context-manifest.schema.json が存在
+- AC2: contract と dynamic context が分離
+- AC3: bin/plangate context <TASK> --phase execute --profile <p> で resolved 出力
+- AC4: mode/profile に応じた context budget 適用
+- AC5: stale plan/stale c3 が Hook/validate と矛盾しない
+- AC6: Prompt Assembly 接続方針が context-engine.md に記載
+- AC7: 既存 workflow を壊さず opt-in で使える
+
+## Notes
+opt-in（明示実行のみ）。EH-3 plan_hash と同方向（stale→invalidated・exit 1
+advisory、ゲート置換せず補完）。決定論（Vector なし）。承認境界不変。
+
+## Estimation
+Risks: EH-3 と矛盾（緩和: plan_hash 実照合・invalidated・ゲート非代替明記）/
+opt-in 破壊（緩和: 明示 CLI のみ・既存非破壊 diff 検証）/ Unknowns: なし

--- a/docs/working/TASK-0097/plan.md
+++ b/docs/working/TASK-0097/plan.md
@@ -1,0 +1,54 @@
+# EXECUTION PLAN — TASK-0097 / #199 PBI-HI-005
+
+## Goal
+phase/mode/profile 別に context を解決する Context Engine v1 を opt-in で
+追加し、契約/作業コンテキストを分離（Prompt Assembly・EH-3 と整合）。
+
+## Constraints / Non-goals
+- Vector DB/embedding / 全 prompt 移行 / C-3・C-4 緩和 / Keep Rate /
+  provider runtime 刷新 はしない。
+- 既存 workflow 非破壊（opt-in・明示 CLI のみ）。EH-3 を代替しない。
+
+## Approach Overview
+context-manifest.schema.json（contract/dynamic 分離・budget・stale_guard）→
+context-engine.py（contract 固定+plan_hash 実照合 / dynamic 記述子 / mode
+budget / stale→invalidated exit1）→ bin/plangate context → context-engine.md
+正本（policy/budget/EH-3 整合/Prompt Assembly 接続/opt-in/Non-goal）。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | context-manifest.schema.json + mapping | agent | 中 | 🚩 AC1/2 |
+| S2 | context-engine.py | agent | 中 | 🚩 AC2/4/5 |
+| S3 | bin/plangate context | agent | 低 | 🚩 AC3/7 |
+| S4 | context-engine.md 正本 | agent | 中 | 🚩 AC5/6 |
+
+## Files / Components to Touch
+- schemas/context-manifest.schema.json（新規）
+- scripts/context-engine.py（新規）
+- scripts/schema_mapping.py（登録）
+- bin/plangate（cmd_context + dispatch + help）
+- docs/ai/context-engine.md（新規・正本）
+
+## Testing Strategy
+- Verification: AC1-7 を smoke（TASK で contract 解決 + stale 注入で
+  invalidated/exit1）+ 生成 JSON validate-schemas + grep + ast/sh -n +
+  既存 workflow 非破壊 diff。
+- Unit/E2E: 該当なし（決定論 resolver・runtime 連携なし）。
+
+## Risks & Mitigations
+- EH-3 矛盾 → plan_hash 実照合・stale=invalidated・ゲート非代替を doc 明記
+- opt-in 破壊 → 明示 CLI のみ・bin/plangate diff で context 追加のみ確認
+- Vector 化誘惑 → 決定論記述子に限定（Non-goal 明記）
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 5 → 中
+- 受入基準数: 7 → 中
+- 変更種別: feat（schema+script+CLI+doc 新規・opt-in）→ 中
+- リスク: 中（EH-3/Prompt Assembly 整合・承認境界注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0097/review-external.md
+++ b/docs/working/TASK-0097/review-external.md
@@ -1,0 +1,18 @@
+# V-3 外部レビュー（Codex）— TASK-0097 / #199
+
+## 結果サマリ
+critical: 0 / major: 2 / minor: 2 / info: 5（初回 NOT APPROVE → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | _BUDGET が mode のみで profile の max_context_policy を無視。doc は「model-profiles と整合」だが未読 | model-profiles.yaml の profile max_context_policy を読み、**mode 由来と profile 由来の保守側（compact<standard<expanded 小さい方）**を採用。PyYAML 不在/未定義は mode のみ。doc に解決規則明記 |
+| MJ-2 | major | c3.json 在で plan_hash 抽出不可時 approved_plan が present+「consistent」表示＝未照合承認 plan を contract に見せ承認境界を弱める | c3 在 & plan_hash 抽出不可 → approved_plan を stale/invalidated・plan_hash_match=false・note「missing/unverified — contract not usable」・exit 1 |
+| mn-1 | minor | doc「動的取得」が実装（記述子のみ）と乖離し engine に git 実行責務と誤読 | 「取得候補を列挙（記述子のみ・実取得は呼び出し側）」へ修正 |
+| mn-2 | minor | help `[--mode][--profile]` 値なし表記 | `[--mode <m>] [--profile <k>]` に整形 |
+| info×5 | info | EH-3 と plan_hash 抽出同方向 / subprocess 不使用 / schema_mapping 登録 / additionalProperties 整合 / opt-in 本物・keep-rate#198 非混入 | 対応不要 |
+
+## 判定
+major 2 / minor 2 を全反映。critical 0。回帰: profile 保守側解決（gpt-5_mini/
+gpt-5_5_pro+light→compact）/ c3 有 plan_hash 無→invalidated+exit1 / 正常系
+rc=0 / schema validate / plan_hash 整合 全 PASS。EH-3 をゲート代替せず補完。

--- a/docs/working/TASK-0097/review-self.md
+++ b/docs/working/TASK-0097/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0097
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-7 ↔ S1-S4 ↔ T1-T7 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | Vector/全移行/ゲート緩和/KeepRate/runtime刷新 Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | smoke + validate-schemas + grep + ast/sh -n + 非破壊 diff |
+| C1-PLAN-05 WB Output | PASS | S1-S4 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | smoke/schema 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S4 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T7 ↔ AC1-7 |
+| C1-TC-02 Edge網羅 | PASS | E1 schema validate / E2 ゲート非代替 |
+| C1-TC-03 自動化可否 | PASS | smoke/jsonschema 自動 |
+| C1-INT-01 EH-3整合 | PASS | plan_hash 実照合・stale=invalidated・ゲート非代替 |
+| C1-INT-02 opt-in非破壊 | PASS | 明示 CLI のみ・bin/plangate diff context 追加のみ |
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0097/test-cases.md
+++ b/docs/working/TASK-0097/test-cases.md
@@ -1,0 +1,13 @@
+# テストケース — TASK-0097 / #199
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | context-manifest.schema.json 存在・JSON 妥当 | 機械検証 |
+| T2 | AC2 | manifest に contract_context/dynamic_context 分離（kind enum 別）| 構造突合 |
+| T3 | AC3 | context TASK --phase execute --profile p で manifest md/json 出力 | smoke |
+| T4 | AC4 | mode 別 budget（ultra_light=compact/3 … critical=expanded/24）適用 | smoke |
+| T5 | AC5 | plan_hash 不一致注入で approved_plan stale/invalidated + exit 1 | smoke |
+| T6 | AC6 | context-engine.md に Prompt Assembly 4層接続方針 + EH-3 整合 | 構造突合 |
+| T7 | AC7 | 明示 CLI のみ動作（bin/plangate diff=context 追加のみ・既存非破壊）| 構造突合 |
+## Edge
+- E1: 生成 context-manifest.json が schema validate PASS
+- E2: C-3/C-4 緩和なし・ゲート非代替が doc/note に明記

--- a/docs/working/TASK-0097/todo.md
+++ b/docs/working/TASK-0097/todo.md
@@ -1,0 +1,14 @@
+# TODO — TASK-0097 / #199
+## 🤖 Agent
+- [x] 準備: #199本文・prompt-assembly/EH-3/schema_mapping 確認
+- [x] S1 schema + mapping（🚩AC1/2）
+- [x] S2 context-engine.py（🚩AC2/4/5）
+- [x] S3 bin/plangate context（🚩AC3/7）
+- [x] S4 context-engine.md 正本（🚩AC5/6）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/schemas/context-manifest.schema.json
+++ b/schemas/context-manifest.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/s977043/plangate/schemas/context-manifest.schema.json",
+  "title": "Context Manifest (Dynamic Context Engine v1)",
+  "description": "phase/mode/profile に応じた resolved context。contract（固定・承認境界）と dynamic（動的取得）を分離。opt-in。正本: docs/ai/context-engine.md (#199 / PBI-HI-005)。C-3/C-4 緩和なし・Vector/embedding なし。",
+  "type": "object",
+  "required": ["task_id", "schema", "phase", "mode", "contract_context", "dynamic_context", "budget"],
+  "additionalProperties": false,
+  "properties": {
+    "task_id": { "type": "string", "pattern": "^TASK-[0-9A-Za-z]+$" },
+    "schema": { "type": "string", "const": "context-manifest/v1" },
+    "phase": { "type": "string", "enum": ["classify", "plan", "approve-wait", "execute", "review", "verify", "handoff"] },
+    "mode": { "type": "string", "enum": ["ultra_light", "light", "standard", "high_risk", "critical"] },
+    "profile": { "type": "string", "maxLength": 64 },
+    "contract_context": {
+      "type": "array",
+      "description": "固定（承認境界・監査可能性）。stale 検知時は invalidated=true",
+      "items": {
+        "type": "object",
+        "required": ["kind", "path", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "enum": ["pbi_input", "approved_plan", "test_cases", "c3_approval"] },
+          "path": { "type": "string", "minLength": 1, "maxLength": 256 },
+          "status": { "type": "string", "enum": ["present", "missing", "stale"] },
+          "plan_hash": { "type": "string", "maxLength": 80 },
+          "invalidated": { "type": "boolean" }
+        }
+      }
+    },
+    "dynamic_context": {
+      "type": "array",
+      "description": "動的取得（記述子のみ。実取得は呼び出し側・budget 内）",
+      "items": {
+        "type": "object",
+        "required": ["kind", "source", "when"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "type": "string", "enum": ["git_status", "git_diff", "recent_files", "test_failure", "repo_structure", "coding_rules", "past_handoff", "related_pbi"] },
+          "source": { "type": "string", "minLength": 1, "maxLength": 256 },
+          "when": { "type": "string", "enum": ["always", "on_demand", "on_failure"] }
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "required": ["max_context_policy", "dynamic_max_items"],
+      "additionalProperties": false,
+      "properties": {
+        "max_context_policy": { "type": "string", "enum": ["compact", "standard", "expanded"] },
+        "dynamic_max_items": { "type": "integer", "minimum": 0, "maximum": 64 }
+      }
+    },
+    "stale_guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "EH-3 plan_hash と矛盾しないための検証結果",
+      "properties": {
+        "plan_hash_match": { "type": ["boolean", "null"] },
+        "note": { "type": "string", "maxLength": 256 }
+      }
+    },
+    "note": { "type": "string", "maxLength": 256 }
+  }
+}

--- a/scripts/context-engine.py
+++ b/scripts/context-engine.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""context-engine.py — Dynamic Context Engine v1 (#199 / PBI-HI-005).
+
+phase / mode / profile に応じて context を解決する。**契約コンテキスト**
+（PBI / 承認済 plan / test-cases / c3.json）は固定し承認境界・監査可能性を
+保つ。**作業コンテキスト**（git status/diff/recent/test failure 等）は
+記述子として列挙（実取得は呼び出し側・budget 内）。
+
+opt-in（既存 workflow 非破壊）。Vector DB / embedding は使わない（Non-goal）。
+C-3/C-4 は緩和しない。stale plan/c3 は EH-3 plan_hash と矛盾しない判定を行う。
+
+正本: docs/ai/context-engine.md / schema: schemas/context-manifest.schema.json
+
+Usage:
+  python3 scripts/context-engine.py <TASK-XXXX> --phase execute \\
+      --mode standard [--profile gpt-5_5] [--no-write]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKING = REPO / "docs" / "working"
+
+# mode → context budget（model-profiles の max_context_policy と整合）
+_BUDGET = {
+    "ultra_light": ("compact", 3),
+    "light": ("compact", 5),
+    "standard": ("standard", 10),
+    "high_risk": ("expanded", 16),
+    "critical": ("expanded", 24),
+}
+_POLICY_RANK = {"compact": 0, "standard": 1, "expanded": 2}
+_RANK_POLICY = {0: "compact", 1: "standard", 2: "expanded"}
+
+
+def _profile_policy(profile: str | None) -> str | None:
+    """model-profiles.yaml の指定 profile の max_context_policy を返す。
+
+    PyYAML 不在や未定義時は None（mode 由来のみ採用）。v1 は両者の
+    **保守側（compact<standard<expanded の小さい方）** を採用し profile の
+    方針と矛盾させない（#199 V-3 MJ-1）。
+    """
+    if not profile:
+        return None
+    try:
+        import yaml
+
+        y = yaml.safe_load(
+            (REPO / "docs" / "ai" / "model-profiles.yaml").read_text()
+        )
+        m = (y or {}).get("models", {}).get(profile)
+        return m.get("max_context_policy") if m else None
+    except Exception:
+        return None
+
+_DYNAMIC = [
+    ("git_status", "git status --porcelain", "always"),
+    ("git_diff", "git diff --stat", "on_demand"),
+    ("recent_files", "git log --name-only -n 5", "on_demand"),
+    ("test_failure", "last test run output", "on_failure"),
+    ("repo_structure", "tree -L 2 (or git ls-files)", "on_demand"),
+    ("coding_rules", "CLAUDE.md / .claude/rules/", "on_demand"),
+    ("past_handoff", "docs/working/TASK-*/handoff.md", "on_demand"),
+    ("related_pbi", "docs/working/ cross-reference", "on_demand"),
+]
+
+
+def _contract(task_id: str) -> tuple[list, dict]:
+    d = WORKING / task_id
+    items = []
+    plan_hash_match = None
+    note = ""
+    spec = [
+        ("pbi_input", d / "pbi-input.md"),
+        ("approved_plan", d / "plan.md"),
+        ("test_cases", d / "test-cases.md"),
+        ("c3_approval", d / "approvals" / "c3.json"),
+    ]
+    c3 = d / "approvals" / "c3.json"
+    plan = d / "plan.md"
+    rec_hash = None
+    if c3.is_file():
+        m = re.search(r'"plan_hash"\s*:\s*"sha256:([0-9a-f]+)"', c3.read_text())
+        rec_hash = m.group(1) if m else None
+    for kind, fp in spec:
+        if not fp.is_file():
+            items.append({"kind": kind, "path": str(fp.relative_to(REPO)),
+                          "status": "missing"})
+            continue
+        entry = {"kind": kind, "path": str(fp.relative_to(REPO)),
+                 "status": "present"}
+        if kind == "approved_plan":
+            if rec_hash:
+                cur = hashlib.sha256(fp.read_bytes()).hexdigest()
+                entry["plan_hash"] = f"sha256:{cur}"
+                if cur != rec_hash:
+                    # EH-3 と矛盾しない: plan_hash 不一致 = stale。契約 invalidate
+                    entry["status"] = "stale"
+                    entry["invalidated"] = True
+                    plan_hash_match = False
+                    note = "plan.md changed after C-3 (EH-3 plan_hash mismatch)"
+                else:
+                    plan_hash_match = True
+            elif c3.is_file():
+                # c3 はあるが plan_hash 抽出不可 → 未照合の承認 plan を
+                # contract として使わせない（承認境界を弱めない / V-3 MJ-2）
+                entry["status"] = "stale"
+                entry["invalidated"] = True
+                plan_hash_match = False
+                note = "plan_hash missing/unverified in c3.json — contract not usable"
+        items.append(entry)
+    return items, {"plan_hash_match": plan_hash_match,
+                   "note": note or ("plan_hash consistent" if plan_hash_match else "no c3/plan to verify")}
+
+
+def build(task_id: str, phase: str, mode: str, profile: str | None) -> dict:
+    pol, dmax = _BUDGET.get(mode, ("standard", 10))
+    ppol = _profile_policy(profile)
+    if ppol in _POLICY_RANK:
+        # mode 由来と profile 由来の保守側（小さい rank）を採用
+        pol = _RANK_POLICY[min(_POLICY_RANK[pol], _POLICY_RANK[ppol])]
+    contract, guard = _contract(task_id)
+    dyn = [{"kind": k, "source": s, "when": w} for k, s, w in _DYNAMIC][:dmax]
+    return {
+        "task_id": task_id,
+        "schema": "context-manifest/v1",
+        "phase": phase,
+        "mode": mode,
+        **({"profile": profile} if profile else {}),
+        "contract_context": contract,
+        "dynamic_context": dyn,
+        "budget": {"max_context_policy": pol, "dynamic_max_items": dmax},
+        "stale_guard": guard,
+        "note": "opt-in resolved context; contract fixed (approval boundary). "
+                "Not a gate; C-3/C-4 unchanged (#199 Non-goal).",
+    }
+
+
+def render_md(m: dict) -> str:
+    g = m.get("stale_guard", {})
+    lines = [
+        f"# Context Manifest: {m['task_id']}",
+        "",
+        f"> phase={m['phase']} mode={m['mode']} "
+        f"profile={m.get('profile', '-')} (opt-in / advisory)",
+        "",
+        "## Contract context（固定・承認境界）",
+        "",
+    ]
+    for c in m["contract_context"]:
+        flag = " ⚠️invalidated" if c.get("invalidated") else ""
+        lines.append(f"- `{c['kind']}` {c['path']} — **{c['status']}**{flag}")
+    lines += ["", "## Dynamic context（記述子・budget 内）", ""]
+    for dctx in m["dynamic_context"]:
+        lines.append(f"- `{dctx['kind']}` ({dctx['when']}): {dctx['source']}")
+    lines += [
+        "",
+        f"## Budget: {m['budget']['max_context_policy']} / "
+        f"dynamic_max_items={m['budget']['dynamic_max_items']}",
+        "",
+        f"## Stale guard: plan_hash_match={g.get('plan_hash_match')} "
+        f"— {g.get('note', '')}",
+        "",
+        "## 関連",
+        "",
+        "- [`docs/ai/context-engine.md`](../../ai/context-engine.md)",
+        "- [`schemas/context-manifest.schema.json`]"
+        "(../../../schemas/context-manifest.schema.json)",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="PlanGate Dynamic Context Engine v1 (#199)")
+    ap.add_argument("task_id")
+    ap.add_argument("--phase", required=True,
+                    choices=["classify", "plan", "approve-wait", "execute",
+                             "review", "verify", "handoff"])
+    ap.add_argument("--mode", default="standard",
+                    choices=["ultra_light", "light", "standard",
+                             "high_risk", "critical"])
+    ap.add_argument("--profile")
+    ap.add_argument("--no-write", action="store_true")
+    a = ap.parse_args()
+    if not re.match(r"^TASK-[0-9A-Za-z]+$", a.task_id):
+        print(f"error: invalid task_id: {a.task_id}", file=sys.stderr)
+        return 2
+    m = build(a.task_id, a.phase, a.mode, a.profile)
+    js = json.dumps(m, indent=2, ensure_ascii=False)
+    md = render_md(m)
+    if a.no_write:
+        print("=== context-manifest.md ===")
+        print(md)
+        print("=== context-manifest.json ===")
+        print(js)
+    else:
+        d = WORKING / a.task_id
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "context-manifest.json").write_text(js + "\n")
+        (d / "context-manifest.md").write_text(md + "\n")
+        print(f"Written: docs/working/{a.task_id}/context-manifest.{{md,json}}")
+    # stale（EH-3 矛盾防止）: invalidated 契約があれば exit 1（advisory 警告）
+    if any(c.get("invalidated") for c in m["contract_context"]):
+        print("WARNING: contract context invalidated (stale plan_hash)",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/schema_mapping.py
+++ b/scripts/schema_mapping.py
@@ -40,6 +40,7 @@ FILENAME_TO_SCHEMA: dict[str, str] = {
     "2026-05-04-baseline.json": "eval-baseline.schema.json",
     "plan-quality-check.json": "plan-quality-check.schema.json",
     "eval-comparison.json": "eval-comparison.schema.json",
+    "context-manifest.json": "context-manifest.schema.json",
 }
 
 


### PR DESCRIPTION
## 概要
#199 を standard で実装。phase/mode/profile に応じた context 解決を **opt-in・advisory・決定論**で追加。契約コンテキスト（PBI/承認 plan/test-cases/c3）を固定し承認境界・監査可能性を維持。

## 変更
- **新規** `schemas/context-manifest.schema.json`（contract/dynamic 分離・budget・stale_guard）
- **新規** `scripts/context-engine.py`（contract 固定+plan_hash 実照合 / dynamic 記述子 / mode×profile 保守側 budget / stale→invalidated exit1）
- `bin/plangate context <TASK> --phase <p> [--mode <m>] [--profile <k>]`（明示実行のみ・既存 workflow 非破壊・keep-rate#198 非混入を diff 検証）
- **新規** `docs/ai/context-engine.md` 正本 + `scripts/schema_mapping.py` 登録

## 整合性
EH-3 plan_hash と**矛盾しない**（stale=invalidated・exit1・**ゲート非代替/補完**）。Prompt Assembly 4 層と矛盾しない接続方針を明記。Vector/embedding 非導入・C-3/C-4 非緩和・全 prompt 移行なし（Non-goal）。

## V-1 / V-3
- V-1: AC1-7 + E1/E2 全 PASS（smoke + stale 注入 invalidated/exit1 + schema validate + 非破壊 diff）
- V-3（Codex）: critical 0 / major 2 / minor 2 → **全反映**（MJ-1 profile 保守側解決 / MJ-2 plan_hash 抽出不可も invalidated=承認境界保護 / mn-1 doc 文言 / mn-2 help）、回帰 PASS

## Mode
standard（feat・schema+script+CLI+doc・opt-in）

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)