### PR TITLE
feat(#200): Reporting & Retrospective v1 / PBI-HI-006 / TASK-0098

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -128,6 +128,7 @@ cmd_help() {
     "  eval <TASK-XXXX> [--baseline]  Run 8-aspect eval (Issue #156)" \
     "  metrics <TASK-XXXX> [--collect|--report] Collect/report workflow metrics (Issue #195)" \
     "  plan-check <TASK-XXXX> [--init|--validate]  Lightweight plan quality check (#213)" \
+    "  report --from <date> --to <date>  Period report for retrospective (#200)" \
     "  review <TASK-XXXX> [--phase]   Run external AI review (c2/v3)" \
     "  exec <TASK-XXXX> [--mode]      Dispatch implementation agent (after C-3)" \
     "  abort <TASK-XXXX> [--reason]   Record abort event in run.ndjson" \
@@ -1251,6 +1252,23 @@ PYV
   esac
 }
 
+cmd_report() {
+  # Reporting & Retrospective v1 — 期間集計 Markdown（advisory / #200）
+  # 正本: docs/ai/reporting.md
+  # 最小チェックのみ（--from/--to 必須検証は scripts/reporting.py argparse に委譲）
+  if [ $# -lt 1 ]; then
+    printf 'Usage: plangate report --from <YYYY-MM-DD> --to <YYYY-MM-DD> [--no-write]\n' >&2
+    return 1
+  fi
+  py="$plangate_root/scripts/reporting.py"
+  if [ ! -f "$py" ]; then
+    printf 'error: scripts/reporting.py not found\n' >&2
+    return 2
+  fi
+  python3 "$py" "$@"
+  return $?
+}
+
 cmd_review() {
   if [ $# -eq 0 ]; then
     printf 'Usage: plangate review <TASK-XXXX> [--phase c2|v3] [--file <path>]\n' >&2
@@ -1400,6 +1418,7 @@ case "$command" in
   eval)        cmd_eval "$@" ;;
   metrics)     cmd_metrics "$@" ;;
   plan-check)  cmd_plan_check "$@" ;;
+  report)      cmd_report "$@" ;;
   review)      cmd_review "$@" ;;
   exec)        cmd_exec "$@" ;;
   abort)       cmd_abort "$@" ;;

--- a/docs/ai/reporting.md
+++ b/docs/ai/reporting.md
@@ -1,0 +1,95 @@
+# Reporting & Retrospective v1（正本）
+
+> PlanGate の実利用シグナル（C-3/C-4/V-1/fix loop/hook violation/Keep Rate/
+> latency）を **期間指定**で集計し、sprint retrospective に貼れる Markdown を
+> 生成する正本。決定論・ローカル artifact のみ。
+> 関連: [#200](https://github.com/s977043/plangate/issues/200)（PBI-HI-006）/
+> TASK-0098 / [`metrics.md`](./metrics.md) / [`eval-runner.md`](./eval-runner.md) /
+> [`keep-rate.md`](./keep-rate.md)（#198・任意入力）/ EPIC #193
+
+## 1. 目的と原則
+
+Metrics v1 / Eval comparison / Keep Rate / Dynamic Context が揃っても、
+結果が retrospective → 次改善 PBI に変換されなければ継続運用にならない。
+本機能は期間集計レポートでその橋渡しをする。
+
+- **advisory のみ**: C-3/C-4 を緩和しない・LLM judge を hard gate にしない
+  （#200 Non-goal・[responsibility-classes.md](../../.claude/rules/responsibility-classes.md)
+  承認境界不変）。
+- **決定論・ローカル**: Web dashboard / 外部 BI / Slack・Discussions 自動
+  投稿はしない（Non-goal）。`docs/working/TASK-*/` の artifact のみ集計。
+- 算出不能は `unknown`（0 と区別）。
+
+## 2. 集計ソースと期間
+
+| ソース | 取得項目 |
+|--------|---------|
+| `approvals/c3.json` | c3_status（APPROVED/CONDITIONAL/REJECTED）, approved_at（期間判定キー）|
+| `approvals/c4-approval.json` | c4_status（APPROVED/REQUEST_CHANGES/REJECTED）|
+| `eval-result.json` | ac_coverage / release_blocker_violations / latency_cost |
+| `keep-rate-result.json` | code/plan keep rate（**#198 / PR #272 提供。無ければ `-`**）|
+| `status.md` | fix loop 回数 / V-1 first pass（ヒューリスティック）|
+
+期間は `c3.json` の `approved_at` が `--from`〜`--to`（YYYY-MM-DD・両端含む）
+に入る TASK を対象とする。
+
+## 3. Report items
+
+| Item | 意味 |
+|------|------|
+| C-3 approved/conditional/rejected | plan 品質 |
+| C-4 approved/request_changes/rejected | exec 品質 |
+| V-1 first pass rate | 実装・受入条件の一致度（status.md 由来・近似）|
+| fix loop max | 自己修正効率（1-2桁・日付除外・上限50）|
+| hook violation | ガードレール違反（_audit/hook-events.log の VIOLATION を期間集計・hook 別）|
+| release blocker total | ガードレール違反傾向 |
+| Keep Rate (code/plan) | AI 成果物の実採用度（#198 入力時）|
+| latency / cost | 運用効率（eval-result 由来）|
+
+## 4. 使い方
+
+```sh
+sh bin/plangate report --from 2026-05-01 --to 2026-05-31
+# → docs/working/_reports/report-2026-05-01_2026-05-31.{md,json}
+sh bin/plangate report --from 2026-05-01 --to 2026-05-31 --no-write  # 標準出力
+```
+
+`--from`/`--to` は `YYYY-MM-DD`。`from > to` はエラー（exit 2）。
+
+## 5. retrospective への接続
+
+1. `bin/plangate report` を sprint 期間で実行。
+2. `docs/working/_reports/report-*.md` を
+   [`docs/working/templates/retrospective-template.md`](../working/templates/retrospective-template.md)
+   §1 に貼付。
+3. テンプレ §3「AI harness improvement 用の問い」に沿って KPT を記入。
+4. レポート末尾の **次の harness improvement PBI 候補（抽出指針）** から
+   1〜3 件を人間が EPIC #193 配下で起票判断（advisory）。
+
+## 6. 次の harness improvement PBI 候補 抽出方針
+
+| シグナル | 候補 PBI 方向 |
+|---------|--------------|
+| C-3 CONDITIONAL/REJECTED 多 | plan 品質強化（Plan Quality Checks #213）|
+| C-4 REQUEST_CHANGES 多 | exec/レビュー観点の PBI |
+| V-1 first pass rate 低 | test-cases 精度 / exec 手順 PBI |
+| fix loop max 高 | fix loop 上限 / EHS-3 escalation 見直し |
+| release blocker total 増 | 該当 aspect の Gate / tool-error-taxonomy 強化 |
+| Keep Rate 低 | 採用されない成果物パターンの retro PBI |
+
+抽出は **advisory**。PBI 化は人間判断（[issue-governance.md](./issue-governance.md)
+に従い起票）。
+
+## 7. Non-goals
+
+- Web dashboard / 外部 BI ツール連携
+- Slack / GitHub Discussions への自動投稿
+- LLM judge を hard gate にすること / C-3 / C-4 gate の緩和
+
+## 8. 関連
+
+- [`metrics.md`](./metrics.md) — Metrics v1（PBI-HI-001）
+- [`eval-runner.md`](./eval-runner.md) — eval-result（PBI-HI-002）
+- [`keep-rate.md`](./keep-rate.md) — Keep Rate（#198・任意入力）
+- [`docs/working/templates/retrospective-template.md`](../working/templates/retrospective-template.md)
+- [`harness-improvement-roadmap.md`](./harness-improvement-roadmap.md) — EPIC #193 Phase 6

--- a/docs/working/TASK-0098/INDEX.md
+++ b/docs/working/TASK-0098/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0098 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0098/approvals/c3.json
+++ b/docs/working/TASK-0098/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0098",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T21:17:54Z",
+  "plan_hash": "sha256:21cdde26353e8e76c90cd83b9426822e19581ff7eef53a364a168d9ad559e7be"
+}

--- a/docs/working/TASK-0098/current-state.md
+++ b/docs/working/TASK-0098/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0098 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0098/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0098 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0098/handoff.md
+++ b/docs/working/TASK-0098/handoff.md
@@ -1,0 +1,31 @@
+# Handoff — TASK-0098 / #200 PBI-HI-006 Reporting & Retrospective
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 report --from --to 期間 report | PASS（from>to exit2）|
+| AC2 metrics/eval/keep rate 集計 | PASS（c3/c4/eval-result/keep-rate/status/hook-log）|
+| AC3 retrospective 貼付 Markdown 生成 | PASS |
+| AC4 reporting.md 運用手順 | PASS（§4/§5）|
+| AC5 retrospective template に harness improvement の問い | PASS |
+| AC6 次の harness improvement PBI 候補抽出 | PASS（report 末尾 + reporting.md §6）|
+V-1 全 PASS。V-3（Codex）critical 0/major 3/minor 3 → 全反映・回帰 PASS。
+## 2. 既知課題
+- v1_first_pass / fix_loop は status.md ヒューリスティック（未観測は unknown
+  と明示区別）。精緻化は metrics events 連携で v2。
+- hook violation は _audit/hook-events.log 全履歴を期間集計（test/dev 行も
+  含むため絶対数は大きめ＝advisory・傾向把握用途）。
+- keep-rate-result.json は #198/PR#272 提供（無ければ '-'・前方参照）。
+## 3. V2 候補
+- metrics events.ndjson 直接連携（C-3/C-4/V-1 を events 由来に厳密化）。
+- hook-events.log の test/dev 行フィルタ（運用ログのみ集計）。
+- report→PBI 候補の半自動起票（issue-governance 連携・人間承認は維持）。
+## 4. 妥協点
+- 決定論ローカル集計に限定（dashboard/外部BI/自動投稿 Non-goal）。advisory・
+  LLM judge を hard gate にしない・C-3/C-4 非緩和（承認境界不変）。
+## 5. 引き継ぎ
+#200 を standard で実装。reporting.py（期間集計）+ bin/plangate report +
+reporting.md 正本 + retrospective-template.md。V-3 で v1 unknown/0 区別 /
+ISO TZ 正規化 / hook violation 集計 / status try / latency unknown / 委譲
+コメントを修正。**これで EPIC #193 子 12/12 完了**（#198/#199/#200 PR 化済）。
+## 6. テスト結果
+V-1: AC1-6 + E1/E2 全 PASS。V-3 反映後 smoke/集計 機械確認 PASS。

--- a/docs/working/TASK-0098/pbi-input.md
+++ b/docs/working/TASK-0098/pbi-input.md
@@ -1,0 +1,27 @@
+# PBI INPUT — TASK-0098 / #200 PBI-HI-006 Reporting & Retrospective
+
+## Context / Why
+eval/metrics/Keep Rate の結果をメンテナ個人確認に閉じず、sprint
+retrospective で使え次の改善 PBI へ変換できる形にする。継続運用化。
+
+## What
+- In: scripts/reporting.py / bin/plangate report / docs/ai/reporting.md（正本）/
+  docs/working/templates/retrospective-template.md
+- Out: Web dashboard / 外部 BI 連携 / Slack・Discussions 自動投稿 /
+  LLM judge を hard gate / C-3・C-4 緩和
+
+## 受入基準（#200）
+- AC1: bin/plangate report --from --to で期間指定 report
+- AC2: metrics/eval/keep rate を集計
+- AC3: sprint retrospective に貼れる Markdown 生成
+- AC4: docs/ai/reporting.md に運用手順
+- AC5: retrospective template に AI harness improvement 用の問い追加
+- AC6: 次の harness improvement PBI 候補を抽出できる
+
+## Notes
+決定論・ローカル artifact のみ（events.ndjson は任意）。keep-rate-result.json
+は #198/PR#272 提供（無ければ '-'・前方参照）。advisory・承認境界不変。
+
+## Estimation
+Risks: fix_loop 日付誤マッチ（緩和: 1-2桁・非日付・上限50・smoke 検証済）/
+keep-rate 前方参照（緩和: 任意入力・graceful）/ Unknowns: なし

--- a/docs/working/TASK-0098/plan.md
+++ b/docs/working/TASK-0098/plan.md
@@ -1,0 +1,51 @@
+# EXECUTION PLAN — TASK-0098 / #200 PBI-HI-006
+
+## Goal
+実利用シグナルを期間集計し retrospective 貼付 Markdown + 次改善 PBI 候補
+抽出指針を生成（決定論・advisory・承認境界不変）。
+
+## Constraints / Non-goals
+- Web dashboard / 外部 BI / 自動投稿 / LLM judge hard gate / C-3・C-4 緩和
+  はしない。
+- events.ndjson 非依存（ローカル artifact 集計）。keep-rate は任意入力。
+
+## Approach Overview
+reporting.py（c3/c4/eval-result/keep-rate-result/status を期間集計、Markdown
++JSON）→ bin/plangate report → reporting.md 正本 → retrospective-template.md
+（harness improvement 用の問い + 次 PBI 候補抽出方針）。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | scripts/reporting.py | agent | 中 | 🚩 AC1/2/3/6 |
+| S2 | bin/plangate report | agent | 低 | 🚩 AC1 |
+| S3 | docs/ai/reporting.md 正本 | agent | 低 | 🚩 AC4/6 |
+| S4 | retrospective-template.md | agent | 低 | 🚩 AC5 |
+
+## Files / Components to Touch
+- scripts/reporting.py（新規）
+- bin/plangate（cmd_report + dispatch + help）
+- docs/ai/reporting.md（新規・正本）
+- docs/working/templates/retrospective-template.md（新規）
+
+## Testing Strategy
+- Verification: AC1-6 を smoke（期間指定 report 生成・集計値・PBI 候補節）+
+  grep 構造突合 + ast/sh -n + fix_loop 誤マッチ非再現。
+- Unit/E2E: 該当なし（決定論集計・外部連携なし）。
+
+## Risks & Mitigations
+- fix_loop 誤マッチ → 1-2桁・非日付・上限50（smoke で 0 化確認済）
+- keep-rate 前方参照 → 任意入力・無ければ '-'（#198/PR#272 依存明記）
+- ゲート誤用 → advisory/C-3・C-4 非緩和を doc/出力/テンプレに明記
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**:
+- 変更ファイル数: 4 → 中
+- 受入基準数: 6 → 中
+- 変更種別: feat（集計 script+CLI+正本+テンプレ）→ 中
+- リスク: 中（集計ヒューリスティック・承認境界注意）
+- **最終判定**: standard（V-3 外部レビュー実施）

--- a/docs/working/TASK-0098/review-external.md
+++ b/docs/working/TASK-0098/review-external.md
@@ -1,0 +1,20 @@
+# V-3 外部レビュー（Codex）— TASK-0098 / #200
+
+## 結果サマリ
+critical: 0 / major: 3 / minor: 3 / info: 4（初回 NOT APPROVE → 全反映）
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | v1_first_pass_rate が unknown と 0 を混同（未観測 TASK も分母）| 観測済（bool 記録）のみ分母、未観測は unknown。observed/unknown 件数を JSON+md 出力（rate は known のみ）|
+| MJ-2 | major | _in_range が ISO TZ 正規化せず文字列日付のみ（TZ で日付ズレ）| fromisoformat で parse→UTC 日付化、parse 不能時のみ YYYY-MM-DD fallback。両端含む正本明記 |
+| MJ-3 | major | doc/template は hook violation 前提だが reporting.py 未集計（正本不整合）| _audit/hook-events.log の VIOLATION を期間集計（ts UTC 日付化・hook 別）、report に追加。doc §3 整合 |
+| mn-1 | minor | status.md read_text が OSError 未捕捉（壊れlog で全体落ち）| try/except OSError でガード（他 artifact と一貫） |
+| mn-2 | minor | latency が '-' 表示で doc「unknown」と揺れ | TASK 内訳の latency を `unknown` 表示に統一 |
+| mn-3 | minor | cmd_report 最小チェックのみで意図不明瞭 | 「--from/--to 必須検証は argparse に委譲」コメント追加 |
+| info×4 | info | keep-rate graceful('-')/#272 明記 / advisory 一貫 / bin diff report のみ(keep-rate#198・context#199 非混入) / subprocess 不使用 | 対応不要 |
+
+## 判定
+major 3 / minor 3 を全反映。critical 0。回帰: v1 observed/unknown 区別 /
+ISO TZ 正規化（+09:00/Z）/ hook violation hook 別集計 / status try /
+fix_loop 非日付 / from>to exit2 全 PASS。advisory・承認境界不変。

--- a/docs/working/TASK-0098/review-self.md
+++ b/docs/working/TASK-0098/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0098
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-6 ↔ S1-S4 ↔ T1-T6 1:1 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | dashboard/BI/自動投稿/LLM judge gate/C-3緩和 Non-goal 明記 |
+| C1-PLAN-04 テスト戦略 | PASS | smoke + grep + ast/sh -n + fix_loop 誤マッチ非再現 |
+| C1-PLAN-05 WB Output | PASS | S1-S4 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | smoke 自動 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S4 単位 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S に 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3.json APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T6 ↔ AC1-6 |
+| C1-TC-02 Edge網羅 | PASS | E1 fix_loop 非日付 / E2 advisory |
+| C1-TC-03 自動化可否 | PASS | smoke/grep 自動 |
+| C1-INT-01 承認境界 | PASS | advisory・C-3/C-4 非緩和（responsibility-classes 不変）|
+| C1-INT-02 依存整合 | PASS | keep-rate 任意入力（#198/PR#272 前方参照・graceful）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0098/test-cases.md
+++ b/docs/working/TASK-0098/test-cases.md
@@ -1,0 +1,12 @@
+# テストケース — TASK-0098 / #200
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | report --from --to で期間 report md/json 生成・from>to は exit2 | smoke |
+| T2 | AC2 | c3/c4/eval-result/keep-rate/status 集計（C-3/C-4/V-1/blocker/keep）| smoke |
+| T3 | AC3 | retrospective 貼付可能 Markdown（TASK 内訳表 + サマリ）| 構造突合 |
+| T4 | AC4 | docs/ai/reporting.md §4 運用手順 | 構造突合 |
+| T5 | AC5 | retrospective-template.md に AI harness improvement 用の問い | 構造突合 |
+| T6 | AC6 | report に「次の harness improvement PBI 候補」抽出指針 | 構造突合 |
+## Edge
+- E1: fix_loop が日付（2026 等）を誤集計しない（上限50・非日付）
+- E2: advisory/C-3・C-4 非緩和が report/doc/テンプレに明記・keep-rate 無→'-'

--- a/docs/working/TASK-0098/todo.md
+++ b/docs/working/TASK-0098/todo.md
@@ -1,0 +1,14 @@
+# TODO — TASK-0098 / #200
+## 🤖 Agent
+- [x] 準備: #200本文・metrics_reporter/c3c4 schema/retro 確認
+- [x] S1 reporting.py（🚩AC1/2/3/6）+ fix_loop bug 修正
+- [x] S2 bin/plangate report（🚩AC1）
+- [x] S3 reporting.md 正本（🚩AC4/6）
+- [x] S4 retrospective-template.md（🚩AC5）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/docs/working/templates/retrospective-template.md
+++ b/docs/working/templates/retrospective-template.md
@@ -1,0 +1,40 @@
+# Sprint Retrospective — <期間 / sprint 名>
+
+> 生成補助: `sh bin/plangate report --from <YYYY-MM-DD> --to <YYYY-MM-DD>`
+> の出力（`docs/working/_reports/`）を貼り付けてから記入する。
+> 正本: [`docs/ai/reporting.md`](../../ai/reporting.md) / EPIC #193。
+
+## 1. PlanGate Report（貼付）
+
+<!-- bin/plangate report の Markdown をここに貼る -->
+
+## 2. KPT
+
+### Keep（続ける）
+-
+
+### Problem（課題）
+-
+
+### Try（次に試す）
+-
+
+## 3. AI harness improvement 用の問い（#200）
+
+- [ ] C-3 CONDITIONAL/REJECTED が増えた要因は？ plan 品質のどこか？
+- [ ] C-4 REQUEST_CHANGES の頻出指摘パターンは？ exec/レビュー観点か？
+- [ ] V-1 first pass rate の変動要因は？ test-cases 精度か exec 手順か？
+- [ ] fix loop が伸びた TASK の共通要因は？ EHS-3 escalation は機能したか？
+- [ ] hook violation 傾向（どの EH-x が多いか）と是正済みか？
+- [ ] Keep Rate が低い成果物の種類は？（code/plan/acceptance/handoff）
+- [ ] latency / cost が悪化した profile/mode は？ Model Profile 見直し要否？
+- [ ] 上記から **次の harness improvement PBI 候補**を 1〜3 件抽出したか？
+
+## 4. 次アクション（追跡可能に）
+
+| アクション | Owner | 期限 | 関連 PBI 候補 |
+|-----------|-------|------|--------------|
+|           |       |      |              |
+
+> 抽出した PBI 候補は EPIC #193 配下で人間が起票判断（advisory・
+> LLM judge を hard gate にしない・C-3/C-4 を緩和しない / #200 Non-goal）。

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -23,6 +23,39 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 WORKING = REPO / "docs" / "working"
 
+UNKNOWN = "unknown"
+C3_STATUSES = ("APPROVED", "CONDITIONAL", "REJECTED")
+C4_STATUSES = ("APPROVED", "REQUEST_CHANGES", "REJECTED")
+# metrics_collector.HOOK_LEVEL_TO_RESULT と整合（VIOLATION/BLOCK=block）
+_HOOK_VIOLATION_LEVELS = {"VIOLATION", "BLOCK"}
+
+
+def _read_json(path: Path) -> dict | None:
+    """存在チェックせず直接読む（TOCTOU 回避）。欠落/不正/不可は None。"""
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _parse_status_md(text: str) -> dict:
+    """status.md から fix_loop / v1_first_pass を抽出（ヒューリスティック）。
+
+    fix loop: 1-2 桁・直後がハイフンの値は日付の誤検出として除外・上限 50。
+    """
+    out: dict = {}
+    nums = re.findall(
+        r"fix[ _-]?loop[^0-9\n]{0,16}?([0-9]{1,2})(?![0-9-])", text, re.I
+    )
+    vals = [int(x) for x in nums if 0 <= int(x) <= 50]
+    if vals:
+        out["fix_loop"] = max(vals)
+    if text:
+        out["v1_first_pass"] = bool(
+            re.search(r"V-1[^\n]*(PASS|first[ _-]?pass)", text, re.I)
+        )
+    return out
+
 
 def _date(s: str) -> _dt.date:
     return _dt.datetime.strptime(s, "%Y-%m-%d").date()
@@ -60,64 +93,30 @@ def collect(lo: _dt.date, hi: _dt.date) -> dict:
     for d in sorted(WORKING.glob("TASK-*")):
         if not d.is_dir():
             continue
-        c3p = d / "approvals" / "c3.json"
-        if not c3p.is_file():
-            continue
-        try:
-            c3 = json.loads(c3p.read_text())
-        except (OSError, ValueError):
-            continue
-        if not _in_range(c3.get("approved_at"), lo, hi):
+        c3 = _read_json(d / "approvals" / "c3.json")
+        if c3 is None or not _in_range(c3.get("approved_at"), lo, hi):
             continue
         rec = {"task_id": d.name, "c3_status": c3.get("c3_status")}
-        c4p = d / "approvals" / "c4-approval.json"
-        if c4p.is_file():
-            try:
-                rec["c4_status"] = json.loads(c4p.read_text()).get("c4_status")
-            except (OSError, ValueError):
-                pass
-        ev = d / "eval-result.json"
-        if ev.is_file():
-            try:
-                e = json.loads(ev.read_text())
-                rec["release_blockers"] = len(
-                    e.get("release_blocker_violations", [])
-                )
-                rec["ac_coverage"] = e.get("ac_coverage", {}).get(
-                    "rate_percent"
-                )
-                rec["latency_cost"] = e.get("latency_cost", {}).get("decision")
-            except (OSError, ValueError):
-                pass
-        kr = d / "keep-rate-result.json"
-        if kr.is_file():
-            try:
-                k = json.loads(kr.read_text())
-                rec["keep_rate"] = {
-                    "code": k.get("code_keep_rate", {}).get("value"),
-                    "plan": k.get("plan_keep_rate", {}).get("value"),
-                }
-            except (OSError, ValueError):
-                pass
-        # fix loop / V-1: status.md ヒューリスティック
-        st = d / "status.md"
-        if st.is_file():
-            try:
-                t = st.read_text()
-            except OSError:
-                t = ""
-            # fix loop 回数: 1-2 桁・直後がハイフン(日付)でない・上限 50
-            mm = re.findall(
-                r"fix[ _-]?loop[^0-9\n]{0,16}?([0-9]{1,2})(?![0-9-])",
-                t, re.I,
+        c4 = _read_json(d / "approvals" / "c4-approval.json")
+        if c4:
+            rec["c4_status"] = c4.get("c4_status")
+        e = _read_json(d / "eval-result.json")
+        if e:
+            rec["release_blockers"] = len(
+                e.get("release_blocker_violations", [])
             )
-            vals = [int(x) for x in mm if 0 <= int(x) <= 50]
-            if vals:
-                rec["fix_loop"] = max(vals)
-            if t:
-                rec["v1_first_pass"] = bool(
-                    re.search(r"V-1[^\n]*(PASS|first[ _-]?pass)", t, re.I)
-                )
+            rec["ac_coverage"] = e.get("ac_coverage", {}).get("rate_percent")
+            rec["latency_cost"] = e.get("latency_cost", {}).get("decision")
+        k = _read_json(d / "keep-rate-result.json")
+        if k:
+            rec["keep_rate"] = {
+                "code": k.get("code_keep_rate", {}).get("value"),
+                "plan": k.get("plan_keep_rate", {}).get("value"),
+            }
+        try:
+            rec.update(_parse_status_md((d / "status.md").read_text()))
+        except OSError:
+            pass
         tasks.append(rec)
     hook_viol = _hook_violations(lo, hi)
     return _aggregate(tasks, lo, hi, hook_viol)
@@ -130,23 +129,21 @@ def _hook_violations(lo: _dt.date, hi: _dt.date) -> dict:
     期間内の VIOLATION 行を hook 別に数える。ログ無/読めない時は unknown。
     """
     log = REPO / "docs" / "working" / "_audit" / "hook-events.log"
-    if not log.is_file():
-        return {"total": "unknown", "by_hook": {}}
-    try:
-        lines = log.read_text().splitlines()
-    except OSError:
-        return {"total": "unknown", "by_hook": {}}
     total = 0
     by_hook: dict = {}
-    for ln in lines:
-        cols = ln.split("\t")
-        if len(cols) < 3 or cols[1] != "VIOLATION":
-            continue
-        if not _in_range(cols[0], lo, hi):
-            continue
-        total += 1
-        hk = cols[2] or "unknown"
-        by_hook[hk] = by_hook.get(hk, 0) + 1
+    try:
+        with log.open(encoding="utf-8") as fh:
+            for ln in fh:
+                cols = ln.rstrip("\n").split("\t", 4)
+                if len(cols) < 3 or cols[1] not in _HOOK_VIOLATION_LEVELS:
+                    continue
+                if not _in_range(cols[0], lo, hi):
+                    continue
+                total += 1
+                hk = cols[2] or UNKNOWN
+                by_hook[hk] = by_hook.get(hk, 0) + 1
+    except OSError:
+        return {"total": UNKNOWN, "by_hook": {}}
     return {"total": total, "by_hook": by_hook}
 
 
@@ -161,29 +158,22 @@ def _aggregate(tasks: list[dict], lo: _dt.date, hi: _dt.date,
     # 未観測（status.md 無 / 文字列無＝key 未設定）は unknown 扱い。
     known = [t for t in tasks if isinstance(t.get("v1_first_pass"), bool)]
     v1p = sum(1 for t in known if t["v1_first_pass"])
-    v1_rate = (round(100.0 * v1p / len(known), 1) if known else "unknown")
+    v1_rate = (round(100.0 * v1p / len(known), 1) if known else UNKNOWN)
     fl = [t["fix_loop"] for t in tasks if isinstance(t.get("fix_loop"), int)]
     rb = sum(t.get("release_blockers", 0) or 0 for t in tasks)
     return {
         "schema": "report/v1",
         "period": {"from": lo.isoformat(), "to": hi.isoformat()},
         "task_count": n,
-        "c3": {
-            "approved": _count("c3_status", "APPROVED"),
-            "conditional": _count("c3_status", "CONDITIONAL"),
-            "rejected": _count("c3_status", "REJECTED"),
-        },
-        "c4": {
-            "approved": _count("c4_status", "APPROVED"),
-            "request_changes": _count("c4_status", "REQUEST_CHANGES"),
-            "rejected": _count("c4_status", "REJECTED"),
-        },
+        "c3": {k.lower(): _count("c3_status", k) for k in C3_STATUSES},
+        "c4": {("request_changes" if k == "REQUEST_CHANGES" else k.lower()):
+               _count("c4_status", k) for k in C4_STATUSES},
         "v1_first_pass_rate": v1_rate,
         "v1_first_pass_observed": len(known),
         "v1_first_pass_unknown": n - len(known),
-        "fix_loop_max": (max(fl) if fl else "unknown"),
+        "fix_loop_max": (max(fl) if fl else UNKNOWN),
         "release_blocker_total": rb,
-        "hook_violation": hook_viol or {"total": "unknown", "by_hook": {}},
+        "hook_violation": hook_viol or {"total": UNKNOWN, "by_hook": {}},
         "tasks": tasks,
     }
 
@@ -191,6 +181,9 @@ def _aggregate(tasks: list[dict], lo: _dt.date, hi: _dt.date,
 def render_md(r: dict) -> str:
     p = r["period"]
     c3, c4 = r["c3"], r["c4"]
+    _pct = "%" if isinstance(r["v1_first_pass_rate"], (int, float)) else ""
+    _bh = r["hook_violation"].get("by_hook")
+    _hv = f" ({_bh})" if _bh else ""
     lines = [
         f"# PlanGate Report: {p['from']} 〜 {p['to']}",
         "",
@@ -202,15 +195,12 @@ def render_md(r: dict) -> str:
         f"{c3['conditional']} / REJECTED {c3['rejected']}",
         f"- C-4: APPROVED {c4['approved']} / REQUEST_CHANGES "
         f"{c4['request_changes']} / REJECTED {c4['rejected']}",
-        f"- V-1 first pass rate: **{r['v1_first_pass_rate']}"
-        f"{'%' if isinstance(r['v1_first_pass_rate'], (int, float)) else ''}**",
+        f"- V-1 first pass rate: **{r['v1_first_pass_rate']}{_pct}**",
         f"- V-1 観測: {r['v1_first_pass_observed']} / 未観測(unknown): "
         f"{r['v1_first_pass_unknown']}",
         f"- fix loop max: {r['fix_loop_max']}",
         f"- release blocker total: {r['release_blocker_total']}",
-        f"- hook violation: {r['hook_violation']['total']}"
-        + (f" ({r['hook_violation']['by_hook']})"
-           if r['hook_violation'].get('by_hook') else ""),
+        f"- hook violation: {r['hook_violation']['total']}{_hv}",
         "",
         "## TASK 内訳",
         "",

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""reporting.py — Reporting & Retrospective (#200 / PBI-HI-006).
+
+PlanGate の実利用シグナル（C-3/C-4/V-1/fix loop/hook violation/Keep Rate/
+latency）を **期間指定**で集計し、sprint retrospective に貼れる Markdown を
+生成する。決定論・ローカル artifact のみ（Web dashboard / 外部 BI / 自動投稿
+は Non-goal）。LLM judge を hard gate にしない。C-3/C-4 は緩和しない。
+
+正本: docs/ai/reporting.md
+
+Usage:
+  python3 scripts/reporting.py --from 2026-05-01 --to 2026-05-31 [--no-write]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKING = REPO / "docs" / "working"
+
+
+def _date(s: str) -> _dt.date:
+    return _dt.datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def _in_range(ts: str | None, lo: _dt.date, hi: _dt.date) -> bool:
+    """approved_at を UTC 日付に正規化して期間判定（両端含む）。
+
+    ISO8601（`...Z` / `+09:00` 等）は fromisoformat で parse し UTC へ。
+    parse 不能時のみ先頭 YYYY-MM-DD を fallback 採用。欠落/不正は除外。
+    """
+    if not ts:
+        return False
+    d = None
+    try:
+        iso = ts.strip().replace("Z", "+00:00")
+        dt = _dt.datetime.fromisoformat(iso)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(_dt.timezone.utc)
+        d = dt.date()
+    except ValueError:
+        m = re.match(r"(\d{4}-\d{2}-\d{2})", ts)
+        if m:
+            try:
+                d = _date(m.group(1))
+            except ValueError:
+                d = None
+    if d is None:
+        return False
+    return lo <= d <= hi
+
+
+def collect(lo: _dt.date, hi: _dt.date) -> dict:
+    tasks = []
+    for d in sorted(WORKING.glob("TASK-*")):
+        if not d.is_dir():
+            continue
+        c3p = d / "approvals" / "c3.json"
+        if not c3p.is_file():
+            continue
+        try:
+            c3 = json.loads(c3p.read_text())
+        except (OSError, ValueError):
+            continue
+        if not _in_range(c3.get("approved_at"), lo, hi):
+            continue
+        rec = {"task_id": d.name, "c3_status": c3.get("c3_status")}
+        c4p = d / "approvals" / "c4-approval.json"
+        if c4p.is_file():
+            try:
+                rec["c4_status"] = json.loads(c4p.read_text()).get("c4_status")
+            except (OSError, ValueError):
+                pass
+        ev = d / "eval-result.json"
+        if ev.is_file():
+            try:
+                e = json.loads(ev.read_text())
+                rec["release_blockers"] = len(
+                    e.get("release_blocker_violations", [])
+                )
+                rec["ac_coverage"] = e.get("ac_coverage", {}).get(
+                    "rate_percent"
+                )
+                rec["latency_cost"] = e.get("latency_cost", {}).get("decision")
+            except (OSError, ValueError):
+                pass
+        kr = d / "keep-rate-result.json"
+        if kr.is_file():
+            try:
+                k = json.loads(kr.read_text())
+                rec["keep_rate"] = {
+                    "code": k.get("code_keep_rate", {}).get("value"),
+                    "plan": k.get("plan_keep_rate", {}).get("value"),
+                }
+            except (OSError, ValueError):
+                pass
+        # fix loop / V-1: status.md ヒューリスティック
+        st = d / "status.md"
+        if st.is_file():
+            try:
+                t = st.read_text()
+            except OSError:
+                t = ""
+            # fix loop 回数: 1-2 桁・直後がハイフン(日付)でない・上限 50
+            mm = re.findall(
+                r"fix[ _-]?loop[^0-9\n]{0,16}?([0-9]{1,2})(?![0-9-])",
+                t, re.I,
+            )
+            vals = [int(x) for x in mm if 0 <= int(x) <= 50]
+            if vals:
+                rec["fix_loop"] = max(vals)
+            if t:
+                rec["v1_first_pass"] = bool(
+                    re.search(r"V-1[^\n]*(PASS|first[ _-]?pass)", t, re.I)
+                )
+        tasks.append(rec)
+    hook_viol = _hook_violations(lo, hi)
+    return _aggregate(tasks, lo, hi, hook_viol)
+
+
+def _hook_violations(lo: _dt.date, hi: _dt.date) -> dict:
+    """docs/working/_audit/hook-events.log の VIOLATION を期間集計（決定論）。
+
+    形式: `<ISO ts>\t<LEVEL>\t<hook>\t<task>\t<msg>`。ts を UTC 日付化し
+    期間内の VIOLATION 行を hook 別に数える。ログ無/読めない時は unknown。
+    """
+    log = REPO / "docs" / "working" / "_audit" / "hook-events.log"
+    if not log.is_file():
+        return {"total": "unknown", "by_hook": {}}
+    try:
+        lines = log.read_text().splitlines()
+    except OSError:
+        return {"total": "unknown", "by_hook": {}}
+    total = 0
+    by_hook: dict = {}
+    for ln in lines:
+        cols = ln.split("\t")
+        if len(cols) < 3 or cols[1] != "VIOLATION":
+            continue
+        if not _in_range(cols[0], lo, hi):
+            continue
+        total += 1
+        hk = cols[2] or "unknown"
+        by_hook[hk] = by_hook.get(hk, 0) + 1
+    return {"total": total, "by_hook": by_hook}
+
+
+def _aggregate(tasks: list[dict], lo: _dt.date, hi: _dt.date,
+               hook_viol: dict | None = None) -> dict:
+    n = len(tasks)
+
+    def _count(field: str, val: str) -> int:
+        return sum(1 for t in tasks if t.get(field) == val)
+
+    # MJ-1: v1_first_pass は観測済（True/False 記録あり）のみ分母に。
+    # 未観測（status.md 無 / 文字列無＝key 未設定）は unknown 扱い。
+    known = [t for t in tasks if isinstance(t.get("v1_first_pass"), bool)]
+    v1p = sum(1 for t in known if t["v1_first_pass"])
+    v1_rate = (round(100.0 * v1p / len(known), 1) if known else "unknown")
+    fl = [t["fix_loop"] for t in tasks if isinstance(t.get("fix_loop"), int)]
+    rb = sum(t.get("release_blockers", 0) or 0 for t in tasks)
+    return {
+        "schema": "report/v1",
+        "period": {"from": lo.isoformat(), "to": hi.isoformat()},
+        "task_count": n,
+        "c3": {
+            "approved": _count("c3_status", "APPROVED"),
+            "conditional": _count("c3_status", "CONDITIONAL"),
+            "rejected": _count("c3_status", "REJECTED"),
+        },
+        "c4": {
+            "approved": _count("c4_status", "APPROVED"),
+            "request_changes": _count("c4_status", "REQUEST_CHANGES"),
+            "rejected": _count("c4_status", "REJECTED"),
+        },
+        "v1_first_pass_rate": v1_rate,
+        "v1_first_pass_observed": len(known),
+        "v1_first_pass_unknown": n - len(known),
+        "fix_loop_max": (max(fl) if fl else "unknown"),
+        "release_blocker_total": rb,
+        "hook_violation": hook_viol or {"total": "unknown", "by_hook": {}},
+        "tasks": tasks,
+    }
+
+
+def render_md(r: dict) -> str:
+    p = r["period"]
+    c3, c4 = r["c3"], r["c4"]
+    lines = [
+        f"# PlanGate Report: {p['from']} 〜 {p['to']}",
+        "",
+        "> retrospective 貼付用。advisory（C-3/C-4 を緩和しない・"
+        "LLM judge を hard gate にしない / #200）",
+        "",
+        f"- 対象 TASK: **{r['task_count']}**",
+        f"- C-3: APPROVED {c3['approved']} / CONDITIONAL "
+        f"{c3['conditional']} / REJECTED {c3['rejected']}",
+        f"- C-4: APPROVED {c4['approved']} / REQUEST_CHANGES "
+        f"{c4['request_changes']} / REJECTED {c4['rejected']}",
+        f"- V-1 first pass rate: **{r['v1_first_pass_rate']}"
+        f"{'%' if isinstance(r['v1_first_pass_rate'], (int, float)) else ''}**",
+        f"- V-1 観測: {r['v1_first_pass_observed']} / 未観測(unknown): "
+        f"{r['v1_first_pass_unknown']}",
+        f"- fix loop max: {r['fix_loop_max']}",
+        f"- release blocker total: {r['release_blocker_total']}",
+        f"- hook violation: {r['hook_violation']['total']}"
+        + (f" ({r['hook_violation']['by_hook']})"
+           if r['hook_violation'].get('by_hook') else ""),
+        "",
+        "## TASK 内訳",
+        "",
+        "| TASK | C-3 | C-4 | AC% | blockers | keep(code/plan) | latency |",
+        "|------|-----|-----|-----|----------|-----------------|---------|",
+    ]
+    for t in r["tasks"]:
+        kr = t.get("keep_rate", {})
+        lines.append(
+            f"| {t['task_id']} | {t.get('c3_status', '-')} | "
+            f"{t.get('c4_status', '-')} | {t.get('ac_coverage', '-')} | "
+            f"{t.get('release_blockers', '-')} | "
+            f"{kr.get('code', '-')}/{kr.get('plan', '-')} | "
+            f"{t.get('latency_cost') or 'unknown'} |"
+        )
+    lines += [
+        "",
+        "## 次の harness improvement PBI 候補（抽出指針）",
+        "",
+        "- C-3 CONDITIONAL/REJECTED 多 → plan 品質 PBI（Plan Quality "
+        "Checks #213 強化）",
+        "- C-4 REQUEST_CHANGES 多 → exec/レビュー観点 PBI",
+        "- V-1 first pass rate 低 → test-cases 精度 / exec 手順 PBI",
+        "- fix loop max 高 → fix loop 上限 / EHS-3 escalation 見直し",
+        "- release blocker total 増 → 該当 aspect の Gate/taxonomy 強化",
+        "- Keep Rate 低 → 採用されない成果物パターンの retro PBI",
+        "",
+        "> 抽出は **advisory**。実際の PBI 化は人間が判断（EPIC #193 配下）。",
+        "",
+        "## 関連",
+        "",
+        "- [`docs/ai/reporting.md`](../ai/reporting.md)",
+        "- [`docs/working/templates/retrospective-template.md`]"
+        "(./templates/retrospective-template.md)",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="PlanGate Reporting v1 (#200)")
+    ap.add_argument("--from", dest="frm", required=True, help="YYYY-MM-DD")
+    ap.add_argument("--to", dest="to", required=True, help="YYYY-MM-DD")
+    ap.add_argument("--no-write", action="store_true")
+    a = ap.parse_args()
+    try:
+        lo, hi = _date(a.frm), _date(a.to)
+    except ValueError:
+        print("error: --from/--to must be YYYY-MM-DD", file=sys.stderr)
+        return 2
+    if lo > hi:
+        print("error: --from is after --to", file=sys.stderr)
+        return 2
+    r = collect(lo, hi)
+    md = render_md(r)
+    js = json.dumps(r, indent=2, ensure_ascii=False)
+    if a.no_write:
+        print("=== report.md ===")
+        print(md)
+        print("=== report.json ===")
+        print(js)
+    else:
+        out = WORKING / "_reports"
+        out.mkdir(parents=True, exist_ok=True)
+        stem = f"report-{a.frm}_{a.to}"
+        (out / f"{stem}.md").write_text(md + "\n")
+        (out / f"{stem}.json").write_text(js + "\n")
+        print(f"Written: docs/working/_reports/{stem}.{{md,json}}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要
#200 を standard で実装。eval/metrics/Keep Rate を **期間指定**で集計し sprint retrospective に貼れる Markdown + 次改善 PBI 候補抽出指針を生成（決定論・advisory）。**EPIC #193 最後の子 PBI**。

## 変更
- **新規** `scripts/reporting.py`: c3/c4/eval-result/keep-rate-result/status/`_audit/hook-events.log` を `--from`/`--to` 期間集計（C-3/C-4/V-1 first pass/fix loop/release blocker/Keep Rate/latency/hook violation）
- `bin/plangate report --from <date> --to <date>`（report 追加のみ・keep-rate#198/context#199 非混入を diff 検証）
- **新規** `docs/ai/reporting.md` 正本（集計ソース / Report items / 運用手順 / retrospective 接続 / 次 PBI 候補抽出方針）
- **新規** `docs/working/templates/retrospective-template.md`（KPT + AI harness improvement 用の問い 8 項目 + 次アクション追跡表）

## V-1 / V-3
- V-1: AC1-6 + E1（fix_loop 非日付）/E2（advisory）全 PASS
- V-3（Codex）: critical 0 / major 3 / minor 3 → **全反映**
  - MJ-1 v1_first_pass の unknown と 0 を区別（observed/unknown 出力）
  - MJ-2 `_in_range` を ISO8601 TZ 正規化（fromisoformat→UTC 日付）
  - MJ-3 hook violation を hook-events.log から hook 別期間集計（doc/template 整合）
  - mn-1 status OSError ガード / mn-2 latency unknown / mn-3 委譲コメント
  - 回帰 PASS（ISO TZ +09:00/Z 判定・hook 別集計・fix_loop 非日付）

## Non-goals 遵守
Web dashboard / 外部 BI / Slack・Discussions 自動投稿 / LLM judge hard gate / C-3・C-4 緩和 — いずれも未実装

## Mode
standard（feat・集計 script+CLI+正本+テンプレ）

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)