### PR TITLE
docs(TASK-0109): C-2 proactive 外部レビュー R-001..R-010 確定反映 (Gemini CRITICAL 含む)

### DIFF
--- a/docs/working/TASK-0109/plan.md
+++ b/docs/working/TASK-0109/plan.md
@@ -14,6 +14,10 @@ Codex provider の「実用上は全面利用可」を **「完璧対応」** �
 - **既存テスト維持**: `tests/run-tests.sh` 101/0 + `tests/hooks/run-tests.sh` 79/0 PASS
 - **後方互換**: 既存 `scripts/ai-dev-workflow` / `scripts/codex-local.sh` ラッパとの責務分界を破らない
 - **dogfooding 実証ベース**: 本セッションの Codex レビュー実行パターン (`codex exec --skip-git-repo-check`) を CLI 内部実装の正本とする
+- **🚨 CRITICAL (R-gemini#1)**: review 用 `codex exec` 呼出時は `--sandbox read-only` を必ず付与。review プロセスがファイル改変できないことを保証する
+- **R-gemini#2**: `codex` CLI 自体に `--timeout` オプションはないため、shell `timeout` コマンドで wrap (デフォルト 600s)
+- **R-gemini#3**: review 出力は `--output-last-message <file>` で純粋なレビュー内容のみをファイル出力し、stdout 解析の脆さを回避
+- **R-gemini#5**: shim/symlink 経由でも repo root を正しく解決するため `CDPATH= cd -- "$(dirname -- "$0")" && pwd` パターンを採用
 
 ### Non-goals
 - Codex Cloud (codex-cloud) 連携の機能追加
@@ -22,18 +26,24 @@ Codex provider の「実用上は全面利用可」を **「完璧対応」** �
 
 ## Approach Overview
 
-3 改善項目を **段階実装** (互いに依存度があるため): CX-1 (CLI wiring) → CX-2 (.codex/hooks 配線) → CX-3 (RFC)。CX-1 は gemini case と対称構造で `codex exec` 直接呼出。CX-2 は `.cursor/hooks/` の plangate-eh1/eh2 patterns を参照。CX-3 は既存 RFC 構造踏襲、CX-1/CX-2 完了後に references を含めて最終形にする。
+3 改善項目を **段階実装**: **T-01 (Phase 1 調査) を CX-2 着手前のハードゲート化** (R-codex#1 反映)。CX-1 (CLI wiring) → **T-01 hook 発火経路調査・確定** → CX-2 (.codex/hooks 配線、経路確定後のみ) → CX-3 (RFC)。
+
+**T-01 ハードゲート条件** (これを満たさない限り CX-2 は着手不可):
+1. `codex` CLI native の hook 機構 (Cursor `hooks.json` 相当) が存在するか確認
+2. 存在しない場合、`scripts/codex-local.sh` ラッパ経由で hook を fan-out する設計に切り替える (.codex/hooks/ 配置ではなく `scripts/codex-local.sh` への bridge 追加)
+3. **EH-3 は「翻訳」ではなく「新規設計」**として扱う (R-codex#2)。`.cursor/hooks.json` には EH-1/EH-2 のみで EH-3 不在のため、`scripts/hooks/check-plan-hash.sh` の Codex 経路発火条件を新規に設計する
+4. T-01 の結論は status.md / handoff.md に記録、不確定なまま CX-2 着手しない
 
 ## Work Breakdown
 
 | # | Step | Output | Owner | Risk | 🚩 Checkpoint |
 |---|------|--------|-------|------|--------------|
-| 1 | **準備**: `.cursor/hooks/` 構造把握 + `bin/plangate` review コードパス確認 + 既存 codex case (placeholder) 抽出 | 調査メモ | AI | low | 既存資産マップ完成 |
-| 2 | **CX-1 (CLI wiring)**: `bin/plangate review` の `codex` case を `codex exec --skip-git-repo-check` 直接呼出に実装。プロンプトは task の plan + review-external.md に流し、stdout を review-external.md に追記。gemini case 構造踏襲 | `bin/plangate` (review 関数内 codex case) | AI | medium | `bin/plangate review TASK-XXXX --phase c2 --reviewer codex` で実 review 生成 + 既存 gemini case regression なし |
+| 1 | **準備 + 🚨 hook 発火経路ハードゲート (R-codex#1/2)**: (a) `.cursor/hooks/` 構造把握 + `bin/plangate` review コードパス確認、(b) **`codex` CLI native hook 機構の有無確定**、(c) 無ければ `scripts/codex-local.sh` 経由 bridge 設計、(d) EH-3 を新規設計として扱う設計メモ、(e) `scripts/codex-local.sh` の現状 (`exec codex`) を fan-out 構造に変更可能か実装可否確認 | 調査メモ + 経路確定 | AI | **high** (CX-2 全 step の前提条件) | hook 発火経路確定 (経路名・bridge 設計・EH-3 新規設計方針を全て status.md に記録) → 確定後のみ CX-2 着手可 |
+| 2 | **CX-1 (CLI wiring)**: `bin/plangate review` の `codex` case を `timeout 600 codex exec --skip-git-repo-check --sandbox read-only --output-last-message <tmpfile>` で実装 (R-gemini#1/2/3)。プロンプトは task の plan + review-external.md に流し、tmpfile を review-external.md に追記。gemini case 構造踏襲。**Codex CLI 未インストール時の error handling 追加** (R-gemini#10) | `bin/plangate` (review 関数内 codex case) | AI | medium | `bin/plangate review TASK-XXXX --phase c2 --reviewer codex` で実 review 生成 + read-only sandbox 検証 + timeout 機能 + 既存 gemini case regression なし |
 | 3 | **CX-2a (hook adapter 設計)**: `.cursor/hooks/cursor-adapter.sh` pattern を参考に `.codex/hooks/codex-adapter.sh` (or 同等経路) 設計。`scripts/codex-local.sh` ラッパとの責務分界文書化 | `.codex/hooks/codex-adapter.sh` (新規) + `.codex/README.md` 更新 (責務分界明示) | AI | **high** (承認境界相当) | EH-1/EH-2 を Codex から呼ぶ際の block/skip 動作確認 |
-| 4 | **CX-2b (hook 配線)**: `.codex/hooks/plangate-eh1-plan.sh` / `plangate-eh2-c3.sh` / `plangate-eh3-hash.sh` を Cursor 版 (`.cursor/hooks/`) を翻訳して追加。本 hook が `scripts/hooks/check-plan-exists.sh` / `check-c3-approval.sh` / `check-plan-hash.sh` を呼び出す形式（EH-3 配線で承認境界実行正本も Codex 経由で尊重） | `.codex/hooks/plangate-eh1-plan.sh` / `plangate-eh2-c3.sh` / `plangate-eh3-hash.sh` (新規) | AI | high | smoke test: Codex 経由 Edit で EH-1 block / C-3 通過後 skip / EH-3 hash mismatch block |
+| 4 | **CX-2b (hook 配線、T-01 経路確定後のみ)**: EH-1/EH-2 は Cursor 版翻訳可、**EH-3 は新規設計** (R-codex#2: Cursor 版に EH-3 不在のため設計コピー不可)。bridge は T-01 で確定した経路に配置 (.codex/hooks/ or scripts/codex-local.sh fan-out)。本 bridge が `scripts/hooks/check-plan-exists.sh` / `check-c3-approval.sh` / `check-plan-hash.sh` を呼び出し、承認境界実行正本を尊重。**shim symlink 解決**: `CDPATH= cd -- "$(dirname -- "$0")" && pwd` パターン (R-gemini#5) | bridge scripts (新規・配置は T-01 確定) | AI | high | smoke test: Codex 経由 Edit で EH-1 block / C-3 通過後 skip / EH-3 hash mismatch block + shim 経由でも repo root 解決 |
 | 5 | **CX-3 (provider-codex RFC)**: `docs/rfc/provider-codex.md` 新規。既存 RFC (provider-cursor.md) 構造踏襲、CX-1/CX-2 完成後の正本ポインタ集約 (`.codex/`, `scripts/ai-dev-workflow`, `scripts/codex-local.sh`, `docs/codex-cloud/`, 新 hooks/) | `docs/rfc/provider-codex.md` (新規) | AI | low | RFC が既存 3 RFC と structure 整合 |
-| 6 | **テスト**: CLI review codex case test + hook adapter test を tests/extras/ + tests/hooks/ に追加 | `tests/extras/ta-13-codex-review.sh` (新規) / `tests/hooks/codex-adapter-test.sh` (新規) | AI | medium | 既存 tests/run-tests 101/0 + tests/hooks 79/0 維持、新規 TC 全 PASS |
+| 6 | **テスト (R-codex#3)**: CLI review codex case test + hook adapter test を tests/extras/ + tests/hooks/ に追加。**TC-05 を wrapper 経由 deterministic 化**: codex CLI を fixture stub に差し替え、`bin/plangate review` 経由で EH-3 発火を deterministic 検証 (manual integration は補助のみ) | `tests/extras/ta-13-codex-review.sh` (新規) / `tests/hooks/codex-adapter-test.sh` (新規) | AI | medium | 既存 tests/run-tests 101/0 + tests/hooks 79/0 維持、新規 TC 全 PASS、TC-05 が wrapper stub で deterministic 実行 |
 | 7 | **handoff + V-1** | TASK-0109/handoff.md | AI | low | AC-1..6 全 PASS |
 
 ## Files / Components to Touch
@@ -51,6 +61,8 @@ Codex provider の「実用上は全面利用可」を **「完璧対応」** �
 | `tests/hooks/codex-adapter-test.sh` | 新規 (CX-2 検証) |
 | `tests/hooks/run-tests.sh` | dispatcher 追記 (新規 test の呼び出し) |
 | `docs/working/TASK-0109/handoff.md` | WF-05 |
+| `README.md` / `README_en.md` / `docs/index.md` | AC-4/AC-6 (Codex provider 表記更新、R-codex#4) |
+| `docs/rfc/provider-codex.md` (Role Mapping 表追加, R-gemini#6) | CX-3 内に Codex Agent ↔ PlanGate Role mapping 表を含める |
 
 ## Testing Strategy
 
@@ -69,10 +81,17 @@ Codex provider の「実用上は全面利用可」を **「完璧対応」** �
 | **CX-2 `scripts/codex-local.sh` ラッパとの責務分界曖昧化** | medium | `.codex/README.md` に責務分界表を追加 (codex-local.sh = auth 管理ラッパ / codex-adapter.sh = hook 呼出 bridge) |
 | **CI 非対応の integration test が手動でしか検証できない** | low | docs/note で明示、ローカル開発者向けの自動検出 (`bin/plangate doctor` で `codex` CLI 有無検出済) で十分 |
 | **CX-3 RFC の Status 表現が他 RFC と不整合** | low | provider-cursor.md / provider-gemini-cli.md / provider-opencode.md と structure 完全踏襲 |
+| **🚨 review 用 codex プロセスがファイル改変する** | **CRITICAL** | `--sandbox read-only` 必須付与 (R-gemini#1)。Constraints / T-02 で固定 |
+| **codex exec の応答が長時間で CI/local hang** | medium | shell `timeout 600` で wrap (R-gemini#2)。codex CLI に `--timeout` なし |
+| **stdout 解析の脆さ (思考メッセージ混在)** | medium | `--output-last-message <file>` でクリーンなレビュー出力のみファイル化 (R-gemini#3) |
+| **shim symlink 経由で repo root 誤検出** | medium | `CDPATH= cd -- "$(dirname -- "$0")" && pwd` (R-gemini#5) |
+| **CX-2 hook 発火経路が未確定のまま実装着手** | **high** | T-01 をハードゲート化、経路確定まで CX-2 凍結 (R-codex#1) |
+| **EH-3 を Cursor 翻訳と誤認** | high | Cursor 版に EH-3 不在のため新規設計として扱う (R-codex#2)。T-04 で明記 |
+| **TC-05 manual のみで AC-2 検証が弱い** | medium | wrapper stub で deterministic 化 (R-codex#3)。T-06 で実装 |
 
 ## Questions / Unknowns
 
-- **CX-2 hook 起動経路**: `codex` CLI 自体に hook 機構があるか、`codex-local.sh` 経由でラップするか → **要 Phase 1 調査**で確定 (T-01 で .cursor/hooks/ pattern 確認後決定)
+- **CX-2 hook 起動経路**: `codex` CLI 自体に hook 機構があるか、`codex-local.sh` 経由でラップするか → **T-01 ハードゲート化済** (R-codex#1 反映)。経路確定まで CX-2 凍結
 - **CX-1 review prompt の組み立て**: gemini case と同等で十分か、Codex 特化の prompt 改善余地あるか → **gemini case 構造踏襲を仮採用**、改善余地は本 PBI 完了後の follow-up
 - **CX-3 RFC の Status**: "Implemented (v8.10.0)" or "Implemented (本 PBI)" → **本 PBI 完了 commit の merged バージョンを Status に記載** (TASK-0106 patterns)
 

--- a/docs/working/TASK-0109/review-external.md
+++ b/docs/working/TASK-0109/review-external.md
@@ -1,0 +1,34 @@
+# TASK-0109 review-external (C-2 proactive 外部レビュー集約)
+
+> 追記専用・差分管理用。R-NNN は指摘 ID。reflected_in = 確定反映コミット。
+
+## Sources
+
+- C-2 proactive (2026-05-24): Codex (設計妥当性レーン) + Gemini (コードベース整合レーン)
+- 経緯: TASK-0109 C-3 直前に proactive 外部レビュー実施。Gemini に **CRITICAL** 発見
+
+## 集約 (R-001..R-010)
+
+| ID | Lane | Severity | 内容 | reflected_in | status |
+|----|------|----------|------|--------------|--------|
+| R-001 (codex#1) | 設計 (Codex) | major | CX-2 hook 起動経路が未確定。`scripts/codex-local.sh` は単に `exec codex` で hook 呼出なし、`.codex/config.toml` にも hook 登録構造なし。`.codex/hooks/*.sh` 追加しても発火保証なし → T-01 ハードゲート化 + 経路確定まで CX-2 着手禁止 | _本コミット_ | reflected |
+| R-002 (codex#2) | 設計 (Codex) | major | EH-3 配線は「Cursor 版翻訳」ではなく「**新規設計**」。実際の `.cursor/hooks.json` は EH-1/EH-2 のみで EH-3 不在 → T-04 で「EH-3 新規設計」と明記 | _本コミット_ | reflected |
+| R-003 (codex#3) | 設計 (Codex) | major | TC-05 manual だけでは AC-2 検証弱い → **wrapper 経由 deterministic test** (codex CLI fixture stub) に強化 | _本コミット_ | reflected |
+| R-004 (codex#4) | 設計 (Codex) | minor | AC-4/AC-6 docs 整合の Work Breakdown / touch files に README.md / README_en.md / docs/index.md が無い → Files + T-09b 追加 | _本コミット_ | reflected |
+| R-005 (gemini#1) | コードベース (Gemini) | **CRITICAL** | review 用 `codex exec` 呼出時に `--sandbox read-only` 必須。review プロセスがファイル改変できないことを保証 → Constraints + T-02 + Risk + TC-05c | _本コミット_ | reflected |
+| R-006 (gemini#2) | コードベース (Gemini) | major | `codex` CLI に `--timeout` なし → shell `timeout` コマンドで wrap (デフォルト 600s) | _本コミット_ | reflected |
+| R-007 (gemini#3) | コードベース (Gemini) | major | `--output-last-message <file>` でクリーンなレビュー出力のみファイル化 (stdout 解析の脆さ回避) | _本コミット_ | reflected |
+| R-008 (gemini#4) | コードベース (Gemini) | major | Hook 発火機構の確認 (Cursor のような hooks.json native サポート不明) → R-001 と統合、T-01 で対応 | _本コミット_ | reflected |
+| R-009 (gemini#5) | コードベース (Gemini) | major | shim/symlink 経由でも repo root 正しく特定 → `CDPATH= cd -- "$(dirname -- "$0")" && pwd` パターン | _本コミット_ | reflected |
+| R-010 (gemini#6) | コードベース (Gemini) | minor | Role Mapping 表 (Codex Agent ↔ PlanGate Role) を `docs/rfc/provider-codex.md` に追加 | _本コミット_ (plan で確定、exec 時実装) | reflected |
+
+## info / 採用しなかった指摘
+
+- (Gemini#7) Status 記載 (v8.10.0 相当) → CX-3 RFC Status は本 PBI 完了 commit の merged バージョン (既存 Q/U 方針通り、再確認のみ)
+- (Gemini#10) Codex CLI 未インストール時の error handling → T-02 に追加済 (info → reflected)
+
+## 反映方針
+
+`.claude/rules/working-context.md` の review-external 差分管理 (#234-C) に従い、本コミットで pbi-input / plan / todo / test-cases / review-self を **1 回確定反映**。Gemini CRITICAL 発見 (R-005) により Constraints / T-02 / TC-05c を強化。Codex major (R-001 hook 経路) により T-01 をハードゲート化、経路確定まで CX-2 凍結。
+
+簡易 C-1 v2 を review-self.md に記録、blocker 0 で C-3 提出可。

--- a/docs/working/TASK-0109/review-self.md
+++ b/docs/working/TASK-0109/review-self.md
@@ -2,7 +2,7 @@
 
 > Source: plan.md / todo.md / test-cases.md / Generated: 2026-05-22
 
-## 判定: **PASS** — C-3 ゲート提出可能
+## 判定: **PASS** — C-3 ゲート提出可能 (C-2 proactive 反映 v2、R-001..R-010 確定反映後)
 
 ## Plan チェック（7 項目）
 

--- a/docs/working/TASK-0109/test-cases.md
+++ b/docs/working/TASK-0109/test-cases.md
@@ -28,7 +28,9 @@
 |----|------|------|------|------|
 | TC-03 | `.codex/hooks/plangate-eh1-plan.sh` 経由で非 plan ファイル Edit (PLANGATE_HOOK_TASK 未設定、no plan.md) | hook 起動 | exit 2 (EH-1 block) | unit |
 | TC-04 | C-3 APPROVED の TASK 文脈で hook 起動 | EH-2 経由 Edit | exit 0 (skip) | unit |
-| TC-05 | `scripts/codex-local.sh` 経由実行で hook も発火 | adapter test | hook 経路で block/skip 正常動作 | integration |
+| TC-05 | EH-3 配線が Codex 経由で発火することを **codex CLI fixture stub** で deterministic 検証 (R-codex#3: manual integration は補助) | `tests/hooks/codex-adapter-test.sh` で stub codex 経由 `bin/plangate review` 実行、plan_hash mismatch で block 確認 | block exit + 補助として実 codex でも smoke 確認 |
+| **TC-05c (R-gemini#1 CRITICAL)** | `bin/plangate review --reviewer codex` 実行時に `--sandbox read-only` フラグが付与されることを検証 | `grep -nE 'sandbox.+read-only' bin/plangate` + stub codex で argv ログ確認 | read-only sandbox 付与 確認 |
+| **TC-05d (R-gemini#2/3)** | `timeout` 600s wrap + `--output-last-message` 利用を検証 | `grep -nE 'timeout.*codex\|output-last-message' bin/plangate` | 両方 該当 |
 | **TC-05b** | `.codex/hooks/plangate-eh3-hash.sh` 経由で plan_hash mismatch ファイル Edit | hook 起動 | exit 2 (EH-3 block、承認境界実行正本が Codex 経由でも尊重) | unit |
 
 ### CX-3 + Provider 表整合

--- a/docs/working/TASK-0109/todo.md
+++ b/docs/working/TASK-0109/todo.md
@@ -5,19 +5,21 @@
 ## 🤖 Agent タスク
 
 ### Phase 1: 準備
-- [ ] **T-01**: `.cursor/hooks/` 構造把握 (cursor-adapter.sh + plangate-eh1-plan.sh + plangate-eh2-c3.sh) + `scripts/codex-local.sh` ラッパ責務確認 + `bin/plangate review` 現状 codex case (placeholder) コード抽出 (owner=agent / Risk=low / 🚩 既存資産マップ完成)
+- [ ] **T-01 🚨 ハードゲート (R-codex#1/2)**: (a) `.cursor/hooks/` 構造把握、(b) `scripts/codex-local.sh` 責務確認、(c) `bin/plangate review` codex case 現状抽出、(d) **`codex` CLI native hook 機構の有無確定**、(e) 無ければ `scripts/codex-local.sh` 経由 bridge 設計、(f) **EH-3 を新規設計として扱う方針確定** (Cursor 版に EH-3 不在)、(g) 結論を status.md に記録 (owner=agent / Risk=**high** / 🚩 経路確定まで T-03/T-04 着手不可)
 
 ### Phase 2: 実装
-- [ ] **T-02 (CX-1)**: `bin/plangate` review 関数 codex case を `codex exec --skip-git-repo-check` 直接呼出に実装、stdout を review-external.md に追記。gemini case 構造踏襲 (owner=agent / Risk=medium / depends_on=T-01 / 🚩 gemini case regression なし + 新 codex review 動作)
+- [ ] **T-02 (CX-1, R-gemini#1/2/3/10)**: `bin/plangate` review 関数 codex case を `timeout 600 codex exec --skip-git-repo-check --sandbox read-only --output-last-message <tmpfile>` で実装、tmpfile を review-external.md に追記。**Codex CLI 未インストール時の error handling** 追加。gemini case 構造踏襲 (owner=agent / Risk=medium / depends_on=T-01 / 🚩 read-only sandbox + timeout + clean output + gemini regression なし)
 - [ ] **T-03 (CX-2a)**: `.codex/hooks/codex-adapter.sh` 設計+実装、`.codex/README.md` に責務分界表 (codex-local.sh = auth / codex-adapter.sh = hook bridge) 追加 (owner=agent / Risk=**high** / depends_on=T-01 / 🚩 既存 scripts/hooks 呼出経由で独自ロジック追加なし)
-- [ ] **T-04 (CX-2b)**: `.codex/hooks/plangate-eh1-plan.sh` / `plangate-eh2-c3.sh` / `plangate-eh3-hash.sh` を `.cursor/hooks/` 翻訳で追加 (`scripts/hooks/check-plan-exists.sh` / `check-c3-approval.sh` / `check-plan-hash.sh` を呼ぶ shim、EH-3 配線で承認境界実行正本も Codex 経由で尊重) (owner=agent / Risk=high / depends_on=T-03 / 🚩 EH-1 block / EH-2 skip / EH-3 block 動作確認)
+- [ ] **T-04 (CX-2b, R-codex#2/R-gemini#5)**: EH-1/EH-2 は Cursor 版翻訳可、**EH-3 は新規設計** (Cursor 版 EH-3 不在)。T-01 で確定した bridge 経路に配置 (`.codex/hooks/` or `scripts/codex-local.sh` fan-out)。bridge が `scripts/hooks/check-plan-exists.sh` / `check-c3-approval.sh` / `check-plan-hash.sh` を呼出。**shim symlink 解決: `CDPATH= cd -- "$(dirname -- "$0")" && pwd`** (owner=agent / Risk=high / depends_on=T-03 / 🚩 EH-1 block / EH-2 skip / EH-3 (新規設計) block + shim 経由 repo root 解決)
 - [ ] **T-05 (CX-3)**: `docs/rfc/provider-codex.md` 新規。既存 provider-cursor/gemini-cli/opencode RFC structure 踏襲、CX-1/CX-2 完了後の正本ポインタ集約 (owner=agent / Risk=low / depends_on=T-02,T-04 / 🚩 既存 3 RFC との structure 整合)
 
 ### Phase 3: 検証
-- [ ] **T-06**: `tests/extras/ta-13-codex-review.sh` 新規 — CX-1 wiring を fake codex で fixture test (owner=agent / Risk=medium / depends_on=T-02 / 🚩 `tests/run-tests.sh` 101+1 件 PASS)
+- [ ] **T-06 (R-codex#3)**: `tests/extras/ta-13-codex-review.sh` 新規 — CX-1 wiring を **codex CLI fixture stub** で deterministic 検証、`bin/plangate review` 経由で EH-3 発火も wrapper test 化 (TC-05 deterministic 化) (owner=agent / Risk=medium / depends_on=T-02 / 🚩 `tests/run-tests.sh` 101+1 PASS + TC-05 stub deterministic)
 - [ ] **T-07**: `tests/hooks/codex-adapter-test.sh` 新規 — CX-2 hook adapter を cursor-adapter-test.sh と同 pattern で fixture test (owner=agent / Risk=medium / depends_on=T-04 / 🚩 `tests/hooks/run-tests.sh` 79+1 件 PASS)
 - [ ] **T-08**: 既存テスト regression — `tests/run-tests.sh` 101/0 + `tests/hooks/run-tests.sh` 79/0 維持 (owner=agent / Risk=low / 🚩 全 PASS)
 - [ ] **T-09**: 承認境界回帰 — `bin/plangate doctor` で codex CLI 検出が継続動作、`PLANGATE_IMPL_AGENT:-codex` / `PLANGATE_EXTERNAL_REVIEWER:-codex` 既定不変 (owner=agent / Risk=medium / depends_on=T-02 / 🚩 doctor PASS + 既定値検証)
+
+- [ ] **T-09b (R-codex#4)**: README.md / README_en.md / docs/index.md の Codex provider 表記更新 (AC-4/AC-6) (owner=agent / Risk=low / depends_on=T-05 / 🚩 3 ファイル整合)
 
 ### Phase 4: 完了
 - [ ] **T-10**: handoff.md 作成 (Rule 5 必須 6 要素) + V-1 (test-cases 全件突合) (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..6 PASS)


### PR DESCRIPTION
## 概要

Codex+Gemini に **C-2 相当 proactive 外部レビュー** を委任、**Gemini が CRITICAL 1 件** を含む合計 10 件を発見。`review-external.md` R-001..R-010 に集約、**1 回確定反映** (plan / todo / test-cases / review-self)。

## CRITICAL (必須対応)

- **R-005 (Gemini)**: review 用 `codex exec` に `--sandbox read-only` 必須付与 — review プロセスがファイル改変できないことを保証

## major (設計再考)

| ID | Lane | 内容 |
|----|------|------|
| R-001 | Codex | CX-2 hook 起動経路未確定 → **T-01 ハードゲート化**、経路確定まで CX-2 凍結 |
| R-002 | Codex | EH-3 は Cursor 翻訳ではなく**新規設計** (Cursor 版に EH-3 不在) |
| R-003 | Codex | TC-05 manual のみでは弱い → **wrapper deterministic** (codex CLI stub) |
| R-006 | Gemini | `timeout 600` wrap (codex CLI に `--timeout` なし) |
| R-007 | Gemini | `--output-last-message <file>` でクリーン出力 |
| R-008 | Gemini | hook 発火機構確認 (R-001 と統合) |
| R-009 | Gemini | shim symlink: `CDPATH= cd -- "$(dirname -- "$0")" && pwd` |

## minor

- R-004 (Codex): AC-4/AC-6 docs に README/README_en/docs/index.md 追加 (T-09b 追加)
- R-010 (Gemini): Role Mapping 表を `docs/rfc/provider-codex.md` に追加

## 影響

- **Gemini CRITICAL 対応**: review プロセスのファイル改変リスクを排除
- **T-01 ハードゲート化**: 不確定なまま CX-2 着手するリスクを排除
- C-1 v2: blocker 0 維持、C-3 提出可

## マージ境界

これは **plan 確定反映のみ**。exec はまだ。マージは Human-owned。

Refs: #315, C-2 proactive (2026-05-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)