### PR TITLE
refactor(#277): scripts パス定数を _paths.py へ共有化 / reuse M-2 / TASK-0101

### DIFF
--- a/docs/working/TASK-0101/INDEX.md
+++ b/docs/working/TASK-0101/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0101 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0101/approvals/c3.json
+++ b/docs/working/TASK-0101/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0101",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-17T22:58:42Z",
+  "plan_hash": "sha256:8307ff9494ea23630c24e107100c5aa36f9df444984c3de09b51a9a873f1ae9d"
+}

--- a/docs/working/TASK-0101/current-state.md
+++ b/docs/working/TASK-0101/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0101 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0101/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0101 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0101/handoff.md
+++ b/docs/working/TASK-0101/handoff.md
@@ -1,0 +1,40 @@
+# Handoff — TASK-0101 / #277 scripts パス定数共有モジュール化（reuse M-2）
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 _paths.py 固定定数(REPO_ROOT/SCRIPTS_DIR/WORKING_DIR/SCHEMAS_DIR)| PASS |
+| AC2 11 script が _paths 参照・ローカル重複除去 | PASS（11/11）|
+| AC3 全スイート回帰なし | PASS（68 passed 0 failed）|
+| AC4 behavior-preserving（smoke + plan_hash 等価）| PASS |
+| AC5 shell/hooks/bin 無変更 | PASS（git diff 空）|
+V-1 PASS。V-3 = Codex 無応答のため precedent に従い機械自己 V-3 全観点 PASS。
+
+## 2. 検討経緯（ユーザー指示: Codex相談→決定→実装）
+- Codex 相談: EPIC #193 完遂で混入懸念消滅・8(実態11)ファイル focused・
+  ユーザー進行希望 → 「今・最小リファクタとして実装」推奨。設計助言
+  （固定定数のみ/override・env・package化なし/shell・hooks 不巻込/
+  plan_hash_util 無理に依存させない/sys.path.insert 慣習整合）を全採用。
+- 実装後 V-3: Codex CLI 10分超無応答 → 確立 precedent（外部不可時は実証
+  検証が意見より強い）で機械自己 V-3 に切替・全観点 PASS。
+
+## 3. 既知課題 / V2
+- bootstrap 行（sys.path.insert）が各 script に 1 行増。将来 scripts/ を
+  正式 package 化する場合は本 bootstrap を __init__ 解決へ移せる（V2・YAGNI）。
+- eval-runner/context-engine/keep-rate/metrics_collector は plan_hash_util 用の
+  既存 sys.path.insert も持つ（重複だが無害・behavior 不変）。統合は V2 任意。
+
+## 4. 妥協点
+- _paths を private 名（直接実行されない共有定数モジュール）に。package 化・
+  env override は YAGNI で見送り（Codex 助言・#277 Non-goal 準拠）。
+- V-3 外部レビューは Codex 無応答により機械自己検証で代替（precedent）。
+
+## 5. 引き継ぎ
+#277（reuse M-2）解消。scripts/_paths.py に REPO/WORKING/SCHEMAS/SCRIPTS を
+集約、11 script を alias import で behavior-preserving 置換（下流変数名・値
+不変）。shell/hooks/bin/plan_hash_util 不変。全スイート 68/0・CLI smoke 全 OK・
+metrics plan_hash 等価。これで reuse follow-up（H-1 #276 / M-2 本 #277）完了。
+EPIC #193 配下の reuse 由来技術負債ゼロ。
+
+## 6. テスト結果
+V-1 AC1/2/5 + V-3 機械 9 観点 + run-tests 68/0 + 主要 CLI 7 smoke + metrics
+plan_hash 等価 + shell 無変更 全 PASS。

--- a/docs/working/TASK-0101/pbi-input.md
+++ b/docs/working/TASK-0101/pbi-input.md
@@ -1,0 +1,31 @@
+# PBI INPUT — TASK-0101 / #277 scripts パス定数共有モジュール化（reuse M-2）
+
+## Context / Why
+#277（reuse M-2）: 11 script が REPO root + docs/working + schemas を各自定義、
+命名も REPO/REPO_ROOT・WORKING/WORKING_DIR・parent.parent/parents[1] 混在。
+EPIC #193 完遂・クローズで「EPIC 混入懸念」消滅 → focused PBI 化可能。
+Codex 相談で「今・最小リファクタとして実装」推奨（YAGNI 拡張は入れない）。
+
+## What
+- In: scripts/_paths.py 新規（固定定数 REPO_ROOT/SCRIPTS_DIR/WORKING_DIR/
+  SCHEMAS_DIR）/ 11 script を _paths 参照へ（既存変数名は alias 維持＝差分最小）
+- Out: env override / 設定注入 / package 化(__init__.py) / shell・hooks 巻込 /
+  plan_hash_util（path 定数なし＝対象外）/ 振る舞い変更
+
+## 受入基準
+- AC1: scripts/_paths.py に REPO_ROOT/SCRIPTS_DIR/WORKING_DIR/SCHEMAS_DIR 固定定数
+- AC2: 11 script（context-engine/keep-rate/reporting/baseline-snapshot/
+  metrics_collector/eval-runner/doctor_check/metrics_reporter/metrics_timeline/
+  schema_mapping/validate-schemas）が _paths 参照・ローカル重複定義除去
+- AC3: 全テストスイート（run-tests.sh）回帰なし（全 PASS）
+- AC4: 主要 CLI/出力が behavior-preserving（smoke + metrics plan_hash 等価）
+- AC5: shell/hooks/bin 無変更（承認境界・対象外を侵さない）
+
+## Notes
+Codex 助言: 固定定数のみ・override/env/package化なし・既存 sys.path.insert
+慣習に整合・plan_hash_util 無理に依存させない。alias import で既存変数名温存
+→ 下流参照不変＝behavior-preserving by construction。
+
+## Estimation
+Risks: import 経路（scripts/ が sys.path 必要）→ bootstrap 1行で両実行経路担保
++ 全スイート/smoke で機械検証 / Unknowns: なし

--- a/docs/working/TASK-0101/plan.md
+++ b/docs/working/TASK-0101/plan.md
@@ -1,0 +1,43 @@
+# EXECUTION PLAN — TASK-0101 / #277 reuse M-2
+
+## Goal
+scripts のパス定数を _paths.py へ集約し命名統一（behavior-preserving）。
+
+## Constraints / Non-goals
+- env override/設定注入/package化/shell・hooks 巻込/plan_hash_util 依存/
+  振る舞い変更 はしない（Codex 助言・YAGNI）。
+
+## Approach Overview
+_paths.py（固定定数）新規 → 11 script の path 定義を `from _paths import` に
+置換、各 script の既存変数名へ alias（差分最小・下流不変）。import bootstrap
+（scripts/ を sys.path へ・既存慣習整合）を 1 行付与。全スイート + smoke +
+metrics plan_hash 等価で behavior-preserving 検証。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | scripts/_paths.py | agent | 低 | 🚩 AC1 |
+| S2 | 11 script 置換（alias 維持）| agent | 中 | 🚩 AC2 |
+| S3 | 回帰: run-tests + smoke + plan_hash 等価 | agent | 中 | 🚩 AC3/4/5 |
+
+## Files / Components to Touch
+- scripts/_paths.py（新規）
+- 上記 11 script（path 定義のみ置換）
+
+## Testing Strategy
+- Verification: sh tests/run-tests.sh 全件 / 主要 CLI smoke（keep-rate/context/
+  report/validate-schemas/eval-runner/metrics_reporter/schema_mapping）/
+  metrics_collector plan_hash 等価 / shell・hooks・bin git diff 空 / py_compile。
+
+## Risks & Mitigations
+- import 経路 → bootstrap(sys.path.insert scripts) 1行・両実行経路で smoke 確認
+- 挙動差 → alias で下流変数名不変・全スイート 68/0・plan_hash 等価で機械保証
+- scope 逸脱 → shell/hooks/bin/plan_hash_util を Non-goal・git diff で不巻込確認
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**: 12 ファイル（新規1+11置換）・schema_mapping/eval 含む・
+behavior-preserving だが横断 → standard（V-3 実施）

--- a/docs/working/TASK-0101/review-external.md
+++ b/docs/working/TASK-0101/review-external.md
@@ -1,0 +1,26 @@
+# V-3 外部レビュー — TASK-0101 / #277
+
+## 実施形態
+Codex V-3 を起動するも CLI が長時間（10 分超）無応答・出力 0 バイト（メモリ
+既知事象: codex/gemini CLI の偶発ハング）。確立済 precedent（外部レビュア
+不可時は実証検証＋セルフ V-3 で代替。behavior-preserving alias refactor では
+機械検証が意見レビューより強い）に従い、Codex が検証する全観点を **機械
+自己 V-3** で代替検証した。
+
+## 自己 V-3（Codex 観点・機械検証）結果
+| # | 観点 | 結果 |
+|---|------|------|
+| 1 | REPO_ROOT 値同一（parent.parent≡parents[1]）| PASS（True・_paths.REPO_ROOT==cwd）|
+| 2 | alias 不変（既存変数名で下流参照継続）| PASS（REPO/WORKING/REPO_ROOT/WORKING_DIR/SCHEMAS_DIR alias）|
+| 3 | 循環 import なし | PASS（ast 解析: _paths は __future__/pathlib のみ・scripts 内参照ゼロ。初回 grep FAIL は docstring "import 方法:" の誤マッチ）|
+| 4 | bootstrap 識別子(_phsys/_phP)衝突なし | PASS（_paths import 専用・他用途なし）|
+| 5 | 被 import 経路（eval-runner/validate-schemas→schema_mapping）| PASS（両 smoke OK）|
+| 6 | from __future__ 位置不変・noqa:E402 妥当 | PASS（各 script 既存行維持）|
+| 7 | Non-goal（env/package化）| PASS（__init__.py 無・env override 無）|
+| 8 | 全スイート回帰 | PASS（68 passed 0 failed）|
+| 9 | scope（shell/bin/hooks/plan_hash_util 不変）| PASS（git diff 空・scripts 変更は対象12のみ）|
+
+## 判定
+critical/major 相当なし（機械検証で全観点 PASS）。behavior-preserving は
+alias 構造 + 68/0 + CLI smoke 全 OK + metrics plan_hash 等価 + scope diff 空
+で機械保証。外部 Codex 未応答は precedent に従い実証検証で代替（意見より強い）。

--- a/docs/working/TASK-0101/review-self.md
+++ b/docs/working/TASK-0101/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0101
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-5 ↔ S1-S3 ↔ T1-T5 |
+| C1-PLAN-02 Unknowns | PASS | なし（Codex 相談で設計確定）|
+| C1-PLAN-03 スコープ | PASS | env/package/shell/plan_hash_util/振る舞い変更 Non-goal |
+| C1-PLAN-04 テスト戦略 | PASS | 全スイート+smoke+plan_hash等価+diff+compile |
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | run-tests/smoke 機械検証 |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3 APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T5 ↔ AC1-5 |
+| C1-TC-02 Edge網羅 | PASS | E1 両経路 / E2 alias 不変 |
+| C1-TC-03 自動化可否 | PASS | run-tests/smoke 自動 |
+| C1-INT-01 behavior-preserving | PASS | alias 下流不変・68/0・plan_hash 等価 |
+| C1-INT-02 scope 遵守 | PASS | shell/hooks/bin/plan_hash_util 無変更 diff 確認 |
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0101/test-cases.md
+++ b/docs/working/TASK-0101/test-cases.md
@@ -1,0 +1,11 @@
+# テストケース — TASK-0101 / #277
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | _paths.py に REPO_ROOT/SCRIPTS_DIR/WORKING_DIR/SCHEMAS_DIR 固定定数 | import 検証 |
+| T2 | AC2 | 11 script が from _paths import・ローカル `=Path(__file__)` path 定義除去 | 構造突合 |
+| T3 | AC3 | sh tests/run-tests.sh 全 PASS（回帰なし）| テスト実行 |
+| T4 | AC4 | keep-rate/context/report/validate-schemas/eval-runner/metrics_reporter/schema_mapping smoke OK + metrics plan_hash 等価 | smoke |
+| T5 | AC5 | scripts/hooks・bin/plangate・plan_hash_util git diff 空 | diff |
+## Edge
+- E1: 直接実行(python3 scripts/x.py)と被import(schema_mapping)両経路で _paths 解決
+- E2: alias（REPO/WORKING 等既存名）維持で下流参照不変＝behavior-preserving

--- a/docs/working/TASK-0101/todo.md
+++ b/docs/working/TASK-0101/todo.md
@@ -1,0 +1,13 @@
+# TODO — TASK-0101 / #277
+## 🤖 Agent
+- [x] Codex 相談で方針確定（今・最小リファクタ実装）
+- [x] S1 _paths.py（🚩AC1）
+- [x] S2 11 script 置換 alias 維持（🚩AC2）
+- [x] S3 全スイート+smoke+plan_hash 等価（🚩AC3/4/5）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/scripts/_paths.py
+++ b/scripts/_paths.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""_paths.py — scripts 共有パス定数（#277 / reuse M-2 / EPIC #193 follow-up).
+
+scripts/*.py に重複していた REPO ルート / docs/working / schemas /
+scripts ディレクトリの算出を 1 箇所へ集約する。固定定数のみ。
+環境変数 override / 設定注入 / package 化はしない（YAGNI・Codex 助言）。
+
+import 方法（既存 sys.path.insert 慣習と整合）:
+- 直接実行（python3 scripts/foo.py）: scripts/ が sys.path[0] に入るため
+  `from _paths import REPO_ROOT, WORKING_DIR` がそのまま動く。
+- 別 script から import される場合: 呼び出し側の
+  `sys.path.insert(0, str(REPO_ROOT / "scripts"))` 慣習を維持すれば解決。
+
+shell / hooks は対象外（本モジュールは Python 消費者専用）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+WORKING_DIR = REPO_ROOT / "docs" / "working"
+SCHEMAS_DIR = REPO_ROOT / "schemas"

--- a/scripts/baseline-snapshot.py
+++ b/scripts/baseline-snapshot.py
@@ -29,8 +29,8 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-WORKING_DIR = REPO_ROOT / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT, WORKING_DIR  # noqa: E402
 EVAL_RUNNER = REPO_ROOT / "scripts" / "eval-runner.py"
 PLANGATE_BIN = REPO_ROOT / "bin" / "plangate"
 DEFAULT_OUT_DIR = REPO_ROOT / "docs" / "ai" / "eval-baselines"

--- a/scripts/context-engine.py
+++ b/scripts/context-engine.py
@@ -26,8 +26,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import plan_hash_util  # noqa: E402
 
-REPO = Path(__file__).resolve().parent.parent
-WORKING = REPO / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT as REPO, WORKING_DIR as WORKING  # noqa: E402
 
 # mode → context budget（model-profiles の max_context_policy と整合）
 _BUDGET = {

--- a/scripts/doctor_check.py
+++ b/scripts/doctor_check.py
@@ -25,7 +25,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT as REPO  # noqa: E402
 
 V860_FILE_CHECKS: list[tuple[str, str]] = [
     ("schemas/plangate-event.schema.json", "fail"),

--- a/scripts/eval-runner.py
+++ b/scripts/eval-runner.py
@@ -32,8 +32,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-WORKING_DIR = REPO_ROOT / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT, WORKING_DIR  # noqa: E402
 EVAL_RUNNER_VERSION = "1.2.0"  # Issue #168: codex session log parser 統合
 
 # Issue #172: schema mapping は scripts/schema_mapping.py に集約（DRY）

--- a/scripts/keep-rate.py
+++ b/scripts/keep-rate.py
@@ -22,8 +22,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import plan_hash_util  # noqa: E402
 
-REPO = Path(__file__).resolve().parent.parent
-WORKING = REPO / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT as REPO, WORKING_DIR as WORKING  # noqa: E402
 AC_LINE = re.compile(r"^\|\s*AC[0-9A-Za-z_-]*\s*\|.*\|\s*(PASS|FAIL|WARN)\s*\|", re.I)
 
 UNKNOWN = "unknown"

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -27,8 +27,8 @@ import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-WORKING_DIR = REPO_ROOT / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT, WORKING_DIR  # noqa: E402
 METRICS_DIR = WORKING_DIR / "_metrics"
 EVENTS_LOG = METRICS_DIR / "events.ndjson"
 HOOK_AUDIT_LOG = WORKING_DIR / "_audit" / "hook-events.log"

--- a/scripts/metrics_reporter.py
+++ b/scripts/metrics_reporter.py
@@ -21,7 +21,8 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT  # noqa: E402
 DEFAULT_EVENTS_LOG = REPO_ROOT / "docs" / "working" / "_metrics" / "events.ndjson"
 
 

--- a/scripts/metrics_timeline.py
+++ b/scripts/metrics_timeline.py
@@ -14,7 +14,8 @@ import json
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT  # noqa: E402
 DEFAULT_LOG = REPO_ROOT / "docs" / "working" / "_metrics" / "events.ndjson"
 
 # phase 正規化順（1.0 A..C-4 + 1.1 WF-01..06 / handoff）。enum 外は末尾。

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -20,8 +20,8 @@ import re
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-WORKING = REPO / "docs" / "working"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT as REPO, WORKING_DIR as WORKING  # noqa: E402
 
 UNKNOWN = "unknown"
 C3_STATUSES = ("APPROVED", "CONDITIONAL", "REJECTED")

--- a/scripts/schema_mapping.py
+++ b/scripts/schema_mapping.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-SCHEMAS_DIR = REPO_ROOT / "schemas"
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT, SCHEMAS_DIR  # noqa: E402
 
 # basename → schema filename
 # 新 schema を追加するときは本ファイルにエントリを足すだけ。

--- a/scripts/validate-schemas.py
+++ b/scripts/validate-schemas.py
@@ -23,7 +23,8 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
+from _paths import REPO_ROOT  # noqa: E402
 
 # Issue #172: schema mapping は scripts/schema_mapping.py に集約（DRY）
 sys.path.insert(0, str(REPO_ROOT / "scripts"))


### PR DESCRIPTION
## 概要
EPIC #193 follow-up の **reuse M-2**（REPO/WORKING パス定数が 11 script に重複・命名不統一）を解消。**Codex 相談で方針確定**（EPIC 完遂で混入懸念消滅 → focused PBI として今・最小リファクタ実装）。behavior-preserving。

## 変更
- **新規** `scripts/_paths.py`: 固定定数 `REPO_ROOT` / `SCRIPTS_DIR` / `WORKING_DIR` / `SCHEMAS_DIR` のみ（env override / 設定注入 / package 化はしない＝YAGNI・Codex 助言）
- 11 script（context-engine / keep-rate / reporting / baseline-snapshot / metrics_collector / eval-runner / doctor_check / metrics_reporter / metrics_timeline / schema_mapping / validate-schemas）の path 定義を `from _paths import` へ置換。**既存変数名へ alias 維持**（REPO/WORKING 等）で下流参照不変＝behavior-preserving by construction。`parent.parent`≡`parents[1]` 統一
- import bootstrap 1 行付与（既存 sys.path.insert 慣習に整合・直接実行/被 import 両経路で解決）

## Non-goal 遵守
shell / hooks / bin/plangate / plan_hash_util **無変更**（git diff 空で確認）・`__init__.py` なし・env override なし

## 検証
- V-1: AC1/AC2(11/11)/AC5 PASS
- V-3: **Codex CLI が 10 分超無応答**（メモリ既知事象）→ 確立 precedent（外部レビュア不可時は実証検証が意見より強い）に従い**機械自己 V-3 全 9 観点 PASS**（REPO_ROOT 値同一 / alias 不変 / 循環 import なし / bootstrap 識別子非衝突 / 被 import 経路 / __future__ 位置 / Non-goal / 回帰 / scope）
- `sh tests/run-tests.sh` → **68 passed, 0 failed** / 主要 CLI 7 smoke 全 OK / metrics_collector plan_hash 等価 / shell・bin・hooks・plan_hash_util 無変更

## Mode
standard（新規 _paths + 11 script 置換・横断・behavior-preserving）

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)