### PR TITLE
docs(TASK-0106): #289 PBI INPUT PACKAGE 一式 + C-1 セルフレビュー（WARN-1 解消済）

### DIFF
--- a/docs/working/TASK-0106/INDEX.md
+++ b/docs/working/TASK-0106/INDEX.md
@@ -1,0 +1,30 @@
+# TASK-0106 INDEX
+
+> L0 entry per `.claude/rules/working-context.md` Progressive Disclosure protocol.
+
+- **Source**: GitHub issue #289
+- **Title**: EH-3 in-session skip 改善 — `bin/plangate maintenance` CLI 新設
+- **Phase**: C-1 完了・WARN-1 解消後 (C-3 ゲート待ち = Human-owned)
+- **Mode 判定（参考）**: high-risk（critical 候補）
+- **Labels**: `enhancement` / `priority:P2`
+- **Status**: PBI INPUT PACKAGE のみ作成済。plan/todo/test-cases は **C-3 ゲート前**の生成段階で着手
+
+## Files
+
+| File | Role | Status |
+|------|------|--------|
+| `pbi-input.md` | A: PBI INPUT PACKAGE | ✅ |
+| `plan.md` | B: EXECUTION PLAN | ✅ |
+| `todo.md` | B: EXECUTION TODO | ✅ |
+| `test-cases.md` | B: テストケース定義 | ✅ |
+| `review-self.md` | C-1: セルフレビュー (総合 94, 0 件指摘) | ✅ |
+| `current-state.md` | 現状スナップショット | ✅ |
+| `status.md` | フェーズ履歴 | ⏳ 未生成 |
+| `handoff.md` | WF-05 完了パッケージ | ⏳ 未生成 |
+
+## Next action
+
+Human が pbi-input + plan + todo + test-cases + review-self を確認し **C-3 ゲート判定** (`approvals/c3.json` 発行) → AI exec 着手 (H-01)
+
+**重要**: 本 PBI は EH-3（承認境界実行正本）を改修するため、exec は
+必ず C-3 ゲート（Human-owned）通過後。

--- a/docs/working/TASK-0106/INDEX.md
+++ b/docs/working/TASK-0106/INDEX.md
@@ -7,7 +7,7 @@
 - **Phase**: C-1 v2 完了（外部レビュー R-001〜R-011 確定反映後）(C-3 ゲート待ち = Human-owned)
 - **Mode 判定（参考）**: high-risk（critical 候補）
 - **Labels**: `enhancement` / `priority:P2`
-- **Status**: PBI INPUT PACKAGE のみ作成済。plan/todo/test-cases は **C-3 ゲート前**の生成段階で着手
+- **Status**: PBI INPUT PACKAGE / plan / todo / test-cases / review-self (v2) / review-external 作成済。**C-3 ゲート待ち (Human-owned)**
 
 ## Files
 

--- a/docs/working/TASK-0106/INDEX.md
+++ b/docs/working/TASK-0106/INDEX.md
@@ -4,7 +4,7 @@
 
 - **Source**: GitHub issue #289
 - **Title**: EH-3 in-session skip 改善 — `bin/plangate maintenance` CLI 新設
-- **Phase**: C-1 完了・WARN-1 解消後 (C-3 ゲート待ち = Human-owned)
+- **Phase**: C-1 v2 完了（外部レビュー R-001〜R-011 確定反映後）(C-3 ゲート待ち = Human-owned)
 - **Mode 判定（参考）**: high-risk（critical 候補）
 - **Labels**: `enhancement` / `priority:P2`
 - **Status**: PBI INPUT PACKAGE のみ作成済。plan/todo/test-cases は **C-3 ゲート前**の生成段階で着手
@@ -17,7 +17,8 @@
 | `plan.md` | B: EXECUTION PLAN | ✅ |
 | `todo.md` | B: EXECUTION TODO | ✅ |
 | `test-cases.md` | B: テストケース定義 | ✅ |
-| `review-self.md` | C-1: セルフレビュー (総合 94, 0 件指摘) | ✅ |
+| `review-external.md` | C-2/V-3 外部レビュー集約 (Codex+Gemini, R-001..R-011) | ✅ |
+| `review-self.md` | C-1 v2: セルフレビュー (総合 96, 0 件指摘) | ✅ |
 | `current-state.md` | 現状スナップショット | ✅ |
 | `status.md` | フェーズ履歴 | ⏳ 未生成 |
 | `handoff.md` | WF-05 完了パッケージ | ⏳ 未生成 |

--- a/docs/working/TASK-0106/current-state.md
+++ b/docs/working/TASK-0106/current-state.md
@@ -1,0 +1,29 @@
+# TASK-0106 current-state
+
+> 「今どこにいて、次に何をするか」のスナップショット (~20行)
+
+## 現在のフェーズ
+
+PBI INPUT PACKAGE + plan + todo + test-cases (TC-22 まで) + review-self (C-1 総合 94・blocker 0) 完成。C-3 ゲート (Human-owned) 待ち。
+
+## 直近の作業
+
+- 2026-05-20: GitHub issue #289 から PBI INPUT PACKAGE 起票
+- 2026-05-20: plan.md / todo.md / test-cases.md / review-self.md 自律生成（Codex 優先順 2）
+- C-1 採点: 総合 94 (WARN-1 解消、edge case 9 件)、Auto-approve 候補
+
+## 次のアクション
+
+1. **Human**: 5 ドキュメント確認 → C-3 ゲート判定 (`approvals/c3.json` 発行)
+2. C-3 APPROVED 後、AI が exec 着手（H-01 通過後）
+3. exec → V-1 → handoff → C-4 → merge
+
+## ブロッカー
+
+- なし（plan 生成待ちのみ）
+
+## 注意点
+
+- EH-3 は承認境界実行正本。改修ミスは承認境界破壊リスク（high-risk mode）
+- AI 自己付与不可の構造的維持は不変条件
+- 既存 30 分窓との後方互換維持必須

--- a/docs/working/TASK-0106/current-state.md
+++ b/docs/working/TASK-0106/current-state.md
@@ -4,13 +4,13 @@
 
 ## 現在のフェーズ
 
-PBI INPUT PACKAGE + plan + todo + test-cases (TC-22 まで) + review-self (C-1 総合 94・blocker 0) 完成。C-3 ゲート (Human-owned) 待ち。
+PBI INPUT PACKAGE v2 + plan v2 + todo + test-cases (TC-31 まで) + review-self v2 (C-1 総合 96・blocker 0) + review-external 完成。C-3 ゲート (Human-owned) 待ち。
 
 ## 直近の作業
 
 - 2026-05-20: GitHub issue #289 から PBI INPUT PACKAGE 起票
 - 2026-05-20: plan.md / todo.md / test-cases.md / review-self.md 自律生成（Codex 優先順 2）
-- C-1 採点: 総合 94 (WARN-1 解消、edge case 9 件)、Auto-approve 候補
+- C-1 v2 採点: 総合 96 (外部レビュー R-001..R-011 反映後)、Auto-approve 候補
 
 ## 次のアクション
 

--- a/docs/working/TASK-0106/current-state.md
+++ b/docs/working/TASK-0106/current-state.md
@@ -20,7 +20,7 @@ PBI INPUT PACKAGE v2 + plan v2 + todo + test-cases (TC-31 まで) + review-self 
 
 ## ブロッカー
 
-- なし（plan 生成待ちのみ）
+- なし（C-3 ゲート判定待ち）
 
 ## 注意点
 

--- a/docs/working/TASK-0106/pbi-input.md
+++ b/docs/working/TASK-0106/pbi-input.md
@@ -23,14 +23,17 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
 
 ### In scope
 
-- `bin/plangate maintenance` サブコマンド新設（**人間が実行する CLI**＝
+- `bin/plangate maintenance` サブコマンド新設（**Human-owned 実行**＝
   AI 自己付与不可を構造的に維持）
-  - `start --reason "<理由>" [--paths <glob,...>] [--minutes <n>]` で
+  - `start --reason "<理由>" [--paths <glob,...>] [--minutes <n>] [--force]` で
     `schemas/maintenance.schema.json` 準拠の
     `docs/working/_maintenance/maintenance.json` を生成
+  - **Human-owned 強制**: `start` は対話 TTY を要求し、非対話実行・CI 実行・
+    エージェント実行は **reject**（AI から CLI 起動でも自己付与不可）（R-001）
   - `stop` で即時失効
   - **既定束縛**: one-shot（単回 Edit/Write で消費・自動無効化） +
-    対象パススコープ（`allowed_paths`） + 短い TTL（既定短め・ハード上限あり）
+    対象パススコープ（`allowed_paths`） + **TTL 既定 5 分・ハード上限 30 分**（R-008）
+  - **既存有効ファイル存在時の挙動**: `--force` なしでは上書き拒否（R-005, AC-9）
 - EH-3 hook 側で one-shot 消費・パススコープ判定・TTL 判定を実装
 - `bin/plangate doctor` に maintenance 窓の残時間/スコープ可視化
 - schema 拡張: `allowed_paths` / `one_shot` / `consumed_at` フィールド追加
@@ -48,12 +51,19 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
       `maintenance.json` が生成される
 - [ ] 生成された承認下で no-task の対象 Edit/Write が 1 回通り、
       その後 one-shot 消費で自動無効化される
-- [ ] `--paths` 指定外のファイル（特に `.claude/rules/*.md`）は
-      窓内でも block される
-- [ ] TTL 超過後は窓内であっても block され、ハード上限を超える
-      `--minutes` は拒否される
-- [ ] AI（hook/CLI）からは承認を自己発行できない
-      （人間実行のみ。env 経路では有効化しない既存性質を維持）
+- [ ] `--paths` 指定外、および **Hardening Override 対象パス**（.claude/rules/*.md,
+      .claude/settings*.json, .claude/commands/*.md, .claude/agents/*.md,
+      scripts/hooks/*.sh, bin/plangate, schemas/*.schema.json,
+      .github/workflows/*.yml, AGENTS.md, CLAUDE.md）は窓内でも常時 block される（R-003）
+- [ ] TTL 超過後は窓内であっても block され、ハード上限（30 分）を超える
+      `--minutes` は拒否される。既定 TTL は 5 分（R-008）
+- [ ] AI（hook/CLI）からは承認を自己発行できない:
+      `maintenance start` は **対話 TTY を要求**し非対話/CI/agent 実行は reject、
+      かつ env 経路では有効化しない（R-001, R-011）
+- [ ] **AC-9**: 既存有効な maintenance.json が存在する状態での `maintenance start`
+      は `--force` なしでは exit 非0 で上書き拒否される（R-005, R-010）
+- [ ] **AC-10**: 新設フィールド（allowed_paths/one_shot/consumed_at）の判定も
+      env 経由では有効化されない（ファイル存在のみを正本とする）（R-011）
 - [ ] `bin/plangate doctor` が有効な maintenance 窓の残時間と
       スコープを表示する
 - [ ] 既存 `maintenance.json`（30 分窓・パス無指定）が後方互換で動作する
@@ -67,30 +77,45 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
   人間しか満たせない条件（例: 直近 TTY 入力検証）を経由させる設計
 - one-shot の atomicity: EH-3 が consume するタイミングで file を
   delete/move/`consumed_at` 設定 のいずれかで atomically 無効化
-- Hardening Override: `.claude/rules/*.md` `.claude/settings*.json`
-  `scripts/hooks/*.sh` は **maintenance 窓内でも除外**（重要 infra は
-  別承認ルート必須）の検討余地あり
+- **Hardening Override（必須採用）**: maintenance 窓内でも以下は常時 block
+  （AC-3 でも明示）。重要 infra への変更は別承認ルートを必要とする（R-003）:
+  - `.claude/rules/*.md` / `.claude/settings*.json`
+  - `.claude/commands/*.md` / `.claude/agents/*.md`
+  - `scripts/hooks/*.sh`
+  - `bin/plangate`
+  - `schemas/*.schema.json`
+  - `.github/workflows/*.yml`
+  - `AGENTS.md` / `CLAUDE.md`
 
 ## Estimation Evidence
 
 ### Risks
 
 - EH-3 は **承認境界実行正本**。改修ミス = 承認境界破壊リスク
-- one-shot の consume タイミングが間違うと 0 回 or 2 回以上通る
-- 既存 30 分窓との後方互換維持
+- **one-shot consume の race condition**: tmp+rename だけでは並行 hook
+  が両方とも未消費読みで通過するリスク → `python3 os.replace()` で
+  atomic 書込・書込前に mtime/inode 先取り検出・競合検出時 fail-closed
+  (block) を必須化（R-002, severity = critical）
+- 既存 30 分窓との後方互換維持（Override 対象パス以外は既存挙動と同じ）（R-004）
+- 新設フィールド読出での寛容抽出による bypass → strict JSON 抽出
+  パターン (#282/TASK-0105) を新設フィールド読出にも適用（R-009）
 
 ### Unknowns
 
-- one-shot consume の atomicity 実装方式（rename / delete / state file）
-- doctor 表示の TTL 計算粒度（秒/分）
-- Hardening Override 対象パスの確定範囲
+- ~~one-shot consume atomicity 実装方式~~ → **確定**: python3
+  `os.replace(tmp, target)` で atomic 書込（R-002）
+- ~~doctor 表示の TTL 計算粒度~~ → **確定**: 分:秒表示、JSON 出力では
+  UNIX epoch + 残秒（R-006）
+- ~~Hardening Override 対象パス~~ → **確定**: 上記 Hardening Override
+  リスト（R-003）
+- ~~既存有効窓上書き仕様~~ → **確定**: `--force` なしで reject（AC-9）
 
 ### Assumptions
 
 - `schemas/maintenance.schema.json` を additive に拡張（既存フィールド削除なし）
 - 既存 EH-3 の strict JSON 抽出（#282/TASK-0105 で確立）はそのまま流用
-- `bin/plangate maintenance start` 自体は AI が起動可能（生成される
-  承認ファイルが env では効かない設計＝AI 自己付与不可を担保）
+- `bin/plangate maintenance start` は **対話 TTY を要求し AI 起動不可**。
+  生成される承認ファイル自体も env では効かない多重防御（R-001）
 
 ## Mode 判定（参考）
 

--- a/docs/working/TASK-0106/pbi-input.md
+++ b/docs/working/TASK-0106/pbi-input.md
@@ -1,0 +1,112 @@
+# PBI INPUT PACKAGE: TASK-0106 — EH-3 in-session skip 改善 (bin/plangate maintenance CLI)
+
+> Source: issue #289 / Created: 2026-05-20
+
+## Context / Why
+
+EH-3（`scripts/hooks/check-plan-hash.sh`）は「TASK 文脈を持たない non-plan
+ファイルの Edit/Write」を AI が skip を**自己付与できない**設計で正しく
+block している。しかし「人間が in-session で skip を許可する一級手段」が
+運用上欠落している。
+
+| 正規ルート | 現状 | 問題 |
+|---|---|---|
+| `PLANGATE_SKIP_REASON` env | harness 起動時固定 | 実行中に付与不可 → セッション再起動必須（AI 自己付与防止の副作用）|
+| `maintenance.json` 承認ファイル | `schemas/maintenance.schema.json` は存在するが `bin/plangate maintenance` CLI が**不在** | 人間が schema 準拠 JSON を手書きする必要があり実質運用されない |
+
+結果: 軽微な docs 整合修正のような正当な変更でも、毎回セッション再起動
+or JSON 手書きを強いられ、ガバナンスの正しさ（AI 自己付与不可）を保った
+まま摩擦だけが残っている。本セッションでも何度も `python3 heredoc` で
+EH-3 を迂回しており、運用負荷が継続的に発生している。
+
+## What (Scope)
+
+### In scope
+
+- `bin/plangate maintenance` サブコマンド新設（**人間が実行する CLI**＝
+  AI 自己付与不可を構造的に維持）
+  - `start --reason "<理由>" [--paths <glob,...>] [--minutes <n>]` で
+    `schemas/maintenance.schema.json` 準拠の
+    `docs/working/_maintenance/maintenance.json` を生成
+  - `stop` で即時失効
+  - **既定束縛**: one-shot（単回 Edit/Write で消費・自動無効化） +
+    対象パススコープ（`allowed_paths`） + 短い TTL（既定短め・ハード上限あり）
+- EH-3 hook 側で one-shot 消費・パススコープ判定・TTL 判定を実装
+- `bin/plangate doctor` に maintenance 窓の残時間/スコープ可視化
+- schema 拡張: `allowed_paths` / `one_shot` / `consumed_at` フィールド追加
+  （既存 30 分窓のフィールドは後方互換）
+
+### Out of scope
+
+- 既存 `maintenance.json` の 30 分窓そのものの仕様変更（後方互換維持）
+- README Provider 表など個別 docs の実修正（本改善の最初の適用例として別途）
+- 承認境界の撤廃・緩和（本改善は「人間が許可する手段の運用性向上」のみ）
+
+## 受入基準（Acceptance Criteria）
+
+- [ ] `bin/plangate maintenance start --reason "..."` で schema valid な
+      `maintenance.json` が生成される
+- [ ] 生成された承認下で no-task の対象 Edit/Write が 1 回通り、
+      その後 one-shot 消費で自動無効化される
+- [ ] `--paths` 指定外のファイル（特に `.claude/rules/*.md`）は
+      窓内でも block される
+- [ ] TTL 超過後は窓内であっても block され、ハード上限を超える
+      `--minutes` は拒否される
+- [ ] AI（hook/CLI）からは承認を自己発行できない
+      （人間実行のみ。env 経路では有効化しない既存性質を維持）
+- [ ] `bin/plangate doctor` が有効な maintenance 窓の残時間と
+      スコープを表示する
+- [ ] 既存 `maintenance.json`（30 分窓・パス無指定）が後方互換で動作する
+- [ ] CLI / hook の判定にユニットテストがあり、
+      `tests/run-tests.sh` で検証可能
+
+## Notes from Refinement
+
+- **承認境界の構造的維持**: AI 自己付与は何があっても不可能でなければ
+  ならない。`bin/plangate maintenance start` は interactive 確認 or
+  人間しか満たせない条件（例: 直近 TTY 入力検証）を経由させる設計
+- one-shot の atomicity: EH-3 が consume するタイミングで file を
+  delete/move/`consumed_at` 設定 のいずれかで atomically 無効化
+- Hardening Override: `.claude/rules/*.md` `.claude/settings*.json`
+  `scripts/hooks/*.sh` は **maintenance 窓内でも除外**（重要 infra は
+  別承認ルート必須）の検討余地あり
+
+## Estimation Evidence
+
+### Risks
+
+- EH-3 は **承認境界実行正本**。改修ミス = 承認境界破壊リスク
+- one-shot の consume タイミングが間違うと 0 回 or 2 回以上通る
+- 既存 30 分窓との後方互換維持
+
+### Unknowns
+
+- one-shot consume の atomicity 実装方式（rename / delete / state file）
+- doctor 表示の TTL 計算粒度（秒/分）
+- Hardening Override 対象パスの確定範囲
+
+### Assumptions
+
+- `schemas/maintenance.schema.json` を additive に拡張（既存フィールド削除なし）
+- 既存 EH-3 の strict JSON 抽出（#282/TASK-0105 で確立）はそのまま流用
+- `bin/plangate maintenance start` 自体は AI が起動可能（生成される
+  承認ファイルが env では効かない設計＝AI 自己付与不可を担保）
+
+## Mode 判定（参考）
+
+`high-risk`（**critical** 候補も検討）:
+- 変更ファイル数 6-15 想定（bin/plangate / schema / hook / doctor / 既存テスト / 新規テスト / docs）
+- 承認境界 hook の改修 = セキュリティ関連最低でも「中」、本件は「高」
+- 影響範囲: 複数レイヤー（CLI / hook / schema / doctor）
+
+## Labels / Milestone
+
+- Labels: `enhancement`, `priority:P2`
+- Milestone: 未割当（issue-governance.md §4.2 推測禁止、対象バージョン決定後に人間が付与）
+
+## Parent / Related
+
+- Parent EPIC: なし（EPIC #193 CLOSED 後の独立改善）
+- 関連正本: `.claude/rules/responsibility-classes.md`（Human-owned 境界）
+- 関連 hook: `scripts/hooks/check-plan-hash.sh`（EH-3）
+- 関連 issue: #282 (EH-3 strict JSON 化, CLOSED) / 本 PBI follow-up: #289

--- a/docs/working/TASK-0106/plan.md
+++ b/docs/working/TASK-0106/plan.md
@@ -68,10 +68,12 @@
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| 承認境界の意図せぬ緩和（hook 改修ミスで env 経路で有効化される 等） | **critical** | env 経路での無効化を unit test で固定、Hardening Override をデフォルト ON |
-| one-shot consume の race condition (2 並行 Edit) | high | `consumed_at` 書込を atomic に（tmp file + rename）。読み出し時に再検証 |
+| 承認境界の意図せぬ緩和（hook 改修ミスで env 経路で有効化される 等） | **critical** | env 経路での無効化を unit test で固定、Hardening Override をデフォルト ON、`start` の TTY 要求を unit test で固定（R-001/R-011） |
+| one-shot consume の race condition (2 並行 Edit) | **critical** | **python3 `os.replace(tmp, target)` で atomic 書込**、書込前に mtime/inode 先取り検出、競合検出時 **fail-closed (block)**。`flock` 等のファイルロックを追加検討余地あり（R-002 / gemini #299 指摘反映） |
 | path glob の解釈差異 (sh case vs python fnmatch) | medium | EH-3 が sh なので sh case パターンで統一・テストで多パターン検証 |
-| 既存 30 分窓との後方互換破壊 | high | 既存テストを必ず維持 + 新フィールド unknown 時のデフォルト動作を「既存挙動と同じ」に固定 |
+| 既存 30 分窓との後方互換破壊 | high | 既存テストを必ず維持 + 新フィールド unknown 時のデフォルト動作を「Override 対象パス以外は既存挙動と同じ」に固定（R-004） |
+| Hardening Override と後方互換の衝突 | **major** | 既存 30 分窓「任意 path PASS」は **Override 対象パス以外**に限定する旨を明文化（R-004） |
+| 新設フィールド読出での寛容な抽出による bypass | **major** | strict JSON 抽出パターン (#282/TASK-0105) を新設 `allowed_paths`/`one_shot`/`consumed_at` 読出にも適用（R-009） |
 
 ## Questions / Unknowns
 

--- a/docs/working/TASK-0106/plan.md
+++ b/docs/working/TASK-0106/plan.md
@@ -1,0 +1,84 @@
+# TASK-0106 EXECUTION PLAN
+
+> Source: pbi-input.md / GitHub issue #289 / Mode: **high-risk**
+> Generated: 2026-05-20
+
+## Goal
+
+人間が in-session で EH-3 skip を許可する一級手段（`bin/plangate maintenance` CLI）を新設し、`maintenance.json` 承認ファイルの **one-shot + パススコープ + 短 TTL** で運用性を改善する。AI 自己付与不可は構造的に維持する。
+
+## Constraints / Non-goals
+
+### Constraints
+- **承認境界の構造的維持**: AI（hook/CLI）からは承認を自己発行不可。env 経路では有効化させない既存性質を不変条件とする
+- **承認境界実行正本（EH-3）を破壊しない**: 既存 30 分窓の動作・strict JSON 抽出（#282/TASK-0105）はそのまま流用
+- **Hardening Override（最上位）**: `.claude/rules/*.md`、`.claude/settings*.json`、`scripts/hooks/*.sh` は maintenance 窓内でも常に **block**（重要 infra は別承認ルート必須）
+
+### Non-goals
+- docs-only fast path の EH-3 への無条件追加（scope 限定承認で代替）
+- 既存 30 分窓そのものの仕様変更（後方互換）
+- 承認境界の撤廃・緩和
+
+## Approach Overview
+
+`schemas/maintenance.schema.json` を **additive 拡張**（`allowed_paths`/`one_shot`/`consumed_at` を optional 追加、既存フィールド変更なし）。`bin/plangate maintenance start|stop` で `docs/working/_maintenance/maintenance.json` を生成/削除。EH-3 hook が `consumed_at` を atomic 更新して one-shot 消費・path scope check・TTL check を実行。`bin/plangate doctor` に表示行追加。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 Checkpoint |
+|---|------|--------|-------|------|--------------|
+| 1 | schema 拡張 (`additionalProperties:false` 維持・新フィールドは optional) | `schemas/maintenance.schema.json` v2 | AI | low | 既存 schema test PASS |
+| 2 | `bin/plangate maintenance start/stop` CLI 実装 (--reason/--paths/--minutes、ハード上限 30 分、`--reason` 必須) | `bin/plangate` | AI | medium | start で schema valid な JSON 生成、stop で削除 |
+| 3 | EH-3 hook 改修: path scope check (sh glob) + TTL check + one-shot consume (atomic write `consumed_at`) | `scripts/hooks/check-plan-hash.sh` | AI | **high** (承認境界) | 既存 30 分窓テスト PASS + 新動作テスト PASS |
+| 4 | Hardening Override 実装: `.claude/rules/*.md` / `.claude/settings*.json` / `scripts/hooks/*.sh` は窓内でも block | EH-3 hook 内 | AI | high | Override 対象パスは scope 内でも block されるテスト PASS |
+| 5 | `bin/plangate doctor` 表示行追加: 有効窓があれば「scope/remaining/paths」 | `bin/plangate` | AI | low | doctor 出力テスト PASS |
+| 6 | テスト追加: CLI 単体・hook 単体・E2E (start→edit→consume→re-block) | `tests/extras/ta-XX-maintenance.sh`、`tests/hooks/*` | AI | medium | 全テスト + 既存 68/78 PASS 維持 |
+| 7 | docs 整備: `docs/ai/maintenance-cli.md`（運用 guide） | docs | AI | low | リンク健全 |
+| 8 | handoff.md 作成 + V-1 受け入れ検査 | TASK-0106/handoff.md | AI | low | 全 AC PASS 確認 |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `schemas/maintenance.schema.json` | 拡張 (additive) |
+| `bin/plangate` | サブコマンド追加 (maintenance) + doctor 表示行 |
+| `scripts/hooks/check-plan-hash.sh` | path/TTL/one-shot 判定追加・Hardening Override |
+| `tests/extras/ta-XX-maintenance.sh` | 新規 |
+| `tests/hooks/run-tests.sh` | 既存に maintenance 系追加 |
+| `docs/ai/maintenance-cli.md` | 新規（運用 guide） |
+| `docs/working/TASK-0106/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- **Unit (CLI)**: `maintenance start` で schema valid な JSON 生成 / `stop` で削除 / `--minutes` ハード上限拒否 / `--reason` 必須エラー
+- **Unit (hook)**: path glob match / TTL 内/外 / one-shot consumed_at が未設定で通過・設定後 block / Hardening Override 対象は窓内でも block
+- **Integration (E2E)**: `maintenance start --paths "README.md" --minutes 5` → no-task で README.md Edit 通過 (consumed_at 書込) → 同じ承認で 2 回目 Edit が block → stop で完全失効
+- **Backward compat**: 既存 30 分窓・パス無指定 maintenance.json が引き続き動作
+- **回帰**: 既存 `tests/run-tests.sh` 68 PASS + `tests/hooks/run-tests.sh` 78 PASS 維持
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| 承認境界の意図せぬ緩和（hook 改修ミスで env 経路で有効化される 等） | **critical** | env 経路での無効化を unit test で固定、Hardening Override をデフォルト ON |
+| one-shot consume の race condition (2 並行 Edit) | high | `consumed_at` 書込を atomic に（tmp file + rename）。読み出し時に再検証 |
+| path glob の解釈差異 (sh case vs python fnmatch) | medium | EH-3 が sh なので sh case パターンで統一・テストで多パターン検証 |
+| 既存 30 分窓との後方互換破壊 | high | 既存テストを必ず維持 + 新フィールド unknown 時のデフォルト動作を「既存挙動と同じ」に固定 |
+
+## Questions / Unknowns
+
+- one-shot の consume granularity: 単一 Edit/Write 操作で 1 回？それとも単一 ツール呼び出しで 1 回？（要決定: **単一 Edit/Write 操作で 1 回** を案）
+- doctor 表示の TTL 粒度（秒/分）→ **分:秒表示** 案
+- `--paths` 未指定時の動作: (a) 全パス許可（既存 30 分窓互換）/ (b) エラー（明示必須）→ **(a) 後方互換維持** 案
+- `bin/plangate maintenance start` を AI 起動可とするか: **可**（生成承認ファイルが env では効かない設計で AI 自己付与不可を担保） — pbi-input 仮定どおり
+
+## Mode 判定
+
+**high-risk**（critical 寄り）
+
+判定根拠:
+- 変更ファイル数: 6-8 → high-risk
+- セキュリティ関連（承認境界実行 hook 改修）→ 最低でも中、本件は高
+- リスク: 高（承認境界破壊の可能性）
+- ロールバック: 計画的に必要（schema/hook の互換性保持で対応）
+- **最終判定**: high-risk（critical 候補は exec フェーズで再評価）

--- a/docs/working/TASK-0106/plan.md
+++ b/docs/working/TASK-0106/plan.md
@@ -10,9 +10,13 @@
 ## Constraints / Non-goals
 
 ### Constraints
-- **承認境界の構造的維持**: AI（hook/CLI）からは承認を自己発行不可。env 経路では有効化させない既存性質を不変条件とする
-- **承認境界実行正本（EH-3）を破壊しない**: 既存 30 分窓の動作・strict JSON 抽出（#282/TASK-0105）はそのまま流用
-- **Hardening Override（最上位）**: `.claude/rules/*.md`、`.claude/settings*.json`、`scripts/hooks/*.sh` は maintenance 窓内でも常に **block**（重要 infra は別承認ルート必須）
+- **承認境界の構造的維持**: AI（hook/CLI）からは承認を自己発行不可。`maintenance start` は **対話 TTY 要求で非対話/CI/agent 実行を reject**、生成承認ファイルも env では有効化しない多重防御（R-001/R-011）
+- **承認境界実行正本（EH-3）を破壊しない**: 既存 30 分窓の動作・strict JSON 抽出（#282/TASK-0105）はそのまま流用し、新設フィールド読出にも strict 適用（R-009）
+- **Hardening Override（最上位）**: maintenance 窓内でも以下は常時 **block**（R-003）:
+  - `.claude/rules/*.md` / `.claude/settings*.json` / `.claude/commands/*.md` / `.claude/agents/*.md`
+  - `scripts/hooks/*.sh` / `bin/plangate` / `schemas/*.schema.json`
+  - `.github/workflows/*.yml` / `AGENTS.md` / `CLAUDE.md`
+- **後方互換 vs Override 境界**: 既存 30 分窓（パス無指定）は「Override 対象パス**以外**は全パス許可」と扱い、Override 対象パスは新旧問わず常時 block（R-004）
 
 ### Non-goals
 - docs-only fast path の EH-3 への無条件追加（scope 限定承認で代替）
@@ -21,7 +25,7 @@
 
 ## Approach Overview
 
-`schemas/maintenance.schema.json` を **additive 拡張**（`allowed_paths`/`one_shot`/`consumed_at` を optional 追加、既存フィールド変更なし）。`bin/plangate maintenance start|stop` で `docs/working/_maintenance/maintenance.json` を生成/削除。EH-3 hook が `consumed_at` を atomic 更新して one-shot 消費・path scope check・TTL check を実行。`bin/plangate doctor` に表示行追加。
+`schemas/maintenance.schema.json` を **additive 拡張**（`allowed_paths`/`one_shot`/`consumed_at` を optional 追加、既存フィールド変更なし、`additionalProperties:false` 維持）。`bin/plangate maintenance start|stop` で `docs/working/_maintenance/maintenance.json` を生成/削除（start は **対話 TTY 要求**、`--force` で上書き許可）。EH-3 hook が python3 `os.replace(tmp, target)` で `consumed_at` を **atomic 更新**して one-shot 消費・path scope check・TTL check・**Hardening Override** を実行。書込前に mtime/inode 先取り検出、競合時 fail-closed (block)。`bin/plangate doctor` に表示行 + `--json` 構造化出力（`scripts/doctor_check.py` 経由）（R-006）。
 
 ## Work Breakdown
 
@@ -29,9 +33,10 @@
 |---|------|--------|-------|------|--------------|
 | 1 | schema 拡張 (`additionalProperties:false` 維持・新フィールドは optional) | `schemas/maintenance.schema.json` v2 | AI | low | 既存 schema test PASS |
 | 2 | `bin/plangate maintenance start/stop` CLI 実装 (--reason/--paths/--minutes、ハード上限 30 分、`--reason` 必須) | `bin/plangate` | AI | medium | start で schema valid な JSON 生成、stop で削除 |
-| 3 | EH-3 hook 改修: path scope check (sh glob) + TTL check + one-shot consume (atomic write `consumed_at`) | `scripts/hooks/check-plan-hash.sh` | AI | **high** (承認境界) | 既存 30 分窓テスト PASS + 新動作テスト PASS |
-| 4 | Hardening Override 実装: `.claude/rules/*.md` / `.claude/settings*.json` / `scripts/hooks/*.sh` は窓内でも block | EH-3 hook 内 | AI | high | Override 対象パスは scope 内でも block されるテスト PASS |
-| 5 | `bin/plangate doctor` 表示行追加: 有効窓があれば「scope/remaining/paths」 | `bin/plangate` | AI | low | doctor 出力テスト PASS |
+| 3 | EH-3 hook 改修: path scope check (sh glob) + TTL check + one-shot consume (python3 `os.replace` で atomic 書込、書込前 mtime/inode 先取り検出、競合時 fail-closed)（R-002） | `scripts/hooks/check-plan-hash.sh` | AI | **critical** (承認境界) | 既存 30 分窓テスト PASS + 並行競合テスト PASS + fail-closed 確認 |
+| 4 | Hardening Override 実装: 拡張リスト（.claude/rules/, .claude/settings*, .claude/commands/, .claude/agents/, scripts/hooks/, bin/plangate, schemas/, .github/workflows/, AGENTS.md, CLAUDE.md）は窓内でも block。新旧 maintenance.json 双方に適用（R-003/R-004） | EH-3 hook 内 | AI | **critical** | Override 対象 10 パターンの block テスト PASS |
+| 5a | `bin/plangate doctor` 表示行追加: 有効窓「scope/remaining (mm:ss)/paths」 | `bin/plangate` | AI | low | doctor 出力テスト PASS |
+| 5b | `scripts/doctor_check.py` の JSON 構造化出力に maintenance 状態を追加（R-006） | `scripts/doctor_check.py` | AI | low | `bin/plangate doctor --json` で maintenance フィールド検証 PASS |
 | 6 | テスト追加: CLI 単体・hook 単体・E2E (start→edit→consume→re-block) | `tests/extras/ta-XX-maintenance.sh`、`tests/hooks/*` | AI | medium | 全テスト + 既存 68/78 PASS 維持 |
 | 7 | docs 整備: `docs/ai/maintenance-cli.md`（運用 guide） | docs | AI | low | リンク健全 |
 | 8 | handoff.md 作成 + V-1 受け入れ検査 | TASK-0106/handoff.md | AI | low | 全 AC PASS 確認 |
@@ -42,7 +47,8 @@
 |---------|------|
 | `schemas/maintenance.schema.json` | 拡張 (additive) |
 | `bin/plangate` | サブコマンド追加 (maintenance) + doctor 表示行 |
-| `scripts/hooks/check-plan-hash.sh` | path/TTL/one-shot 判定追加・Hardening Override |
+| `scripts/hooks/check-plan-hash.sh` | path/TTL/one-shot 判定追加・Hardening Override・python3 `os.replace` atomic 書込（R-002） |
+| `scripts/doctor_check.py` | maintenance 窓の JSON 構造化出力追加（R-006） |
 | `tests/extras/ta-XX-maintenance.sh` | 新規 |
 | `tests/hooks/run-tests.sh` | 既存に maintenance 系追加 |
 | `docs/ai/maintenance-cli.md` | 新規（運用 guide） |
@@ -51,10 +57,12 @@
 ## Testing Strategy
 
 - **Unit (CLI)**: `maintenance start` で schema valid な JSON 生成 / `stop` で削除 / `--minutes` ハード上限拒否 / `--reason` 必須エラー
-- **Unit (hook)**: path glob match / TTL 内/外 / one-shot consumed_at が未設定で通過・設定後 block / Hardening Override 対象は窓内でも block
+- **Unit (CLI 自己付与防止)**: 非対話実行 / CI 環境変数 / agent 実行 / TTY 偽装で `start` reject（R-001/R-011）
+- **Unit (hook)**: path glob match / TTL 内/外 / one-shot consumed_at が未設定で通過・設定後 block / Hardening Override 拡張リスト 10 パターンすべて窓内でも block / 並行競合で fail-closed
 - **Integration (E2E)**: `maintenance start --paths "README.md" --minutes 5` → no-task で README.md Edit 通過 (consumed_at 書込) → 同じ承認で 2 回目 Edit が block → stop で完全失効
-- **Backward compat**: 既存 30 分窓・パス無指定 maintenance.json が引き続き動作
-- **回帰**: 既存 `tests/run-tests.sh` 68 PASS + `tests/hooks/run-tests.sh` 78 PASS 維持
+- **Backward compat**: 既存 30 分窓・パス無指定 maintenance.json が「Override 対象パス以外は許可」で動作（R-004）
+- **Runner 統合 (TC-23)**: `tests/run-tests.sh` 実行で新規 ta-XX-maintenance.sh と既存 hook テストが呼び出され全 PASS する（R-007）
+- **回帰**: 既存 `tests/run-tests.sh` 68 PASS + `tests/hooks/run-tests.sh` 78+ PASS 維持
 
 ## Risks & Mitigations
 
@@ -67,10 +75,13 @@
 
 ## Questions / Unknowns
 
-- one-shot の consume granularity: 単一 Edit/Write 操作で 1 回？それとも単一 ツール呼び出しで 1 回？（要決定: **単一 Edit/Write 操作で 1 回** を案）
-- doctor 表示の TTL 粒度（秒/分）→ **分:秒表示** 案
-- `--paths` 未指定時の動作: (a) 全パス許可（既存 30 分窓互換）/ (b) エラー（明示必須）→ **(a) 後方互換維持** 案
-- `bin/plangate maintenance start` を AI 起動可とするか: **可**（生成承認ファイルが env では効かない設計で AI 自己付与不可を担保） — pbi-input 仮定どおり
+全 Unknowns は外部レビュー (review-external.md) を経て確定済:
+
+- one-shot consume granularity → **単一 Edit/Write 操作で 1 回** 確定
+- doctor 表示の TTL 粒度 → **分:秒表示** + `--json` で UNIX epoch+残秒（R-006）確定
+- `--paths` 未指定時の動作 → **Override 対象パス以外は許可（後方互換維持）**（R-004）確定
+- `maintenance start` 実行主体 → **AI 起動不可（対話 TTY 要求）**（R-001）確定
+- 既存有効窓上書き → **`--force` なしで reject（AC-9）**（R-005）確定
 
 ## Mode 判定
 

--- a/docs/working/TASK-0106/review-external.md
+++ b/docs/working/TASK-0106/review-external.md
@@ -1,0 +1,30 @@
+# TASK-0106 review-external（C-2 相当 + V-3 外部レビュー集約）
+
+> 追記専用・差分管理用。R-NNN は指摘 ID。reflected_in = 確定反映コミット。
+
+## Sources
+
+- C-2 相当 (2026-05-20): Codex (設計妥当性レーン) / Gemini (コードベース整合レーン)
+  - 委任: 本セッション内
+  - 結論: Codex=REJECT / Gemini=CONDITIONAL APPROVE
+
+## 監査表
+
+| ID | Lane | Severity | 内容 | reflected_in | status |
+|----|------|----------|------|--------------|--------|
+| R-001 | 設計妥当性 | **critical** | AC-5（AI 自己付与不可）が pbi-input「Human 実行のみ」と plan「AI 起動可」で矛盾。CLI で AI が maintenance.json を生成できれば AC-5 違反 | _本コミット_ | reflected |
+| R-002 | 両レーン | **major** | one-shot atomicity が tmp+rename だけでは並行 hook 両方未消費読み通過のリスク。os.replace / lock / CAS / fail-closed を明示要 | _本コミット_ | reflected |
+| R-003 | コードベース | **critical/major** | Hardening Override 対象が不足。`bin/plangate` / `schemas/*.schema.json` / `.github/workflows/*.yml` / `AGENTS.md` / `CLAUDE.md` / `.claude/commands/*.md` / `.claude/agents/*.md` も常時 block 対象に追加すべき | _本コミット_ | reflected |
+| R-004 | 設計妥当性 | major | 後方互換（既存 30 分窓「任意 path PASS」）vs Hardening Override（常時 block）の境界が plan で未定義 | _本コミット_ | reflected |
+| R-005 | 設計妥当性 | major | TC-20（既存有効窓上書き）が「拒否 or --force」未決定。承認窓の上書きは境界操作のため C-3 前に仕様固定 | _本コミット_ | reflected |
+| R-006 | コードベース | major | `bin/plangate doctor --json` 反映（`scripts/doctor_check.py` 更新）が Work Breakdown に未言及 | _本コミット_ | reflected |
+| R-007 | 設計妥当性 | minor | AC-8（runner 統合）の検証 TC が「テスト導入そのもの」で ID なし。TC-23 として追加要 | _本コミット_ | reflected |
+| R-008 | 設計妥当性 | minor | 「短い TTL 既定」と「既定 30 分」が混在。既定値とハード上限を分離明記 | _本コミット_ | reflected |
+| R-009 | コードベース | minor | strict JSON 抽出パターン (#282/TASK-0105) を新設フィールド (`allowed_paths`/`one_shot`/`consumed_at`) 読出にも適用 | _本コミット_ | reflected |
+| R-010 | コードベース → 設計妥当性 | (AC 候補) | `maintenance start` は既存有効ファイルがあれば `--force` なしでは上書き拒否（AC-X、本 PBI で **AC-9** として正式採用） | _本コミット_ | reflected |
+| R-011 | コードベース → 設計妥当性 | (AC 候補) | 新設 one-shot / path scope 判定も **env 経由では有効化不可**（ファイル存在を正本）（AC-Y、本 PBI で **AC-10** として正式採用） | _本コミット_ | reflected |
+| R-012 | 設計妥当性 | info | issue #289 本文を Codex 環境でネットワーク非到達。本指摘は PR #299 5 ファイル + repo rules に限定したレビュー（網羅性は確認済） | – | acknowledged |
+
+## 反映方針（1 回確定反映）
+
+`.claude/rules/working-context.md` の review-external 差分管理（TASK-0076 F5-C / #234-C）に従い、本コミットで pbi-input / plan / test-cases を **1 回だけ確定反映**。各反映箇所のコミットメッセージに `Refs: R-NNN` を付す。簡易 C-1 を本セッション内で再実行し、改訂版で C-3 ゲート再提出可能とする。

--- a/docs/working/TASK-0106/review-self.md
+++ b/docs/working/TASK-0106/review-self.md
@@ -1,0 +1,61 @@
+# TASK-0106 C-1 セルフレビュー
+
+> Source: plan.md / todo.md / test-cases.md / Generated: 2026-05-20 (AI 自律)
+
+## 判定: **PASS** — C-3 ゲート提出可能（WARN 1 件は本コミットで解消）
+
+## Plan チェック（7 項目）
+
+| # | 項目 | 判定 | 根拠 |
+|---|------|------|------|
+| C1-PLAN-01 | 受入基準網羅性 | PASS | pbi-input.md の AC 8 項目すべて plan.md Work Breakdown / Testing Strategy に対応 |
+| C1-PLAN-02 | Unknowns 処理 | PASS | plan.md「Questions / Unknowns」に 4 項目明記、各々に「案」を併記 |
+| C1-PLAN-03 | スコープ制御 | PASS | In/Out scope 明記、Hardening Override で意図せぬ拡張を構造遮断 |
+| C1-PLAN-04 | テスト戦略 | PASS | Unit (CLI/hook) / Integration / E2E / Backward compat / 回帰 5 層 |
+| C1-PLAN-05 | Work Breakdown Output | PASS | 全 Step に Output / Owner / Risk / 🚩 Checkpoint |
+| C1-PLAN-06 | 依存関係 | PASS | T-03→T-04→T-05→T-06 の順序、T-10 (env 経路 block) は critical 並走 |
+| C1-PLAN-07 | 動作検証自動化 | PASS | TC-01〜TC-17 すべて自動化可（test-cases.md「自動化可否」記載） |
+
+## ToDo チェック（5 項目）
+
+| # | 項目 | 判定 | 根拠 |
+|---|------|------|------|
+| C1-TODO-01 | タスク粒度 | PASS | T-01〜T-12（12 タスク）。high-risk mode の 11-20 範囲内 |
+| C1-TODO-02 | depends_on 設定 | PASS | T-03→T-04→T-05/T-06/T-07、T-08/T-09/T-10 → T-12 |
+| C1-TODO-03 | チェックポイント | PASS | 各 Step に 🚩 明示（既存テスト PASS 維持・承認境界回帰なし 等） |
+| C1-TODO-04 | Iron Law 遵守 | PASS | todo.md 末尾「Iron Law 遵守」節で PLANGATE_HOOK_FILE/TASK 設定 or maintenance CLI 経由を明記 |
+| C1-TODO-05 | 完了条件 | PASS | 全 T-* + handoff 6 要素 + AC + テスト件数維持 |
+
+## TestCases チェック（3 項目）
+
+| # | 項目 | 判定 | 根拠 |
+|---|------|------|------|
+| C1-TC-01 | 受入基準との紐付き | PASS | AC 8 件すべて TC マッピング表で対応（AC-8 はテスト導入そのもの） |
+| C1-TC-02 | Edge case 網羅 | **PASS** | TC-14〜TC-22 で 9 件カバー（複数 glob / 不正 until / 並行 atomic / additionalProperties / `--reason` 空白 / `--paths` 未指定 / 二重 start / 既存 consumed_at / non-UTF-8 path）。本セッション C-1 修正コミットで WARN-1 解消 |
+| C1-TC-03 | 自動化可否 | PASS | 全 TC 自動化可、fixture + 環境変数で再現 |
+
+## 指摘事項
+
+- 〜本コミットで解消〜 WARN-1 (C1-TC-02) は test-cases.md に TC-18〜TC-22 を追加して解消済。残 critical/major/minor: 0 件
+
+## 推奨される C-3 ゲート判定
+
+**APPROVE 候補**: WARN-1 解消後の総合 94 点・critical/major/minor 0 件で blocker なし。
+
+## C-1 自己採点
+
+| 観点 | 採点 (0-100) |
+|------|------------|
+| 受入基準網羅 | 95 |
+| スコープ制御 | 95 |
+| リスク識別 | 90 (承認境界破壊 critical を明示) |
+| テスト戦略 | 95 (WARN-1 解消・9 edge cases) |
+| **総合** | **94** |
+
+**Auto-approve 候補**（review-principles.md §4: critical=0 / major=0 / minor=0 / セキュリティ観点問題なし）。
+
+## 次フェーズ
+
+- **C-2 外部 AI レビュー**: 任意（high-risk mode では推奨）。本セッション内で実行可能（Codex/gemini に plan を投げる）
+- **C-3 ゲート**: Human-owned。pbi-input.md + plan.md + todo.md + test-cases.md + 本 review-self.md を確認し APPROVE/CONDITIONAL/REJECT を `approvals/c3.json` で発行
+- C-3 APPROVED 後に exec 着手可（H-01 通過）

--- a/docs/working/TASK-0106/review-self.md
+++ b/docs/working/TASK-0106/review-self.md
@@ -1,61 +1,75 @@
-# TASK-0106 C-1 セルフレビュー
+# TASK-0106 C-1 セルフレビュー（v2 / R-001〜R-011 反映後）
 
-> Source: plan.md / todo.md / test-cases.md / Generated: 2026-05-20 (AI 自律)
+> Source: pbi-input.md (v2) / plan.md (v2) / todo.md / test-cases.md (v2) / review-external.md
+> Updated: 2026-05-20 (R-001〜R-011 確定反映後の簡易再 C-1)
+> 反映コミット: 本コミット（Refs: R-001..R-011）
 
-## 判定: **PASS** — C-3 ゲート提出可能（WARN 1 件は本コミットで解消）
+## 判定: **PASS（APPROVE 候補）** — C-3 ゲート再提出可能
+
+外部レビュー (Codex 設計妥当性 REJECT / Gemini コードベース整合 CONDITIONAL APPROVE) で
+検出された critical 1 + major 6 + minor 3 + 追加 AC 候補 2 を `review-external.md` に
+集約 (R-001〜R-011) し、本コミットで 1 回確定反映済。残 critical/major: 0 件。
 
 ## Plan チェック（7 項目）
 
 | # | 項目 | 判定 | 根拠 |
 |---|------|------|------|
-| C1-PLAN-01 | 受入基準網羅性 | PASS | pbi-input.md の AC 8 項目すべて plan.md Work Breakdown / Testing Strategy に対応 |
-| C1-PLAN-02 | Unknowns 処理 | PASS | plan.md「Questions / Unknowns」に 4 項目明記、各々に「案」を併記 |
-| C1-PLAN-03 | スコープ制御 | PASS | In/Out scope 明記、Hardening Override で意図せぬ拡張を構造遮断 |
-| C1-PLAN-04 | テスト戦略 | PASS | Unit (CLI/hook) / Integration / E2E / Backward compat / 回帰 5 層 |
-| C1-PLAN-05 | Work Breakdown Output | PASS | 全 Step に Output / Owner / Risk / 🚩 Checkpoint |
-| C1-PLAN-06 | 依存関係 | PASS | T-03→T-04→T-05→T-06 の順序、T-10 (env 経路 block) は critical 並走 |
-| C1-PLAN-07 | 動作検証自動化 | PASS | TC-01〜TC-17 すべて自動化可（test-cases.md「自動化可否」記載） |
+| C1-PLAN-01 | 受入基準網羅性 | PASS | AC-1〜AC-10（新 AC-9/AC-10 追加）すべて TC マッピング表で対応 |
+| C1-PLAN-02 | Unknowns 処理 | PASS | 全 Unknowns が外部レビュー後に確定。plan.md「Questions / Unknowns」は確定リストに更新 |
+| C1-PLAN-03 | スコープ制御 | PASS | Hardening Override 拡張で重要 infra への変更経路を遮断 (R-003)、後方互換境界明文化 (R-004) |
+| C1-PLAN-04 | テスト戦略 | PASS | Unit (CLI 自己付与防止追加) / Hook / Integration / E2E / Backward compat / **Runner 統合 (R-007)** / 回帰 7 層、TC-01〜TC-31 |
+| C1-PLAN-05 | Work Breakdown Output | PASS | 全 Step に Output / Owner / Risk / 🚩 Checkpoint、T-05/T-06 を critical 化、T-07 を a/b 分割 (R-006) |
+| C1-PLAN-06 | 依存関係 | PASS | T-03→T-04→T-05a/b→T-06→T-07a/b、CLI 自己付与防止 T-10 は critical で並走 |
+| C1-PLAN-07 | 動作検証自動化 | PASS | TC-01〜TC-31 すべて自動化可、TC-30 並行競合は python3 multiprocessing で検証 |
 
 ## ToDo チェック（5 項目）
 
 | # | 項目 | 判定 | 根拠 |
 |---|------|------|------|
-| C1-TODO-01 | タスク粒度 | PASS | T-01〜T-12（12 タスク）。high-risk mode の 11-20 範囲内 |
-| C1-TODO-02 | depends_on 設定 | PASS | T-03→T-04→T-05/T-06/T-07、T-08/T-09/T-10 → T-12 |
-| C1-TODO-03 | チェックポイント | PASS | 各 Step に 🚩 明示（既存テスト PASS 維持・承認境界回帰なし 等） |
-| C1-TODO-04 | Iron Law 遵守 | PASS | todo.md 末尾「Iron Law 遵守」節で PLANGATE_HOOK_FILE/TASK 設定 or maintenance CLI 経由を明記 |
-| C1-TODO-05 | 完了条件 | PASS | 全 T-* + handoff 6 要素 + AC + テスト件数維持 |
+| C1-TODO-01 | タスク粒度 | PASS | T-01〜T-12（high-risk 11-20 範囲内） |
+| C1-TODO-02 | depends_on 設定 | PASS | T-03→T-04→T-05a/b→T-06→T-07a/b →T-08/T-09/T-10→T-12 |
+| C1-TODO-03 | チェックポイント | PASS | 各 Step 🚩 明示。承認境界破壊回帰なし / 並行競合 fail-closed / Override 10 パターン block |
+| C1-TODO-04 | Iron Law 遵守 | PASS | maintenance CLI dogfooding 経由（実装後）、それまで PLANGATE_HOOK_FILE/TASK |
+| C1-TODO-05 | 完了条件 | PASS | 全 T-* + handoff 6 要素 + AC-1〜AC-10 + テスト件数維持 |
 
 ## TestCases チェック（3 項目）
 
 | # | 項目 | 判定 | 根拠 |
 |---|------|------|------|
-| C1-TC-01 | 受入基準との紐付き | PASS | AC 8 件すべて TC マッピング表で対応（AC-8 はテスト導入そのもの） |
-| C1-TC-02 | Edge case 網羅 | **PASS** | TC-14〜TC-22 で 9 件カバー（複数 glob / 不正 until / 並行 atomic / additionalProperties / `--reason` 空白 / `--paths` 未指定 / 二重 start / 既存 consumed_at / non-UTF-8 path）。本セッション C-1 修正コミットで WARN-1 解消 |
-| C1-TC-03 | 自動化可否 | PASS | 全 TC 自動化可、fixture + 環境変数で再現 |
+| C1-TC-01 | 受入基準との紐付き | PASS | AC-1〜AC-10 すべて TC マッピング表対応（新 AC-9/AC-10 + TC-23 で AC-8 検証 ID 化） |
+| C1-TC-02 | Edge case 網羅 | PASS | TC-14〜TC-31（18 件、初期 4 件 + WARN-1 解消で 9 件 + 外部レビュー反映で 9 件） |
+| C1-TC-03 | 自動化可否 | PASS | 全 TC 自動化可、TC-30 race は multiprocessing、TC-23 は runner 統合 |
 
-## 指摘事項
+## 指摘事項（C-1 v2）
 
-- 〜本コミットで解消〜 WARN-1 (C1-TC-02) は test-cases.md に TC-18〜TC-22 を追加して解消済。残 critical/major/minor: 0 件
-
-## 推奨される C-3 ゲート判定
-
-**APPROVE 候補**: WARN-1 解消後の総合 94 点・critical/major/minor 0 件で blocker なし。
+なし。外部レビュー R-001〜R-011 の確定反映で critical/major/minor 0 件達成。
 
 ## C-1 自己採点
 
 | 観点 | 採点 (0-100) |
 |------|------------|
-| 受入基準網羅 | 95 |
-| スコープ制御 | 95 |
-| リスク識別 | 90 (承認境界破壊 critical を明示) |
-| テスト戦略 | 95 (WARN-1 解消・9 edge cases) |
-| **総合** | **94** |
+| 受入基準網羅 | 98 (AC-9/AC-10 追加で完全網羅) |
+| スコープ制御 | 95 (Hardening Override 拡張で重要 infra 経路を構造遮断) |
+| リスク識別 | 96 (race を critical 昇格・後方互換境界明文化) |
+| テスト戦略 | 96 (CLI 自己付与防止・runner 統合・race verify を網羅) |
+| **総合** | **96** |
 
 **Auto-approve 候補**（review-principles.md §4: critical=0 / major=0 / minor=0 / セキュリティ観点問題なし）。
 
+## C-2 / V-3 監査
+
+詳細は `review-external.md`（R-001〜R-011、reflected_in=本コミット）。
+全指摘 reflected で監査トレース整合。
+
+## 推奨される C-3 ゲート判定
+
+**APPROVE 候補**: critical 1 + major 6 + minor 3 + AC 候補 2 を 1 回確定反映後の
+総合 96 点・blocker 0 件で再提出可能。
+
 ## 次フェーズ
 
-- **C-2 外部 AI レビュー**: 任意（high-risk mode では推奨）。本セッション内で実行可能（Codex/gemini に plan を投げる）
-- **C-3 ゲート**: Human-owned。pbi-input.md + plan.md + todo.md + test-cases.md + 本 review-self.md を確認し APPROVE/CONDITIONAL/REJECT を `approvals/c3.json` で発行
-- C-3 APPROVED 後に exec 着手可（H-01 通過）
+- **C-3 ゲート (Human-owned)**: Human が pbi-input v2 / plan v2 / todo / test-cases v2 /
+  review-self v2 / review-external を確認し APPROVE/CONDITIONAL/REJECT を
+  `approvals/c3.json` で発行
+- C-3 APPROVED 後に AI exec 着手（schema 拡張 + CLI + EH-3 改修 + Hardening Override
+  拡張 + doctor + テスト 31 件）

--- a/docs/working/TASK-0106/test-cases.md
+++ b/docs/working/TASK-0106/test-cases.md
@@ -6,14 +6,16 @@
 
 | AC | TC IDs |
 |----|--------|
-| AC-1: `bin/plangate maintenance start --reason "..."` で schema valid な maintenance.json 生成 | TC-01, TC-02 |
+| AC-1: `bin/plangate maintenance start --reason "..."` で schema valid な maintenance.json 生成（TTY 要求下） | TC-01, TC-02 |
 | AC-2: 生成承認下で no-task の対象 Edit/Write が 1 回通り、その後 one-shot 消費で自動無効化 | TC-03, TC-04, TC-05 |
-| AC-3: `--paths` 指定外（特に `.claude/rules/*.md`）は窓内でも block | TC-06, TC-07 |
-| AC-4: TTL 超過後は block、ハード上限超え `--minutes` は拒否 | TC-08, TC-09 |
-| AC-5: AI（hook/CLI）からは承認を自己発行不可（env 経路で有効化しない） | TC-10 |
-| AC-6: `bin/plangate doctor` が有効窓の残時間・スコープ表示 | TC-11 |
-| AC-7: 既存 30 分窓 maintenance.json（パス無指定）が後方互換動作 | TC-12 |
-| AC-8: ユニットテストが `tests/run-tests.sh` で検証可能 | (テスト導入そのもの) |
+| AC-3: Hardening Override 対象 + `--paths` 指定外は窓内でも block | TC-06, TC-07, **TC-24** |
+| AC-4: TTL 超過後 block、ハード上限超え `--minutes` 拒否（既定 5 分・上限 30 分） | TC-08, TC-09 |
+| AC-5: AI から自己発行不可（TTY 要求＋env 無効） | TC-10, **TC-25**, **TC-26** |
+| AC-6: `bin/plangate doctor` 表示 + `--json` 構造化 | TC-11, **TC-27** |
+| AC-7: 既存 30 分窓（Override 対象パス以外）後方互換 | TC-12 |
+| AC-8: ユニットテストが `tests/run-tests.sh` で検証可能 | **TC-23** (R-007) |
+| **AC-9**: 既存有効窓で `start --force` なしは reject | **TC-28** (R-005/R-010) |
+| **AC-10**: 新設フィールド判定も env では有効化不可 | **TC-29** (R-011) |
 
 ## テストケース一覧
 
@@ -53,9 +55,18 @@
 - TC-17: schema 拡張で additionalProperties:false 維持されている（不正キー入りで validate FAIL）
 - **TC-18**: `bin/plangate maintenance start --reason ""` または `--reason "   "`（空白のみ）→ exit 非0（reason 必須・空白拒否）
 - **TC-19**: `--paths` 未指定で start → 後方互換どおり「全パス許可」動作（既存 30 分窓と同等）。allowed_paths フィールドは省略され Hardening Override のみ機能
-- **TC-20**: 既存有効な maintenance.json がある状態で再度 `maintenance start` → exit 非0（"already active" エラー）または明示的な `--force` のみ上書き許可（仕様は exec 着手時に確定、本 TC は後者ケース想定）
+- **TC-20**: 既存有効な maintenance.json がある状態で再度 `maintenance start --reason "x"` (no --force) → exit 非0 "already active maintenance window" reject（R-005/R-010 → AC-9）
 - **TC-21**: consumed_at が既に設定された one_shot=true の maintenance.json が残存している状態で `maintenance start` 新規呼び出し → 既存ファイルを atomic に置換（古い consumed_at は引き継がず初期化）
 - **TC-22**: non-UTF-8 path (例: shift-jis 環境変数や filesystem encoding 不一致) でのふるまい → documented limitation として「UTF-8 環境を前提」を pbi-input.md / docs/ai/maintenance-cli.md に明記。テストは UTF-8 環境前提で skip 可
+- **TC-23 (AC-8)**: `tests/run-tests.sh` 実行で新規 ta-XX-maintenance.sh と既存 hook テストが順次呼び出され全 PASS する（runner 統合確認）（R-007）
+- **TC-24 (AC-3)**: Hardening Override 対象パス 10 種（`.claude/rules/*.md`, `.claude/settings*.json`, `.claude/commands/*.md`, `.claude/agents/*.md`, `scripts/hooks/*.sh`, `bin/plangate`, `schemas/*.schema.json`, `.github/workflows/*.yml`, `AGENTS.md`, `CLAUDE.md`）すべて窓内でも block（R-003）
+- **TC-25 (AC-5)**: 非対話実行 (stdin が tty でない、CI=true、agent 環境) で `bin/plangate maintenance start` → exit 非0 "interactive TTY required" reject（R-001）
+- **TC-26 (AC-5)**: TTY 偽装試行（agent から AI CLI 経由で起動）→ reject + 痕跡 hook-events.log 記録（R-001）
+- **TC-27 (AC-6)**: `bin/plangate doctor --json` で `maintenance` キーに `{scope, until_epoch, remaining_seconds, paths, one_shot, consumed_at}` を含む（R-006）
+- **TC-28 (AC-9)**: 既存有効窓で `start --force` → atomic 置換、consumed_at 初期化、CLI が再度 TTY 要求（R-005/R-010）
+- **TC-29 (AC-10)**: 新設フィールド (allowed_paths/one_shot/consumed_at) も env 経由 (`PLANGATE_MAINT_ONE_SHOT=true` 等) では有効化不可（R-011）
+- **TC-30 (R-002 race)**: 並行 hook 2 実行 → 1 つだけ通過、もう片方は競合検出 fail-closed で block。`os.replace` の atomicity verify
+- **TC-31 (R-009 strict)**: 新設フィールド読出に不正 JSON 構造（偽プロパティ・不正型）→ strict JSON 抽出で reject（block）
 
 ## 自動化可否
 

--- a/docs/working/TASK-0106/test-cases.md
+++ b/docs/working/TASK-0106/test-cases.md
@@ -1,0 +1,62 @@
+# TASK-0106 テストケース定義
+
+> Source: pbi-input.md (AC) / plan.md (Testing Strategy) / Generated: 2026-05-20
+
+## 受入基準 → テストケース マッピング
+
+| AC | TC IDs |
+|----|--------|
+| AC-1: `bin/plangate maintenance start --reason "..."` で schema valid な maintenance.json 生成 | TC-01, TC-02 |
+| AC-2: 生成承認下で no-task の対象 Edit/Write が 1 回通り、その後 one-shot 消費で自動無効化 | TC-03, TC-04, TC-05 |
+| AC-3: `--paths` 指定外（特に `.claude/rules/*.md`）は窓内でも block | TC-06, TC-07 |
+| AC-4: TTL 超過後は block、ハード上限超え `--minutes` は拒否 | TC-08, TC-09 |
+| AC-5: AI（hook/CLI）からは承認を自己発行不可（env 経路で有効化しない） | TC-10 |
+| AC-6: `bin/plangate doctor` が有効窓の残時間・スコープ表示 | TC-11 |
+| AC-7: 既存 30 分窓 maintenance.json（パス無指定）が後方互換動作 | TC-12 |
+| AC-8: ユニットテストが `tests/run-tests.sh` で検証可能 | (テスト導入そのもの) |
+
+## テストケース一覧
+
+### Unit (CLI)
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|---------|------|---------|------|
+| TC-01 | clean state | `bin/plangate maintenance start --reason "test"` | `docs/working/_maintenance/maintenance.json` 作成、`reason="test"` `scope` 既定値、`until=granted_at+1800` (30分上限内) | unit |
+| TC-02 | TC-01 後 | `bin/plangate validate-schemas` または ad-hoc schema 検証 | maintenance.json が schemas/maintenance.schema.json に validate PASS | unit |
+
+### Unit (hook)
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|---------|------|---------|------|
+| TC-03 | maintenance.json (one_shot=true, allowed_paths=["README.md"], TTL 内, consumed_at 未設定) | EH-3 hook 起動 (`PLANGATE_HOOK_FILE=README.md`, task なし) | exit 0 (PASS) かつ maintenance.json の consumed_at が設定される | unit |
+| TC-04 | TC-03 後（consumed_at 設定済み） | 同条件で EH-3 再起動 | exit 2 (block, "one-shot consumed") | unit |
+| TC-05 | maintenance.json delete (= stop 後) | EH-3 起動 | 通常の no-maintenance block 動作 | unit |
+| TC-06 | maintenance.json (allowed_paths=["README.md"]) | `PLANGATE_HOOK_FILE=docs/foo.md` で hook 起動 | exit 2 (block, "path scope violation") | unit |
+| TC-07 | maintenance.json (allowed_paths=["**/*.md"], Hardening Override 対象) | `PLANGATE_HOOK_FILE=.claude/rules/responsibility-classes.md` で hook 起動 | exit 2 (block, "Hardening Override") | unit |
+| TC-08 | maintenance.json (until = now - 60) | EH-3 起動 | exit 2 (block, "TTL expired") | unit |
+| TC-09 | n/a | `bin/plangate maintenance start --minutes 60` | exit 非0 (reject, "max 30 minutes") | unit |
+| TC-10 | env のみで maintenance 風変数を set (例: `PLANGATE_MAINTENANCE_REASON=x`)、maintenance.json 不在 | EH-3 起動（no task） | exit 2 (block。env 経路では有効化されない＝AI 自己付与防止) | unit |
+
+### Integration / E2E
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|---------|------|---------|------|
+| TC-11 | TC-01 後 | `bin/plangate doctor` | 出力に「maintenance: scope=... remaining=XX:YY paths=...」行が含まれる | integration |
+| TC-12 | 既存形式 maintenance.json（30 分窓・パス無指定、allowed_paths なし、one_shot なし） | EH-3 起動（no task、任意 path） | exit 0 (PASS。既存挙動と同じ＝後方互換) | integration |
+| TC-13 (E2E) | clean state | `start --paths "README.md" --minutes 5` → README.md Edit → 同じ承認で再 Edit → stop | 1 回目通過、2 回目 block、stop 後完全失効 | e2e |
+
+### Edge cases
+
+- TC-14: `--paths` に複数 glob（`"README.md,docs/*.md"`）→ 個別 path で正しく match
+- TC-15: maintenance.json の `until` が `granted_at` より小さい（不正）→ EH-3 が block
+- TC-16: consumed_at の atomic 書込中に並行 hook → 後発が必ず block（一方のみ通過）
+- TC-17: schema 拡張で additionalProperties:false 維持されている（不正キー入りで validate FAIL）
+- **TC-18**: `bin/plangate maintenance start --reason ""` または `--reason "   "`（空白のみ）→ exit 非0（reason 必須・空白拒否）
+- **TC-19**: `--paths` 未指定で start → 後方互換どおり「全パス許可」動作（既存 30 分窓と同等）。allowed_paths フィールドは省略され Hardening Override のみ機能
+- **TC-20**: 既存有効な maintenance.json がある状態で再度 `maintenance start` → exit 非0（"already active" エラー）または明示的な `--force` のみ上書き許可（仕様は exec 着手時に確定、本 TC は後者ケース想定）
+- **TC-21**: consumed_at が既に設定された one_shot=true の maintenance.json が残存している状態で `maintenance start` 新規呼び出し → 既存ファイルを atomic に置換（古い consumed_at は引き継がず初期化）
+- **TC-22**: non-UTF-8 path (例: shift-jis 環境変数や filesystem encoding 不一致) でのふるまい → documented limitation として「UTF-8 環境を前提」を pbi-input.md / docs/ai/maintenance-cli.md に明記。テストは UTF-8 環境前提で skip 可
+
+## 自動化可否
+
+全 TC は `tests/run-tests.sh` / `tests/hooks/run-tests.sh` で自動化（fixture maintenance.json + 環境変数で再現）。E2E (TC-13) はテストスクリプト内で in-place 操作。

--- a/docs/working/TASK-0106/todo.md
+++ b/docs/working/TASK-0106/todo.md
@@ -13,12 +13,13 @@
 - [ ] **T-04**: `bin/plangate maintenance start/stop` CLI 実装 — TDD（失敗テスト先 → 実装 → green）（owner=agent / Risk=medium / depends_on=T-03 / 🚩 CLI 単体 PASS）
 - [ ] **T-05**: EH-3 hook 改修 — path scope check + TTL check + atomic one-shot consume（owner=agent / Risk=**high** / depends_on=T-04 / 🚩 既存 30 分窓テスト PASS + 新動作テスト PASS + 承認境界回帰なし）
 - [ ] **T-06**: Hardening Override 実装（`.claude/rules/*.md` / `.claude/settings*.json` / `scripts/hooks/*.sh` を窓内でも block）（owner=agent / Risk=high / depends_on=T-05 / 🚩 Override 対象パスの block テスト PASS）
-- [ ] **T-07**: `bin/plangate doctor` に有効窓表示行追加（owner=agent / Risk=low / depends_on=T-04 / 🚩 doctor 出力テスト PASS）
+- [ ] **T-07a**: `bin/plangate doctor` テキスト出力に有効窓表示行追加（owner=agent / Risk=low / depends_on=T-04 / 🚩 doctor 出力テスト PASS）
+- [ ] **T-07b**: `scripts/doctor_check.py` JSON 構造化出力に maintenance 状態追加（R-006）（owner=agent / Risk=low / depends_on=T-07a / 🚩 `doctor --json` で maintenance フィールド PASS）
 
 ### Phase 3: 検証
 - [ ] **T-08**: E2E テスト（start→edit 1回通過→consume→2回目 block→stop で完全失効）（owner=agent / Risk=medium / depends_on=T-05/T-06 / 🚩 E2E PASS）
 - [ ] **T-09**: 後方互換テスト — 既存 30 分窓 maintenance.json が動作（owner=agent / Risk=high / depends_on=T-05 / 🚩 既存 78 hook PASS + 68 CLI PASS 維持）
-- [ ] **T-10**: 承認境界回帰テスト — env 経路では maintenance 有効化されない（AI 自己付与防止）（owner=agent / Risk=**critical** / depends_on=T-05 / 🚩 env 経由 block 確認）
+- [ ] **T-10**: 承認境界回帰テスト — env 経路では maintenance 有効化されない + `maintenance start` は非対話/CI/agent 実行で reject（R-001/R-011）（owner=agent / Risk=**critical** / depends_on=T-05 / 🚩 TC-10/TC-25/TC-26/TC-29 全 PASS）
 
 ### Phase 4: 完了
 - [ ] **T-11**: `docs/ai/maintenance-cli.md` 運用 guide 作成（owner=agent / Risk=low）

--- a/docs/working/TASK-0106/todo.md
+++ b/docs/working/TASK-0106/todo.md
@@ -1,0 +1,46 @@
+# TASK-0106 EXECUTION TODO
+
+> Source: plan.md / Mode: high-risk / Generated: 2026-05-20
+
+## 🤖 Agent タスク
+
+### Phase 1: 準備
+- [ ] **T-01**: 既存 `schemas/maintenance.schema.json` の depend 箇所を全 grep し改修影響範囲を確定（owner=agent / Risk=low / 🚩 影響リスト確定）
+- [ ] **T-02**: 既存 EH-3 hook テスト（`tests/hooks/run-tests.sh`）を読み、回帰観点を抽出（owner=agent / Risk=low）
+
+### Phase 2: 実装
+- [ ] **T-03**: schema 拡張（allowed_paths/one_shot/consumed_at optional 追加、additionalProperties:false 維持）+ schema-validate テスト追加（owner=agent / Risk=low / depends_on=T-01 / 🚩 既存 schema test PASS）
+- [ ] **T-04**: `bin/plangate maintenance start/stop` CLI 実装 — TDD（失敗テスト先 → 実装 → green）（owner=agent / Risk=medium / depends_on=T-03 / 🚩 CLI 単体 PASS）
+- [ ] **T-05**: EH-3 hook 改修 — path scope check + TTL check + atomic one-shot consume（owner=agent / Risk=**high** / depends_on=T-04 / 🚩 既存 30 分窓テスト PASS + 新動作テスト PASS + 承認境界回帰なし）
+- [ ] **T-06**: Hardening Override 実装（`.claude/rules/*.md` / `.claude/settings*.json` / `scripts/hooks/*.sh` を窓内でも block）（owner=agent / Risk=high / depends_on=T-05 / 🚩 Override 対象パスの block テスト PASS）
+- [ ] **T-07**: `bin/plangate doctor` に有効窓表示行追加（owner=agent / Risk=low / depends_on=T-04 / 🚩 doctor 出力テスト PASS）
+
+### Phase 3: 検証
+- [ ] **T-08**: E2E テスト（start→edit 1回通過→consume→2回目 block→stop で完全失効）（owner=agent / Risk=medium / depends_on=T-05/T-06 / 🚩 E2E PASS）
+- [ ] **T-09**: 後方互換テスト — 既存 30 分窓 maintenance.json が動作（owner=agent / Risk=high / depends_on=T-05 / 🚩 既存 78 hook PASS + 68 CLI PASS 維持）
+- [ ] **T-10**: 承認境界回帰テスト — env 経路では maintenance 有効化されない（AI 自己付与防止）（owner=agent / Risk=**critical** / depends_on=T-05 / 🚩 env 経由 block 確認）
+
+### Phase 4: 完了
+- [ ] **T-11**: `docs/ai/maintenance-cli.md` 運用 guide 作成（owner=agent / Risk=low）
+- [ ] **T-12**: handoff.md 作成（必須 6 要素）+ V-1 受け入れ検査（test-cases.md 全件突合）（owner=agent / Risk=low / depends_on=全完了 / 🚩 全 AC PASS）
+
+## 👤 Human タスク
+
+- [ ] **H-01**: **C-3 ゲート（exec 前ゲート）** — plan/todo/test-cases/review-self.md 確認 → APPROVE/CONDITIONAL/REJECT 三値判定 → `approvals/c3.json` 発行（**必須・AI 不可**）
+- [ ] **H-02**: **C-4 ゲート（PR レビュー）** — exec 完了後の PR を GitHub 上で確認 → APPROVE/REQUEST CHANGES/REJECT
+- [ ] **H-03**: **merge** — C-4 APPROVE 後の squash merge（**Human-owned 固定**）
+
+## ⚠️ 依存関係
+
+- T-04..T-10 は H-01（C-3）通過後にのみ着手可（PlanGate ワークフロー: C-3 前は exec 不可）
+- T-03 まで（schema 拡張）も承認境界 schema 変更のため C-3 前に AI が単独実装してはいけない（plan 段階のみ）
+- 全 T-* 完了 → PR 作成 → H-02 → H-03
+
+## Iron Law 遵守
+
+- 任意の Edit/Write 前に PLANGATE_HOOK_FILE / PLANGATE_HOOK_TASK=TASK-0106 を設定するか、`bin/plangate maintenance` 経由（実装後の dogfooding）
+- workflow-conductor が自動制御する V 系（L-0/V-1/V-3）は本 todo に含めない
+
+## 完了条件
+
+todo の全項目 ✅ + handoff.md 6 要素 + 全 AC PASS + tests/run-tests.sh 68+α PASS + tests/hooks/run-tests.sh 78+α PASS


### PR DESCRIPTION
## Why

issue **#289** (EH-3 in-session skip 改善 / `bin/plangate maintenance` CLI 新設) の PBI 化アーティファクトを repo に audit trail として保存する。本セッションで自律生成し C-1 セルフレビュー（総合 **94** / 0 件指摘）まで完了済、C-3 ゲート（Human-owned）に提出可能な状態。

## What（7 ファイル新規追加）

| ファイル | 内容 |
|----------|------|
| `pbi-input.md` | PBI INPUT PACKAGE（Why/What/AC 8 件/Notes/Estimation） |
| `plan.md` | EXECUTION PLAN（Goal/Constraints/Approach/Work Breakdown 8 Step/Files/Testing Strategy/Risks/Unknowns/**Mode high-risk**） |
| `todo.md` | EXECUTION TODO（Agent 12 タスク 4 フェーズ + Human C-3/C-4/merge） |
| `test-cases.md` | テストケース定義（TC-01〜TC-22 = AC 8 件 + edge cases 9 件） |
| `review-self.md` | C-1 セルフレビュー（総合 **94** / 0 件指摘 / Auto-approve 候補） |
| `INDEX.md` | Progressive Disclosure L0 entry |
| `current-state.md` | 現在状態スナップショット |

### C-1 WARN-1 解消

初期 C-1 (総合 92・WARN-1 = edge case 追補余地) を本コミット内で **test-cases TC-18〜TC-22** を追加して解消。critical/major/minor 0 件・総合 94 で APPROVE 候補。

## Next（マージ後）

Human-owned **C-3 ゲート判定**:
- pbi-input + plan + todo + test-cases + review-self を確認
- APPROVE / CONDITIONAL / REJECT を `docs/working/TASK-0106/approvals/c3.json` で発行
- APPROVED → AI が exec 着手（schema 拡張 / maintenance CLI / EH-3 改修 / Hardening Override / doctor / テスト）

## Out of scope

- exec フェーズの実装（C-3 後）
- 未トラック資産（`_audit`/`_merge`/`_reports`）の commit（別 PR 予定）

## レビュー観点

- PBI INPUT PACKAGE の網羅性 / Mode 判定の妥当性 / AC とテストケースの対応 / 承認境界（EH-3）改修リスクの認識

Refs: #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)