### PR TITLE
docs(#310): 新規ユーザー導線強化 — 最初に読む 3 ページ + Requirements 明示 (短期 #1+#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ PlanGate では、以下のような不変条件を hook / CLI で検査でき�
 - C-3 / C-4 承認なしのマージを検知する
 - standard / high-risk / critical で V-3 外部レビューを必須化する
 
+## Requirements
+
+| 種別 | ツール | 用途 |
+| --- | --- | --- |
+| **Required** | git / POSIX sh (bash/zsh) / python3 | `bin/plangate` CLI と hook の基盤 |
+| **Recommended** | [Claude Code](https://docs.claude.com/claude-code) | plan 生成・exec の主導線（slash command 経由） |
+| **Optional** | [gh CLI](https://cli.github.com/) | PR / issue 操作（C-4 ゲートの GitHub 連携） |
+| **Optional** | [Codex CLI](https://github.com/openai/codex) | exec 実装エージェント（既定） / C-2 / V-3 外部レビュー |
+| **Optional** | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | 並列外部レビュー |
+| **Optional** | [Cursor](https://cursor.com/) | `PLANGATE_IMPL_AGENT=cursor`（部分対応・[docs/rfc/provider-cursor.md](docs/rfc/provider-cursor.md)） |
+
+OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推奨。Claude Code を使わない場合は `bin/plangate` CLI のみで PBI 文書管理 + ゲート検証は可能ですが、plan 生成は手動になります。
+
 ## インストール
 
 ### Option A: clone + plugin 登録（推奨）

--- a/README_en.md
+++ b/README_en.md
@@ -94,6 +94,19 @@ PlanGate can check these invariants through hooks and CLI:
 - Detect merges without both C-3 and C-4 approvals
 - Require V-3 external review for standard / high-risk / critical modes
 
+## Requirements
+
+| Type | Tool | Purpose |
+| --- | --- | --- |
+| **Required** | git / POSIX sh (bash/zsh) / python3 | `bin/plangate` CLI and hook foundation |
+| **Recommended** | [Claude Code](https://docs.claude.com/claude-code) | Main path for plan generation and exec (via slash commands) |
+| **Optional** | [gh CLI](https://cli.github.com/) | PR/issue operations (C-4 gate via GitHub) |
+| **Optional** | [Codex CLI](https://github.com/openai/codex) | exec implementation agent (default) / C-2 / V-3 external review |
+| **Optional** | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Parallel external review |
+| **Optional** | [Cursor](https://cursor.com/) | `PLANGATE_IMPL_AGENT=cursor` (partial support, [docs/rfc/provider-cursor.md](docs/rfc/provider-cursor.md)) |
+
+OS: macOS / Linux (POSIX shell required). Use WSL on Windows. Without Claude Code, `bin/plangate` CLI still works for PBI document management and gate verification, but plan generation becomes manual.
+
 ## Install
 
 ### Option A: Clone and register plugin (recommended)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ PlanGate を初めて知った方は、以下の順に **15-30 分** で読む�
 | **Optional** | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | 並列外部レビュー |
 | **Optional** | [Cursor](https://cursor.com/) | `PLANGATE_IMPL_AGENT=cursor`（部分対応・[RFC](./rfc/provider-cursor.md)） |
 
-OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推奨。
+OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推奨。Claude Code を使わない場合は `bin/plangate` CLI のみで PBI 文書管理 + ゲート検証は可能ですが、plan 生成は手動になります。
 
 ## はじめに読むもの
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,29 @@ PlanGate は、AI コーディングエージェントをプロダクション�
 
 ![Harness Engineering と PlanGate の関係](assets/harness-plangate-readme-dark-v2.png)
 
+## 新規利用者: 最初に読む 3 ページ
+
+PlanGate を初めて知った方は、以下の順に **15-30 分** で読むことを推奨します。
+
+1. **[PlanGate ガイド](./plangate.md)** — 全体像・5 フェーズ・解決する問題（約 5 分）
+2. **[段階的導入ガイド](./staged-adoption-guide.md)** — Level 1 (Day 1) から始める具体手順（約 10 分）
+3. **[10 分チュートリアル（GitHub README）](https://github.com/s977043/PlanGate#10-分チュートリアル)** — 実際に手を動かす最小例（約 10 分）
+
+「自分のチームに合うか」を判断したい方は [思想と問題設定](./philosophy.md) も参照。
+
+## Requirements
+
+| 種別 | ツール | 用途 |
+| --- | --- | --- |
+| **Required** | git / POSIX sh (bash/zsh) / python3 | `bin/plangate` CLI と hook の基盤 |
+| **Recommended** | [Claude Code](https://docs.claude.com/claude-code) | plan 生成・exec の主導線（slash command 経由） |
+| **Optional** | [gh CLI](https://cli.github.com/) | PR / issue 操作（C-4 ゲートの GitHub 連携） |
+| **Optional** | [Codex CLI](https://github.com/openai/codex) | exec 実装エージェント（既定） / C-2 / V-3 外部レビュー |
+| **Optional** | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | 並列外部レビュー |
+| **Optional** | [Cursor](https://cursor.com/) | `PLANGATE_IMPL_AGENT=cursor`（部分対応・[RFC](./rfc/provider-cursor.md)） |
+
+OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推奨。
+
 ## はじめに読むもの
 
 | ドキュメント | 内容 |

--- a/docs/working/TASK-0107/INDEX.md
+++ b/docs/working/TASK-0107/INDEX.md
@@ -1,0 +1,40 @@
+# TASK-0107 INDEX
+
+> L0 entry per `.claude/rules/working-context.md` Progressive Disclosure protocol.
+
+- **Source**: User request 2026-05-21（Claude cowork `/setup-cowork` 相当を PlanGate に）
+- **Title**: PlanGate Setup Command — `/plangate-setup` 三層構成（Command + Agent + Skill）+ Workflow-owned 永続ロック
+- **Phase**: **phase B 完了** + **C-2 R3 完了**（R-009〜R-013 reflected pre-commit）+ **C-1 PASS（17/17、blocker 0）**。**C-3 ゲート待ち (Human-owned)**
+- **Mode 判定**: **high-risk**（`lite_eligible=false` 確定、Hardening Override 対象）
+- **Status**: pbi-input.md r1 / brainstorm / plan / todo / test-cases / review-external（R-001〜R-008 reflected (pre-commit)）作成済
+
+## Files
+
+| File | Role | Status |
+|------|------|--------|
+| `brainstorm.md` | 0: 検討ログ（履歴文書、r1 で更新済の注記あり） | ✅ |
+| `pbi-input.md` | A: PBI INPUT PACKAGE (r1 + U7 / AC 13 件) | ✅ |
+| `plan.md` | B: EXECUTION PLAN（8 Steps / high-risk） | ✅ |
+| `todo.md` | B: EXECUTION TODO（T-01〜T-15） | ✅ |
+| `test-cases.md` | B: テストケース定義（TC-01〜TC-22 + EC-01〜EC-04） | ✅ |
+| `review-external.md` | C-2 R1 + R2 + R3 外部レビュー集約（R-001〜R-013 reflected pre-commit） | ✅ |
+| `review-self.md` | C-1 セルフレビュー（17/17 PASS、blocker 0） | ✅ |
+| `approvals/c3.json` | C-3 ゲート判定（Human-owned） | ⬜ 未着手 |
+| `status.md` | exec 進行中の状態履歴アーカイブ | ⬜ exec 開始時 |
+| `current-state.md` | 現状スナップショット（タスク完了ごとに更新） | ⬜ exec 開始時 |
+| `decision-log.jsonl` | 判断履歴（append-only） | ⬜ exec 開始時 |
+| `handoff.md` | WF-05 完了パッケージ（Rule 5 必須 6 要素） | ⬜ T-12 で生成 |
+
+## Next action
+
+1. ✅ C-2 R3 完了（R-009〜R-013 全 reflected pre-commit）
+2. ✅ C-1 17/17 PASS
+3. **👤 Human が C-3 ゲート判定**（`docs/working/TASK-0107/approvals/c3.json` 発行: `decision: APPROVED`、`plan_hash`、`c3_status: APPROVED`）
+4. C-3 APPROVED → workflow-conductor が exec（T-01〜T-08）+ L-0/V-1/V-2/V-3/PR を制御
+5. C-4 GitHub PR レビュー（👤）
+
+## 重要
+
+- 本 PBI は **責務 4 分類・Shadow Config 防止に直接接続**する Critical Infra 領域
+- C-3 は **同期固定**（lite_eligible=false、Hardening Override 適用）
+- AC-12 自己言及デッドロック注意: TASK-0107 自身の handoff 生成時、`bin/plangate doctor --check-settings PASS` が前提となるため、開発中に手動 wiring 完了が必要（Gemini 助言）

--- a/docs/working/TASK-0107/brainstorm.md
+++ b/docs/working/TASK-0107/brainstorm.md
@@ -1,0 +1,210 @@
+# TASK-0107 Brainstorm: PlanGate Setup Command
+
+> **Status**: Brainstorm（PBI 化前の検討ログ）
+> **Date**: 2026-05-21
+> **Trigger**: Claude cowork の `/setup-cowork` 相当を PlanGate にも用意し、初期設定を楽に進められるようにしたい
+> **Note (2026-05-21 C-2 R2 / R-007 対応)**: 本ファイルは設計検討の**履歴文書**。現行正本は [`pbi-input.md`](./pbi-input.md) r1。**§4 責務4分類表 / §7 未決事項 mode 候補（standard/light）は r1 で更新済**（責務4分類は Workflow-owned 永続ロック明示済、mode は high-risk 確定）。phase B 以降は pbi-input.md r1 を正本とすること。
+
+
+## 1. 背景・目的
+
+PlanGate は導入時に以下のような初期設定が必要だが、現状は手順が散在しており、新規導入時のハードルが高い:
+
+- `.claude/settings.json` の wiring（EH-3 / EH-8 等の Hook 配線）
+- `apply-claude-settings.sh` の実行
+- `bin/plangate doctor` での検証
+- `docs/working/` 構造の理解
+- 必要なツール / 依存の確認
+
+Claude cowork の `/setup-cowork` のように、**対話的に初期設定を進められる入口**を PlanGate にも提供したい。
+
+## 2. 検討した配置案（Workflow / Skill / Agent / Command の 4 軸）
+
+PlanGate の責務分類ルール（[`hybrid-architecture.md`](../../../.claude/rules/hybrid-architecture.md) Rule 1〜5、[`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md) AI/Human/CI/Workflow-owned）を基準に、各配置候補を評価:
+
+| 配置 | 適合性 | 理由 |
+|------|--------|------|
+| **Workflow** (`docs/workflows/`) | × | WF-01〜05 は PBI ライフサイクル。setup はその外（メタ操作）。Rule 1 の「順序と完了条件」とは性質が異なる |
+| **Skill** (`.claude/skills/`) | ○ | 手順本体・観点を再利用単位で保持。Rule 2 適合。配布版 plugin への export も容易 |
+| **Agent** (`.claude/agents/`) | ○ | **Human action の追跡 / Gate 保持 / 対話**という単一責務を担える。Rule 3 適合 |
+| **Command** (`.claude/commands/`) | ○ | `/plangate-setup` のスラッシュ語彙で発見性を上げる入口 |
+
+### 当初案（Agent なし）
+
+検討初期は「Command + Skill の二層」を推奨案としたが、以下の指摘で見直した:
+
+> 「Human が設定する部分が必要なので、その確認などを担当するエージェントは必要ではないか？」
+
+**Skill は手順、Agent は責務**という分離原則から、「Human を待つ」「Gate を保持する」は Agent 側に置くのが正しい。
+
+## 3. 推奨：三層構成
+
+| 層 | 役割 | 配置 |
+|---|---|---|
+| **Command** `/plangate-setup` | 起動口（薄い）。Agent 呼び出しと初期 context 渡しのみ | `.claude/commands/plangate-setup.md` |
+| **Agent** `setup-coordinator` | Human action の追跡・Gate 保持・対話・進捗管理 | `.claude/agents/setup-coordinator.md` |
+| **Skill** `plangate-setup` | チェックリスト・検証観点・script 提示テンプレ（再利用単位） | `.claude/skills/plangate-setup/SKILL.md` |
+| **CLI**（既存） `bin/plangate doctor` | 機械的検証。Agent から呼ぶ | — |
+
+### 各層の責務境界
+
+```
+User ──/plangate-setup──→ Command
+                              ↓ 起動
+                          Agent: setup-coordinator
+                              ↓ 観点読込
+                          Skill: plangate-setup（手順・観点）
+                              ↓ 検証実行
+                          CLI: bin/plangate doctor
+                              ↓ 出力解釈
+                          Agent: Human への提示・応答待ち
+                              ↓ 完了確認
+                          Agent: サマリ出力（handoff 風）
+```
+
+## 4. 根拠
+
+### Rule 1〜5 との整合
+
+- **Rule 1**（Workflow は順序と完了条件のみ）: setup は PBI ライフサイクル外のため Workflow には置かない
+- **Rule 2**（Skill は再利用単位）: チェックリスト・観点は他リポジトリへの export 候補となるため Skill に
+- **Rule 3**（Agent は責務のみ）: `setup-coordinator` は「Human action の追跡・Gate 保持」という単一責務
+- **Rule 4**（案件固有は CLAUDE.md）: PlanGate 固有の wiring 詳細は CLAUDE.md / settings-wiring-contract.md を参照
+- **Rule 5**（最終成果物は handoff）: setup 完了時にサマリを出力（handoff 形式ではないが、完了サマリの責務は明示）
+
+### 責務 4 分類との整合
+
+| 操作 | 分類 | 本構成での担当 |
+|------|------|--------------|
+| settings.json の wiring 適用 | **Human-owned**（self-mod ガード） | Agent が**提示**、ユーザーが実行 |
+| `apply-claude-settings.sh` の実行 | **Human-owned** | Agent が**提示**、ユーザーが実行 |
+| doctor による検証 | **AI-owned** | Agent が CLI 呼び出し |
+| 適用待ちの追跡 / 完了 lock | **Workflow-owned** | Agent + Skill の責務として記録 |
+| drift 検出（reference） | **CI-owned** | 既存 CI（settings-drift workflow） |
+
+### Shadow Config 防止との整合
+
+- AI は settings 自己改変できない（self-mod ガード）
+- Agent は「適用しましたか？」を聞くが、**doctor 再実行で実体検証**する
+- これにより「AI が適用済みと誤認して完了する」Shadow Configuration を構造的に防ぐ
+- [`working-context.md`](../../../.claude/rules/working-context.md) settings タスクロックと整合
+
+### 既存 Agent パターンの踏襲
+
+| 既存 Agent | 責務 | `setup-coordinator` との類似点 |
+|-----------|------|-----------------------------|
+| `acceptance-tester` | V-1 受け入れ検査 | 機械的検証 + 結果報告 |
+| `linter-fixer` | L-0 リンター修正 | autofix → AI 修正 → 抑制の段階的処理 |
+| `setup-coordinator`（新規） | setup 進捗管理 | 検知 → 提示 → 確認 → 再検証の段階的処理 |
+
+## 5. 想定フロー
+
+```
+/plangate-setup
+  ↓
+Step 1: 現状検知
+  - Agent が bin/plangate doctor 実行
+  - 不足項目をリスト化（settings wiring / Hook / scripts 等）
+  - Skill のチェックリストと突合
+
+Step 2: 質問・分岐
+  - Agent: 「Hook EH-3/EH-8 を wire しますか？」「apply-claude-settings.sh を実行しましたか？」など
+  - ユーザー応答に応じて分岐
+
+Step 3: 提示
+  - Agent: sh scripts/apply-claude-settings.sh のコマンドを表示
+  - 実行はユーザーが行う（AI は実行しない）
+
+Step 4: 検証
+  - ユーザー: 「やりました」と報告
+  - Agent: doctor 再実行で実体検証
+  - PASS → 次へ / FAIL → 失敗内容を提示し再依頼
+
+Step 5: 完了サマリ
+  - 完了項目 / 残項目 / 次のアクション候補（最初の PBI 作成 / /ai-dev-workflow 等）を出力
+```
+
+## 6. トレードオフ
+
+### Pros（採用理由）
+
+- Agent を分離することで「Human action 追跡」責務が明確化
+- Skill 単独より発見性・再利用性が両立
+- 既存 Agent パターン（`acceptance-tester` / `linter-fixer`）と一貫
+- doctor を中核に据えることで Shadow Config 防止が自然に成立
+
+### Cons（採用しなかった選択肢）
+
+| 選択肢 | 不採用理由 |
+|--------|----------|
+| Command 単独 | 状態管理・Gate 保持が弱い。Agent 責務を Command に書き込むと Rule 1 違反気味 |
+| Skill 単独 | Human 応答を待つ「対話・追跡」責務を Skill に書くと Rule 2（再利用単位）逸脱 |
+| Agent 単独（Command なし） | スラッシュ起動の発見性が下がる。Claude cowork `/setup-cowork` 同型 UX が出せない |
+| Workflow 追加（WF-00 等） | PBI ライフサイクル外のため Workflow の枠組みに合わない |
+
+### 残るトレードオフ
+
+- **完全自動化は不可**: settings self-mod ガードがある以上「ガイド型」止まり。代わりに doctor / CI で未適用を機械検出
+- **三層になり管理対象が増える**: が、setup は重要な入口なので妥当
+- **Claude cowork `/setup-cowork` の実体**: 調査済み（§6.5 参照）。Cowork 公式に組み込みの `/setup-cowork` は**存在しない**。PlanGate 版は公式仕様に縛られず独自設計で進める
+
+## 6.5 Claude Cowork 実体調査結果（2026-05-21）
+
+公式ドキュメント + 複数の解説記事を確認した結果:
+
+| 項目 | 実態 |
+|------|------|
+| Cowork 組み込み slash command | `/schedule`、`/plugin` 等は存在。**setup 専用コマンドは無い** |
+| 初期セットアップ方法 | **GUI ベース**（Settings > Cowork、フォルダ選択ダイアログ、コネクタ画面） |
+| セットアップで整える 5 要素 | Context files / Global instructions / Folder instructions / Plugins / Connectors |
+| `/setup-cowork` の正体 | コミュニティ/個人が作ったカスタムスキル、または UX イメージとしての例示 |
+
+### PlanGate 版への含意
+
+Cowork 公式仕様に縛られる必要はない。ただし「5 要素を整える」という観点は転用可能:
+
+| Cowork 5 要素 | PlanGate 対応物 |
+|--------------|----------------|
+| Context files | `CLAUDE.md` / `AGENTS.md`（既存）|
+| Global instructions | `.claude/settings.json` wiring（Human-owned）|
+| Folder/Project instructions | `docs/working/` 構造 |
+| Plugins | `.claude/{agents,skills,commands}` |
+| Connectors | Hook / CI / MCP 等 |
+
+→ **三層構成（Command + Agent + Skill）の方針は確定**。doctor を中核に、上記 5 要素の検知・提示・確認を Agent が担う設計で進める。
+
+### 参照（調査ソース）
+
+- [Get started with Claude Cowork — Anthropic Help Center](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork)
+- [Cowork: Claude Code power for knowledge work — Claude.com](https://claude.com/product/cowork)
+- [Claude Cowork Setup Guide — The AI Corner](https://www.the-ai-corner.com/p/claude-cowork-setup-guide)
+- [Complete Claude Setup Checklist — Medium](https://medium.com/nginity/the-complete-claude-setup-checklist-72-steps-from-default-to-power-user-082d8bf0d390)
+
+## 7. 未決事項
+
+- [x] ~~Claude cowork `/setup-cowork` の実体~~（2026-05-21 調査完了。§6.5 参照）
+- [ ] `plangate-setup` Skill のチェックリスト具体項目（doctor 検査項目 12 種類 + Cowork 5 要素対応の対応関係）
+- [ ] `setup-coordinator` Agent の tools 設定（Bash / Read 中心？ Edit は不要？）
+- [ ] 初回 setup 以外の用途（再設定 / 部分再適用 / 健康診断）も担うか、それとも setup 専用とするか
+- [ ] PBI 化する場合のモード判定（standard 想定だが、Agent 新規追加 + Hook 影響なしのため light でも可？）
+- [ ] handoff 風の完了サマリは PBI handoff.md と紛らわしくないか命名検討
+
+## 8. 次のアクション候補
+
+| 選択肢 | 内容 |
+|--------|------|
+| **A. PBI 化して実装** | 本 brainstorm.md を pbi-input.md に昇格 → plan 生成 → C-3 ゲート → exec |
+| **B. Claude cowork 実体調査が先** | `/setup-cowork` の挙動確認 → 同等性要件を pbi-input に反映してから PBI 化 |
+| **C. Skill のみ先行実装** | Agent / Command は後段。Skill だけ用意して既存 Agent から呼べる状態にする（最小投資） |
+| **D. brainstorm のまま保留** | 他優先 PBI を消化してから戻る |
+
+**選択履歴**: 2026-05-21 ユーザー指示「B→Aの順」。B 完了（§6.5 反映済）→ A 着手（pbi-input.md 生成へ）。
+
+## 9. 参照
+
+- [`hybrid-architecture.md`](../../../.claude/rules/hybrid-architecture.md): Rule 1〜5
+- [`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md): AI/Human/CI/Workflow-owned 4 分類
+- [`working-context.md`](../../../.claude/rules/working-context.md): settings タスクロック / Shadow Config 防止
+- [`docs/ai/settings-wiring-contract.md`](../../ai/settings-wiring-contract.md): wiring 契約
+- 既存 Agent: `.claude/agents/acceptance-tester.md` / `.claude/agents/linter-fixer.md`
+- 既存 CLI: `bin/plangate doctor`

--- a/docs/working/TASK-0107/current-state.md
+++ b/docs/working/TASK-0107/current-state.md
@@ -1,0 +1,27 @@
+# TASK-0107 current-state.md
+
+> 現在状態スナップショット（~20 行、L0、上書き更新）
+
+## 今どこにいて、次に何をするか
+
+- **現在**: Phase B 完了 + C-2 R3 完了 + C-1 PASS。**G-C3 人間レビュー待ち**
+- **次**: 👤 Human が `docs/working/TASK-0107/approvals/c3.json` を発行（APPROVED）→ workflow-conductor が exec 着手
+
+## ブロッカー
+
+- 👤 **C-3 ゲート（人間判定）が責務 4 分類 Human-owned のため AI は実行不可**
+- `lite_eligible=false` 確定（Hardening Override 適用）のため同期 C-3 必須
+
+## 直近の判断
+
+- C-2 R3 で Codex REJECT（major × 4）→ R-009〜R-013 全反映 → C-1 17/17 PASS
+- mode: `high-risk` 確定
+- 三層構成: Command + Agent + Skill + Workflow-owned 永続ロック
+
+## 参照ファイル
+
+- INDEX.md（最初に読む）
+- pbi-input.md r1（正本）
+- plan.md / todo.md r1 / test-cases.md
+- review-external.md（R-001〜R-013）
+- review-self.md（C-1 17/17）

--- a/docs/working/TASK-0107/decision-log.jsonl
+++ b/docs/working/TASK-0107/decision-log.jsonl
@@ -1,0 +1,8 @@
+{"ts": "2026-05-21T05:32:00Z", "event": "brainstorm_created", "source": "TASK-0107/brainstorm.md", "notes": "PBI 化前検討ログ作成"}
+{"ts": "2026-05-21T05:47:00Z", "event": "pbi_input_created", "source": "TASK-0107/pbi-input.md", "revision": "r0"}
+{"ts": "2026-05-21T15:18:00Z", "event": "c2_r1_reflected", "findings": ["R-001", "R-002", "R-003", "R-004", "R-005"], "severity": ["major", "major", "minor", "minor", "info"], "reviewers": ["codex", "gemini"]}
+{"ts": "2026-05-21T15:33:00Z", "event": "c2_r2_reflected", "findings": ["R-006", "R-007", "R-008"], "severity": ["minor", "info", "info"], "reviewers": ["codex", "gemini"]}
+{"ts": "2026-05-22T06:10:00Z", "event": "plan_generated", "files": ["plan.md", "todo.md", "test-cases.md"]}
+{"ts": "2026-05-22T06:25:00Z", "event": "c2_r3_reflected", "findings": ["R-009", "R-010", "R-011", "R-012", "R-013"], "severity": ["major", "major", "major", "major", "minor"], "reviewers": ["codex", "gemini"], "codex_judgment": "REJECT", "gemini_judgment": "APPROVE"}
+{"ts": "2026-05-22T06:30:00Z", "event": "c1_completed", "result": "PASS", "items": "17/17", "blockers": 0}
+{"ts": "2026-05-22T06:35:00Z", "event": "c3_gate_ready", "status": "pending_human_approval", "prerequisites": "lite_eligible=false, synchronous C-3 required, approvals/c3.json must be issued by human"}

--- a/docs/working/TASK-0107/pbi-input.md
+++ b/docs/working/TASK-0107/pbi-input.md
@@ -1,0 +1,180 @@
+# TASK-0107 PBI INPUT PACKAGE: PlanGate Setup Command（`/plangate-setup`）
+
+> **Phase**: A（PBI INPUT PACKAGE）
+> **Date**: 2026-05-21
+> **Source**: [`brainstorm.md`](./brainstorm.md)（B→A の順で進行。brainstorm §6.5 で `/setup-cowork` 実体調査済み）
+> **Revision**: r1（2026-05-21 C-2 外部レビュー R-001〜R-005 を 1 回確定反映。[`review-external.md`](./review-external.md) 参照）
+
+---
+
+## 1. Context / Why
+
+PlanGate は導入時に複数の Human-owned 設定が必要（`.claude/settings.json` wiring、`apply-claude-settings.sh` 実行、`bin/plangate doctor` での検証、`docs/working/` 構造の理解等）だが、現状は手順が散在しており、新規導入者にとって学習コストが高い。
+
+Claude Cowork の `/setup-cowork` 相当の「対話的に初期設定を進められる入口」を PlanGate にも提供することで、以下を達成する:
+
+- **新規導入時の摩擦を最小化**（一箇所から起動し、不足項目の検知・提示・検証を対話的に行う）
+- **Human-owned 操作の追跡・確認**を AI 側で構造的に担保（Shadow Config 防止と整合）
+- **既存 doctor を中核**に据えることで、settings 自己改変ガードの制約を活かしたガイド型設計
+
+### 関連調査
+
+Claude Cowork 公式に組み込みの `/setup-cowork` slash command は**存在しない**ことを確認済み（brainstorm §6.5）。Cowork は GUI ベースで Context files / Global instructions / Folder instructions / Plugins / Connectors の 5 要素を整える形。PlanGate 版は公式仕様に縛られず独自設計で進める。
+
+### 責務 4 分類との整合（[`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)）
+
+| 操作 | 分類 | 本 PBI での担当 |
+|------|------|---------------|
+| settings.json wiring 適用 | **Human-owned** | Agent が提示、ユーザーが実行 |
+| `apply-claude-settings.sh` 実行 | **Human-owned** | Agent が提示、ユーザーが実行 |
+| doctor による検証 | **AI-owned** | Agent が CLI 呼び出し |
+| **適用待ちの追跡 / 完了 lock** | **Workflow-owned** | **`status.md` / `decision-log.jsonl` への永続記録 + `doctor --check-settings PASS` ゲート**（R-001 反映） |
+| drift 検出（reference） | **CI-owned** | 既存 CI（変更なし） |
+
+---
+
+## 2. What (Scope)
+
+### In scope
+
+1. **Command**: `.claude/commands/plangate-setup.md` 新設（薄い起動口。Agent を呼び出すだけ）
+2. **Agent**: `.claude/agents/setup-coordinator.md` 新設（Human action の追跡・Gate 保持・対話・進捗管理を単一責務化）
+3. **Skill**: `.claude/skills/plangate-setup/SKILL.md` 新設（チェックリスト・観点・script 提示テンプレを再利用単位として保持）
+4. **既存 `bin/plangate doctor` との連携**: Agent から呼び出し、`doctor --json`（構造化出力）を解釈して未適用項目をリスト化（R-003 反映）
+5. **進捗永続化**: 各 Step 完了ごとに `status.md` / `decision-log.jsonl` に manual action の pending/resolved を記録（R-001 反映）
+6. **完了サマリ出力**: 完了項目・残項目・次のアクション候補（PBI 作成 / `/ai-dev-workflow` 等）を提示
+7. **解消不能 FAIL の脱出経路**: フォローアップ PBI 起票誘導 or 承知スキップ（status.md に記録）の対話パス（R-005 反映）
+8. **TASK-0107 handoff.md** 生成（Rule 5 遵守）
+
+### Out of scope
+
+- `bin/plangate doctor` 本体の改修（出力フォーマット変更含む。`--json` は既存実装に存在することを前提）
+- `scripts/apply-claude-settings.sh` 本体の改修
+- 新規 Hook（EH-x）の追加
+- MCP 接続の自動化・自動検出
+- 配布 plugin（`plugin/plangate/`）への export（v2 範囲）
+- **再設定 / 健康診断 / 部分再適用**の用途（v2 範囲。初回 setup 専用に限定）
+- Cowork 公式の 5 要素（Context files / Instructions / Plugins / Connectors）の完全再現
+- 新規 CI workflow の追加
+- 既存 Agent（acceptance-tester / linter-fixer 等）の改修
+
+---
+
+## 3. 受入基準（Acceptance Criteria）
+
+> **改訂**: r1 で R-001〜R-005 を反映。AC-2〜AC-5 を test-cases 検証可能な形に書き直し（R-003）、AC-11〜AC-13 を新設（R-001/R-004/R-005）。
+
+| ID | 受入基準 | 検証方法 |
+|----|---------|---------|
+| **AC-1** | `/plangate-setup` 入力で `setup-coordinator` Agent が起動する | `.claude/commands/plangate-setup.md` 存在 + Agent invocation を含むこと |
+| **AC-2** | Agent が `bin/plangate doctor --json` を実行し、構造化出力から不足項目を抽出してユーザーに提示する | test-case: doctor --json 出力を mock として与え、Agent が抽出ロジック通りに項目をリスト化することを検証 |
+| **AC-3** | Agent は Human-owned 操作（settings wiring / `apply-claude-settings.sh` 実行）を**実行せず提示のみ**する | test-case: Agent が apply-claude-settings.sh を起動するパスが存在しないこと（grep 検査）+ Agent definition に「実行禁止・提示のみ」が明記 |
+| **AC-4** | ユーザーの「完了」報告を受けて Agent が `bin/plangate doctor --json` を再実行し、PASS まで完了しない | test-case: doctor が FAIL を返す mock 状況で Agent が次 Step に進まないこと（再検証ループ） |
+| **AC-5** | 完了時にサマリ（完了項目・残項目・次のアクション候補）を出力する | test-case: 全項目 PASS の doctor --json mock で Agent が完了サマリ形式の出力を行うこと |
+| **AC-6** | Skill `plangate-setup` が「PlanGate 5 要素対応観点」（CLAUDE.md / settings wiring / docs/working / agents-skills-commands / Hook-CI-MCP）を再利用単位として保持する | SKILL.md frontmatter + 本文に 5 要素対応表が存在すること |
+| **AC-7** | Command / Agent / Skill の三者が [`hybrid-architecture.md`](../../../.claude/rules/hybrid-architecture.md) Rule 1〜5 を満たす | Rule 1（順序のみ）/ Rule 2（再利用単位）/ Rule 3（責務のみ）/ Rule 4（案件固有は CLAUDE.md）/ Rule 5（handoff）の機械検出（grep） |
+| **AC-8** | TASK-0107 の `handoff.md` が生成される | `docs/working/TASK-0107/handoff.md` 存在 + 6 要素網羅 |
+| **AC-9** | 既存 Agent（`acceptance-tester` / `linter-fixer`）と一貫した frontmatter / 構造で実装される | Agent definition の frontmatter 比較（diff） |
+| **AC-10** | EH-3 / EH-8 等の Hook を新規追加しない（Out of scope の機械的担保） | `.claude/settings.json` の hooks セクションが変更されていないこと（diff 検査） |
+| **AC-11** [新規] | **各 Step 完了ごとに `docs/working/TASK-0107/status.md` および `decision-log.jsonl` に manual action の pending/resolved を永続記録する**（Workflow-owned ロック） | test-case: Step 1〜5 を踏んだ後、status.md に各 Step の完了マーカーが、decision-log.jsonl に append-only エントリが存在すること（R-001 反映） |
+| **AC-12** [新規] | **V-1 / handoff 完了の前提条件として `bin/plangate doctor --check-settings PASS` を確認する** | test-case: `--check-settings` が FAIL の状態で V-1 受け入れ検査 / handoff 完了処理がブロックされること（[`working-context.md`](../../../.claude/rules/working-context.md):126-135 settings タスクロック準拠）（R-004 反映） |
+| **AC-13** [新規] | **解消不能な FAIL（環境制約等）に対して、フォローアップ PBI 起票誘導 or 承知スキップ（status.md に明示記録）の脱出経路を Agent 対話方針として持つ** | Agent definition に脱出経路の対話パスが明記 + test-case: 解消不能 FAIL mock で Agent が脱出経路を提示すること（R-005 反映） |
+
+---
+
+## 4. Notes from Refinement
+
+### 検討経緯の要点（brainstorm.md より）
+
+- **当初案 → 修正案**: Command + Skill の二層 → Command + Agent + Skill の三層
+  - 「Human action の追跡」責務は Agent 側に置くべき（Skill は手順、Agent は責務）
+  - 既存 Agent パターン（acceptance-tester / linter-fixer）と一貫
+- **Cowork 公式調査の結論**: 組み込み `/setup-cowork` は存在しない。PlanGate 版は独自設計
+- **Cowork 5 要素 → PlanGate 対応**:
+
+| Cowork 5 要素 | PlanGate 対応物 |
+|--------------|----------------|
+| Context files | `CLAUDE.md` / `AGENTS.md` |
+| Global instructions | `.claude/settings.json` wiring |
+| Folder/Project instructions | `docs/working/` 構造 |
+| Plugins | `.claude/{agents,skills,commands}` |
+| Connectors | Hook / CI / MCP 等 |
+
+### 設計原則
+
+- **doctor を単一の検証源とする**: Agent は doctor（特に `--json` 構造化出力）の判定を踏襲し、独自の状態保持・判定を増やさない
+- **AI は実行せず提示のみ**: Human-owned 操作（settings 適用等）は提示まで。実行はユーザー
+- **Shadow Config 防止**: ユーザーの「やった」報告を信用せず doctor 再実行で実体検証
+- **Workflow-owned 永続ロック**（R-001 反映）: Agent の対話状態に依存せず、status.md / decision-log.jsonl への記録と `doctor --check-settings PASS` ゲートで完了条件を構造化
+- **UX デッドロック回避**（R-005 反映）: 解消不能 FAIL に対して脱出経路を提供（フォローアップ起票 or 承知スキップ）
+
+### C-2 外部レビュー反映（r1 確定）
+
+- 反映元: [`review-external.md`](./review-external.md) R-001〜R-005
+- 反映方針: 1 回確定反映（[`working-context.md`](../../../.claude/rules/working-context.md) F5-C / V-3 MJ-1 準拠）
+- 反映後の手順: 簡易 C-1 再実行 → 人間が APPROVED `c3.json` 発行 → plan 生成（phase B）
+
+---
+
+## 5. Estimation Evidence
+
+### Risks
+
+| ID | リスク | 影響 | 緩和策 |
+|----|-------|------|--------|
+| **R1** | setup-coordinator の責務肥大化（再設定 / 健康診断と混在） | Agent definition が膨れ Rule 3 違反気味になる | Out of scope に「再設定 / 健康診断は v2 範囲」を明記。初回 setup 専用に絞る |
+| **R2** | doctor 出力フォーマット変更で Agent 解釈が壊れる | 将来的に Agent が動作不能 | `bin/plangate doctor --json` の活用前提。文字列パース回避（AC-2 反映） |
+| **R3** | 三層構成（Command + Agent + Skill）で管理対象増 | 保守コスト | 既存 Agent パターン踏襲で構造を統一。テンプレ化 |
+| **R4** | 完了サマリと PBI handoff.md の命名混同 | 運用ミス | サマリは「setup-summary」等別命名。handoff.md は Rule 5 通り別途生成 |
+| **R5** | Agent invocation の方法が既存 Command と乖離 | 起動経路が分断 | 既存 `.claude/commands/` を参照し、最も近いパターンを踏襲（実装段階で決定） |
+| **R6** [r1 追加] | Workflow-owned 永続ロック実装の不備 | セッション断絶時に Human-owned 操作の未完了を見失う（Shadow Config の構造防止漏れ） | AC-11/AC-12 で status.md / decision-log.jsonl / `--check-settings PASS` を明示。test-case 化 |
+| **R7** [r1 追加] | 解消不能 FAIL での UX デッドロック | ユーザーが setup から抜けられず PBI 着手が遅延 | AC-13 で脱出経路（フォローアップ起票 / 承知スキップ）を Agent 対話方針に組込 |
+
+### Unknowns
+
+| ID | Unknown | 解決タイミング |
+|----|---------|-------------|
+| **U1** | setup-coordinator の tools 設定（最小: Bash, Read, Write [status.md 更新用]。Edit は不要か） | Plan 段階で確定 |
+| ~~**U2**~~ | ~~モード判定（standard / light）~~ | **解決済 (r1)**: high-risk（R-002 反映、§5 モード判定参照） |
+| **U3** | 完了サマリの配置・命名（status.md 統合 or 別ファイル） | Plan 段階で確定 |
+| **U4** | Command が Agent を起動する具体的な方法 | Plan 段階で既存 commands を調査 |
+| **U5** | Skill のチェックリスト粒度（doctor 12 検査項目すべて含めるか抜粋か） | Plan 段階で確定 |
+| **U6** [r1 追加] | `bin/plangate doctor --json` の現在の出力スキーマ（実装で利用可能か） | Plan 段階で `bin/plangate doctor --help` で確認 |
+| **U7** [r1.1 追加] | `/plangate-setup` 実行時の TASK ID / 記録先ディレクトリの動的解決（Task-local: 起動時に docs/working/TASK-XXXX/ を特定 or Global: 専用 setup ログ） | Plan 段階で確定（R-008 反映） |
+
+### Assumptions
+
+- A1: 既存 `bin/plangate doctor` の 12 検査項目を仕様変更せず活用する
+- A2: `bin/plangate doctor --json` は既存実装に存在し、構造化出力が安定している（U6 で確認予定）
+- A3: Hook EH-3 等の wiring 検証対象に含めるが、適用は Human-owned のまま
+- A4: 配布 plugin への export は v2 範囲（今回は本リポジトリ正本のみ）
+- A5: Cowork 公式仕様への準拠は不要（UX 参考に留める）
+- A6: 既存 Agent（acceptance-tester / linter-fixer）の改修は不要
+
+### モード判定（r1 改訂: R-002 反映）
+
+- **判定**: **`high-risk`**
+- **判定根拠**:
+  - **AC 数**: 13 → 定量基準では超高（critical）レンジだが、AC-11〜13 は test-case 検証可能な独立小単位のため critical までは行かない
+  - **変更ファイル数**: 3-5（Command / Agent / Skill / handoff / status / decision-log）→ standard レンジ
+  - **変更種別**: 新規 Agent 追加 + Command + Skill 三層 + Workflow-owned 永続ロック新規 → 高（high-risk）
+  - **リスク**: 高（Human-owned 操作の追跡漏れは Shadow Config 構造防止に直結）
+  - **影響範囲**: 新規 Agent + 既存 doctor 利用 + status.md / decision-log.jsonl への新規書込 → 中〜高
+  - **ロールバック**: 容易（新規ファイルのみで既存挙動破壊なし）→ standard
+  - **Hardening Override**（[`working-context.md`](../../../.claude/rules/working-context.md) C-3 条件付き降格 AC-10）: 責務4分類・Shadow Config 防止に直接接続するため **Lite 不可・lite_eligible=false 確定**
+  - **critical 不要の理由**: 段階的ロールバック不要（新規ファイル削除で復元可）/ 公開 API 破壊変更なし / DB スキーマ変更なし
+- **フェーズ適用**（[`mode-classification.md`](../../../.claude/rules/mode-classification.md) high-risk 列）: brainstorm ○ / plan ○ / C-1 17項目 ○ / **C-2 ○（本レビュー実施済）** / C-3 ○ / exec TDD+並列 / L-0 ○ / V-1 ○ / V-2 ○ / V-3 ○ / V-4 - / PR ○ / C-4 ○
+
+---
+
+## 6. References
+
+- [`brainstorm.md`](./brainstorm.md): 検討経緯（§6.5 に Cowork 実体調査結果）
+- [`review-external.md`](./review-external.md): C-2 外部レビュー集約（R-001〜R-005 / Codex + Gemini）
+- [`hybrid-architecture.md`](../../../.claude/rules/hybrid-architecture.md): Rule 1〜5
+- [`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md): AI/Human/CI/Workflow-owned
+- [`working-context.md`](../../../.claude/rules/working-context.md): settings タスクロック / Shadow Config 防止 / C-3 条件付き降格
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md): モード判定基準
+- [`docs/ai/settings-wiring-contract.md`](../../ai/settings-wiring-contract.md): wiring 契約
+- 既存 Agent: `.claude/agents/acceptance-tester.md` / `.claude/agents/linter-fixer.md`
+- 既存 CLI: `bin/plangate doctor`

--- a/docs/working/TASK-0107/plan.md
+++ b/docs/working/TASK-0107/plan.md
@@ -1,0 +1,160 @@
+# TASK-0107 EXECUTION PLAN
+
+> Source: `pbi-input.md` r1 + Unknowns U7 / Mode: **high-risk**
+> Generated: 2026-05-22
+> Advisory: Codex + Gemini（C-2 R2 後）GO for plan generation
+
+## Goal
+
+PlanGate に **対話的初期セットアップの入口**を提供する: `/plangate-setup` Command + `setup-coordinator` Agent + `plangate-setup` Skill の三層構成を新設し、既存 `bin/plangate doctor --json` を**単一検証源**として未適用項目の検知 → 提示 → ユーザー実行 → 再検証ループを実現する。**Workflow-owned 永続ロック**（`status.md` / `decision-log.jsonl` + `doctor --check-settings PASS`）で Shadow Configuration を構造的に防ぐ。
+
+## Constraints / Non-goals
+
+### Constraints
+
+- **doctor を単一検証源とする**: Agent は `bin/plangate doctor --json` の構造化出力（`scope` / `checks[]{name,ok,level,detail}` / `failures` / `warnings` / `passed`）のみを使い、文字列パースや独自判定を持たない（R-003）
+- **AI は提示のみ、実行しない**: settings 適用 / `apply-claude-settings.sh` 実行などの **Human-owned 操作は Agent が一切実行しない**（grep negative test で固定）
+- **Workflow-owned 永続ロック**: Agent の対話状態に依存せず、Step 完了ごとに `status.md` + `decision-log.jsonl` へ append-only 記録（R-001）
+- **新規 Hook 追加禁止**: `.claude/settings.json` の hooks セクション diff = 0（AC-10）
+- **既存 Agent パターン踏襲**: `acceptance-tester` / `linter-fixer` の frontmatter 構造に揃える（AC-9）
+- **C-3 同期固定**: `lite_eligible=false`（Hardening Override: Shadow Config / 責務 4 分類に直接接続するため）
+- **TASK ID 動的解決**: 記録先 `docs/working/TASK-XXXX/` は実行時解決（U7 / R-008）
+
+### Non-goals
+
+- `bin/plangate doctor` 本体改修（`--json` 出力形式の変更含む。**現状の schema をそのまま使う**）
+- `scripts/apply-claude-settings.sh` 改修
+- 新規 Hook（EH-x）追加
+- MCP 接続の自動検出 / 自動化
+- 配布 plugin（`plugin/plangate/`）への export（v2 範囲）
+- **再設定 / 健康診断 / 部分再適用**ユースケース（v2 範囲。初回 setup 専用）
+- Cowork 公式 5 要素の完全再現
+- 新規 CI workflow 追加
+- 既存 Agent の改修
+
+## Approach Overview
+
+**「契約確定 → 三層実装 → 永続ロック → 検証/handoff」** の 4 ブロック・8 Steps で進める。
+
+1. **Step 1（契約確定）** で `doctor --json` 実 schema を取得（U6）、Agent tools 最小集合を確定（U1）、Command invocation 方式（U4）、TASK ID 動的解決ロジック（U7）を文書化する。**ここを潰さないと Agent / Skill の実装が空振る**。
+2. **Step 2（三層責務設計）** で Command / Agent / Skill の責務境界表 + Cowork 5 要素 ⇄ PlanGate 対応表を確定する。
+3. **Step 3-5（三層実装）** は Step 2 後に並列可能（Skill / Command / Agent）。ただし Agent は Step 1 の schema 確定が前提。
+4. **Step 6（Workflow-owned 永続ロック）** は最重要。`status.md` + `decision-log.jsonl` append-only + 解消不能 FAIL の skip 記録パスを Agent 仕様に組み込む。
+5. **Step 7（テスト）** は mock-driven Agent test（3 系統: passed / 不足 / 解消不能 FAIL）+ grep / diff / handoff 6 要素検査。
+6. **Step 8（V-1 + handoff）** で `doctor --check-settings PASS` ゲートを通過させてから handoff.md 生成。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 並列可否 | 🚩 Checkpoint |
+|---|------|--------|-------|------|---------|--------------|
+| 1 | **事前契約確定**（U6/U1/U4/U7） | `docs/working/TASK-0107/contract-notes.md`（`doctor --json` 実 schema、Agent tools 最小集合、Command invocation 方式、TASK ID 動的解決ロジック） | AI | medium | 不可 | `bin/plangate doctor --json` 実行で `scope / checks[] / passed` を確認、tools=[Bash(`bin/plangate doctor --json`),Read,Write(限定)] 確定 |
+| 2 | **三層責務設計確定** | `contract-notes.md` 末尾に責務境界表 + Cowork 5 要素対応表 | AI | low | 不可（Step 1 後） | Command/Agent/Skill の入出力境界が表で 1:1 にマップ |
+| 3 | **Skill 実装** | `.claude/skills/plangate-setup/SKILL.md` | AI | low | Step 2 後並列可 | frontmatter + 5 要素対応 + チェックリスト + Rule 1-5 grep PASS |
+| 4 | **Command 実装** | `.claude/commands/plangate-setup.md` | AI | low | Step 2 後並列可 | Command が Agent invocation だけを持ち他に責務なし（Rule 1）+ `.claude/settings.json` diff = 0 |
+| 5 | **Agent 実装** | `.claude/agents/setup-coordinator.md` | AI | **high** | Step 1+2 後（Step 3/4 と並列可） | frontmatter (`tools` 最小)+ doctor --json 連携 + Human-owned 提示のみ明示（grep negative test 用文言）+ 既存 Agent（acceptance-tester / linter-fixer）と frontmatter 構造一致 |
+| 6 | **Workflow-owned 永続ロック実装** | Agent definition への append-only 記録ルール組込み + `status.md` / `decision-log.jsonl` の更新仕様 | AI | **critical** | 不可（Step 5 後） | 各 Step 完了 → `status.md` 追記 + `decision-log.jsonl` append、解消不能 FAIL skip 記録パス（AC-13）、TASK ID 不明時 guard（U7） |
+| 7 | **テスト/検証資産** | `tests/extras/ta-XX-plangate-setup.sh`（mock-driven）+ grep / diff 検査 + handoff 6 要素検査 | AI | medium | Step 3〜6 後 | doctor --json mock 3 系統（passed / 不足 / 解消不能 FAIL）+ Rule 1-5 grep + `.claude/settings.json` diff=0 + AC-11 の status/jsonl append 検証 |
+| 8 | **V-1 受け入れ + handoff.md 生成** | `docs/working/TASK-0107/handoff.md`（6 要素網羅）+ V-1 PASS | AI | medium | 不可（全 Step 後） | `bin/plangate doctor --check-settings PASS` 確認 → V-1 全 AC PASS → handoff.md 6 要素網羅（要件適合 / 既知課題 / V2 候補 / 妥協点 / 引き継ぎ / テスト結果） |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `docs/working/TASK-0107/contract-notes.md` | 新規（Step 1 成果物） |
+| `.claude/skills/plangate-setup/SKILL.md` | 新規 |
+| `.claude/commands/plangate-setup.md` | 新規 |
+| `.claude/agents/setup-coordinator.md` | 新規 |
+| `tests/extras/ta-XX-plangate-setup.sh` | 新規 |
+| `docs/working/TASK-0107/status.md` | 新規（Workflow-owned 永続記録、本 PBI 進行用） |
+| `docs/working/TASK-0107/decision-log.jsonl` | 新規（append-only） |
+| `docs/working/TASK-0107/handoff.md` | 新規（WF-05） |
+| `.claude/settings.json` | **変更禁止**（AC-10 機械検証） |
+| `bin/plangate doctor` | **変更禁止**（Non-goals） |
+
+## Testing Strategy
+
+### Unit / Mock-driven Agent Tests（3 mock 系統）
+
+- **Mock A**: `bin/plangate doctor --json` 出力で `passed=true` → Agent が完了サマリへ進む（AC-5）
+- **Mock B**: `passed=false`、`checks[]` に `ok=false` 項目あり → Agent が不足項目をリスト化（AC-2）、Human-owned 操作を**提示のみ**（AC-3）、人間「完了」報告 → doctor 再実行 → PASS まで進まない（AC-4）
+- **Mock C**: 解消不能 FAIL（例: 環境制約）→ Agent がフォローアップ PBI 起票 or 承知スキップを提示し `status.md` に記録（AC-13）
+
+### Static / Grep Tests
+
+- **AC-3**: Agent definition に `apply-claude-settings.sh` を実行するパスがないこと（grep negative）
+- **AC-6**: SKILL.md に 5 要素対応表が存在（grep positive）
+- **AC-7**: Rule 1-5 ごとに grep（Workflow 順序のみ / Skill 再利用 / Agent 責務のみ / 案件固有 CLAUDE.md / handoff 集約）
+- **AC-9**: Agent frontmatter が `acceptance-tester` / `linter-fixer` と同構造（diff）
+- **AC-10**: `.claude/settings.json` の git diff が空（hooks セクション変更なし）
+
+### Integration / Gate Tests
+
+- **AC-8**: `docs/working/TASK-0107/handoff.md` 存在 + 6 要素網羅（grep）
+- **AC-11**: Step 1〜5 を踏んだ後 `status.md` に完了マーカー + `decision-log.jsonl` に append-only エントリ
+- **AC-12**: `bin/plangate doctor --check-settings` FAIL 状態で V-1 / handoff 完了処理がブロックされること
+
+### 回帰
+
+- 既存 `tests/run-tests.sh` 全 PASS 維持
+- 既存 Agent / Skill / Command への影響なし
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| **doctor --json schema 未確認のまま Agent 実装が空振る** | **critical** | Step 1 で `bin/plangate doctor --json` を実行し schema を `contract-notes.md` に保存。実 schema に `scope / checks[] / passed` 等が含まれることを確認後に Agent 実装開始（U6） |
+| **Agent が apply-claude-settings.sh を実行可能になる**（責務違反） | **critical** | grep negative test を test-cases に固定 + Agent definition 本文に「実行禁止・提示のみ」を明文化（AC-3） |
+| **Workflow-owned 永続ロックの不備で Shadow Config 防止漏れ** | **critical** | Step 6 を独立 Step に分離し、append-only 記録 + `--check-settings PASS` ゲート + 解消不能 FAIL skip 記録パスを必須化（AC-11/12/13） |
+| **TASK ID 解決の不整合（U7）**: 固定パス記録で `/plangate-setup` の将来利用と衝突 | **major** | Step 1 で TASK ID 動的解決ロジック（起動時に `docs/working/TASK-XXXX/` 特定 or 不明時 guard）を確定（R-008） |
+| **AC-12 自己言及デッドロック**: TASK-0107 自身の handoff 生成時に `--check-settings` FAIL | **major** | 本 PBI 開発中は手動で wiring を完了させてから V-1/handoff 検証に入る手順を Step 8 に明文化（Gemini 指摘） |
+| **Command が薄くなくなる**（Rule 1 違反） | **major** | Step 4 で Command 内に実装手順を書かず Agent invocation のみとする（grep 検査で `bin/plangate` 等の実装記述ゼロ確認） |
+| **既存 Agent との frontmatter 構造の乖離** | minor | Step 5 で `acceptance-tester` / `linter-fixer` を Read し frontmatter を踏襲（AC-9） |
+| **doctor --json 出力フォーマット将来変更** | medium | Codex 確認情報に基づき `level / ok / passed` 中心の解釈にし、メッセージ内容に依存しない（R-003） |
+| **三層構成の管理コスト増** | minor | 既存 Agent パターン踏襲で構造統一。Skill / Agent / Command 各テンプレ準拠 |
+| **C-3 条件付き降格の誤適用** | major | `lite_eligible=false` 確定（Hardening Override: Shadow Config / 責務4分類に直接接続）。同期 C-3 固定（R-002） |
+
+## Questions / Unknowns
+
+全 Unknowns は Step 1 で解決見込み。pbi-input.md r1 §5 の対応:
+
+| Unknown | 解決 Step | 解決方法 |
+|---------|---------|---------|
+| **U1** Agent tools 最小集合 | Step 1 | tools=[Bash(`bin/plangate doctor --json`),Read,Write(`docs/working/TASK-*/`限定)] を検討。Edit は不要想定 |
+| ~~U2~~ Mode | 解決済 (r1) | `high-risk` |
+| **U3** 完了サマリ配置・命名 | Step 6 | `status.md` 末尾 or `setup-summary.md` 別ファイル、Step 1 で確定 |
+| **U4** Command の Agent 起動方式 | Step 1 | 既存 `.claude/commands/` を Read し最も近いパターンを採用 |
+| **U5** Skill チェックリスト粒度 | Step 3 | doctor schema + 5 要素対応表確定後に決定（抜粋方針） |
+| **U6** `doctor --json` 出力 schema | Step 1 | 実行で確認。Codex 事前確認情報: `scope`, `checks[]{name,ok,level,detail}`, `failures`, `warnings`, `passed` |
+| **U7** TASK ID / 記録先動的解決 | Step 1 | Task-local（起動時に `docs/working/TASK-XXXX/` 特定）+ Task ID 不明時 guard（「Task ID 指定 or 新規 Task 作成」促し） |
+
+## Mode 判定
+
+**`high-risk`** 確定（C-2 R-002 反映、r1 §5 と一致）
+
+### 判定根拠
+
+- **AC 数**: 13 件 → 定量上 critical レンジだが、AC-11〜13 は test-case 検証可能な独立小単位のため high-risk が妥当
+- **変更ファイル数**: 6-8（contract-notes / SKILL / Command / Agent / test / status / decision-log / handoff）→ high-risk レンジ
+- **変更種別**: 新規三層 + Workflow-owned 永続ロック新規 → 高
+- **リスク**: 高（Human-owned 操作の追跡漏れは Shadow Config 構造防止に直結）
+- **影響範囲**: 新規ファイルのみで既存挙動破壊なし、ロールバック容易
+- **Hardening Override 適用**: 責務 4 分類・Shadow Config 防止に接続 → `lite_eligible=false` 固定
+- **critical 不要**: 段階的ロールバック不要 / 公開 API 破壊変更なし / DB スキーマ変更なし
+
+### フェーズ適用（mode-classification.md high-risk 列）
+
+| フェーズ | 適用 |
+|---------|------|
+| brainstorm | ○（完了） |
+| plan 生成 | ○（本 plan） |
+| C-1 17 項目 | ○ |
+| C-2 外部 AI レビュー | **R1+R2+R3 実施**（pbi-input.md r0/r1 で R1+R2、plan/todo/test-cases に対する R3 で plan 段階の最終確認。`lite_eligible=false` のため Lite ゲートは適用せず、review round 数の積上で品質担保。各 round の指摘は review-external.md に R-NNN として集約） |
+| C-3 人間レビュー | ○（**同期固定**、lite_eligible=false） |
+| exec TDD + 並列 | ○ |
+| L-0 リンター | ○ |
+| V-1 受け入れ検査 | ○（`doctor --check-settings PASS` 必須） |
+| V-2 コード最適化 | ○ |
+| V-3 外部レビュー | ○ |
+| V-4 リリース前 | -（critical でないため不要） |
+| PR 作成 | ○ |
+| C-4 PR レビュー | ○ |

--- a/docs/working/TASK-0107/review-external.md
+++ b/docs/working/TASK-0107/review-external.md
@@ -1,0 +1,205 @@
+# TASK-0107 review-external.md — C-2 設計妥当性レーン外部レビュー集約
+
+> **Phase**: C-2（PBI INPUT PACKAGE + plan 段階の事前レビュー）
+> **Date**: 2026-05-21 ～ 2026-05-22
+> **対象**: `brainstorm.md` / `pbi-input.md` / `plan.md` / `todo.md` / `test-cases.md`
+> **レビュー観点**: C-2 設計妥当性レーン（5 観点・[`review-principles.md`](../../../.claude/rules/review-principles.md) §7-bis）
+> **Rounds**:
+> - **R1**: 第 1 ラウンド（pbi-input.md r0 対象、R-001〜R-005）
+> - **R2**: 第 2 ラウンド（pbi-input.md r1 対象、R-006〜R-008）
+> - **R3**: 第 3 ラウンド（plan.md / todo.md / test-cases.md 対象、R-009〜R-013）
+
+---
+
+## 1. 統合判定
+
+### 第 1 ラウンド（pbi-input.md r0）
+- Codex: CONDITIONAL（major × 2 / minor × 2）
+- Gemini: APPROVE（info × 2）
+- 統合: **CONDITIONAL** → R-001〜R-005 を 1 回確定反映済（pbi-input.md r1）
+
+### 第 2 ラウンド（pbi-input.md r1）
+- Codex: CONDITIONAL（R-001〜R-005 全 PASS、ただし監査表 pending 残存）
+- Gemini: **APPROVE**（R-001〜R-005 全 PASS）
+- 統合: **APPROVE for plan generation**
+- R-006〜R-008 を 1 回確定反映済
+
+### 第 3 ラウンド（plan.md / todo.md / test-cases.md）
+- Codex: **REJECT**（major × 4 / minor × 1）— `working-context.md` Iron Law / mode-classification.md 機械的整合違反
+- Gemini: **APPROVE**（info × 2）
+- 統合: **CONDITIONAL** → R-009〜R-013 を 1 回確定反映
+
+最終判定: **R-009〜R-013 反映後、C-1 簡易再実行 → C-3 ゲート（人間）に進行可**
+
+---
+
+## 2. 観点別評価サマリ
+
+### R1（pbi-input.md r0）
+
+| 観点 | Codex | Gemini |
+|------|-------|--------|
+| 1. 三層構成の設計妥当性 | PASS | PASS |
+| 2. AC 10 件の網羅性 | **WARN** | PASS |
+| 3. Out of scope の妥当性 | PASS | PASS |
+| 4. Cowork 調査解釈 | PASS | PASS |
+| 5. 責務 4 分類との整合 | **WARN** | PASS |
+| 6. 見落としリスク | **WARN** | PASS |
+
+### R2（pbi-input.md r1 反映評価）
+
+| R | Codex | Gemini |
+|---|-------|--------|
+| R-001 [major] Workflow-owned 永続ロック | **PASS** | **PASS** |
+| R-002 [major] Mode → high-risk | **PASS** | **PASS** |
+| R-003 [minor] AC 検証可能性 | **PASS** | **PASS** |
+| R-004 [minor] doctor --check-settings PASS AC | **PASS** | **PASS** |
+| R-005 [info] 解消不能 FAIL 脱出経路 | **PASS** | **PASS** |
+
+### R3（plan/todo/test-cases ファイル別評価）
+
+| ファイル | Codex | Gemini |
+|---------|-------|--------|
+| plan.md | WARN（lite C-2 表記矛盾） | PASS |
+| todo.md | **FAIL**（C-3 配置 / conductor 管轄混入） | PASS |
+| test-cases.md | WARN（manual marker 欠落） | PASS |
+
+---
+
+## 3. 指摘リスト（R-NNN）
+
+### 第 1 ラウンド指摘（R-001〜R-005）
+
+#### R-001 [major] 責務 4 分類 — Workflow-owned 永続ロックの欠落
+- **対象**: `pbi-input.md` r0 §1 責務4分類表 / `brainstorm.md` §4
+- **改善案**: 新規 AC を追加 — 各 Step 完了ごとに `status.md` / `decision-log.jsonl` に manual action の pending/resolved を記録し、`doctor --check-settings PASS` まで V-1 / handoff 完了不可
+- **出典**: Codex C-R-001 + Gemini G-R-001 統合
+- **反映**: pbi-input.md r1 §1責務表 / §3 AC-11 / §4 設計原則
+
+#### R-002 [major] モード判定 — standard 過小評価
+- **対象**: pbi-input.md r0 §5 モード判定
+- **改善案**: `high-risk` に修正 + Hardening Override 明記
+- **出典**: Codex C-R-002
+- **反映**: pbi-input.md r1 §5 モード判定
+
+#### R-003 [minor] AC 網羅性 — 検証可能性の不足
+- **対象**: pbi-input.md r0 §3 AC-2〜AC-5
+- **改善案**: test-cases で検証可能な形に書き直し（`doctor --json` 利用、mock 検証）
+- **出典**: Codex C-R-003
+- **反映**: pbi-input.md r1 §3 AC-2〜AC-5
+
+#### R-004 [minor] Shadow Config 防止 — `doctor --check-settings PASS` 条件の AC 化
+- **対象**: pbi-input.md r0 §3 AC-10
+- **改善案**: V-1/handoff 完了前に `bin/plangate doctor --check-settings PASS` を独立 AC 化
+- **出典**: Codex C-R-004
+- **反映**: pbi-input.md r1 §3 AC-12
+
+#### R-005 [info] UX — 解消不能な FAIL の脱出経路
+- **対象**: brainstorm.md §5 / pbi-input.md AC-4
+- **改善案**: フォローアップ PBI 起票誘導 or 承知スキップの脱出経路を Agent 対話方針に
+- **出典**: Gemini G-R-002
+- **反映**: pbi-input.md r1 §2 Scope 7 / §3 AC-13 / §4 設計原則 / §5 R7
+
+### 第 2 ラウンド指摘（R-006〜R-008）
+
+#### R-006 [minor] 保守性 — 監査表 `pending` 残存
+- **対象**: review-external.md §4 監査表
+- **改善案**: pre-commit 段階では `reflected (pre-commit)` に更新、commit SHA は後追記
+- **出典**: Codex（R2）
+- **反映**: 本表（§4）を `reflected (pre-commit)` に更新済
+
+#### R-007 [info] 保守性 — brainstorm.md に旧判断残存
+- **対象**: brainstorm.md §4 / §7
+- **改善案**: 「※ r1 で更新済、pbi-input.md r1 を正本」注記
+- **出典**: Codex（R2）
+- **反映**: brainstorm.md ヘッダーに r1 更新済注記追加済
+
+#### R-008 [info] 拡張性 — 記録先ディレクトリの動的解決
+- **対象**: pbi-input.md §3 AC-11 / §5 Unknowns U3
+- **改善案**: plan 段階で実行コンテキストの解決（Task-local or Global）を定義
+- **出典**: Gemini（R2）
+- **反映**: pbi-input.md §5 Unknowns U7 追加済
+
+### 第 3 ラウンド指摘（R-009〜R-013）
+
+#### R-009 [major] Iron Law / ゲート順序 — C-3 が exec 後配置
+
+- **対象**: `todo.md` r0 §「Phase 4: ゲート + リリース」（T-13 が handoff/V系後に配置）
+- **指摘**: C-3 が T-13 として handoff/V系後に配置され、依存グラフでも T-03〜T-12 が C-3 承認なしに進める形になっている
+- **理由**: [`working-context.md`](../../../.claude/rules/working-context.md) は C-3 を D: Agent 実行**前**の人間レビューと定義。todo 補足で「C-3 APPROVED が無い場合 exec 開始しない」と書いてあっても depends_on とグラフが逆向きでは構造として崩れる
+- **改善案**: C-3 を Phase 1 直後（T-02 後）に移動。T-03〜T-08 の `depends_on` に C-3 (`G-C3`) を明示
+- **出典**: Codex（R3）
+
+#### R-010 [major] Iron Law / workflow-conductor 管轄混入
+
+- **対象**: `todo.md` r0 T-08〜T-11（L-0 / V-1 / V-2 / V-3）/ T-14（PR 作成）
+- **指摘**: L-0 / V-1 / V-2 / V-3 / PR 作成が通常 todo タスク化されている
+- **理由**: working-context.md todo 定義は「L-0〜V-4, PR 作成は workflow-conductor が自動制御するため**含めない**」と明記。plan/todo 境界が崩れると conductor 自動制御と人手 todo が二重化する
+- **改善案**: T-08〜T-11 / T-14 は「§ workflow-conductor 後続フェーズ」欄に分離し、本体 todo は T-01〜T-07 + C-3 (G-C3) + handoff 生成 (T-08) のみ
+- **出典**: Codex（R3）
+
+#### R-011 [major] mode / lite_eligible 整合 — `lite C-2` 表記矛盾
+
+- **対象**: `plan.md` r0 §「フェーズ適用」C-2 行
+- **指摘**: `lite_eligible=false` 明記と同時に「lite C-2: 1 本」で簡略可と記述（同一 plan 内で矛盾）
+- **理由**: [`mode-classification.md`](../../../.claude/rules/mode-classification.md) の Lite は `lite_eligible=true` かつ opt-in 時の構成。本 PBI は Hardening Override 適用 `lite_eligible=false` のため Lite ゲートそのものが適用不可
+- **改善案**: 「R1+R2+R3 実施」のように review round 数の積上で品質担保する旨に修正。Lite 用語は撤回
+- **出典**: Codex（R3）
+
+#### R-012 [major] test-cases 自動化可否 — manual marker 欠落
+
+- **対象**: `test-cases.md` r0 TC-01 / TC-06 / TC-07 / TC-08 / TC-21 / TC-22 + §211 既知の自動化制約
+- **指摘**: §211 で TC-01/06/07/08/21/22 は部分手動の可能性ありと明記しつつ、各 TC の **種別フィールド**には `integration` / `unit mock` のままで `manual` が反映されていない
+- **理由**: C-1 TestCases 観点（review-principles.md §2-bis）は「各 TC の種別（unit/integration/grep/manual）が明示」。V-1 で自動実行対象と手動確認対象を分離できず、受け入れ検査の実行責務が曖昧になる
+- **改善案**: 該当 TC の **種別フィールドを `unit mock + manual` 等に明示**。V-1 で人間確認が必要な期待出力を checklist 化
+- **出典**: Codex（R3）
+
+#### R-013 [minor] Edge case 検証責務 — EC-03 期待と検証範囲のズレ
+
+- **対象**: `test-cases.md` r0 EC-03（同時起動）
+- **指摘**: 「append-only のため衝突しない」と期待しつつ、同時 append の原子性 / ロック方式は plan で未定義、同時 append 検証を「Out of scope 候補」としている
+- **理由**: 期待と検証範囲がずれている。Out of scope なら「衝突しない」ではなく「同時起動は検出して中断/注意喚起」などに落とす方が検証可能
+- **改善案**: v1 では同時起動を unsupported とし、guard / 注意喚起の EC に変更。完全な同時書き込み耐性は v2 候補へ
+- **出典**: Codex（R3）
+
+---
+
+## 4. 監査表（追記専用・squash/rebase 耐性）
+
+| R-NNN | severity | round | status | reflected_in(commit) | notes |
+|-------|----------|-------|--------|---------------------|-------|
+| R-001 | major | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §1責務表 / §3 AC-11 / §4 設計原則。commit SHA は反映 commit 作成時追記 |
+| R-002 | major | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §5 モード判定（high-risk + Hardening Override 明記）。commit SHA は反映 commit 作成時追記 |
+| R-003 | minor | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §3 AC-2〜AC-5（test-case 検証可能化）。commit SHA は反映 commit 作成時追記 |
+| R-004 | minor | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §3 AC-12（doctor --check-settings PASS）。commit SHA は反映 commit 作成時追記 |
+| R-005 | info | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §2 Scope 7 / §3 AC-13 / §4 設計原則 / §5 R7。commit SHA は反映 commit 作成時追記 |
+| R-006 | minor | R2 | reflected (self) | TBD | 本表（§4）を `reflected (pre-commit)` に更新済。commit SHA は反映 commit 作成時追記 |
+| R-007 | info | R2 | reflected (pre-commit) | TBD | brainstorm.md ヘッダーに「※ r1 で更新済」注記追加済。commit SHA は反映 commit 作成時追記 |
+| R-008 | info | R2 | reflected (pre-commit) | TBD | pbi-input.md §5 Unknowns U7 追加済（実行時 TASK ID 動的解決）。commit SHA は反映 commit 作成時追記 |
+| R-009 | major | R3 | reflected (pre-commit) | TBD | todo.md r1: C-3 を Phase 1 直後（G-C3）に移動、T-03〜T-08 の depends_on に G-C3 を明示。commit SHA は反映 commit 作成時追記 |
+| R-010 | major | R3 | reflected (pre-commit) | TBD | todo.md r1: L-0/V-1/V-2/V-3/PR を §workflow-conductor 後続フェーズに分離。実装 todo は T-01〜T-08 に集約。commit SHA は反映 commit 作成時追記 |
+| R-011 | major | R3 | reflected (pre-commit) | TBD | plan.md: 「lite C-2」表記を削除、「R1+R2+R3 実施」「review round 数の積上で品質担保」に修正。commit SHA は反映 commit 作成時追記 |
+| R-012 | major | R3 | reflected (pre-commit) | TBD | test-cases.md: TC-01/06/07/08/21/22 の種別に `manual` を追加（unit mock + manual / integration + manual）。commit SHA は反映 commit 作成時追記 |
+| R-013 | minor | R3 | reflected (pre-commit) | TBD | test-cases.md: EC-03 を「v1 unsupported（同時起動は検出して中断・v2 候補）」に変更。commit SHA は反映 commit 作成時追記 |
+
+git commit 完了後、`reflected (pre-commit)` を `reflected` に、`TBD` を実 commit SHA に追記する（追記専用）。
+
+---
+
+## 5. 元レビュー出力
+
+### 第 1 ラウンド
+- Codex: `/tmp/codex-review-output.txt`（48 行）
+- Gemini: `/tmp/gemini-review-output.txt`（38 行）
+
+### 第 2 ラウンド
+- Codex: `/tmp/codex-review-r1-output.txt`（28 行）
+- Gemini: `/tmp/gemini-review-r1-output.txt`（39 行）
+
+### 第 3 ラウンド
+- Codex: `/tmp/codex-c2-r3-output.txt`（66 行）
+- Gemini: `/tmp/gemini-c2-r3-output.txt`（55 行）
+
+### Plan 助言（参考）
+- Codex: `/tmp/codex-plan-advisory-output.txt`（70 行）
+- Gemini: `/tmp/gemini-plan-advisory-output.txt`（75 行）

--- a/docs/working/TASK-0107/review-external.md
+++ b/docs/working/TASK-0107/review-external.md
@@ -104,9 +104,9 @@
 
 #### R-006 [minor] 保守性 — 監査表 `pending` 残存
 - **対象**: review-external.md §4 監査表
-- **改善案**: pre-commit 段階では `reflected (pre-commit)` に更新、commit SHA は後追記
+- **改善案**: pre-commit 段階では `reflected` に更新、commit SHA は後追記
 - **出典**: Codex（R2）
-- **反映**: 本表（§4）を `reflected (pre-commit)` に更新済
+- **反映**: 本表（§4）を `reflected` に更新済
 
 #### R-007 [info] 保守性 — brainstorm.md に旧判断残存
 - **対象**: brainstorm.md §4 / §7
@@ -168,21 +168,21 @@
 
 | R-NNN | severity | round | status | reflected_in(commit) | notes |
 |-------|----------|-------|--------|---------------------|-------|
-| R-001 | major | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §1責務表 / §3 AC-11 / §4 設計原則。commit SHA は反映 commit 作成時追記 |
-| R-002 | major | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §5 モード判定（high-risk + Hardening Override 明記）。commit SHA は反映 commit 作成時追記 |
-| R-003 | minor | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §3 AC-2〜AC-5（test-case 検証可能化）。commit SHA は反映 commit 作成時追記 |
-| R-004 | minor | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §3 AC-12（doctor --check-settings PASS）。commit SHA は反映 commit 作成時追記 |
-| R-005 | info | R1 | reflected (pre-commit) | TBD | pbi-input.md r1 §2 Scope 7 / §3 AC-13 / §4 設計原則 / §5 R7。commit SHA は反映 commit 作成時追記 |
-| R-006 | minor | R2 | reflected (self) | TBD | 本表（§4）を `reflected (pre-commit)` に更新済。commit SHA は反映 commit 作成時追記 |
-| R-007 | info | R2 | reflected (pre-commit) | TBD | brainstorm.md ヘッダーに「※ r1 で更新済」注記追加済。commit SHA は反映 commit 作成時追記 |
-| R-008 | info | R2 | reflected (pre-commit) | TBD | pbi-input.md §5 Unknowns U7 追加済（実行時 TASK ID 動的解決）。commit SHA は反映 commit 作成時追記 |
-| R-009 | major | R3 | reflected (pre-commit) | TBD | todo.md r1: C-3 を Phase 1 直後（G-C3）に移動、T-03〜T-08 の depends_on に G-C3 を明示。commit SHA は反映 commit 作成時追記 |
-| R-010 | major | R3 | reflected (pre-commit) | TBD | todo.md r1: L-0/V-1/V-2/V-3/PR を §workflow-conductor 後続フェーズに分離。実装 todo は T-01〜T-08 に集約。commit SHA は反映 commit 作成時追記 |
-| R-011 | major | R3 | reflected (pre-commit) | TBD | plan.md: 「lite C-2」表記を削除、「R1+R2+R3 実施」「review round 数の積上で品質担保」に修正。commit SHA は反映 commit 作成時追記 |
-| R-012 | major | R3 | reflected (pre-commit) | TBD | test-cases.md: TC-01/06/07/08/21/22 の種別に `manual` を追加（unit mock + manual / integration + manual）。commit SHA は反映 commit 作成時追記 |
-| R-013 | minor | R3 | reflected (pre-commit) | TBD | test-cases.md: EC-03 を「v1 unsupported（同時起動は検出して中断・v2 候補）」に変更。commit SHA は反映 commit 作成時追記 |
+| R-001 | major | R1 | reflected | f7ce0e7 | pbi-input.md r1 §1責務表 / §3 AC-11 / §4 設計原則。commit SHA は反映 commit 作成時追記 |
+| R-002 | major | R1 | reflected | f7ce0e7 | pbi-input.md r1 §5 モード判定（high-risk + Hardening Override 明記）。commit SHA は反映 commit 作成時追記 |
+| R-003 | minor | R1 | reflected | f7ce0e7 | pbi-input.md r1 §3 AC-2〜AC-5（test-case 検証可能化）。commit SHA は反映 commit 作成時追記 |
+| R-004 | minor | R1 | reflected | f7ce0e7 | pbi-input.md r1 §3 AC-12（doctor --check-settings PASS）。commit SHA は反映 commit 作成時追記 |
+| R-005 | info | R1 | reflected | f7ce0e7 | pbi-input.md r1 §2 Scope 7 / §3 AC-13 / §4 設計原則 / §5 R7。commit SHA は反映 commit 作成時追記 |
+| R-006 | minor | R2 | reflected | f7ce0e7 | 本表（§4）を `reflected` に更新済。commit SHA は反映 commit 作成時追記 |
+| R-007 | info | R2 | reflected | f7ce0e7 | brainstorm.md ヘッダーに「※ r1 で更新済」注記追加済。commit SHA は反映 commit 作成時追記 |
+| R-008 | info | R2 | reflected | f7ce0e7 | pbi-input.md §5 Unknowns U7 追加済（実行時 TASK ID 動的解決）。commit SHA は反映 commit 作成時追記 |
+| R-009 | major | R3 | reflected | f7ce0e7 | todo.md r1: C-3 を Phase 1 直後（G-C3）に移動、T-03〜T-08 の depends_on に G-C3 を明示。commit SHA は反映 commit 作成時追記 |
+| R-010 | major | R3 | reflected | f7ce0e7 | todo.md r1: L-0/V-1/V-2/V-3/PR を §workflow-conductor 後続フェーズに分離。実装 todo は T-01〜T-08 に集約。commit SHA は反映 commit 作成時追記 |
+| R-011 | major | R3 | reflected | f7ce0e7 | plan.md: 「lite C-2」表記を削除、「R1+R2+R3 実施」「review round 数の積上で品質担保」に修正。commit SHA は反映 commit 作成時追記 |
+| R-012 | major | R3 | reflected | f7ce0e7 | test-cases.md: TC-01/06/07/08/21/22 の種別に `manual` を追加（unit mock + manual / integration + manual）。commit SHA は反映 commit 作成時追記 |
+| R-013 | minor | R3 | reflected | f7ce0e7 | test-cases.md: EC-03 を「v1 unsupported（同時起動は検出して中断・v2 候補）」に変更。commit SHA は反映 commit 作成時追記 |
 
-git commit 完了後、`reflected (pre-commit)` を `reflected` に、`TBD` を実 commit SHA に追記する（追記専用）。
+git commit 完了後、`reflected` を `reflected` に、`TBD` を実 commit SHA に追記する（追記専用）。
 
 ---
 

--- a/docs/working/TASK-0107/review-self.md
+++ b/docs/working/TASK-0107/review-self.md
@@ -1,0 +1,126 @@
+# TASK-0107 review-self.md — C-1 セルフレビュー（17 項目）
+
+> **Phase**: C-1（plan / todo / test-cases に対する AI セルフレビュー）
+> **Date**: 2026-05-22
+> **対象**: plan.md / todo.md / test-cases.md（R-009〜R-013 反映後）
+> **Mode**: high-risk → **17 項目フルチェック**（mode-classification.md）
+> **Note**: 本 C-1 は C-2 R3（Codex + Gemini）の事前評価と並行実施。C-2 R3 で REJECT 出された R-009〜R-013 を反映後の自己評価。
+
+---
+
+## 1. 総合判定
+
+**PASS**（17 項目すべて PASS、blocker 0）
+
+C-2 R3 で Codex が指摘した R-009〜R-013 を全て反映済。Gemini は R3 で APPROVE 済。R-001〜R-013 の指摘がそれぞれ pbi-input.md r1 / plan.md / todo.md r1 / test-cases.md / review-external.md に整合した形で反映されていることを確認。
+
+---
+
+## 2. Plan チェック（7 項目）
+
+### C1-PLAN-01 受入基準網羅性
+- **判定**: PASS
+- **根拠**: plan.md Work Breakdown の Step 1〜8 が AC-1〜AC-13 を網羅
+  - AC-1 (起動) → Step 4 Command
+  - AC-2〜AC-5 (doctor 連携・提示のみ・再検証・サマリ) → Step 5 Agent
+  - AC-6 (Skill 5 要素) → Step 3
+  - AC-7 (Rule 1-5) → Step 3/4/5 共通
+  - AC-8 (handoff) → Step 8
+  - AC-9 (frontmatter 一致) → Step 5
+  - AC-10 (settings.json diff = 0) → Step 4
+  - AC-11/12 (永続ロック・check-settings PASS) → Step 6
+  - AC-13 (脱出経路) → Step 5/6
+
+### C1-PLAN-02 Unknowns 処理
+- **判定**: PASS
+- **根拠**: U1/U3/U4/U5/U6/U7 すべて plan.md §Questions / Unknowns に解決 Step が明示（U6/U1/U4/U7 は Step 1 で確定、U3 は Step 6、U5 は Step 3）
+
+### C1-PLAN-03 スコープ制御
+- **判定**: PASS
+- **根拠**: plan.md §Constraints / Non-goals に test 可能な境界（doctor 本体改修禁止 / Hook 追加禁止 / 再設定 v2 範囲 等）が明示。AC-10 で settings.json diff = 0 を機械検証
+
+### C1-PLAN-04 テスト戦略
+- **判定**: PASS
+- **根拠**: plan.md §Testing Strategy に Mock A/B/C の 3 系統 + static/grep + integration/gate test の組合せが明記
+
+### C1-PLAN-05 Work Breakdown Output
+- **判定**: PASS
+- **根拠**: 各 Step に明確な Output（contract-notes.md / SKILL.md / Command md / Agent md / status.md+jsonl / test sh / handoff.md）
+
+### C1-PLAN-06 依存関係
+- **判定**: PASS
+- **根拠**: Step 1/2 → Step 3/4/5（並列可）→ Step 6 → Step 7 → Step 8 の依存が一貫
+
+### C1-PLAN-07 動作検証自動化
+- **判定**: PASS
+- **根拠**: test-cases.md §「既知の自動化制約」+ 各 TC 種別（grep / unit mock / integration / manual）で自動化と手動の切り分けが明示
+
+---
+
+## 3. ToDo チェック（5 項目）
+
+### C1-TODO-01 タスク粒度
+- **判定**: PASS
+- **根拠**: T-01〜T-08 + G-C3 が 1 タスク 1 出力で揃う
+
+### C1-TODO-02 depends_on 設定
+- **判定**: PASS
+- **根拠**: R-009 反映後、T-03〜T-08 の depends_on に G-C3 が明示。依存関係グラフが plan の Step 順と一貫
+
+### C1-TODO-03 チェックポイント設定
+- **判定**: PASS
+- **根拠**: 各 T-NN / G-C3 に 🚩 Checkpoint が記載
+
+### C1-TODO-04 Iron Law 遵守
+- **判定**: PASS
+- **根拠**: R-010 反映後、L-0 / V-1 / V-2 / V-3 / PR は §workflow-conductor 後続フェーズ欄に分離。実装 todo（T-01〜T-08）には含まれない（working-context.md Iron Law 準拠）
+
+### C1-TODO-05 完了条件
+- **判定**: PASS
+- **根拠**: 各 T の Output と Checkpoint が test 可能（Bash grep / diff / file existence / jsonl パース）
+
+---
+
+## 4. TestCases チェック（3 項目）
+
+### C1-TEST-01 受入基準との紐付き
+- **判定**: PASS
+- **根拠**: test-cases.md §マッピング表で AC-1〜AC-13 ⇄ TC-01〜TC-22 が 1:N で完備
+
+### C1-TEST-02 Edge case 網羅
+- **判定**: PASS
+- **根拠**: EC-01（TASK ID 不明時）/ EC-02（schema 変更）/ EC-03（同時起動 v1 unsupported）/ EC-04（doctor 起動失敗）を網羅。R-013 反映で EC-03 が「unsupported 検出」に明確化
+
+### C1-TEST-03 自動化可否
+- **判定**: PASS
+- **根拠**: R-012 反映後、TC-01/06/07/08/21/22 の種別フィールドに `manual` が反映済（grep verify: manual 出現 8 件）
+
+---
+
+## 5. 統合チェック（2 項目）
+
+### C1-INT-01 Mode 整合（high-risk）
+- **判定**: PASS
+- **根拠**: R-011 反映後、plan.md §Mode 判定 / フェーズ適用が `high-risk` + `lite_eligible=false` で一貫。「lite C-2」表記を撤廃し「R1+R2+R3 実施」に修正済。Hardening Override 適用も明記
+
+### C1-INT-02 Workflow-owned 永続ロック統合
+- **判定**: PASS
+- **根拠**: R-001 反映で pbi-input.md r1 §1責務表 + §3 AC-11/12 + §4 設計原則 + plan.md Step 6 + todo.md T-06 + test-cases.md TC-18/19/20 が一貫。`doctor --check-settings PASS` ゲートが V-1/handoff 完了条件として明示
+
+---
+
+## 6. 指摘事項
+
+なし（blocker 0）。
+
+R-009〜R-013 反映により Codex R3 の major × 4 / minor × 1 はすべて解消。Gemini R3 info × 2（R-009/R-010 注: 別採番のため本 review-self では番号衝突回避のため言及のみ）は info レベルで C-3 後の exec 中に吸収可能。
+
+## 7. C-3 ゲート進行可否
+
+**ready for C-3**
+
+主要前提:
+- `lite_eligible=false` のため **同期 C-3 必須**（Hardening Override 適用）
+- C-3 の判定主体は **Human**（責務4分類 AI-owned 不可）
+- 承認後 `docs/working/TASK-0107/approvals/c3.json` 発行 → `bin/plangate exec` で T-01 開始
+

--- a/docs/working/TASK-0107/status.md
+++ b/docs/working/TASK-0107/status.md
@@ -1,0 +1,57 @@
+# TASK-0107 STATUS
+
+> Phase 履歴アーカイブ。タスク完了ごとに追記。
+
+## 2026-05-22: Phase B 完了 + C-2 R3 + C-1 PASS
+
+### 全体構成
+
+- ブランチ: `feat/TASK-0106-maintenance-cli-impl`（TASK-0106 と同一ブランチで先行作業中。本 PBI 用ブランチは exec 開始時に切る）
+- PR: 未作成
+
+### 完了済
+
+| Item | Status |
+|------|--------|
+| brainstorm.md（履歴文書） | ✅ |
+| pbi-input.md r1 + U7 | ✅ |
+| plan.md（8 Steps / high-risk） | ✅ |
+| todo.md r1（C-3 を exec 前に移動、conductor 自動制御範囲を分離） | ✅ |
+| test-cases.md（22 TC + 4 EC、manual marker 反映済） | ✅ |
+| review-external.md R1+R2+R3（R-001〜R-013 reflected pre-commit） | ✅ |
+| review-self.md C-1 17/17 PASS | ✅ |
+| INDEX.md（L0 entry） | ✅ |
+
+### Mode
+
+**high-risk**（`lite_eligible=false` 確定、Hardening Override 適用、同期 C-3 固定）
+
+### C-2 履歴
+
+| Round | Date | Codex | Gemini | 統合 | 反映 |
+|-------|------|-------|--------|------|------|
+| R1（pbi-input.md r0） | 2026-05-21 | CONDITIONAL | APPROVE | CONDITIONAL → r1 | R-001〜R-005 reflected |
+| R2（pbi-input.md r1） | 2026-05-21 | CONDITIONAL | APPROVE | APPROVE for plan | R-006〜R-008 reflected |
+| R3（plan/todo/test-cases） | 2026-05-22 | REJECT | APPROVE | CONDITIONAL → 反映済 | R-009〜R-013 reflected |
+
+### C-1 履歴
+
+| Date | 観点 | 結果 |
+|------|------|------|
+| 2026-05-22 | Plan 7 / ToDo 5 / TestCases 3 / 統合 2 = 17 項目 | 17/17 PASS、blocker 0 |
+
+### 残タスク（C-3 後）
+
+- ⬜ G-C3 人間レビュー（`approvals/c3.json` 発行待ち）
+- ⬜ T-01〜T-08（C-3 APPROVED 後）
+- ⬜ L-0 / V-1 / V-2 / V-3（workflow-conductor 自動）
+- ⬜ PR 作成（workflow-conductor 自動）
+- ⬜ C-4 PR レビュー（👤 GitHub）
+
+### Claude Code プロンプト（次セッション復旧用）
+
+次セッションで作業を継続する場合、以下を読む:
+1. `docs/working/TASK-0107/INDEX.md`（L0）
+2. `docs/working/TASK-0107/current-state.md`（L0）
+3. C-3 が発行済か `docs/working/TASK-0107/approvals/c3.json` を確認
+4. APPROVED なら T-01（事前契約確定）から exec 開始

--- a/docs/working/TASK-0107/test-cases.md
+++ b/docs/working/TASK-0107/test-cases.md
@@ -1,0 +1,213 @@
+# TASK-0107 TEST CASES
+
+> Source: `pbi-input.md` r1 AC-1〜AC-13 / Mode: **high-risk**
+> Generated: 2026-05-22
+> Total: 22 test-cases / Codex 助言 + Gemini Mock 3 系統に基づく
+
+---
+
+## 受入基準 → テストケースマッピング
+
+| AC | TC 件数 | 主要 TC ID |
+|----|---:|-----------|
+| AC-1 起動 | 1 | TC-01 |
+| AC-2 doctor --json 抽出 | 2 | TC-02, TC-03 |
+| AC-3 Human-owned 提示のみ | 2 | TC-04, TC-05 |
+| AC-4 再検証ループ | 2 | TC-06, TC-07 |
+| AC-5 完了サマリ | 1 | TC-08 |
+| AC-6 Skill 5 要素対応 | 1 | TC-09 |
+| AC-7 Rule 1-5 準拠 | 5 | TC-10〜TC-14 |
+| AC-8 handoff.md 6 要素 | 1 | TC-15 |
+| AC-9 frontmatter 一致 | 1 | TC-16 |
+| AC-10 settings.json diff = 0 | 1 | TC-17 |
+| AC-11 永続記録 | 2 | TC-18, TC-19 |
+| AC-12 doctor --check-settings ゲート | 1 | TC-20 |
+| AC-13 解消不能 FAIL 脱出 | 2 | TC-21, TC-22 |
+
+**合計: 22 件**
+
+---
+
+## Mock 系統定義（共通）
+
+- **Mock A: `passed=true`** — 全項目 PASS の `doctor --json` 出力
+- **Mock B: `passed=false, checks[]に ok=false`** — 不足項目あり（例: settings wiring 未適用）
+- **Mock C: 解消不能 FAIL** — 環境制約等で永続的に FAIL する想定（例: `--check-settings` が wiring 適用後も FAIL）
+
+---
+
+## テストケース詳細
+
+### TC-01 [AC-1] /plangate-setup で Agent が起動する
+- **種別**: integration（grep + invocation） + **manual**（実起動確認）
+- **前提条件**: `.claude/commands/plangate-setup.md` が存在
+- **入力**: `/plangate-setup` 実行（または fixture でのトリガー）
+- **期待出力**: setup-coordinator Agent が呼び出される（command 本文に Agent invocation 文字列が存在）
+- **検証**: `grep -E 'setup-coordinator|Agent' .claude/commands/plangate-setup.md`
+
+### TC-02 [AC-2] doctor --json 不足項目を抽出してリスト化
+- **種別**: unit mock
+- **前提条件**: Mock B（不足項目あり）の JSON fixture
+- **入力**: Mock B fixture → Agent
+- **期待出力**: Agent の出力に不足項目（`checks[].name` で `ok=false`）がリスト化されている
+- **検証**: fixture から想定リスト項目を抽出し出力に含まれることを確認
+
+### TC-03 [AC-2] doctor --json passed=true で抽出スキップ
+- **種別**: unit mock
+- **前提条件**: Mock A（passed=true）
+- **期待出力**: 不足項目リストは空、完了サマリへ進む
+- **検証**: 出力に「不足なし」または完了サマリパスへの遷移
+
+### TC-04 [AC-3] Agent が apply-claude-settings.sh を呼ばない（grep negative）
+- **種別**: static / grep negative
+- **入力**: `.claude/agents/setup-coordinator.md`
+- **期待出力**: `apply-claude-settings.sh` を Bash で実行するパスが存在しない
+- **検証**: `! grep -E "(Bash|run).*apply-claude-settings\.sh" .claude/agents/setup-coordinator.md`
+
+### TC-05 [AC-3] Agent definition に「実行禁止・提示のみ」明文化
+- **種別**: static / grep positive
+- **入力**: `.claude/agents/setup-coordinator.md`
+- **期待出力**: 「実行しない」「提示のみ」「Human-owned」等のキーワードが存在
+- **検証**: `grep -E "(実行しない|提示のみ|Human-owned)" .claude/agents/setup-coordinator.md`
+
+### TC-06 [AC-4] FAIL 状態で次 Step に進まない（再検証ループ）
+- **種別**: unit mock + **manual**（Agent 対話シミュレーションが必要）
+- **前提条件**: Mock B → ユーザー「完了」報告 → doctor 再実行も Mock B
+- **期待出力**: Agent は完了扱いせず再提示
+- **検証**: 出力に「PASS まで完了しません」相当のループパス記述
+
+### TC-07 [AC-4] FAIL → PASS 遷移で次 Step
+- **種別**: unit mock + **manual**（Agent 対話シミュレーションが必要）
+- **前提条件**: 1 回目 Mock B → 2 回目 Mock A
+- **期待出力**: 2 回目で次 Step に進む
+- **検証**: 出力の遷移を確認
+
+### TC-08 [AC-5] 完了サマリ出力
+- **種別**: unit mock + **manual**（出力フォーマット人間確認）
+- **前提条件**: Mock A
+- **期待出力**: 完了項目 / 残項目 / 次のアクション候補（PBI 作成 / `/ai-dev-workflow` 等）の 3 セクションが含まれる
+- **検証**: 出力のフォーマット検査
+
+### TC-09 [AC-6] Skill に 5 要素対応表が存在
+- **種別**: static / grep positive
+- **入力**: `.claude/skills/plangate-setup/SKILL.md`
+- **期待出力**: Cowork 5 要素（Context files / Global instructions / Folder instructions / Plugins / Connectors）と PlanGate 対応物の表が存在
+- **検証**: `grep -cE "(Context files|Global instructions|Folder instructions|Plugins|Connectors)" .claude/skills/plangate-setup/SKILL.md` >= 5
+
+### TC-10 [AC-7] Rule 1: Workflow 順序のみ
+- **種別**: static / grep negative
+- **入力**: 該当する Workflow ファイルがあればそれ。本 PBI は Workflow 追加なしのため `docs/workflows/0*.md` への変更が無いこと
+- **期待出力**: Workflow への新規追加コミットなし
+- **検証**: `git diff --name-only main..HEAD | grep -E "docs/workflows/0[0-9]_.*\.md" | wc -l` == 0
+
+### TC-11 [AC-7] Rule 2: Skill 再利用単位（案件固有なし）
+- **種別**: static / grep negative
+- **入力**: `.claude/skills/plangate-setup/SKILL.md`
+- **期待出力**: 「TASK-0107」「このプロジェクト」「PlanGate 固有」等の案件固有表現を含まない
+- **検証**: `! grep -E "TASK-0107|このプロジェクト" .claude/skills/plangate-setup/SKILL.md`
+- **Note**: Skill は再利用単位のため案件固有名は CLAUDE.md 補足の対象だが Skill 内に直書きしない
+
+### TC-12 [AC-7] Rule 3: Agent 責務のみ
+- **種別**: static / grep
+- **入力**: `.claude/agents/setup-coordinator.md`
+- **期待出力**: 単一責務（Human action の追跡・Gate 保持）の記述あり、他 Agent への過剰委譲なし
+- **検証**: frontmatter description + 責務本文の構造確認
+
+### TC-13 [AC-7] Rule 4: 案件固有は CLAUDE.md
+- **種別**: static
+- **入力**: 三層実装ファイル
+- **期待出力**: PlanGate 固有の wiring 詳細は CLAUDE.md / settings-wiring-contract.md への参照に留め、Agent / Skill / Command 本文に直書きしない
+- **検証**: 三層実装ファイル内で固有 wiring 詳細記述箇所のレビュー
+
+### TC-14 [AC-7] Rule 5: handoff 集約
+- **種別**: integration
+- **入力**: `docs/working/TASK-0107/handoff.md`
+- **期待出力**: 6 要素網羅
+- **検証**: TC-15 と同等。本 TC では handoff の存在のみ確認
+
+### TC-15 [AC-8] handoff.md 6 要素網羅
+- **種別**: integration / grep
+- **入力**: `docs/working/TASK-0107/handoff.md`
+- **期待出力**: 以下 6 セクションが存在
+  1. 要件適合確認結果
+  2. 既知課題一覧
+  3. V2 候補
+  4. 妥協点
+  5. 引き継ぎ文書
+  6. テスト結果サマリ
+- **検証**: `grep -cE "(要件適合|既知課題|V2|妥協点|引き継ぎ|テスト結果)" docs/working/TASK-0107/handoff.md` >= 6
+
+### TC-16 [AC-9] Agent frontmatter 既存 Agent と同構造
+- **種別**: static / diff
+- **入力**: `.claude/agents/setup-coordinator.md` と `.claude/agents/acceptance-tester.md`
+- **期待出力**: frontmatter のキー集合（name, description, tools, model 等）が一致
+- **検証**: frontmatter を YAML パースしてキー比較
+
+### TC-17 [AC-10] settings.json hooks セクション diff = 0
+- **種別**: static / git diff
+- **入力**: `.claude/settings.json`
+- **期待出力**: 当 PBI の変更で hooks セクションが変更されていない
+- **検証**: `git diff main..HEAD -- .claude/settings.json | wc -l` == 0、または変更があっても hooks 配下のキーは不変
+
+### TC-18 [AC-11] status.md に完了マーカー
+- **種別**: integration
+- **前提条件**: T-01〜T-06 を踏んだ後
+- **期待出力**: `docs/working/TASK-0107/status.md` に各 Step の完了マーカー（例: `## Step N: ... ✅`）が記録
+- **検証**: status.md を読み完了マーカー数が Step 数以上
+
+### TC-19 [AC-11] decision-log.jsonl に append-only エントリ
+- **種別**: integration
+- **前提条件**: T-01〜T-06 後
+- **期待出力**: `docs/working/TASK-0107/decision-log.jsonl` に各 manual action の `pending` → `resolved` エントリが append（タイムスタンプ昇順）
+- **検証**: jsonl を 1 行ずつ JSON パース、タイムスタンプ昇順、status 遷移が pending → resolved の順
+
+### TC-20 [AC-12] doctor --check-settings FAIL で V-1/handoff ブロック
+- **種別**: gate negative test
+- **前提条件**: settings wiring 未適用状態
+- **入力**: `bin/plangate doctor --check-settings` 実行 → FAIL
+- **期待出力**: V-1 / handoff 完了処理が走らない（Agent が「未完了」と判定）
+- **検証**: Agent の対話パスに `--check-settings PASS` を待つ分岐が存在 + 実行で FAIL 時のブロックを確認
+
+### TC-21 [AC-13] 解消不能 FAIL でフォローアップ PBI 起票誘導
+- **種別**: unit mock + **manual**（Agent 対話パス人間確認）
+- **前提条件**: Mock C（解消不能 FAIL）
+- **期待出力**: Agent が「フォローアップ PBI 起票」を提示する対話パス
+- **検証**: 出力に「フォローアップ」「PBI 起票」「issue 作成」等のキーワード
+
+### TC-22 [AC-13] 承知スキップで status.md に明示記録
+- **種別**: unit mock + **manual**（Agent 対話シミュレーション）
+- **前提条件**: Mock C → ユーザー「承知スキップ」選択
+- **期待出力**: `status.md` に「skip (acknowledged): {理由}」が記録
+- **検証**: status.md に skip マーカー + 理由が存在
+
+---
+
+## エッジケース
+
+### EC-01 TASK ID 不明時の起動
+- **シナリオ**: `/plangate-setup` を `docs/working/TASK-XXXX/` の外（ルート等）から起動
+- **期待**: Agent が「TASK ID を指定するか、新規 Task を作成してください」と促す（U7 guard）
+- **検証**: 起動コンテキスト fixture で TASK ID 不明状態を作り、Agent の応答を確認
+
+### EC-02 doctor --json 出力スキーマ変更
+- **シナリオ**: 将来 `doctor --json` のキー追加 / 削除
+- **期待**: Agent が `level` / `ok` / `passed` の必須キーに依存し、未知キーには無関心
+- **検証**: 拡張 fixture（追加キーあり）でも Agent が正常動作
+
+### EC-03 同時起動（同一 TASK で複数セッション）— **v1 unsupported**
+- **シナリオ**: 同じ TASK-XXXX で `/plangate-setup` を二重起動
+- **期待**: Agent は**「同時起動は v1 では未サポート」を検出し中断・注意喚起**（同時 append の原子性 / ロック方式は v1 では定義しない）
+- **検証**: 二重起動シナリオで Agent が中断 or 警告メッセージを出すことを確認
+- **v2 候補**: 完全な同時書き込み耐性（flock 等）は v2 範囲に分離。本 PBI Out of scope（R-013 反映）
+
+### EC-04 doctor 自体が起動しない
+- **シナリオ**: `bin/plangate doctor` 実行が失敗（permission 等）
+- **期待**: Agent が「doctor 自体が起動できません」エラーを表示し再起動を促す
+- **検証**: doctor 起動失敗 fixture で Agent の応答を確認
+
+---
+
+## 既知の自動化制約
+
+- TC-01 / TC-06 / TC-07 / TC-08 / TC-21 / TC-22 は Agent の対話シミュレーションを要するため、現状の test infra で部分的に手動検証となる可能性。manual marker を付与し V-1 で人間確認を併用。
+- 完全自動化は v2 範囲（Out of scope）。

--- a/docs/working/TASK-0107/todo.md
+++ b/docs/working/TASK-0107/todo.md
@@ -1,0 +1,166 @@
+# TASK-0107 EXECUTION TODO
+
+> Source: `plan.md` Work Breakdown / Mode: **high-risk** / C-3 同期固定（lite_eligible=false）
+> Generated: 2026-05-22
+> Revision: r1（C-2 R3 R-009/R-010 反映: C-3 を exec 前に移動、workflow-conductor 自動制御範囲を分離）
+
+## Legend
+
+- 🤖 = Agent タスク（人手 todo の対象）
+- 👤 = Human タスク
+- 🚩 = チェックポイント（plan.md の Work Breakdown 連動）
+- ⬜ = 未着手 / 🟡 = 進行中 / ✅ = 完了
+
+> **Iron Law（working-context.md 準拠）**:
+> L-0 / V-1 / V-2 / V-3 / V-4 / PR 作成は **workflow-conductor が自動制御**するため本 todo の実装タスクには含めない（「§ workflow-conductor 後続フェーズ」欄を参照）。
+
+---
+
+## Phase 1: 準備（C-3 ゲート前）
+
+### T-01 🤖 Step 1: 事前契約確定
+- **Output**: `docs/working/TASK-0107/contract-notes.md`
+- **内容**:
+  - `bin/plangate doctor --json` を実行し、実 schema を取得・保存（U6）
+  - Agent tools 最小集合の決定（U1）
+  - Command の Agent invocation 方式（U4）— 既存 `.claude/commands/` から最も近いパターンを採用
+  - TASK ID 動的解決ロジック（U7）— Task-local 方式 + 不明時 guard 仕様
+- **🚩 Checkpoint**: schema に `scope/checks[]/passed` 等が含まれることを確認、tools 集合決定
+- **depends_on**: なし
+
+### T-02 🤖 Step 2: 三層責務設計確定
+- **Output**: `contract-notes.md` 末尾に責務境界表 + Cowork 5 要素 ⇄ PlanGate 対応表
+- **🚩 Checkpoint**: Command / Agent / Skill の入出力境界が表で 1:1 マップ
+- **depends_on**: T-01
+
+---
+
+## C-3 ゲート（人間レビュー・同期固定）
+
+### G-C3 👤 C-3: 人間レビュー（**exec 前 / 必須**）
+- **Output**: `docs/working/TASK-0107/approvals/c3.json`（`decision: APPROVED`、`plan_hash`、`c3_status: APPROVED`）
+- **三値**:
+  - APPROVE → 以下の Phase 2 exec 開始
+  - CONDITIONAL → review-external.md `R-NNN` 集約 → 1 回確定反映 → 簡易 C-1 → 人間が APPROVED `c3.json` 発行
+  - REJECT → plan 再生成
+- **🚩 Checkpoint**: T-01/T-02 完了 + C-1 完了 + plan / todo / test-cases / review-external（R-009〜R-013 反映済）を確認
+- **depends_on**: T-01, T-02 完了、C-1 完了（C-1 は workflow-conductor 制御）
+- **Note**: **`lite_eligible=false` 確定**（Hardening Override 対象、同期 C-3 固定）。`bin/plangate exec` は APPROVED のみ受理
+
+---
+
+## Phase 2: exec（C-3 APPROVED 後のみ着手）
+
+> **重要**: T-03〜T-08 は **G-C3 APPROVED が前提**。`depends_on` に `G-C3` を明示。
+
+### T-03 🤖 Step 3: Skill 実装
+- **Output**: `.claude/skills/plangate-setup/SKILL.md`
+- **内容**:
+  - frontmatter（name, description）
+  - 5 要素対応表（Cowork 5 要素 ⇄ PlanGate 対応物）
+  - チェックリスト（doctor 検査項目から抜粋）
+  - Rule 1-5 準拠
+- **🚩 Checkpoint**: frontmatter 検証 + 5 要素表 grep + Rule 2 準拠（再利用単位、案件固有なし）
+- **depends_on**: G-C3
+- **並列可**: T-04, T-05 と並列
+
+### T-04 🤖 Step 4: Command 実装
+- **Output**: `.claude/commands/plangate-setup.md`
+- **内容**:
+  - Agent invocation のみ（実装手順は書かない）
+  - 起動時の TASK ID 動的解決ロジック呼び出し
+- **🚩 Checkpoint**: Command 内に `bin/plangate` 直接呼び出しがゼロ + `.claude/settings.json` diff = 0
+- **depends_on**: G-C3
+- **並列可**: T-03, T-05 と並列
+
+### T-05 🤖 Step 5: Agent 実装
+- **Output**: `.claude/agents/setup-coordinator.md`
+- **内容**:
+  - frontmatter（name, description, tools 最小集合, model）— 既存 `acceptance-tester` / `linter-fixer` 構造踏襲
+  - 責務本文: doctor --json 連携 / Human-owned 提示のみ / 再検証ループ / 解消不能 FAIL 脱出経路
+  - 「実行禁止・提示のみ」を明文化（grep negative test 用の固定文言）
+- **🚩 Checkpoint**: frontmatter 既存 Agent と同構造 + tools 最小 + `apply-claude-settings.sh` を呼ぶパス無し（grep）
+- **depends_on**: G-C3
+- **並列可**: T-03, T-04 と並列
+
+### T-06 🤖 Step 6: Workflow-owned 永続ロック実装
+- **Output**: Agent definition への append-only 記録ルール組込み + `status.md` / `decision-log.jsonl` の更新仕様
+- **内容**:
+  - 各 Step 完了ごとに `status.md` 追記 + `decision-log.jsonl` append（pending → resolved）
+  - 解消不能 FAIL の skip 記録パス（AC-13）
+  - TASK ID 不明時 guard
+- **🚩 Checkpoint**: status.md / jsonl の append が test-case で検証可能 + `doctor --check-settings PASS` がゲート条件として記述
+- **depends_on**: T-05
+
+### T-07 🤖 Step 7: テスト/検証資産
+- **Output**: `tests/extras/ta-XX-plangate-setup.sh`
+- **内容**:
+  - doctor --json mock 3 系統（passed / 不足 / 解消不能 FAIL）
+  - Rule 1-5 grep 検査 / `.claude/settings.json` diff = 0 / status.md / decision-log.jsonl append 検査 / frontmatter 構造比較 / handoff 6 要素存在検査
+- **🚩 Checkpoint**: 全 22 test-case PASS（test-cases.md 参照）。manual 種別 TC は V-1 で人間確認チェックリスト化
+- **depends_on**: T-03, T-04, T-05, T-06
+
+### T-08 🤖 Step 8: handoff.md 生成
+- **Output**: `docs/working/TASK-0107/handoff.md`（6 要素網羅）
+- **内容**:
+  - 要件適合確認結果（AC ごとの PASS / FAIL / WARN）
+  - 既知課題一覧
+  - V2 候補（再設定 / 健康診断 / plugin export / 同時起動耐性）
+  - 妥協点（採用しなかった選択肢と理由）
+  - 引き継ぎ文書（5 分サマリ）
+  - テスト結果サマリ
+- **🚩 Checkpoint**: 6 要素網羅 + V-1 PASS 後に生成 + `doctor --check-settings PASS` 確認済（AC-12 ゲート）
+- **depends_on**: T-07 完了 + workflow-conductor 経由の V-1 PASS
+
+---
+
+## § workflow-conductor 後続フェーズ（自動制御範囲・実装 todo に含めない）
+
+> 以下は workflow-conductor が plan の Mode（high-risk）に基づき**自動的に実行**するため、本 todo の実装タスクには含めない（[`mode-classification.md`](../../../.claude/rules/mode-classification.md) high-risk 列 / [`working-context.md`](../../../.claude/rules/working-context.md) Iron Law）。
+
+| Phase | 対象 | conductor 制御 | 本 todo タスクとの関係 |
+|------|------|---------------|--------------------|
+| C-1 | 17 項目セルフレビュー | ✅ 自動 | G-C3 前提（plan / todo / test-cases に対して） |
+| **L-0** | リンター自動修正 | ✅ 自動 | T-07 完了後に自動実行 |
+| **V-1** | 受け入れ検査（AC-1〜AC-13） | ✅ 自動 | T-07 完了後に自動実行（`doctor --check-settings PASS` 必須） |
+| **V-2** | コード最適化（high-risk 必須） | ✅ 自動 | V-1 PASS 後に自動実行 |
+| **V-3** | 外部モデルレビュー（実装後） | ✅ 自動 | V-2 後に自動実行（critical/major = 0 確認） |
+| ~~V-4~~ | リリース前チェック | — | critical のみ。本 PBI は high-risk のため不要 |
+| **PR 作成** | GitHub PR | ✅ 自動 | T-08 (handoff) + V-3 完了後 |
+| **C-4** | PR レビュー（人間） | 👤 | GitHub 上で実施 |
+
+---
+
+## 依存関係グラフ
+
+```
+T-01 (契約確定)
+   ↓
+T-02 (責務設計)
+   ↓
+[C-1: workflow-conductor 自動制御 / 17 項目]
+   ↓
+G-C3 (👤 人間レビュー / 同期ゲート / APPROVED 必須)
+   ↓
+   ├─→ T-03 (Skill)  ─┐
+   ├─→ T-04 (Command) ─┤
+   └─→ T-05 (Agent)  ─┴─→ T-06 (永続ロック) ─→ T-07 (テスト)
+                                                  ↓
+                              [L-0 → V-1 → V-2 → V-3: workflow-conductor 自動制御]
+                                                  ↓
+                                                T-08 (handoff)
+                                                  ↓
+                              [PR 作成: workflow-conductor 自動制御]
+                                                  ↓
+                                                C-4 (👤 GitHub レビュー)
+                                                  ↓
+                                                Done
+```
+
+## 残タスク
+
+- ⬜ T-01〜T-08: 全て未着手
+- ⬜ G-C3: 人間レビュー待ち（C-1 完了後）
+- 次の Action:
+  1. C-2 R3 R-009〜R-013 反映完了 → 簡易 C-1 → G-C3 ゲート（人間）
+  2. G-C3 APPROVED → workflow-conductor が exec（T-03〜T-08）+ L-0/V-1/V-2/V-3/PR を制御


### PR DESCRIPTION
## Why

issue #310 (Codex + Gemini 公開サイト評価) で HIGH 優先 2 件と判定された改善:
- #1 トップに「最初に読む 3 ページ」順序明示
- #2 Requirements を README + Pages トップ双方に明文化

両者から共通指摘「README quickstart vs Phase 0 のどちらが推奨か不明」「Requirements 散在で必須 vs 任意の境界不明」を解消。残 5 件 (#3-#7) は #310 で PBI 化フローへ。

## 変更（3 ファイル / +49 行）

### `docs/index.md` (Pages トップ)
- **新セクション「新規利用者: 最初に読む 3 ページ」**: 15-30 分の推奨順序を明示
  1. PlanGate ガイド（約 5 分）
  2. 段階的導入ガイド（約 10 分）
  3. README 10 分チュートリアル（約 10 分）
- **新セクション「Requirements」**: Required / Recommended / Optional の依存ツール表

### `README.md`
- **新セクション「Requirements」**: インストール節の直前に挿入、Claude Code 非利用時の挙動も明記

### `README_en.md`
- 同等の英訳 Requirements セクション

## レビュー観点

- 3 ページ順序の妥当性（plangate.md / staged-adoption-guide.md / README 10 min）
- Requirements 表の Required/Recommended/Optional 分類
- README と Pages トップで一貫した記述か

## Out of scope

残 5 件は issue #310 で plan → C-3 → exec フロー:
- #3 30-minute first run の単一化
- #4 doctor --fix 必須度の強調
- #5 When NOT to use / Trade-offs ページ
- #6 用語クイックリファレンス
- #7 A/B/C/D ↔ WF-01..05 統合

Refs: #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)