### PR TITLE
docs(TASK-0108): C-2 proactive 外部レビュー R-001..R-006 確定反映

### DIFF
--- a/docs/working/TASK-0108/pbi-input.md
+++ b/docs/working/TASK-0108/pbi-input.md
@@ -28,7 +28,7 @@
 
 ## 受入基準 (Acceptance Criteria)
 
-- [ ] **AC-1**: 公開トップ + README + staged-adoption-guide の 3 箇所で「30 分初回体験のエントリポイント」が 1 本に統一・矛盾なし
+- [ ] **AC-1**: 公開トップ (`docs/index.md` / Pages 配信) + README + staged-adoption-guide の **3 箇所**で「30 分初回体験のエントリポイント」が 1 本に統一・矛盾なし。`staged-adoption-guide.md` Phase 0 を**正本**、README は短縮版・docs/index.md は導線として明示
 - [ ] **AC-2**: README install 節直後に `doctor --fix` 必須度の警告ブロックがあり、見落とせない強調（**太字** + 注意マーク）
 - [ ] **AC-3**: `docs/when-not-to-use.md`（or 同等セクション）が存在し、Trade-offs / 適用しないべきケース 5 件以上を具体例で記載
 - [ ] **AC-4**: 用語略号 (EH/WF/V/C/L) の意味と参照先を Glossary として 1 箇所に集約、主要 doc 冒頭からリンク

--- a/docs/working/TASK-0108/plan.md
+++ b/docs/working/TASK-0108/plan.md
@@ -28,11 +28,11 @@ issue #310 残 5 項目 (#3-#7) を反映し、外部新規 OSS 利用者の初�
 
 | # | Step | Output | Owner | Risk | 🚩 Checkpoint |
 |---|------|--------|-------|------|--------------|
-| 1 | **#3 30-min first run 単一化** — README の「10 分チュートリアル」を `docs/staged-adoption-guide.md` の Phase 0 とリンクで紐付け、どちらが「正」(staged-adoption が主、README は短縮版) かを冒頭で明示 | README.md + staged-adoption-guide.md | AI | low | 両ファイル冒頭で導線統一を確認、内容矛盾なし |
-| 2 | **#4 doctor --fix 必須度強調** — README install 節直後に「⚠️ これを実行しないとゲート (強制力) は機能しません」blockquote 追加 | README.md / README_en.md | AI | low | 視覚的目立つ box 表示、英訳整合 |
+| 1 | **#3 30-min first run 単一化** — README + README_en + docs/index.md の 3 箇所で `staged-adoption-guide.md` Phase 0 を**正本**として明示、README は短縮版・docs/index.md は導線。アンカー `[Phase 0](./docs/staged-adoption-guide.md#phase-0-体験day-1)` まで具体化 | README.md + README_en.md + docs/index.md + staged-adoption-guide.md | AI | low | 3 ファイル冒頭で導線統一、アンカー解決確認 |
+| 2 | **#4 doctor --fix 必須度強調** — README install 節直後に「⚠️ これを実行しないとゲート (強制力) は機能しません」blockquote 追加。**MD028 回避**: 空行にも `> ` を含める | README.md / README_en.md | AI | low | 視覚的目立つ box 表示、英訳整合、markdownlint MD028 pass |
 | 3 | **#5 When NOT to use ページ新規** — `docs/when-not-to-use.md` 新規作成、philosophy.md からリンク。短期プロト過剰/PBI 文化なし/Claude Code 非利用時の制約等 5 件以上 | docs/when-not-to-use.md (新規) + docs/philosophy.md (link) + docs/index.md (link) | AI | low | 5 件以上の具体的トレードオフ、攻撃的でないトーン |
 | 4 | **#6 用語 Glossary 新規** — `docs/glossary.md` 新規作成、EH-1〜EH-9/EHS-1〜3/WF-01〜05/V-1〜4/C-1〜4/L-0 等の略号 1 行解説 + 参照先 URL。主要 doc 冒頭から 1 行リンク | docs/glossary.md (新規) + docs/index.md (link) + 主要 doc (plangate.md/philosophy.md 等) 冒頭 link | AI | low | 全略号網羅、参照先実在 |
-| 5 | **#7 呼称統合 (LOW)** — A/B/C/D ↔ WF-01..05 の対応表を 1 箇所 (docs/glossary.md or workflows/README.md) に集約、新規ユーザー向けに WF-XX 優先表記方針を docs/ai/project-rules.md に明文化 (破壊的変更なし、対応表で吸収) | docs/glossary.md (or workflows/README.md) + docs/ai/project-rules.md (方針追記) | AI | medium | 対応表が機械的に正しい、既存 ABCD 参照は壊さない |
+| 5 | **#7 呼称統合 (LOW)** — A/B/C/D ↔ WF-01..05 対応表は**`docs/glossary.md` を正本**とし、既存 `docs/workflows/README.md` 対応表は glossary.md 参照に切替 (重複解消)。`docs/plangate.md` の見出しは `## A: PBI INPUT (WF-01/02)` のように**併記**に留め既存アンカー ID を維持。docs/ai/project-rules.md に「新規 doc は WF-XX 優先、既存 ABCD は対応表で吸収」方針追記 | docs/glossary.md (正本) + docs/workflows/README.md (参照に切替) + docs/plangate.md (見出し併記) + docs/ai/project-rules.md (方針追記) | AI | medium | 正本/参照関係明確 + 既存アンカー破壊なし + 対応表が機械的に正しい |
 | 6 | **C-2 任意外部レビュー** — Codex + Gemini 再委任、本 PR 反映後の評価で `CONDITIONAL Yes → Yes` を再確認 (AC-6) | review-external.md (本セッション内) | AI | low | 両レビュアから新たな major 0 件 |
 | 7 | **handoff + V-1** | TASK-0108/handoff.md | AI | low | AC-1..7 全 PASS |
 
@@ -49,6 +49,9 @@ issue #310 残 5 項目 (#3-#7) を反映し、外部新規 OSS 利用者の初�
 | `docs/index.md` | リンク追記 (#5, #6) |
 | `docs/plangate.md` | 冒頭 Glossary link (#6) |
 | `docs/ai/project-rules.md` | 呼称方針追記 (#7) |
+| `README_en.md` | T-03 (#3) 英訳 + アンカー追加 |
+| `docs/plangate.md` | T-07 (#7) 見出し併記 (アンカー維持) |
+| `docs/workflows/README.md` | T-07 (#7) 対応表を glossary 参照に切替 |
 | `docs/workflows/README.md` | 必要なら対応表参照 (#7) |
 | `docs/working/TASK-0108/handoff.md` | WF-05 |
 
@@ -63,7 +66,10 @@ issue #310 残 5 項目 (#3-#7) を反映し、外部新規 OSS 利用者の初�
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| **#7 呼称統合で既存 ABCD 参照リンクが壊れる** | medium | 既存 ABCD 表現は本文に残し、新規 ABCD ↔ WF-XX 対応表を docs/glossary.md に追加するだけにする（破壊回避） |
+| **#7 呼称統合で既存 ABCD 参照リンクが壊れる** | medium | 既存 ABCD 表現は本文に残し、`docs/plangate.md` の見出しは「`## A: PBI INPUT (WF-01/02)`」のように併記でアンカー ID 維持。対応表は `docs/glossary.md` 正本 + `docs/workflows/README.md` 参照切替で重複解消 (R-codex#1) |
+| **markdownlint MD028 (blank-line-in-blockquote) 違反** | low | T-04 警告 box の空行にも `> ` を含める実装ガイドを本 plan に明記 (R-gemini#1) |
+| **TC-08 外部レビュー判定プロトコル弱い** | medium | AC-6 の判定基準を「同一プロンプト / 対象ファイル一覧 / APPROVE-CONDITIONAL-REJECT / major 0・未解決 conditional 0」まで固定 (R-codex#2、test-cases.md TC-08 詳細化) |
+| **docs/index.md 「最初に読む 3 ページ」の純度** | low | #5 When NOT to use と #6 Glossary は「最初に読む 3 ページ」ではなく `## Reference` 等の補足セクションに配置 (R-gemini#3) |
 | **Glossary が肥大化して維持コスト増** | low | 略号一覧 + 参照先 URL のみで本文重複を避ける、各略号は 1 行解説 |
 | **When NOT to use が攻撃的トーンになる** | low | 「適用しないべきケース」「他ツールが適する場合」表現に統一、競合排他的表現を避ける |
 | **doctor --fix 強調 box が markdownlint MD028 (blank-line-in-blockquote) 違反** | low | 標準 blockquote 構文で書く、必要なら警告マーク用 emoji 使用 |

--- a/docs/working/TASK-0108/review-external.md
+++ b/docs/working/TASK-0108/review-external.md
@@ -1,0 +1,28 @@
+# TASK-0108 review-external (C-2 proactive 外部レビュー集約)
+
+> 追記専用・差分管理用。R-NNN は指摘 ID。reflected_in = 確定反映コミット。
+
+## Sources
+
+- C-2 proactive (2026-05-24): Codex (設計妥当性レーン) + Gemini (コードベース整合レーン)
+- 経緯: TASK-0108 C-3 直前に Codex 推奨優先順 (本セッション) で proactive 外部レビュー実施
+
+## 集約 (R-001..R-006)
+
+| ID | Lane | Severity | 内容 | reflected_in | status |
+|----|------|----------|------|--------------|--------|
+| R-001 | 設計妥当性 (Codex) | major | AC-1 検証対象から docs/index.md (公開トップ) が抜けている。TC-01/02 も README + staged-adoption のみで 3 箇所統一 AC で誤判定リスク | _本コミット_ | reflected |
+| R-002 | 設計妥当性 (Codex) | major | TC-08 外部レビュー判定プロトコル弱い。「同一プロンプト / 対象ファイル / APPROVE-CONDITIONAL-REJECT / major 0 + 未解決 conditional 0」まで固定 | _本コミット_ | reflected |
+| R-003 | 設計妥当性 (Codex) | minor | #7 呼称統合: 既存 `docs/workflows/README.md` 対応表との重複解消が曖昧。glossary.md 正本 + workflows/README.md 参照切替を明記 | _本コミット_ | reflected |
+| R-004 | コードベース (Gemini) | major | #7 呼称統合で `docs/plangate.md` `A`/`B`/`C`/`D` アンカー ID 維持必須。見出しは「`## A: PBI INPUT (WF-01/02)`」併記に留める | _本コミット_ | reflected |
+| R-005 | コードベース (Gemini) | major | T-04 README 警告 box の markdownlint MD028 違反対策必須 (空行にも `> ` 含める) | _本コミット_ | reflected |
+| R-006 | コードベース (Gemini) | minor | docs/index.md 「最初に読む 3 ページ」純度維持 — #5 When NOT to use / #6 Glossary は別セクション (`## Reference`) へ配置 | _本コミット_ (plan で方針確定、exec 時実装) | reflected |
+
+## info / 採用しなかった指摘
+
+- (Gemini) docs/staged-adoption-guide.md へのアンカーリンク具体化 → R-001 と統合
+- (Codex) info: docs/ai/project-rules.md 改修は AC-5 で扱う (本 plan で out of scope 化しない)
+
+## 反映方針
+
+`.claude/rules/working-context.md` の review-external 差分管理 (#234-C) に従い、本コミットで pbi-input / plan / todo / test-cases / review-self を **1 回確定反映**。簡易 C-1 v2 を review-self.md に記録、blocker 0 で C-3 提出可。

--- a/docs/working/TASK-0108/review-self.md
+++ b/docs/working/TASK-0108/review-self.md
@@ -2,7 +2,7 @@
 
 > Source: plan.md / todo.md / test-cases.md / Generated: 2026-05-22
 
-## 判定: **PASS** — C-3 ゲート提出可能
+## 判定: **PASS** — C-3 ゲート提出可能 (C-2 proactive 反映 v2、R-001..R-006 確定反映後)
 
 ## Plan チェック（7 項目）
 

--- a/docs/working/TASK-0108/test-cases.md
+++ b/docs/working/TASK-0108/test-cases.md
@@ -6,7 +6,7 @@
 
 | AC | TC IDs |
 |----|--------|
-| AC-1: 公開トップ + README + staged-adoption-guide で 30 分初回体験エントリポイントが 1 本に統一・矛盾なし | TC-01, TC-02 |
+| AC-1: 公開トップ + README + staged-adoption-guide で 30 分初回体験エントリポイントが 1 本に統一・矛盾なし | TC-01, TC-02, **TC-01b** |
 | AC-2: README install 直後に doctor --fix 必須度の警告ブロック有・見落とせない強調 | TC-03 |
 | AC-3: docs/when-not-to-use.md 存在、Trade-offs / 適用しないべきケース 5 件以上 | TC-04 |
 | AC-4: 用語略号 (EH/WF/V/C/L) Glossary を 1 箇所に集約、主要 doc 冒頭からリンク | TC-05, TC-06 |
@@ -29,6 +29,7 @@
 |----|---------|--------------|------|
 | TC-01 | README に staged-adoption-guide.md への 「first run の正本リンク」が冒頭で明示 | `grep -n 'staged-adoption-guide\\|first run\\|正本' README.md` | 該当行 1 件以上、冒頭 (L100 以内) |
 | TC-02 | staged-adoption-guide.md に「30 分初回体験の正本」明記 + README への参照 | `grep -n '正本\\|README.md.*Quickstart' docs/staged-adoption-guide.md` | 該当 1 件以上 |
+| **TC-01b** | docs/index.md (公開トップ) で staged-adoption-guide.md を「正本」と明示 + アンカー解決 (`#phase-0-体験day-1`) | `grep -nE 'staged-adoption-guide.*正本' docs/index.md` | 該当 1 件以上 |
 | TC-03 | README install 節直後 (L100-L130) に doctor --fix 必須警告 (⚠️ / 注意 / 必須) | `grep -nE 'doctor --fix.*必須\\|⚠️.*doctor' README.md` | 該当 1 件以上、L100-L130 範囲 |
 | TC-04 | docs/when-not-to-use.md 実在、トレードオフ 5 件以上記載 | `ls docs/when-not-to-use.md && grep -cE '^- \\|^\\d+\\.' docs/when-not-to-use.md` | 5 行以上の bullet/numbered |
 | TC-05 | docs/glossary.md 実在、EH-1〜EH-9 / EHS-1〜3 / WF-01〜05 / V-1〜4 / C-1〜4 / L-0 略号網羅 | `grep -cE '^- \\*\\*EH-[0-9]+\\*\\*\\|^- \\*\\*WF-' docs/glossary.md` | 各カテゴリで該当行あり、計 25 行以上 |
@@ -39,7 +40,7 @@
 
 | ID | 内容 | 種別 |
 |----|------|------|
-| TC-08 | Codex + Gemini に再委任、両者から「新規 OSS 利用者が初期導入を Yes と判定可能」評価。前回 CONDITIONAL Yes と比較して major 改善ポイント 0 件 (= 既に修正反映済) | manual (review-external.md に追記) |
+| TC-08 | **外部レビュー判定プロトコル固定**: 同一プロンプト (新規 OSS 利用者視点で公開導線を評価) → 対象ファイル一覧 (#3/#4/#5/#6/#7 変更全て) → 判定 (APPROVE/CONDITIONAL/REJECT) → 合格条件 (**major 0 + 未解決 conditional 0 + 両者から「Yes (初期導入可能)」**) = AC-6 PASS。結果は review-external.md に R-NNN 追記 | manual (review-external.md) |
 
 ### Edge cases
 

--- a/docs/working/TASK-0108/todo.md
+++ b/docs/working/TASK-0108/todo.md
@@ -9,11 +9,11 @@
 - [ ] **T-02**: 既存 docs/philosophy.md / docs/index.md / plangate.md の冒頭構造を確認、Glossary/When-NOT リンク挿入位置を決定 (owner=agent / Risk=low)
 
 ### Phase 2: 実装 (5 改善項目)
-- [ ] **T-03 (#3)**: 30-min first run 単一化 — staged-adoption-guide.md Phase 0 を「正」とし、README は「短縮版・正本へのリンク」と冒頭で明示。両ファイルの相互参照固定 (owner=agent / Risk=low / depends_on=T-01 / 🚩 矛盾なし)
-- [ ] **T-04 (#4)**: README install 直後に doctor --fix 必須度 警告 box 追加 (⚠️ + blockquote)。README_en.md にも英訳 (owner=agent / Risk=low / 🚩 視覚的目立つ、英訳整合)
+- [ ] **T-03 (#3)**: 30-min first run 単一化 — staged-adoption-guide.md Phase 0 を**正本**、README + README_en + docs/index.md 3 ファイルで参照固定。アンカー `#phase-0-体験day-1` まで具体化 (owner=agent / Risk=low / depends_on=T-01 / 🚩 3 ファイル矛盾なし + アンカー解決)
+- [ ] **T-04 (#4)**: README install 直後に doctor --fix 必須度 警告 box 追加 (⚠️ + blockquote)。**MD028 回避: 空行にも `> ` 含める**。README_en.md にも英訳 (owner=agent / Risk=low / 🚩 視覚的目立つ + 英訳整合 + markdownlint pass)
 - [ ] **T-05 (#5)**: docs/when-not-to-use.md 新規作成 (短期プロト過剰/PBI 文化なし/Claude Code 非利用時制約 等 5 件以上)。docs/philosophy.md と docs/index.md からリンク (owner=agent / Risk=low / 🚩 5 件以上、攻撃的でない)
 - [ ] **T-06 (#6)**: docs/glossary.md 新規作成 (EH-1〜EH-9 / EHS-1〜3 / WF-01〜05 / V-1〜4 / C-1〜4 / L-0 / PBI 等 略号 1 行解説 + 参照 URL)。docs/index.md + plangate.md + philosophy.md 冒頭から 1 行リンク (owner=agent / Risk=low / 🚩 全略号網羅、参照先実在)
-- [ ] **T-07 (#7)**: ABCD ↔ WF-01..05 対応表を docs/glossary.md 末尾に追加。docs/ai/project-rules.md に「新規 doc は WF-XX 優先表記、既存 ABCD は対応表で吸収」方針追記 (owner=agent / Risk=medium / depends_on=T-06 / 🚩 対応表が機械的に正しい、既存 ABCD 参照は壊さない)
+- [ ] **T-07 (#7)**: ABCD ↔ WF-01..05 対応表を **docs/glossary.md 末尾に正本配置**、docs/workflows/README.md 既存対応表は glossary.md 参照に切替 (重複解消)。docs/plangate.md 見出しは `## A: PBI INPUT (WF-01/02)` 併記で**アンカー ID 維持**。docs/ai/project-rules.md に呼称方針追記 (owner=agent / Risk=medium / depends_on=T-06 / 🚩 正本/参照関係明確 + 既存アンカー破壊なし)
 
 ### Phase 3: 検証
 - [ ] **T-08**: markdownlint 全 markdown ファイル pass (owner=agent / Risk=low / 🚩 lint pass)


### PR DESCRIPTION
## 概要

Codex+Gemini に **C-2 相当 proactive 外部レビュー** を委任した結果、両者から CONDITIONAL 判定 + 6 件指摘を集約。`review-external.md` に R-001..R-006 として記録し、**1 回確定反映** (pbi-input / plan / todo / test-cases / review-self)。

## 反映内容

| ID | Lane | Sev | 内容 |
|----|------|-----|------|
| R-001 | 設計 (Codex) | major | AC-1 / TC に docs/index.md 明示追加 (TC-01b 新規) |
| R-002 | 設計 (Codex) | major | TC-08 外部レビュー判定プロトコル固定化 (同一プロンプト / major 0 + 未解決 conditional 0) |
| R-003 | 設計 (Codex) | minor | #7 呼称統合 — glossary 正本 + workflows/README 参照切替で重複解消 |
| R-004 | コード (Gemini) | major | #7 docs/plangate.md アンカー ID 維持 (見出し併記) |
| R-005 | コード (Gemini) | major | T-04 README 警告 box の markdownlint MD028 対策 |
| R-006 | コード (Gemini) | minor | docs/index.md「最初に読む 3 ページ」純度維持 |

## C-1 v2 結果

総合 94 → 96、blocker 0 維持。C-3 ゲート提出可。

## マージ境界

これは **plan 確定反映のみ** (exec はまだ)。マージは Human-owned。

Refs: #310, C-2 proactive (2026-05-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)