### PR TITLE
feat(#200 v2): reporting の v1_first_pass/fix_loop を events 由来で厳密化 / TASK-0102

### DIFF
--- a/docs/working/TASK-0102/INDEX.md
+++ b/docs/working/TASK-0102/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0102 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0102/approvals/c3.json
+++ b/docs/working/TASK-0102/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0102",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-18T00:23:21Z",
+  "plan_hash": "sha256:c331304ea73fbeb4eafecbf3d9fbee3a7887113bfb48e2ade45776c11bdc032a"
+}

--- a/docs/working/TASK-0102/current-state.md
+++ b/docs/working/TASK-0102/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0102 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0102/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0102 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0102/handoff.md
+++ b/docs/working/TASK-0102/handoff.md
@@ -1,0 +1,30 @@
+# Handoff — TASK-0102 / #200 v2: reporting v1/fix_loop events 厳密化
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 events 由来 v1/fix_loop（precedence events>status.md>unknown）| PASS |
+| AC2 events 不在で従来挙動完全等価 | PASS（2 期間 in-place 等価）|
+| AC3 events 存在時 厳密値反映 | PASS（TASK-0095 True / TASK-0090 False,fix_loop2）|
+| AC4 metrics_reporter.load_events 再利用（再実装なし）| PASS |
+| AC5 全スイート回帰なし | PASS（68 passed 0 failed）|
+V-1 全 PASS。V-3（Codex）APPROVE・critical/major 0・minor 1 反映。
+## 2. 経緯
+#200 dogfooding 振り返り（v1 観測 1/32 最低シグナル）→ Codex 戦略相談
+（振り返り→停止推奨）だがユーザー明示指示「improvement-seeds 1 件実装」→
+3 候補から本件（最高価値・最小リスク・#200 handoff §3 v2）選定 → 実装 →
+V-3 で不正 verdict 防御追加。
+## 3. 既知課題 / V2
+- 残 improvement-seeds（hook-events test/dev フィルタ / run-id スコープ）は
+  未実装・YAGNI 保留（過剰実装回避）。
+- v1 初回判定は events.ndjson append-only 前提（ts ソートしない＝Codex info）。
+## 4. 妥協点
+- status.md ヒューリスティック削除せず fallback 維持（clean checkout/CI で
+  従来挙動保証）。reporting.py 単独変更。
+## 5. 引き継ぎ
+#200 v2: reporting の v1_first_pass/fix_loop を events.ndjson 由来で厳密化、
+metrics_reporter.load_events 再利用、precedence events>status.md>unknown、
+events 不在 behavior-preserving。V-3 で有効 verdict のみ採用を反映。dogfooding
+振り返り起点の improvement-seeds 1 件消化。
+## 6. テスト結果
+V-1 AC1-5 + V-3 反映後: events不在 2 期間 in-place 等価 / 合成 events 厳密化 /
+不正 verdict スキップ / run-tests 68/0 / scope reporting.py のみ 全 PASS。

--- a/docs/working/TASK-0102/pbi-input.md
+++ b/docs/working/TASK-0102/pbi-input.md
@@ -1,0 +1,33 @@
+# PBI INPUT — TASK-0102 / #200 v2: reporting の v1/fix_loop を events 厳密化
+
+## Context / Why
+#200 dogfooding 振り返り（本セッション run）で v1_first_pass が最低シグナル
+（観測 1/32）と判明。status.md ヒューリスティックは低精度。Metrics v1 の
+events.ndjson（v1_completed/fix_loop_incremented）が決定論正本。ユーザー指示
+「improvement-seeds を 1 件実装」で本候補（#200 handoff §3 既記載 v2）を選定。
+
+## What
+- In: scripts/reporting.py — events.ndjson 由来で v1_first_pass/fix_loop を
+  厳密導出、events 不在時は status.md ヒューリスティックへ fallback。
+  metrics_reporter.load_events を再利用（再実装回避）。
+- Out: 他 improvement-seeds（hook test フィルタ/run-id スコープ）/ events
+  schema 変更 / status.md ヒューリスティック削除 / hook violation・C-3/C-4 変更
+
+## 受入基準
+- AC1: events.ndjson の v1_completed(verdict)/fix_loop_incremented(fix_loop_count)
+  から v1_first_pass/fix_loop を導出（precedence: events > status.md > unknown）
+- AC2: events 不在（gitignore・clean checkout）で従来挙動と完全等価
+  （behavior-preserving）
+- AC3: events 存在時に厳密値が反映（初回 v1_completed PASS→True / FAIL→False、
+  fix_loop_count max）
+- AC4: metrics_reporter.load_events を再利用（reporting に再実装しない）
+- AC5: 全スイート回帰なし（run-tests.sh）
+
+## Notes
+events.ndjson は .gitignore 対象（metrics.md §2）→ clean checkout で不在＝
+load_events []→status.md fallback で従来挙動。reporting.py のみ変更
+（metrics_reporter/_paths/shell/bin/schema 不変）。
+
+## Estimation
+Risks: events 不在で挙動変化（緩和: in-place 等価検証 2 期間）/ 再実装重複
+（緩和: load_events 再利用）/ Unknowns: なし

--- a/docs/working/TASK-0102/plan.md
+++ b/docs/working/TASK-0102/plan.md
@@ -1,0 +1,43 @@
+# EXECUTION PLAN — TASK-0102 / #200 v2 events 厳密化
+
+## Goal
+reporting の v1_first_pass/fix_loop を events.ndjson 由来で厳密化、events
+不在時は status.md fallback（behavior-preserving）。
+
+## Constraints / Non-goals
+- 他 improvement-seeds / events schema / status.md 削除 / hook・C-3/C-4 は
+  変更しない。reporting.py 単独変更。
+
+## Approach Overview
+metrics_reporter.load_events 再利用で events.ndjson を 1 回ロード→task 別
+index。_events_signals で v1_first_pass(初回 v1_completed verdict==PASS)/
+fix_loop(fix_loop_incremented count max) 導出。collect で precedence
+events>status.md>unknown。events 不在は [] → status.md fallback = 従来等価。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | _events_signals + load_events 再利用 import | agent | 中 | 🚩 AC1/AC4 |
+| S2 | collect precedence 統合 | agent | 中 | 🚩 AC1 |
+| S3 | 等価(events不在)+厳密化(events有)+全スイート検証 | agent | 中 | 🚩 AC2/3/5 |
+
+## Files / Components to Touch
+- scripts/reporting.py（単独）
+
+## Testing Strategy
+- Verification: events 不在で main 版と in-place 等価（2 期間）/ 合成
+  events.ndjson で厳密値（TASK-0095 PASS→True, TASK-0090 FAIL/fix_loop 2）/
+  run-tests.sh 全件 / metrics_reporter/_paths/shell/bin 無変更 diff / compile。
+
+## Risks & Mitigations
+- 挙動変化 → events 不在 in-place 等価で機械保証（2 期間 OK）
+- 再実装 → load_events 再利用（reporting に重複定義しない）
+- scope → reporting.py のみ・他 git diff 空で確認
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**: reporting.py 単独だが events 連携・precedence ロジック追加・
+behavior-preserving 検証要 → standard（V-3 実施）

--- a/docs/working/TASK-0102/review-external.md
+++ b/docs/working/TASK-0102/review-external.md
@@ -1,0 +1,15 @@
+# V-3 外部レビュー（Codex）— TASK-0102 / #200 v2
+
+## 結果サマリ
+critical: 0 / major: 0 / minor: 1 / info: 6 — **APPROVE**
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| mn-1 | minor | 不正 v1_completed 行で verdict 欠落時 status.md fallback を塞ぐ（load_events は schema validation しない）| `_events_signals` を有効 verdict（schema enum: PASS/FAIL/WARN/APPROVED/CONDITIONAL/REJECTED/REQUEST_CHANGES）を持つ v1_completed のみ候補化。無効/欠落時は v1_first_pass 未設定→status.md fallback 維持。回帰: 等価2期間 OK / verdict 欠落行スキップで TASK-0090=2件目FAIL採用=False 確認 |
+| info×6 | info | events不在 behavior-preserving 成立 / 部分 fallback 正 / fix_loop_count 非int 防御済 / 初回判定 append-only 前提妥当 / load_events import 副作用許容(__main__ガード) / Non-goal 遵守 | 対応不要 |
+
+## 判定
+APPROVE（critical/major 0）。minor 1 反映。events 不在 in-place 等価（2 期間）/
+合成 events 厳密化 / 不正 verdict スキップ / run-tests 68/0 / scope=reporting.py
+のみ / metrics_reporter・_paths・shell・bin 無変更。

--- a/docs/working/TASK-0102/review-self.md
+++ b/docs/working/TASK-0102/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0102
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-5 ↔ S1-S3 ↔ T1-T4 |
+| C1-PLAN-02 Unknowns | PASS | なし |
+| C1-PLAN-03 スコープ | PASS | 他seed/schema/status削除/hook/C-3C-4 Non-goal・reporting単独 |
+| C1-PLAN-04 テスト戦略 | PASS | in-place等価+合成events smoke+全スイート+diff+compile |
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | 機械等価/smoke |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3 APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T4 ↔ AC1-5 |
+| C1-TC-02 Edge網羅 | PASS | E1 precedence / E2 scope |
+| C1-TC-03 自動化可否 | PASS | in-place/smoke 自動 |
+| C1-INT-01 behavior-preserving | PASS | events不在で2期間 in-place 等価・68/0 |
+| C1-INT-02 再利用 | PASS | metrics_reporter.load_events 再利用（重複実装なし）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0102/test-cases.md
+++ b/docs/working/TASK-0102/test-cases.md
@@ -1,0 +1,10 @@
+# テストケース — TASK-0102 / #200 v2
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1/AC4 | reporting に _events_signals + from metrics_reporter import load_events・再実装なし | 構造突合 |
+| T2 | AC2 | events.ndjson 不在で main 版と report.json 等価（2026-05-01..31 / 05-17..18）| in-place 等価 |
+| T3 | AC3 | 合成 events: TASK-0095 v1=True / TASK-0090 v1=False,fix_loop=2 / observed 増 | smoke |
+| T4 | AC5 | sh tests/run-tests.sh 68 passed 0 failed | テスト |
+## Edge
+- E1: precedence events>status.md>unknown（events 部分のみ有でも status.md 補完）
+- E2: scope = reporting.py のみ（metrics_reporter/_paths/shell/bin 無変更）

--- a/docs/working/TASK-0102/todo.md
+++ b/docs/working/TASK-0102/todo.md
@@ -1,0 +1,13 @@
+# TODO — TASK-0102 / #200 v2
+## 🤖 Agent
+- [x] dogfooding 振り返り→候補選定（Codex 戦略相談・ユーザー指示で実装決定）
+- [x] S1 _events_signals + load_events 再利用（🚩AC1/4）
+- [x] S2 collect precedence（🚩AC1）
+- [x] S3 等価+厳密化+全スイート（🚩AC2/3/5）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import sys as _phsys; from pathlib import Path as _phP; _phsys.path.insert(0, str(_phP(__file__).resolve().parent))
 from _paths import REPO_ROOT as REPO, WORKING_DIR as WORKING  # noqa: E402
+from metrics_reporter import load_events  # noqa: E402
 
 UNKNOWN = "unknown"
 C3_STATUSES = ("APPROVED", "CONDITIONAL", "REJECTED")
@@ -57,6 +58,38 @@ def _parse_status_md(text: str) -> dict:
     return out
 
 
+def _events_signals(task_events: list[dict]) -> dict:
+    """metrics events から v1_first_pass / fix_loop を厳密導出（#200 v2）。
+
+    events.ndjson（Metrics v1・gitignore）は決定論的な正本シグナル。
+    - v1_first_pass: 最初の `v1_completed` の verdict が PASS なら True、
+      FAIL/WARN 等なら False（fix loop 再実行を含む append 順＝時系列）
+    - fix_loop: `fix_loop_incremented` の fix_loop_count の最大
+    どちらも該当 event 無しなら未設定（呼び出し側が status.md へ fallback）。
+    """
+    out: dict = {}
+    # 有効 verdict（schema enum）を持つ v1_completed のみ候補。verdict 欠落/
+    # 不正行は除外し status.md fallback を塞がない（V-3 minor 防御）。
+    _VALID_VERDICT = {"PASS", "FAIL", "WARN", "APPROVED",
+                      "CONDITIONAL", "REJECTED", "REQUEST_CHANGES"}
+    v1 = [
+        e for e in task_events
+        if e.get("event") == "v1_completed"
+        and e.get("verdict") in _VALID_VERDICT
+    ]
+    if v1:
+        out["v1_first_pass"] = v1[0]["verdict"] == "PASS"
+    fl = [
+        e.get("fix_loop_count")
+        for e in task_events
+        if e.get("event") == "fix_loop_incremented"
+        and isinstance(e.get("fix_loop_count"), int)
+    ]
+    if fl:
+        out["fix_loop"] = max(fl)
+    return out
+
+
 def _date(s: str) -> _dt.date:
     return _dt.datetime.strptime(s, "%Y-%m-%d").date()
 
@@ -89,6 +122,17 @@ def _in_range(ts: str | None, lo: _dt.date, hi: _dt.date) -> bool:
 
 
 def collect(lo: _dt.date, hi: _dt.date) -> dict:
+    # events.ndjson（gitignore・clean checkout で不在の場合 [] → status.md
+    # fallback で従来挙動を維持）。load_events は metrics_reporter を再利用。
+    _events = load_events(WORKING / "_metrics" / "events.ndjson")
+    _ev_by_task: dict = {}
+    for _e in _events:
+        _tid = _e.get("task_id")
+        if _tid:
+            _ev_by_task.setdefault(_tid, []).append(_e)
+    _ev_by_task = {
+        _t: _events_signals(_evs) for _t, _evs in _ev_by_task.items()
+    }
     tasks = []
     for d in sorted(WORKING.glob("TASK-*")):
         if not d.is_dir():
@@ -113,10 +157,19 @@ def collect(lo: _dt.date, hi: _dt.date) -> dict:
                 "code": k.get("code_keep_rate", {}).get("value"),
                 "plan": k.get("plan_keep_rate", {}).get("value"),
             }
+        # シグナル優先順: events.ndjson（決定論正本）> status.md ヒューリ
+        # スティック > unknown。events 不在時は従来挙動（behavior-preserving）。
+        ev_sig = _ev_by_task.get(d.name, {})
+        status_sig = {}
         try:
-            rec.update(_parse_status_md((d / "status.md").read_text()))
+            status_sig = _parse_status_md((d / "status.md").read_text())
         except OSError:
             pass
+        for key in ("v1_first_pass", "fix_loop"):
+            if key in ev_sig:
+                rec[key] = ev_sig[key]
+            elif key in status_sig:
+                rec[key] = status_sig[key]
         tasks.append(rec)
     hook_viol = _hook_violations(lo, hi)
     return _aggregate(tasks, lo, hi, hook_viol)


### PR DESCRIPTION
## 概要
#200 dogfooding 振り返り（本セッション run で v1_first_pass が最低シグナル＝観測 1/32）→ **ユーザー指示「improvement-seeds 1 件実装」**で 3 候補から最高価値・最小リスク・#200 handoff §3 既記載の本件を選定。behavior-preserving。

## 変更（scripts/reporting.py 単独）
- events.ndjson の `v1_completed.verdict` / `fix_loop_incremented.fix_loop_count` から v1_first_pass/fix_loop を厳密導出
- precedence: **events > status.md ヒューリスティック > unknown**（部分 fallback 可）
- `metrics_reporter.load_events` を再利用（再実装なし）
- events.ndjson は .gitignore → clean checkout/CI で `[]` → status.md fallback で**従来挙動完全等価**

## V-1 / V-3
- V-1: AC1-5 + E1/E2 全 PASS
- V-3（Codex）: **APPROVE**（critical/major 0 / minor 1 反映: 有効 verdict（schema enum）を持つ v1_completed のみ候補化＝不正/欠落行で status.md fallback を塞がない防御）
- 検証: events 不在で 2 期間 **in-place 等価** / 合成 events で TASK-0095=True・TASK-0090=False,fix_loop2 / 不正 verdict 行スキップ / `run-tests.sh` **68 passed 0 failed** / scope=reporting.py のみ

## Non-goal 遵守
events schema 不変 / status.md ヒューリスティック削除せず fallback 維持 / reporting.py 単独 / hook・C-3・C-4 不変。残 improvement-seeds（hook test フィルタ/run-id スコープ）は YAGNI 保留（過剰実装回避）

## 補足
本コミットは前回 backgrounded compound stall（既知パターン）で未コミットだったものを foreground 小分けで復旧（commit 1502607 / push 確定）。

## Mode
standard（events 連携 + precedence・behavior-preserving）

🤖 Generated with [Claude Code](https://claude.com/claude-code)