### PR TITLE
docs(TASK-0106): C-3 提出前 fixup — pbi-input:99 絶対表現 + review-self 集計同期

### DIFF
--- a/docs/working/TASK-0106/pbi-input.md
+++ b/docs/working/TASK-0106/pbi-input.md
@@ -96,9 +96,12 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
 
 ## Notes from Refinement
 
-- **承認境界の構造的維持**: AI 自己付与は何があっても不可能でなければ
-  ならない。`bin/plangate maintenance start` は interactive 確認 or
-  人間しか満たせない条件（例: 直近 TTY 入力検証）を経由させる設計
+- **承認境界の維持（best-effort + 監査・R-012）**: AI 自己付与は **多層
+  防御（L1 isatty / L2 env barrier / L3 parent process heuristic / L4 対話
+  nonce `PLANGATE_MAINT_ACK`）で実用的に抑止し、全 start 試行を
+  hook-events.log に env snapshot + ppid + isatty 結果で監査記録**する。
+  完全な構造保証は**別 PBI に分割**することを明示（pbi-input In scope /
+  AC-5 / plan Constraints と整合）
 - one-shot の atomicity: EH-3 が consume するタイミングで file を
   delete/move/`consumed_at` 設定 のいずれかで atomically 無効化
 - **Hardening Override（必須採用）**: maintenance 窓内でも以下は常時 block

--- a/docs/working/TASK-0106/pbi-input.md
+++ b/docs/working/TASK-0106/pbi-input.md
@@ -60,23 +60,30 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
 
 ## 受入基準（Acceptance Criteria）
 
-- [ ] `bin/plangate maintenance start --reason "..."` で schema valid な
-      `maintenance.json` が生成される
-- [ ] 生成された承認下で no-task の対象 Edit/Write が 1 回通り、
+- [ ] **AC-1**: `bin/plangate maintenance start --reason "..."` で schema
+      valid な `maintenance.json` が生成される
+- [ ] **AC-2**: 生成された承認下で no-task の対象 Edit/Write が 1 回通り、
       その後 one-shot 消費で自動無効化される
-- [ ] `--paths` 指定外、および **Hardening Override 対象パス**（.claude/rules/*.md,
-      .claude/settings*.json, .claude/commands/*.md, .claude/agents/*.md,
-      scripts/hooks/*.sh, bin/plangate, schemas/*.schema.json,
-      .github/workflows/*.yml, AGENTS.md, CLAUDE.md）は窓内でも常時 block される（R-003）
-- [ ] TTL 超過後は窓内であっても block され、ハード上限（30 分）を超える
-      `--minutes` は拒否される。既定 TTL は 5 分（R-008）
-- [ ] AI による承認の自己発行を **多層 best-effort で抑止し、全試行を監査
-      可能化** する（R-001/R-012）。`maintenance start` は L1 isatty / L2 env
-      barrier (CI/CLAUDE_AGENT/CURSOR_AGENT/PLANGATE_BYPASS_HOOK) / L3 parent
-      process heuristic / L4 対話 nonce (`PLANGATE_MAINT_ACK`) の 4 層で
-      reject、全試行を hook-events.log に env snapshot + ppid + isatty で
-      記録。env 経路では承認ファイルを有効化しない（R-011）。完全な構造
+- [ ] **AC-3**: `--paths` 指定外、および **Hardening Override 対象パス**
+      （.claude/rules/*.md, .claude/settings*.json, .claude/commands/*.md,
+      .claude/agents/*.md, scripts/hooks/*.sh, bin/plangate,
+      schemas/*.schema.json, .github/workflows/*.yml, AGENTS.md, CLAUDE.md）
+      は窓内でも常時 block される（R-003）
+- [ ] **AC-4**: TTL 超過後は窓内であっても block され、ハード上限（30 分）
+      を超える `--minutes` は拒否される。既定 TTL は 5 分（R-008）
+- [ ] **AC-5**: AI による承認の自己発行を **多層 best-effort で抑止し、全試行
+      を監査可能化** する（R-001/R-012）。`maintenance start` は L1 isatty /
+      L2 env barrier (CI/CLAUDE_AGENT/CURSOR_AGENT/PLANGATE_BYPASS_HOOK) /
+      L3 parent process heuristic / L4 対話 nonce (`PLANGATE_MAINT_ACK`) の
+      4 層で reject、全試行を hook-events.log に env snapshot + ppid + isatty
+      で記録。env 経路では承認ファイルを有効化しない（R-011）。完全な構造
       保証は別 PBI スコープ（明示的 best-effort）
+- [ ] **AC-6**: `bin/plangate doctor` が有効な maintenance 窓の残時間と
+      スコープを表示する
+- [ ] **AC-7**: 既存 `maintenance.json`（30 分窓・パス無指定）が後方互換
+      で動作する（Override 対象パス以外）
+- [ ] **AC-8**: CLI / hook の判定にユニットテストがあり、
+      `tests/run-tests.sh` で検証可能
 - [ ] **AC-9**: 既存有効な maintenance.json が存在する状態での `maintenance start`
       は `--force` なしでは exit 非0 で上書き拒否される（R-005, R-010）
 - [ ] **AC-10**: 新設フィールド（allowed_paths/one_shot/consumed_at）の判定も
@@ -88,12 +95,6 @@ EH-3 を迂回しており、運用負荷が継続的に発生している。
 - [ ] **AC-13**: `bin/plangate doctor --json` 出力に maintenance scope が含まれ、
       `maintenance.json` 有無・残 TTL・scope/paths/one_shot/consumed_at が
       機械可読で取得可能（R-030）
-- [ ] `bin/plangate doctor` が有効な maintenance 窓の残時間と
-      スコープを表示する
-- [ ] 既存 `maintenance.json`（30 分窓・パス無指定）が後方互換で動作する
-- [ ] CLI / hook の判定にユニットテストがあり、
-      `tests/run-tests.sh` で検証可能
-
 ## Notes from Refinement
 
 - **承認境界の維持（best-effort + 監査・R-012）**: AI 自己付与は **多層

--- a/docs/working/TASK-0106/review-self.md
+++ b/docs/working/TASK-0106/review-self.md
@@ -20,10 +20,10 @@ v2/v3 外部レビュー（Codex+Gemini）で検出された **critical 1**（R-
 
 | # | 項目 | 判定 | 根拠 |
 |---|------|------|------|
-| C1-PLAN-01 | 受入基準網羅性 | PASS | AC-1〜AC-10、TC-01〜TC-31（+ TC-26a/b/c/d で 35 件）対応 |
+| C1-PLAN-01 | 受入基準網羅性 | PASS | **AC-1〜AC-13**（v3.2 で AC-11/12/13 追加）すべて TC-01〜TC-34 マッピング表で対応 |
 | C1-PLAN-02 | Unknowns 処理 | PASS | 全 Unknowns 確定。R-012 は best-effort 明示で取扱い確定 |
 | C1-PLAN-03 | スコープ制御 | PASS | Hardening Override 10 パターン全 todo 化（R-015 解消）、Override 判定順序明文化（R-020）、構造保証は別 PBI 分割（R-012 明示） |
-| C1-PLAN-04 | テスト戦略 | PASS | Unit (L1-L4 各層) / Hook / Integration / E2E / Backward compat / Runner 統合 / 回帰、計 35 件 |
+| C1-PLAN-04 | テスト戦略 | PASS | Unit (L1-L4 各層) / Hook (flock + inode 再確認) / Integration / E2E / Backward compat / Runner 統合 / 回帰、**TC-01〜TC-34 計 34 件**（R-031 反映後） |
 | C1-PLAN-05 | Work Breakdown Output | PASS | T-04 を多層防御 + 監査ログ込みに、T-05 を flock 必須化、T-06 を 10 パターン明示に拡張（R-012/R-015/R-017） |
 | C1-PLAN-06 | 依存関係 | PASS | T-03→T-04（多層防御）→T-05（flock+os.replace）→T-06（10 パターン Override）→T-07a/b（doctor）→T-08..T-12 |
 | C1-PLAN-07 | 動作検証自動化 | PASS | 全 TC 自動化可、L1-L4 各層の reject + 監査ログ + race fail-closed を unit/integration で検証 |


### PR DESCRIPTION
## Why

Codex C-3 レビュー（4 ラウンド目）の minor + info 指摘を C-3 提出前に解消する小規模 PR。
これで critical=major=minor=info=0 / 残 blocker 0 になり、C-3 ゲート提出が**論点 1 点のみ**（R-012 best-effort 設計の Human 承認）に絞られる。

## 変更（2 ファイル / 8 insertion / 5 deletion）

| ファイル | 変更 |
|---------|------|
| `pbi-input.md:99` Notes from Refinement | 古い絶対表現「AI 自己付与は何があっても不可能でなければならない」→ R-012 best-effort + L1-L4 多層防御 + 監査 + 別 PBI 分割の方針に整合 |
| `review-self.md` C1-PLAN-01 / C1-PLAN-04 | AC-1〜10 / TC-01〜31 の古い集計 → **AC-1〜13 / TC-01〜34**（v3.2 状態）に同期 |

## Out of scope
- TASK-0106 の他改訂（v3.2 で確定）

## レビュー観点
- v3.2 の他箇所（In scope / AC-5 / plan Constraints）と整合

Refs: TASK-0106 C-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)