### PR TITLE
docs: harness-improvement-roadmap を完了状態へ同期 / TASK-0104

### DIFF
--- a/docs/ai/harness-improvement-roadmap.md
+++ b/docs/ai/harness-improvement-roadmap.md
@@ -1,7 +1,7 @@
 # Harness Improvement Roadmap
 
-> **Status**: v1.1（Phase 0 / 1 + Governance Done — v8.6.0 で完走、Phase 2 以降と Lightweight Plan Quality Checks は Proposed）
-> **Progress**: Phase 0 ✅ / Phase 1 ✅ / Governance (#201, #202) ✅ / Phase 2〜6 🔵 Open / Lightweight Plan Quality Checks (#213) 🔵 Open
+> **Status**: v1.2（Phase 0〜6 + Governance + Lightweight Plan Quality Checks すべて Done — EPIC #193 は CLOSED/COMPLETED 2026-05-17。本表は完了状態に同期済）
+> **Progress**: Phase 0〜6 ✅ / Governance (#201, #202) ✅ / Lightweight Plan Quality Checks (#213) ✅ / 全子 PBI 12/12 CLOSED（EPIC #193 CLOSED）
 > 関連: [`philosophy.md`](../philosophy.md) / [`eval-plan.md`](./eval-plan.md) / [`eval-runner.md`](./eval-runner.md) / [`metrics.md`](./metrics.md) / [`metrics-privacy.md`](./metrics-privacy.md) / [`issue-governance.md`](./issue-governance.md) / [`eval-baselines/2026-05-04-baseline.md`](./eval-baselines/2026-05-04-baseline.md) / [`model-profiles.md`](./model-profiles.md) / [`prompt-assembly.md`](./prompt-assembly.md) / [`tool-policy.md`](./tool-policy.md) / [`hook-enforcement.md`](./hook-enforcement.md)
 
 ## 1. 目的
@@ -58,21 +58,21 @@ PlanGate にはすでに以下が存在する。
 | --- | --- | --- | --- | --- |
 | 0 | Baseline alignment | 既存 eval / hook / profile の現在地を固定する | baseline report | ✅ Done (v8.6.0 / #194) |
 | 1 | Metrics v1 | 実利用シグナルを保存できるようにする | event schema / metrics command | ✅ Done (v8.6.0 / #195) |
-| **v8.7.0 主** | **段階的導入ガイド** | OSS 利用者の最大摩擦「どこまで使えばよいか不明」を解消する | Level 1-5 導入レベル / docs | 🔵 Open (v8.7.0 / #226) |
-| **v8.7.0 主** | **Plugin 成熟化** | 配布の確実性を機能思想より先に固める | 解決順 / prefix / 更新手順 | 🔵 Open (v8.7.0 / #224) |
-| **v8.7.0 主** | **バージョニング安定性ポリシー** | breaking vs additive を明文化、既存 artifact 互換を保証 | versioning-policy.md | 🔵 Open (v8.7.0 / #225) |
-| v8.7.0 副 | Run Outcome Review v1 | run 完了時の振り返りを軽量 markdown で標準化 | outcome-review.md template | 🔵 Open (v8.7.0 / #228) |
-| v8.7.0 副 | Lightweight Plan Quality Checks | 計画の不足・リスク・前提・完了条件を軽量に構造化する | Plan Check / Risk Check / Done Check | 🔵 Open (v8.7.0 / #213) |
-| v8.7.0 副 | Harness Eval expansion | eval-runner をハーネス変更判断に使いやすくする | comparison / release gate 拡張 | 🔵 Open (v8.7.0 / #196) |
-| v8.7.0 副 | Tool Error Taxonomy | hook/tool failure の分類軸 | error taxonomy / recovery policy | 🔵 Open (v8.7.0 / #203) |
-| v8.7.0 副 | PlanGateBench Fixture | 評価対象固定 | fixture suite | 🔵 Open (v8.7.0 / #204) |
-| v8.7.0 実験 | Trace Timeline v1 (Experimental) | 観測基盤の最小実装、quickstart 非掲載 | schema 1.1 additive / timeline JSON | 🔵 Open (v8.7.0 / #229) |
-| v8.8.0 | Dogfooding Eval v1 | PlanGate 自身を評価対象にする (single judge + human rationale) | eval suite / fixture | 🔵 Open (v8.8.0 / #231) |
-| v8.8.0 | Gate Event Normalization | gate_id / phase / status の語彙正規化 | normalized schema | 🔵 Open (v8.8.0 / #230) |
-| v8.8.0 | Model Profile v2 | モデルごとの実行特性を表現する | edit interface / retry / capability | 🔵 Open (v8.8.0 / #197) ← v8.7.0 から押し出し |
-| v8.8.0 | Keep Rate | AI 成果物が残ったかを測る | code / plan / acceptance / handoff keep rate | 🔵 Open (v8.8.0 / #198) |
-| v8.9.0 候補 | Dynamic Context Engine | 契約コンテキストと作業コンテキストを分離する | context manifest / context command | 🔵 Open (v8.9.0 / #199) |
-| v8.9.0 候補 | Reporting & Retrospective | スプリント改善に接続する | metrics report / retrospective template | 🔵 Open (v8.9.0 / #200) |
+| **v8.7.0 主** | **段階的導入ガイド** | OSS 利用者の最大摩擦「どこまで使えばよいか不明」を解消する | Level 1-5 導入レベル / docs | ✅ Done (v8.7.0 / #226 / PR #264) |
+| **v8.7.0 主** | **Plugin 成熟化** | 配布の確実性を機能思想より先に固める | 解決順 / prefix / 更新手順 | ✅ Done (v8.7.0 / #224 / PR #266) |
+| **v8.7.0 主** | **バージョニング安定性ポリシー** | breaking vs additive を明文化、既存 artifact 互換を保証 | versioning-policy.md | ✅ Done (v8.7.0 / #225 / PR #263) |
+| v8.7.0 副 | Run Outcome Review v1 | run 完了時の振り返りを軽量 markdown で標準化 | outcome-review.md template | ✅ Done (v8.7.0 / #228 / PR #259) |
+| v8.7.0 副 | Lightweight Plan Quality Checks | 計画の不足・リスク・前提・完了条件を軽量に構造化する | Plan Check / Risk Check / Done Check | ✅ Done (v8.7.0 / #213 / PR #267) |
+| v8.7.0 副 | Harness Eval expansion | eval-runner をハーネス変更判断に使いやすくする | comparison / release gate 拡張 | ✅ Done (v8.7.0 / #196 / PR #268) |
+| v8.7.0 副 | Tool Error Taxonomy | hook/tool failure の分類軸 | error taxonomy / recovery policy | ✅ Done (v8.7.0 / #203 / PR #269) |
+| v8.7.0 副 | PlanGateBench Fixture | 評価対象固定 | fixture suite | ✅ Done (v8.7.0 / #204 / PR #270) |
+| v8.7.0 実験 | Trace Timeline v1 (Experimental) | 観測基盤の最小実装、quickstart 非掲載 | schema 1.1 additive / timeline JSON | ✅ Done (v8.7.0 / #229 / PR #260) |
+| v8.8.0 | Dogfooding Eval v1 | PlanGate 自身を評価対象にする (single judge + human rationale) | eval suite / fixture | ✅ Done (v8.8.0 / #231 / PR #262) |
+| v8.8.0 | Gate Event Normalization | gate_id / phase / status の語彙正規化 | normalized schema | ✅ Done (v8.8.0 / #230 / PR #261) |
+| v8.8.0 | Model Profile v2 | モデルごとの実行特性を表現する | edit interface / retry / capability | ✅ Done (v8.8.0 / #197 / PR #271) ← v8.7.0 から押し出し |
+| v8.8.0 | Keep Rate | AI 成果物が残ったかを測る | code / plan / acceptance / handoff keep rate | ✅ Done (v8.8.0 / #198 / PR #272) |
+| v8.9.0 候補 | Dynamic Context Engine | 契約コンテキストと作業コンテキストを分離する | context manifest / context command | ✅ Done (v8.9.0 / #199 / PR #273) |
+| v8.9.0 候補 | Reporting & Retrospective | スプリント改善に接続する | metrics report / retrospective template | ✅ Done (v8.9.0 / #200 / PR #274) |
 | - | Issue/Label/Milestone Governance | Issue 運用ルール固定 | issue-governance.md / Issue Form | ✅ Done (v8.6.0 / #201) |
 | - | Metrics Privacy Policy | metrics 公開・秘匿境界 | metrics-privacy.md | ✅ Done (v8.6.0 / #202) |
 

--- a/docs/working/TASK-0104/INDEX.md
+++ b/docs/working/TASK-0104/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0104 INDEX
+
+> 生成日: 2026-05-18
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0104/approvals/c3.json
+++ b/docs/working/TASK-0104/approvals/c3.json
@@ -1,0 +1,8 @@
+{
+  "task_id": "TASK-0104",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "mine_take",
+  "approved_at": "2026-05-18T09:55:21Z",
+  "plan_hash": "sha256:7e42cbebf2d3414a5b6cdc2258d62f82059638b3c7495ad02da371147b5f5330"
+}

--- a/docs/working/TASK-0104/current-state.md
+++ b/docs/working/TASK-0104/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0104 現在状態
+
+> 更新日: 2026-05-18
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0104/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0104 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0104/handoff.md
+++ b/docs/working/TASK-0104/handoff.md
@@ -1,0 +1,22 @@
+# Handoff — TASK-0104 / roadmap doc 状態同期
+## 1. 要件適合確認
+| AC | 判定 |
+|----|------|
+| AC1 🔵 Open→✅ Done 同期（残0）| PASS（15 件置換・残 0）|
+| AC2 PR 番号付記 | PASS（#259-274 対応付け）|
+| AC3 Status/Progress 同期 | PASS（EPIC #193 CLOSED・12/12 反映）|
+| AC4 本文・Phase 不変 | PASS（状態列+ヘッダのみ）|
+## 2. 経緯
+残タスク確認の Codex 相談で「#282=Defer 維持・停止が正解」確認 + 盲点
+（roadmap doc が完了済を Open 表記＝stale）指摘 → AI 踏込可な整合修正として実施。
+## 3. 既知課題 / V2
+- #282（check-plan-hash strict 化）は別件・Defer 継続（承認境界・Human トリガ）。
+## 4. 妥協点
+- ロードマップ本文・Phase 定義は変更せず状態列のみ同期（誤った歴史改変回避）。
+## 5. 引き継ぎ
+Codex 盲点指摘の docs stale を解消。harness-improvement-roadmap.md の
+🔵 Open 15 件を ✅ Done（PR 番号付）へ、Status/Progress を EPIC #193 CLOSED
+に同期。コード/挙動非変更（light docs）。残=#282 のみ（Defer・Human トリガ）。
+## 6. テスト結果
+T1-T4 + E1 全 PASS（残 Open 0 / PR 付記 / GitHub state 全 CLOSED 突合 /
+diff 状態列のみ）。run-tests 影響なし（markdown）。

--- a/docs/working/TASK-0104/pbi-input.md
+++ b/docs/working/TASK-0104/pbi-input.md
@@ -1,0 +1,27 @@
+# PBI INPUT — TASK-0104 / roadmap doc 状態同期（Codex 盲点指摘）
+
+## Context / Why
+残タスク確認の Codex 相談で盲点指摘: docs/ai/harness-improvement-roadmap.md
+が #196-204/#213/#224-231 を 🔵 Open と記載するが GitHub 上は全 CLOSED
+（EPIC #193 CLOSED/COMPLETED）。stale ドキュメント。evidence-based 文化に
+反するため整合修正（#282 には触れない・実装でなく状態同期のみ）。
+
+## What
+- In: docs/ai/harness-improvement-roadmap.md（Status/Progress + 表 Status 列を
+  完了状態へ同期。PR 番号付記でトレース可能化）
+- Out: #282 着手 / コード変更 / ロードマップ内容（Phase 定義・本文）の変更 /
+  EPIC 再オープン
+
+## 受入基準
+- AC1: 表の 🔵 Open が GitHub CLOSED 実態に合わせ ✅ Done に同期（残 0）
+- AC2: 各完了行に対応 PR 番号を付記（トレーサビリティ）
+- AC3: Status/Progress ヘッダが EPIC #193 CLOSED を反映
+- AC4: ロードマップの Phase 定義・本文は不変（状態列のみ変更）
+
+## Notes
+純 docs 整合（markdown）。run-tests 影響なし。Codex 確認: #282 は Defer 維持
+（本 PBI は別件・docs stale 解消）。
+
+## Estimation
+Risks: 状態誤記（緩和: GitHub 実 state 全 CLOSED 確認済・PR 番号突合）/
+Unknowns: なし

--- a/docs/working/TASK-0104/plan.md
+++ b/docs/working/TASK-0104/plan.md
@@ -1,0 +1,35 @@
+# EXECUTION PLAN — TASK-0104 / roadmap doc 状態同期
+
+## Goal
+harness-improvement-roadmap.md を GitHub 実態（全 CLOSED）に同期し
+トレース可能化。
+
+## Constraints / Non-goals
+- #282 着手 / コード変更 / ロードマップ本文・Phase 定義変更 / EPIC 再オープン
+  はしない。状態列と Status/Progress のみ。
+
+## Approach Overview
+表の `🔵 Open (vX / #NNN)` を `✅ Done (vX / #NNN / PR #MMM)` へ機械置換
+（issue→マージ PR マップ）。Status/Progress ヘッダを EPIC #193 CLOSED 反映。
+
+## Work Breakdown
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| S1 | 表 Status 列 + ヘッダ同期 | agent | 低 | 🚩 AC1-4 |
+
+## Files / Components to Touch
+- docs/ai/harness-improvement-roadmap.md（単独）
+
+## Testing Strategy
+- Verification: 残 🔵 Open=0 / 各行 PR 番号付記 / GitHub 実 state 全 CLOSED
+  突合 / 本文 diff が状態列のみ / run-tests 影響なし（markdown）。
+
+## Risks & Mitigations
+- 状態誤記 → 全子 PBI CLOSED を gh で確認済・PR マップ突合
+
+## Questions / Unknowns
+なし
+
+## Mode判定
+**モード**: light
+**判定根拠**: 単一 docs ファイルの状態同期・コード/挙動非変更 → light

--- a/docs/working/TASK-0104/review-self.md
+++ b/docs/working/TASK-0104/review-self.md
@@ -1,0 +1,12 @@
+# C-1（light 簡易 / Plan 7項目）— TASK-0104
+| ID | 判定 | 根拠 |
+|----|------|------|
+| C1-PLAN-01 受入網羅 | PASS | AC1-4 ↔ S1 ↔ T1-T4 |
+| C1-PLAN-02 Unknowns | PASS | なし（GitHub 実 state 確認済）|
+| C1-PLAN-03 スコープ | PASS | #282/コード/本文/EPIC 再open を Non-goal・状態列のみ |
+| C1-PLAN-04 テスト戦略 | PASS | grep/diff/GitHub state 突合 |
+| C1-PLAN-05 WB Output | PASS | S1 Output+🚩 |
+| C1-PLAN-06 依存 | PASS | light（差分確認）|
+| C1-PLAN-07 検証自動化 | PASS | grep/diff 自動 |
+
+**判定: PASS**

--- a/docs/working/TASK-0104/test-cases.md
+++ b/docs/working/TASK-0104/test-cases.md
@@ -1,0 +1,9 @@
+# テストケース — TASK-0104
+| ID | AC | 期待 | 種別 |
+|----|----|------|------|
+| T1 | AC1 | grep '🔵 Open' docs/ai/harness-improvement-roadmap.md = 0 | 構造突合 |
+| T2 | AC2 | 完了行に PR #NNN 付記（#264/#266/#263/#259/#267/#268/#269/#270/#260/#262/#261/#271/#272/#273/#274）| 構造突合 |
+| T3 | AC3 | Status/Progress に EPIC #193 CLOSED / 全子 12/12 反映 | 構造突合 |
+| T4 | AC4 | 本文・Phase 定義不変（git diff は状態列+ヘッダのみ）| diff |
+## Edge
+- E1: GitHub 実 state 全 CLOSED と一致（#194-204/#213/#193）

--- a/docs/working/TASK-0104/todo.md
+++ b/docs/working/TASK-0104/todo.md
@@ -1,0 +1,8 @@
+# TODO — TASK-0104
+## 🤖 Agent
+- [x] 残タスク確認 Codex 相談 → 盲点(roadmap stale)特定
+- [x] S1 表+ヘッダ同期（🚩AC1-4）
+- [ ] V-1 受け入れ確認
+- [ ] handoff.md
+## 👤 Human
+- [ ] C-3 差分確認 / C-4 PRレビュー


### PR DESCRIPTION
## 概要
**残タスク確認の Codex 相談で盲点指摘**: `docs/ai/harness-improvement-roadmap.md` が #196-204/#213/#224-231 を 🔵 Open と記載するが GitHub 上は**全 CLOSED**（EPIC #193 CLOSED/COMPLETED 2026-05-17）= stale ドキュメント。evidence-based 文化に反するため整合修正（#282 には触れない・実装でなく状態同期のみ）。

## 変更（docs/ai/harness-improvement-roadmap.md 単独）
- 表 Status 列の 🔵 Open **15 件 → ✅ Done**（対応マージ PR #259-274 を付記しトレース可能化）
- Status/Progress ヘッダを「Phase 0〜6 + Governance + Plan Quality Checks すべて Done・全子 PBI 12/12 CLOSED・EPIC #193 CLOSED」に同期
- ロードマップ本文・Phase 定義は**不変**（状態列+ヘッダのみ／歴史改変回避）

## V-1（light・V-3 スキップ）
- T1: 残 🔵 Open = **0** / T2: 完了行に PR 番号付記 / T3: ヘッダに EPIC #193 CLOSED 反映 / T4: git diff は状態列+ヘッダのみ（本文不変）
- GitHub 実 state 全 CLOSED（#194-204/#213/#193）と突合済 / run-tests **68/0** 影響なし（markdown）

## 位置づけ
残タスク確認 Codex 相談の結論「**#282=Defer 維持・停止が正解**」+ 唯一の AI 踏込可な一手として本 doc 整合を実施。#282（check-plan-hash strict 化）は別件・承認境界ゆえ Defer 継続（Human トリガ待ち）。

## Mode
light（単一 docs の状態同期・コード/挙動非変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)