### PR TITLE
feat(#281): reporting 精度 follow-up — test/dev フィルタ + run スコープ / TASK-0103

### DIFF
--- a/docs/ai/reporting.md
+++ b/docs/ai/reporting.md
@@ -56,6 +56,43 @@ sh bin/plangate report --from 2026-05-01 --to 2026-05-31 --no-write  # 標準出
 
 `--from`/`--to` は `YYYY-MM-DD`。`from > to` はエラー（exit 2）。
 
+## 4-bis. 精度オプション（#281 / opt-in・behavior-preserving）
+
+dogfooding 振り返りで顕在化した精度限界への opt-in 改善。**いずれも未指定
+時は従来挙動と完全等価**（behavior-preserving）。
+
+### `--exclude-test-hooks`
+
+hook violation 集計から **test/dev 由来行を構造化判定で除外**する。
+判定軸（雑な文字列一致でなく構造化キー）:
+
+- `hook-events.log` の task 列が `TASK-HOOKTEST` プレフィックス → 除外
+- task 列が `tests/fixtures/` を含むパス → 除外
+- `-`（TASK 文脈なし）等の曖昧行は **除外しない**（実 violation を隠さない）
+
+```sh
+sh bin/plangate report --from 2026-05-01 --to 2026-05-31 --exclude-test-hooks
+```
+
+### `--tasks <TASK-id,...>`（run スコープ）
+
+集計対象を指定 TASK 集合に限定（= 1 run の TASK セット単位の集計）。
+period 窓は維持したうえで対象 TASK を絞る追加条件。未指定時は全 TASK
+（従来挙動）。空指定（`""` / `","`）は exit 2。
+
+**run スコープ時の hook violation**: `--tasks` 指定時は hook violation 集計も
+対象 TASK セットの行のみに限定する（`-`＝TASK 文脈なし・fixtures パス等は
+run 外として除外）。これにより `task_count` と hook violation のスコープが
+一致する（#281 V-3 MJ-1）。
+
+```sh
+sh bin/plangate report --from 2026-05-01 --to 2026-05-31 --tasks TASK-0102,TASK-0101
+```
+
+> 真の run-id（イベント単位の run 識別）スコープには run_id インフラ新設が
+> 必要で本 PBI の Out-of-scope（#281）。本オプションは run=TASK セットの
+> 軽量近似であり、run_id 化は将来課題。
+
 ## 5. retrospective への接続
 
 1. `bin/plangate report` を sprint 期間で実行。

--- a/docs/working/TASK-0103/INDEX.md
+++ b/docs/working/TASK-0103/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0103 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0103/approvals/c3.json
+++ b/docs/working/TASK-0103/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0103",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-18T07:25:10Z",
+  "plan_hash": "sha256:becd503bc1aa715937fa85c6cf86763b637501f2cb74e81db0b8fc21c8acfa4a"
+}

--- a/docs/working/TASK-0103/current-state.md
+++ b/docs/working/TASK-0103/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0103 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0103/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0103 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0103/handoff.md
+++ b/docs/working/TASK-0103/handoff.md
@@ -1,0 +1,34 @@
+# Handoff — TASK-0103 / #281 reporting 精度 follow-up
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 test/dev 除外+判定軸明文化 | PASS（_is_test_hook_row 構造化・§4-bis）|
+| AC2 run スコープ・未指定 period 等価 | PASS（V-3 MJ-1: hook も限定・task_count とスコープ一致）|
+| AC3 events/log 不在で従来等価 | PASS（opt-in default off・2 期間 in-place 等価）|
+| AC4 全スイート回帰なし | PASS（68 passed 0 failed）|
+| AC5 reporting.md 運用手順+精度限界 | PASS（§4-bis 判定軸/run スコープ/run_id limitation）|
+V-1 全 PASS。V-3（Codex）REQUEST_CHANGES→major 2 全反映→回帰 PASS。
+
+## 2. 経緯
+#281/#282 状態確認 + Codex 相談 →「#281=Do（最小・承認境界外・reporting
+単独）/ #282=Defer（承認境界・Human トリガ）」確定。#281 実装、V-3 で
+--tasks の hook スコープ漏れ/空入力判定を是正。
+
+## 3. 既知課題 / V2
+- 真の run-id スコープは run_id インフラ新設要＝Out-of-scope。--tasks は
+  run=TASK セットの軽量近似（§4-bis 明記）。
+- #282（check-plan-hash.sh strict 化）は承認境界ゆえ Defer（別 issue・Human トリガ）。
+
+## 4. 妥協点
+- run スコープは run_id でなく TASK セット近似（インフラ新設回避・Codex 助言）。
+- 両機能 opt-in default off（behavior-preserving 厳守）。
+
+## 5. 引き継ぎ
+#281: reporting に test/dev 構造化フィルタ（TASK-HOOKTEST/tests/fixtures・
+`-`/実TASK 残置＝実 violation 隠さない）と run(task-set)スコープを opt-in 追加。
+未指定で従来 period 完全等価。V-3 で hook violation も run スコープ限定・
+空入力 exit2 を是正。#282 は Defer（Human トリガ待ち）。
+
+## 6. テスト結果
+V-1 AC1-5 + V-3 反映後: 2 期間 in-place 等価 / フィルタ 3381→1103 /
+run スコープ task_count・hook 一致 / --tasks '' exit2 / run-tests 68/0。

--- a/docs/working/TASK-0103/pbi-input.md
+++ b/docs/working/TASK-0103/pbi-input.md
@@ -1,0 +1,28 @@
+# PBI INPUT — TASK-0103 / #281 reporting 精度 follow-up
+
+## Context / Why
+#200 dogfooding 振り返りで (1)hook violation 絶対数膨張（test/dev 混入）
+(2)期間窓に旧 TASK 混入 が顕在化。Codex 相談で「#281=Do（最小・承認境界外・
+reporting単独）/ #282=Defer（承認境界・Human トリガ）」と方針確定。
+
+## What
+- In: scripts/reporting.py（--exclude-test-hooks 構造化フィルタ / --tasks run
+  スコープ・共に opt-in）/ docs/ai/reporting.md（判定軸明文化）
+- Out: events/hook-events schema 変更 / 既存 period 破壊 / run_id インフラ
+  新設 / C-3・C-4・承認境界変更 / #282（別 issue・Defer）
+
+## 受入基準（#281）
+- AC1: hook violation が test/dev 由来行を除外でき判定軸が reporting.md に明文化
+- AC2: run スコープ（--tasks 任意）追加・未指定時 period 従来挙動と完全等価
+- AC3: events.ndjson 不在/clean checkout で従来挙動等価（in-place 検証）
+- AC4: run-tests.sh 回帰なし
+- AC5: reporting.md に運用手順+精度限界更新
+
+## Notes
+test/dev 判定は構造化キー（TASK-HOOKTEST prefix / tests/fixtures パス）。
+`-` 曖昧行は除外しない（実 violation 隠蔽回避・Codex 落とし穴1）。両 opt-in
+default=従来＝behavior-preserving。run_id 化は Out-of-scope（limitation 明記）。
+
+## Estimation
+Risks: 実 violation 誤除外（緩和: 構造化キー限定・曖昧残置）/ period 破壊
+（緩和: opt-in・2期間 in-place 等価）/ Unknowns: なし

--- a/docs/working/TASK-0103/plan.md
+++ b/docs/working/TASK-0103/plan.md
@@ -1,0 +1,41 @@
+# EXECUTION PLAN — TASK-0103 / #281
+
+## Goal
+reporting に test/dev 構造化フィルタと run(task-set) スコープを opt-in 追加。
+未指定で従来 period 挙動と完全等価。
+
+## Constraints / Non-goals
+- schema/period 破壊・run_id インフラ新設・承認境界変更・#282 はしない。
+
+## Approach Overview
+_is_test_hook_row（構造化判定）+ _hook_violations(exclude_test) +
+collect(only_tasks,exclude_test) + main 引数(--exclude-test-hooks/--tasks 共に
+opt-in default off)。reporting.md §4-bis に判定軸・limitation 明文化。2 期間
+in-place 等価 + フィルタ/スコープ smoke + 全スイートで検証。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | _is_test_hook_row + filter/scope 配線 | agent | 中 | 🚩 AC1/2 |
+| S2 | reporting.md §4-bis 明文化 | agent | 低 | 🚩 AC1/5 |
+| S3 | 等価+フィルタ+スコープ+全スイート | agent | 中 | 🚩 AC2/3/4 |
+
+## Files / Components to Touch
+- scripts/reporting.py / docs/ai/reporting.md（単独）
+
+## Testing Strategy
+- Verification: opt-in 未指定で main 版と 2 期間 in-place 等価 /
+  --exclude-test-hooks で 3340→1082 減少 / --tasks で対象限定・空 exit2 /
+  run-tests.sh 全件 / scope=reporting.py+reporting.md のみ / compile。
+
+## Risks & Mitigations
+- 実 violation 誤除外 → 構造化キー（HOOKTEST/fixtures）限定・`-` 残置
+- period 破壊 → opt-in default off・2 期間 in-place 等価で機械保証
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: standard
+**判定根拠**: reporting.py + doc・opt-in 追加・behavior-preserving 検証要 →
+standard（V-3 実施）

--- a/docs/working/TASK-0103/review-external.md
+++ b/docs/working/TASK-0103/review-external.md
@@ -1,0 +1,16 @@
+# V-3 外部レビュー（Codex）— TASK-0103 / #281
+
+## 結果サマリ
+1回目: critical 0 / **major 2** / minor 0（REQUEST_CHANGES）→ 全反映 → 回帰 PASS
+
+## 指摘と対応
+| ID | severity | 指摘 | 対応 |
+|----|----------|------|------|
+| MJ-1 | major | `--tasks` が hook violation 未適用（run スコープ指定でも hook は period 全体・docs/AC2 違反）| `_hook_violations` に only_tasks 追加。指定時 cols[3] が TASK セットの行のみ（`-`/fixtures は run 外＝除外）。collect から伝播。§4-bis に hook 行扱い明記 |
+| MJ-2 | major | `--tasks ""` が falsy で未指定扱い（空 exit2 未充足）| `if a.tasks is not None:` に変更。`""`/`","` exit2・未指定のみ None |
+| info×4 | info | default off behavior-preserving / test/dev 判定健全 / cols[3] len 保護 / §4-bis AC 充足 | 対応不要 |
+
+## 判定
+major 2 全反映。critical 0。回帰: opt-in 未指定 2 期間 in-place 等価 /
+--tasks で task_count と hook violation スコープ一致 / --tasks '' exit2・
+未指定 exit0 / run-tests 68/0 / scope=reporting.py+md のみ。

--- a/docs/working/TASK-0103/review-self.md
+++ b/docs/working/TASK-0103/review-self.md
@@ -1,0 +1,29 @@
+# C-1 セルフレビュー（standard / 17 項目）— TASK-0103
+## Plan（7）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-5 ↔ S1-S3 ↔ T1-T5 |
+| C1-PLAN-02 Unknowns | PASS | なし（Codex 相談で方針確定）|
+| C1-PLAN-03 スコープ | PASS | schema/period/run_id/承認境界/#282 Non-goal |
+| C1-PLAN-04 テスト戦略 | PASS | 2期間 in-place 等価+smoke+全スイート+compile |
+| C1-PLAN-05 WB Output | PASS | S1-S3 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | standard 17→C-3→exec→V-1→V-3 |
+| C1-PLAN-07 検証自動化 | PASS | 機械等価/smoke |
+## ToDo（5）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TODO-01 粒度 | PASS | S1-S3 |
+| C1-TODO-02 depends_on | PASS | C-3→exec→V-1→V-3 |
+| C1-TODO-03 チェックポイント | PASS | 各 S 🚩 |
+| C1-TODO-04 Iron Law | PASS | c3 APPROVED 後 exec |
+| C1-TODO-05 完了条件 | PASS | V-1/V-3/handoff |
+## TestCases（3）+ 統合（2）
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-TC-01 受入紐付き | PASS | T1-T5 ↔ AC1-5 |
+| C1-TC-02 Edge網羅 | PASS | E1 実violation非隠蔽 / E2 scope |
+| C1-TC-03 自動化可否 | PASS | in-place/smoke 自動 |
+| C1-INT-01 behavior-preserving | PASS | opt-in default off・2期間等価・68/0 |
+| C1-INT-02 Codex方針整合 | PASS | #281 Do 最小・構造化判定・#282 不触（Defer）|
+
+**判定: PASS**（指摘なし）

--- a/docs/working/TASK-0103/test-cases.md
+++ b/docs/working/TASK-0103/test-cases.md
@@ -1,0 +1,11 @@
+# テストケース — TASK-0103 / #281
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | _is_test_hook_row 構造化判定（HOOKTEST/tests/fixtures）+ reporting.md §4-bis 明文化 | 構造突合 |
+| T2 | AC1 | --exclude-test-hooks で hook violation 減少（3340→1082）・`-` 行残置 | smoke |
+| T3 | AC2 | --tasks で対象 TASK 限定（2件）・空入力 exit2・未指定=従来 | smoke |
+| T4 | AC3 | opt-in 未指定で main 版と 2 期間 in-place 等価 | 機械等価 |
+| T5 | AC4 | run-tests.sh 68 passed 0 failed | テスト |
+## Edge
+- E1: `-`/実 TASK-xxxx 行は除外されない（実 violation 隠蔽なし）
+- E2: scope=reporting.py+reporting.md のみ・#282/schema/period 不変

--- a/docs/working/TASK-0103/todo.md
+++ b/docs/working/TASK-0103/todo.md
@@ -1,0 +1,13 @@
+# TODO — TASK-0103 / #281
+## 🤖 Agent
+- [x] #281/#282 状態確認 + Codex 相談（#281 Do/#282 Defer 確定）
+- [x] S1 filter/scope 配線（🚩AC1/2）
+- [x] S2 reporting.md §4-bis（🚩AC1/5）
+- [x] S3 等価+smoke+全スイート（🚩AC2/3/4）
+- [ ] V-1 受け入れ検査
+- [ ] V-3 外部レビュー（Codex）
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 計画レビュー / C-4 PRレビュー
+## ⚠️ 依存
+- standard: C-1 17項目 → C-3 → exec → V-1 → V-3

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -121,7 +121,9 @@ def _in_range(ts: str | None, lo: _dt.date, hi: _dt.date) -> bool:
     return lo <= d <= hi
 
 
-def collect(lo: _dt.date, hi: _dt.date) -> dict:
+def collect(lo: _dt.date, hi: _dt.date,
+            only_tasks: set | None = None,
+            exclude_test: bool = False) -> dict:
     # events.ndjson（gitignore・clean checkout で不在の場合 [] → status.md
     # fallback で従来挙動を維持）。load_events は metrics_reporter を再利用。
     _events = load_events(WORKING / "_metrics" / "events.ndjson")
@@ -136,6 +138,8 @@ def collect(lo: _dt.date, hi: _dt.date) -> dict:
     tasks = []
     for d in sorted(WORKING.glob("TASK-*")):
         if not d.is_dir():
+            continue
+        if only_tasks is not None and d.name not in only_tasks:
             continue
         c3 = _read_json(d / "approvals" / "c3.json")
         if c3 is None or not _in_range(c3.get("approved_at"), lo, hi):
@@ -171,11 +175,27 @@ def collect(lo: _dt.date, hi: _dt.date) -> dict:
             elif key in status_sig:
                 rec[key] = status_sig[key]
         tasks.append(rec)
-    hook_viol = _hook_violations(lo, hi)
+    hook_viol = _hook_violations(lo, hi, exclude_test=exclude_test,
+                                 only_tasks=only_tasks)
     return _aggregate(tasks, lo, hi, hook_viol)
 
 
-def _hook_violations(lo: _dt.date, hi: _dt.date) -> dict:
+def _is_test_hook_row(task_col: str) -> bool:
+    """hook-events.log の task 列が test/dev 由来か（構造化判定）。
+
+    雑な文字列一致でなく構造化キーで判定（Codex 落とし穴1）:
+    - `TASK-HOOKTEST` プレフィックス（フック専用テスト TASK）
+    - `tests/fixtures/` を含むパス（テスト fixture 経路）
+    `-`（TASK 文脈なし）等の曖昧行は **除外しない**（実 violation を隠さない）。
+    """
+    if not task_col:
+        return False
+    return task_col.startswith("TASK-HOOKTEST") or "tests/fixtures/" in task_col
+
+
+def _hook_violations(lo: _dt.date, hi: _dt.date,
+                     exclude_test: bool = False,
+                     only_tasks: set | None = None) -> dict:
     """docs/working/_audit/hook-events.log の VIOLATION を期間集計（決定論）。
 
     形式: `<ISO ts>\t<LEVEL>\t<hook>\t<task>\t<msg>`。ts を UTC 日付化し
@@ -192,6 +212,14 @@ def _hook_violations(lo: _dt.date, hi: _dt.date) -> dict:
                     continue
                 if not _in_range(cols[0], lo, hi):
                     continue
+                if exclude_test and len(cols) >= 4 \
+                        and _is_test_hook_row(cols[3]):
+                    continue
+                if only_tasks is not None:
+                    # run スコープ: 対象 TASK セットの行のみ。`-`(TASK 文脈
+                    # なし)・fixtures パス等は run 外として除外（Codex MJ-1）
+                    if len(cols) < 4 or cols[3] not in only_tasks:
+                        continue
                 total += 1
                 hk = cols[2] or UNKNOWN
                 by_hook[hk] = by_hook.get(hk, 0) + 1
@@ -298,6 +326,10 @@ def main() -> int:
     ap.add_argument("--from", dest="frm", required=True, help="YYYY-MM-DD")
     ap.add_argument("--to", dest="to", required=True, help="YYYY-MM-DD")
     ap.add_argument("--no-write", action="store_true")
+    ap.add_argument("--exclude-test-hooks", action="store_true",
+                    help="hook violation 集計から test/dev 由来行を除外（#281）")
+    ap.add_argument("--tasks",
+                    help="run スコープ: 集計対象を TASK-id (カンマ区切り) に限定（#281）")
     a = ap.parse_args()
     try:
         lo, hi = _date(a.frm), _date(a.to)
@@ -307,7 +339,13 @@ def main() -> int:
     if lo > hi:
         print("error: --from is after --to", file=sys.stderr)
         return 2
-    r = collect(lo, hi)
+    only = None
+    if a.tasks is not None:
+        only = {x.strip() for x in a.tasks.split(',') if x.strip()}
+        if not only:
+            print('error: --tasks is empty after parsing', file=sys.stderr)
+            return 2
+    r = collect(lo, hi, only_tasks=only, exclude_test=a.exclude_test_hooks)
     md = render_md(r)
     js = json.dumps(r, indent=2, ensure_ascii=False)
     if a.no_write:


### PR DESCRIPTION
## 概要
#281（#200 dogfooding 振り返り由来 backlog）を実装。**#281/#282 状態確認 → Codex 相談**で「#281=Do（最小・承認境界外・reporting 単独）/ #282=Defer（承認境界・Human トリガ待ち）」と方針確定し #281 を実装。behavior-preserving。

## 変更（scripts/reporting.py + docs/ai/reporting.md 単独）
- `--exclude-test-hooks`（opt-in）: hook violation 集計から test/dev 由来を**構造化判定**で除外（`TASK-HOOKTEST` prefix / `tests/fixtures/` パス。`-`＝TASK 文脈なし・実 TASK-xxxx は残置＝実 violation を隠さない＝Codex 落とし穴1 充足）
- `--tasks <id,...>`（opt-in）: run=TASK セットスコープ（period は維持の追加条件）
- 両者 default off → 未指定で従来 period 挙動と**完全等価**
- `reporting.md` §4-bis: 判定軸・run スコープ・run_id limitation を明文化

## V-1 / V-3
- V-1: AC1-5 + E1/E2 全 PASS
- V-3（Codex）: 1回目 **REQUEST_CHANGES（major 2）→ 全反映**
  - MJ-1: `_hook_violations` に only_tasks 適用（run スコープ時 hook violation も対象 TASK セット限定＝task_count とスコープ一致）
  - MJ-2: `--tasks `/`,` も exit2（未指定のみ None＝従来）
- 回帰: opt-in 未指定で 2 期間 **in-place 等価** / `--exclude-test-hooks` 3381→1103 / run スコープ task_count・hook 一致 / `run-tests.sh` **68 passed 0 failed** / scope=reporting.py+md のみ

## Non-goal 遵守
events/hook-events schema 不変 / period 破壊なし / run_id インフラ新設なし（--tasks は軽量近似・limitation 明記）/ #282・承認境界・EH-3・check-plan-hash 不触

## 補足
前回 backgrounded compound stall（既知パターン）で未コミットだったものを foreground 小分け復旧（commit dca19c9 / push 確定）。#282 は Codex 助言どおり Defer（承認境界ゆえ Human トリガ待ち・別 issue 維持）。

## Mode
standard（reporting.py + doc・opt-in 追加・behavior-preserving）

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)