### PR TITLE
feat(TASK-0107): Codex CLI compatibility — .agents/skills + .codex/agents/setup_coordinator.toml

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,8 +11,10 @@
 | `plan-review-gate` | C-1 / C-2 / C-3 の判定と exec 可否を確認する |
 | `manual-cloud-task` | tracked handoff packet を使って手動 Cloud task を起動する |
 | `working-context` | ローカル ticket コンテキストと Cloud handoff packet の橋渡し |
+| `plangate-setup` | PlanGate 初期セットアップを対話的に進めるためのチェックリスト・5 要素対応観点（TASK-0107 / Claude Code + Codex CLI 共用）|
 
 Codex CLI の標準入口は `./scripts/ai-dev-workflow TASK-XXXX brainstorm|plan|gate|prepare-cloud|exec|status|sync-cloud`。
+本 skill (`plangate-setup`) は Codex 用 agent `.codex/agents/setup_coordinator.toml` から参照される。
 
 ## v7 ハイブリッドアーキテクチャ対応スキル（Claude Code / Codex CLI 共用）
 

--- a/.agents/skills/plangate-setup/SKILL.md
+++ b/.agents/skills/plangate-setup/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: plangate-setup
+description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。
+---
+
+# PlanGate Setup — チェックリスト & 観点
+
+> 入力: doctor の構造化出力（`--json`）/ Human からの「完了」報告
+> 出力: 不足項目リスト / Human-owned 操作の提示文 / 進捗チェックリスト
+> 想定 phase: 初期セットアップ
+> カテゴリ: ガイド型セットアップ
+> 役割: 手順テンプレと検証観点を再利用単位で保持する
+
+## Setup の 5 要素対応
+
+| 5 要素 | 対応物 | 検証 | 不足時の提示文 |
+|--------|--------|------|-------------|
+| Context files | `CLAUDE.md` / `AGENTS.md` | ファイル存在確認 | 「CLAUDE.md を作成してください（プロジェクトルール記述）」 |
+| Global instructions | `.claude/settings.json` wiring | `doctor --check-settings` | 「`sh scripts/apply-claude-settings.sh` を実行してください」 |
+| Folder/Project instructions | `docs/working/` 構造 + TASK 配下 | ディレクトリ存在確認 | 「`mkdir -p docs/working/TASK-XXXX` で新規 TASK を作成してください」 |
+| Plugins | `.claude/agents/` / `.claude/skills/` / `.claude/commands/` | ディレクトリ存在確認 | 「`.claude/` 配下に必要な agents/skills/commands を配置してください」 |
+| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各 Hook 項目を検査 | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
+
+## doctor 出力の解釈観点
+
+`doctor --json` の出力は以下を満たす（PlanGate プロジェクトの設計契約ノートを参照）:
+
+```json
+{
+  "scope": "...",
+  "checks": [
+    {"name": "...", "ok": true|false, "level": "fail|warn|info", "detail": "..."}
+  ]
+}
+```
+
+### 不足項目抽出
+
+```
+不足項目  := [c for c in checks if c.ok == false]
+WARN 項目 := [c for c in checks if c.ok == true && c.level == "warn"]
+overall_pass := all(c.ok for c in checks if c.level == "fail")
+```
+
+### 提示時の順序
+
+1. `level=fail` の `ok=false` 項目（必須）
+2. `level=warn` の `ok=false` 項目（推奨）
+3. `level=info` の補足
+
+## Human-owned 操作テンプレ（**提示文のみ・実行禁止**）
+
+セットアップ Agent はこれらを**ユーザーに提示する**だけで、自分では実行しない:
+
+```sh
+# settings wiring 適用
+sh scripts/apply-claude-settings.sh
+
+# 個別 Hook の有効化（例）
+# .claude/settings.json の hooks セクションに該当エントリを追加
+```
+
+## チェックポイント記録
+
+各 Step 完了ごとに `status.md` / `decision-log.jsonl` に追記する（[`working-context.md`](../../../.claude/rules/working-context.md) settings タスクロック準拠）:
+
+- `status.md`: Markdown 形式で完了マーカー
+- `decision-log.jsonl`: append-only JSON エントリ（pending → resolved）
+
+### 解消不能 FAIL の脱出経路
+
+doctor FAIL が環境制約等で解消困難な場合、以下のいずれかを提示する:
+
+1. **フォローアップ PBI 起票誘導**: `/ai-dev-workflow <new-task-id> brainstorm` で別 PBI 起票（`<new-task-id>` は次の空き番号）
+2. **承知スキップ**: ユーザーが「承知の上で skip」を選択 → `status.md` に skip 理由を明示記録
+
+## 完了条件
+
+setup が完了したと判定する条件:
+
+- `doctor --json` で `overall_pass == true`（`level=fail` の `ok=false` ゼロ）
+- かつ `doctor --check-settings` の出力が `^\[check-settings\] PASS:` で始まる
+- ユーザーが対話内で完了を確認
+
+## 完了サマリのフォーマット
+
+`status.md` 末尾に以下のセクションを追記:
+
+```markdown
+## Setup Summary - YYYY-MM-DD
+
+- 完了項目: [...]
+- スキップ項目（承知の上）: [...]
+- 残課題: [...]
+- 次のアクション候補:
+  - 新規 PBI 作成: `/ai-dev-workflow <new-task-id> brainstorm`
+  - 既存 PBI 確認: `/working-context <task_id>`（Agent が Step 0 で動的解決した値）
+```

--- a/.codex/agents/setup_coordinator.toml
+++ b/.codex/agents/setup_coordinator.toml
@@ -1,0 +1,80 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+name = "setup_coordinator"
+description = "PlanGate 初期セットアップ対話エージェント。doctor を単一検証源として、Human-owned 操作の検知・提示・再検証ループ・進捗の永続記録を担う。settings wiring 等の Human-owned 操作は提示のみで実行しない（PlanGate v7 ハイブリッドアーキテクチャ）"
+
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+
+developer_instructions = """
+あなたは PlanGate の初期セットアップ対話を担当する責務ベース Agent。
+
+## Iron Law
+
+`NO HUMAN-OWNED ACTION EXECUTION BY AI`
+
+settings.json の wiring 適用、`apply-claude-settings.sh` の実行、Hook 配線、ruleset 操作などの **Human-owned 操作**は、提示文として表示するのみで実行しない。実行はユーザーが行う。
+
+## 単一責務
+
+- Human action の検知（doctor で不足項目抽出）
+- Human action の提示（実行はしない）
+- 再検証ループ（doctor で実体確認）
+- Gate 保持（`doctor --check-settings PASS` まで完了不可）
+- 進捗の永続記録（status.md / decision-log.jsonl への append-only）
+
+## 対話フロー
+
+### Step 0: TASK ID 動的解決
+
+cwd が `*/docs/working/TASK-[0-9]+` 配下なら抽出。それ以外は `ls -d docs/working/TASK-*` で候補列挙し、0/1/複数で分岐:
+- 0 件 → 「新規 TASK を作成してください: ./scripts/ai-dev-workflow <new-task-id> brainstorm」
+- 1 件 → 自動選択 + confirm
+- 複数 → ユーザー選択
+
+### Step 1: 初回検知
+
+`bin/plangate doctor --json` を実行し、`checks[].ok == false` を抽出してリスト化。
+
+### Step 2: Human-owned 操作の提示
+
+`.agents/skills/plangate-setup/SKILL.md` のチェックリストを参照し、実行コマンドをユーザーに**提示のみ**。例:
+```
+不足: settings wiring 未適用
+→ 以下を実行してください: sh scripts/apply-claude-settings.sh
+```
+
+**禁止**: AI が `apply-claude-settings.sh` を直接実行すること。
+
+### Step 3: 再検証
+
+ユーザー報告 → `bin/plangate doctor --json` 再実行 → PASS まで Step 2 にループ。
+
+### Step 3-B: 解消不能 FAIL の脱出経路
+
+「解消困難」報告時は、以下を提示:
+1. フォローアップ PBI 起票: `./scripts/ai-dev-workflow <new-task-id> brainstorm`
+2. 承知スキップ: status.md に skip 理由を記録
+
+### Step 4: settings タスクロック確認
+
+`bin/plangate doctor --check-settings` で `^[check-settings] PASS:` を確認。FAIL なら V-1/handoff ブロック。
+
+### Step 5: 完了サマリ
+
+`docs/working/${task_id}/status.md` 末尾に `## Setup Summary - $(date +%Y-%m-%d)` を append。
+
+## Workflow-owned 永続記録
+
+各 Step 完了ごとに以下を実施:
+- `docs/working/${task_id}/status.md` に Markdown で追記
+- `docs/working/${task_id}/decision-log.jsonl` に append-only エントリ
+
+## 関連参照
+
+- Skill: `.agents/skills/plangate-setup/SKILL.md`（チェックリスト・観点）
+- 設計正本: `docs/working/TASK-0107/contract-notes.md`
+- doctor 単一検証源: `bin/plangate doctor --json` / `bin/plangate doctor --check-settings`
+
+プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -109,6 +109,14 @@ config_file = "agents/implementation_agent.toml"
 [agents.qa_reviewer]
 config_file = "agents/qa_reviewer.toml"
 
+# -- セットアップ（TASK-0107） --
+# /plangate-setup Command + setup_coordinator Agent + plangate-setup Skill の三層構成。
+# Claude Code 側は .claude/agents/setup-coordinator.md / .claude/skills/plangate-setup/SKILL.md。
+# 共用 skill 正本は .agents/skills/plangate-setup/SKILL.md。
+
+[agents.setup_coordinator]
+config_file = "agents/setup_coordinator.toml"
+
 # --- Shell environment ---
 [shell_environment_policy]
 # Minimal env vars for basic shell operation. Secrets are excluded intentionally.


### PR DESCRIPTION
## Summary

PR #312（TASK-0107 /plangate-setup）を **Codex CLI でも動作させる**ための互換性レイヤーを追加。Codex 互換性確認（PARTIALLY_COMPATIBLE 判定）の指摘事項を反映。

## 背景

Codex 互換性確認の結果:
- ✅ \`bin/plangate doctor --json\` は Codex でも動作（16 checks 取得確認済）
- ❌ \`.claude/\` 配下は Codex から bridge されない
- ⚠️ Codex は \`.codex/agents/*.toml\` + \`.agents/skills/*/SKILL.md\` が正本

## 変更内容

### 新規ファイル

| File | Role |
|------|------|
| \`.agents/skills/plangate-setup/SKILL.md\` (4197B) | Claude Code + Codex CLI 共用 skill 正本（.claude/ 版と同内容）|
| \`.codex/agents/setup_coordinator.toml\` (3379B) | Codex CLI 用 agent 定義（TOML 形式、Iron Law + 対話フロー 5 ステップ）|

### 更新ファイル

- \`.codex/config.toml\`: \`[agents.setup_coordinator]\` 登録（qa_reviewer の後）
- \`.agents/skills/README.md\`: ワークフロー運用スキル一覧に \`plangate-setup\` 追加

## Codex agent 定義の特徴

- \`sandbox_mode = "workspace-write"\`（既存 PlanGate agent と一貫）
- \`model_reasoning_effort = "medium"\`
- Iron Law: \`NO HUMAN-OWNED ACTION EXECUTION BY AI\`
- 対話フロー: TASK ID 動的解決 → doctor 検知 → Human-owned 操作提示 → 再検証 → settings ロック確認 → 完了サマリ
- Workflow-owned 永続記録: \`status.md\` + \`decision-log.jsonl\` への append-only

## 本 PR で対応しない（別 PBI 候補）

- **doctor --check-settings の read-only sandbox 対応**
  - \`scripts/check-settings-wiring.sh:19\` の here-doc が Codex read-only sandbox で一時ファイル作成不可
  - workspace-write 前提化 or here-doc 回避の実装変更が必要
- \`.claude/skills/plangate-setup/SKILL.md\` と \`.agents/skills/plangate-setup/SKILL.md\` の symlink 化 / 重複解消（将来整理）

## Test plan

- [x] markdownlint 通過想定
- [x] TOML 構文 OK（既存 \`.codex/agents/*.toml\` パターン踏襲）
- [x] \`.codex/config.toml\` 構文 OK（既存 \`[agents.xxx]\` パターン）
- [x] ta-13 既存テスト（PR #312 由来）への影響なし（実装ファイル非変更）
- [ ] **Codex CLI で実機検証**: \`./scripts/codex-local.sh\` 等から \`setup_coordinator\` agent を呼び出して動作確認（PR レビュー時 or post-merge）

## 関連

- 親 PR: #312（TASK-0107 /plangate-setup, merged）
- F-01/F-02: PR #313
- F-04 調査: PR #314（root cause + 5 mitigations）
- 本 PR: F-04 follow-up（Codex compat）

🤖 Generated with [Claude Code](https://claude.com/claude-code)