### PR TITLE
fix(TASK-0106): gemini-code-assist #307 medium 4 件採用 (follow-up)

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -688,7 +688,9 @@ try:
     consumed = d.get("consumed_at") is not None
     active = (int(d.get("granted_at", 0)) <= now and rem > 0 and not consumed)
     if active:
-        print(f"active remaining={rem//60:02d}:{rem%60:02d} scope={d.get('scope','')} one_shot={str(one_shot).lower()} paths={d.get('allowed_paths') if d.get('allowed_paths') is not None else '(any non-Override)'}")
+        ap = d.get('allowed_paths')
+        paths_str = ap if ap is not None else '(any non-Override)'
+        print(f"active remaining={rem//60:02d}:{rem%60:02d} scope={d.get('scope','')} one_shot={str(one_shot).lower()} paths={paths_str}")
     elif consumed:
         print(f"consumed (one_shot) — re-issue with 'plangate maintenance start' if needed")
     elif rem == 0:
@@ -1237,7 +1239,7 @@ cmd_maintenance() {
     # $1=event $2=verdict $3=detail (JSON-safe)
     _ev="$1"; _vd="$2"; _dt="$3"
     printf '{"ts":"%s","event":"%s","verdict":"%s","ppid":%s,"isatty_stdin":%s,"detail":%s}\n' \
-      "$(_ts_iso)" "$_ev" "$_vd" "$PPID" \
+      "$(_ts_iso)" "$_ev" "$_vd" "${PPID:-0}" \
       "$([ -t 0 ] && printf true || printf false)" \
       "$(printf '%s' "$_dt" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
       >> "$_hook_events" 2>/dev/null || true

--- a/bin/plangate
+++ b/bin/plangate
@@ -688,7 +688,7 @@ try:
     consumed = d.get("consumed_at") is not None
     active = (int(d.get("granted_at", 0)) <= now and rem > 0 and not consumed)
     if active:
-        print(f"active remaining={rem//60:02d}:{rem%60:02d} scope={d.get('scope','')} one_shot={str(one_shot).lower()} paths={d.get('allowed_paths') or '(any non-Override)'}")
+        print(f"active remaining={rem//60:02d}:{rem%60:02d} scope={d.get('scope','')} one_shot={str(one_shot).lower()} paths={d.get('allowed_paths') if d.get('allowed_paths') is not None else '(any non-Override)'}")
     elif consumed:
         print(f"consumed (one_shot) — re-issue with 'plangate maintenance start' if needed")
     elif rem == 0:
@@ -1237,7 +1237,7 @@ cmd_maintenance() {
     # $1=event $2=verdict $3=detail (JSON-safe)
     _ev="$1"; _vd="$2"; _dt="$3"
     printf '{"ts":"%s","event":"%s","verdict":"%s","ppid":%s,"isatty_stdin":%s,"detail":%s}\n' \
-      "$(_ts_iso)" "$_ev" "$_vd" "$$" \
+      "$(_ts_iso)" "$_ev" "$_vd" "$PPID" \
       "$([ -t 0 ] && printf true || printf false)" \
       "$(printf '%s' "$_dt" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
       >> "$_hook_events" 2>/dev/null || true
@@ -1326,7 +1326,7 @@ cmd_maintenance() {
       if [ -n "$_paths" ]; then
         _allowed_json=$(printf '%s' "$_paths" | python3 -c 'import json,sys; print(json.dumps([p.strip() for p in sys.stdin.read().split(",") if p.strip()]))')
       fi
-      _user="${USER:-mine_take}"
+      _user="${USER:-unknown}"
       python3 - "$_maint" "$_user" "$_reason" "$_now" "$_until" "$_allowed_json" <<'PYW'
 import json, sys, os
 target, user, reason, granted_at, until_, allowed_json = sys.argv[1:7]

--- a/scripts/hooks/check-plan-hash.sh
+++ b/scripts/hooks/check-plan-hash.sh
@@ -160,7 +160,7 @@ try:
     if allowed is not None:
         if not isinstance(allowed, list):
             print("INVALID|allowed_paths not array"); sys.exit(0)
-        matched = any(fnmatch.fnmatch(norm_target, pat) for pat in allowed)
+        matched = any(fnmatch.fnmatchcase(norm_target, pat) for pat in allowed)
         if not matched:
             print(f"OUT_OF_SCOPE|target={norm_target} not in allowed_paths={allowed}")
             sys.exit(0)


### PR DESCRIPTION
## Why

#307 (TASK-0106 exec フェーズ) が **gemini-code-assist の medium 指摘 4 件が
未解決**のまま MERGED された (2026-05-21、commit `3f6bdbf`)。これら 4 件は
すべて技術的に妥当な改善のため、本 follow-up PR で反映。

## 反映内容（差分 4 行）

| # | 場所 | 修正前 | 修正後 | 意義 |
|---|------|--------|--------|------|
| 1 | `bin/plangate:691` (doctor maintenance 表示) | `d.get('allowed_paths') or '(any non-Override)'` | `... if ... is not None else ...` | 空配列 `[]` (=全パス拒否) を `(any non-Override)` と誤表示する bug を修正 |
| 2 | `bin/plangate:1240` (audit log) | `"$$"` (現在 PID) | `"$PPID"` (親 PID) | L3 親プロセス防御の文脈と整合 |
| 3 | `bin/plangate:1329` (CLI start) | `\${USER:-mine_take}` | `\${USER:-unknown}` | 個人名ハードコードを汎用化 |
| 4 | `scripts/hooks/check-plan-hash.sh:163` (allowed_paths 照合) | `fnmatch.fnmatch` | `fnmatch.fnmatchcase` | セキュリティ照合の OS 依存性 (macOS/Linux 差) を排除し case-sensitive 一貫化 |

## レグレッション

- `tests/run-tests.sh`: **82/0** PASS 維持
- `tests/hooks/run-tests.sh`: **79/0** PASS 維持

## 補足

#307 マージ時、gemini medium 4 件は **未解決スレッド残存**で BLOCKED 状態
でしたが merge されました（mergeable=MERGEABLE/BLOCKED）。技術的に妥当な
改善を取り込み逃すべきでないため本 follow-up を起こします。

Refs: #289 (already closed via #307), TASK-0106 follow-up, gemini #307 medium x4

🤖 Generated with [Claude Code](https://claude.com/claude-code)