### PR TITLE
docs(TASK-0108/0109): C-3 Review Packet — Human 判定用材料

### DIFF
--- a/docs/working/TASK-0108/c3-review-packet.md
+++ b/docs/working/TASK-0108/c3-review-packet.md
@@ -1,0 +1,76 @@
+# TASK-0108 C-3 Review Packet (Human-owned 判定用材料)
+
+> 本ファイルは **C-3 ゲート判定を行う人間** のための参考資料。c3.json 発行は本ファイルに従わず、人間の独自判定で行う。
+
+## 1. Phase 状態
+
+- **Phase**: B 完了 (plan / todo / test-cases / review-self / **review-external (C-2 proactive)** 揃った)
+- **Mode**: standard
+- **C-1**: PASS (総合 96 = R-001..R-006 確定反映後)
+- **C-2 (proactive)**: Codex CONDITIONAL + Gemini CONDITIONAL APPROVE → **R-001..R-006 全て本 PR で 1 回確定反映済**
+- **未解決 conditional**: **0 件**
+- **major / critical 残**: **0 件**
+
+## 2. plan_hash (post-merge 予測値)
+
+```
+sha256:5b28f765fa725eafd1f3991aab8a41acfd2a830be846f3f22cd21ddf460bb535
+```
+
+> 上記は `origin/docs/task-0108-c2-reflect:docs/working/TASK-0108/plan.md` の SHA-256。PR #322 が squash でなく **plan.md に追加変更なしで** merge されれば main 上で同値になる。squash 後 plan.md が改変された場合は再算出が必要。
+
+## 3. CI 結果 (PR #322)
+
+```
+Markdown lint            pass   6s
+SKIP_REASON 追認         pass   8s
+check                    pass   6s
+plangate CLI tests       pass   18s
+settings wiring drift    pass   6s
+```
+
+すべて PASS。merge-ready。
+
+## 4. C-2 proactive レビュー差分要約
+
+| ID | 反映内容 |
+|----|----------|
+| R-001 (Codex major) | AC-1 / TC に `docs/index.md` 明示追加 (TC-01b 新規) |
+| R-002 (Codex major) | TC-08 外部レビュー判定プロトコル固定化 (同一プロンプト / major 0 + 未解決 conditional 0) |
+| R-003 (Codex minor) | #7 呼称統合: glossary.md 正本 + workflows/README.md 参照切替 |
+| R-004 (Gemini major) | `docs/plangate.md` ABCD アンカー ID 維持 (見出し併記方式) |
+| R-005 (Gemini major) | T-04 README 警告 box の markdownlint MD028 対策 (空行にも `> `) |
+| R-006 (Gemini minor) | docs/index.md 「最初に読む 3 ページ」純度維持 |
+
+## 5. C-3 判定 template (人間が編集して `approvals/c3.json` に発行)
+
+```json
+{
+  "task_id": "TASK-0108",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "human",
+  "approved_at": "2026-05-24T00:00:00Z",
+  "plan_hash": "sha256:5b28f765fa725eafd1f3991aab8a41acfd2a830be846f3f22cd21ddf460bb535",
+  "_review_summary": "C-2 proactive (Codex + Gemini) R-001..R-006 を 1 回確定反映済。major/未解決 conditional 0。exec 可。",
+  "_schema_reference": "schemas/c3-approval.schema.json"
+}
+```
+
+**判定の選択肢** (Human の主観で決定):
+- **APPROVED**: 上記 template そのまま → `bin/plangate exec` 受理可
+- **CONDITIONAL**: `c3_status` を `"CONDITIONAL"` に変更し `"conditions"` 必須記載
+- **REJECTED**: `c3_status` を `"REJECTED"` に変更し `"rejection_reason"` 必須記載
+
+## 6. Exec 着手前のチェックリスト (人間)
+
+- [ ] PR #322 を main にマージ
+- [ ] マージ後 `git checkout main && git pull` で main を更新
+- [ ] `sha256sum docs/working/TASK-0108/plan.md` で plan_hash を再算出 (上記値と一致確認)
+- [ ] `docs/working/TASK-0108/approvals/c3.json` を発行
+- [ ] AI に「TASK-0108 exec 開始」を指示 → AI は `bin/plangate exec TASK-0108` 経由で実装着手
+
+## 7. exec 範囲予告 (参考)
+
+- T-01..T-11 / 推定 7-10 ファイル変更 (docs only)
+- 主要 touch: README.md, README_en.md, docs/index.md, docs/staged-adoption-guide.md, docs/glossary.md, docs/plangate.md, docs/workflows/README.md, docs/ai/project-rules.md

--- a/docs/working/TASK-0109/c3-review-packet.md
+++ b/docs/working/TASK-0109/c3-review-packet.md
@@ -1,0 +1,91 @@
+# TASK-0109 C-3 Review Packet (Human-owned 判定用材料)
+
+> 本ファイルは **C-3 ゲート判定を行う人間** のための参考資料。c3.json 発行は本ファイルに従わず、人間の独自判定で行う。
+
+## 1. Phase 状態
+
+- **Phase**: B 完了 (plan / todo / test-cases / review-self / **review-external (C-2 proactive)** 揃った)
+- **Mode**: standard (CX-2 hook 配線部分のみ high-risk 相当)
+- **C-1**: PASS (R-001..R-010 確定反映後)
+- **C-2 (proactive)**: Codex CONDITIONAL + Gemini CONDITIONAL APPROVE → **R-001..R-010 全て本 PR で 1 回確定反映済**
+- **未解決 conditional**: **0 件**
+- **CRITICAL 残**: **0 件** (R-005 Gemini CRITICAL `--sandbox read-only` は plan / TC-05c で固定済)
+
+## 2. plan_hash (post-merge 予測値)
+
+```
+sha256:5c1e1b439508b981f340924cd15808ee36a9c1eb81552d931c6529304f7afcc2
+```
+
+> 上記は `origin/docs/task-0109-c2-reflect:docs/working/TASK-0109/plan.md` の SHA-256。
+
+## 3. CI 結果 (PR #323)
+
+```
+Markdown lint            pass   4s
+SKIP_REASON 追認         pass   3s
+check                    pass   8s
+plangate CLI tests       pass   16s
+settings wiring drift    pass   6s
+```
+
+すべて PASS。merge-ready。
+
+## 4. C-2 proactive レビュー差分要約 (CRITICAL を含む)
+
+| ID | Sev | 反映内容 |
+|----|-----|----------|
+| R-005 (Gemini) | **CRITICAL** | review 用 `codex exec` に `--sandbox read-only` 必須 → Constraints + T-02 + Risks + TC-05c で固定 |
+| R-001 (Codex) | major | CX-2 hook 起動経路未確定 → **T-01 ハードゲート化**、経路確定まで CX-2 凍結 |
+| R-002 (Codex) | major | EH-3 は Cursor 翻訳ではなく**新規設計** |
+| R-003 (Codex) | major | TC-05 manual のみでは弱い → wrapper deterministic test (codex CLI stub) |
+| R-006 (Gemini) | major | `timeout 600` wrap (codex CLI に `--timeout` なし) |
+| R-007 (Gemini) | major | `--output-last-message <file>` でクリーン出力 |
+| R-008 (Gemini) | major | hook 発火機構確認 (R-001 と統合) |
+| R-009 (Gemini) | major | shim symlink `CDPATH= cd -- "$(dirname -- "$0")" && pwd` |
+| R-004 (Codex) | minor | README / README_en / docs/index.md を Files + T-09b に追加 |
+| R-010 (Gemini) | minor | Role Mapping 表を `docs/rfc/provider-codex.md` に |
+
+## 5. C-3 判定 template (人間が編集して `approvals/c3.json` に発行)
+
+```json
+{
+  "task_id": "TASK-0109",
+  "phase": "C-3",
+  "c3_status": "APPROVED",
+  "approved_by": "human",
+  "approved_at": "2026-05-24T00:00:00Z",
+  "plan_hash": "sha256:5c1e1b439508b981f340924cd15808ee36a9c1eb81552d931c6529304f7afcc2",
+  "_review_summary": "C-2 proactive (Codex + Gemini) R-001..R-010 を 1 回確定反映済。CRITICAL 1 件 (R-005 --sandbox read-only) は plan/TC-05c で固定。major/未解決 conditional 0。T-01 hard gate により CX-2 hook 経路確定後のみ CX-2 着手。",
+  "_schema_reference": "schemas/c3-approval.schema.json"
+}
+```
+
+## 6. Exec 着手前のチェックリスト (人間)
+
+- [ ] PR #323 を main にマージ
+- [ ] マージ後 `git checkout main && git pull`
+- [ ] `sha256sum docs/working/TASK-0109/plan.md` で plan_hash 再算出 → 上記値と一致確認
+- [ ] `docs/working/TASK-0109/approvals/c3.json` を発行
+- [ ] AI に「TASK-0109 exec 開始」を指示
+
+## 7. exec 着手後の Gate 構造 (重要)
+
+```
+T-01 (ハードゲート: hook 経路確定) ──┬─→ T-02 (CX-1 CLI wiring)
+                                    └─→ [経路確定後のみ] T-03 → T-04 (CX-2 hook 配線)
+                                                                  ↓
+                                                          T-05 (CX-3 RFC)
+                                                                  ↓
+                                                       T-06..T-09b (テスト + docs)
+                                                                  ↓
+                                                          T-10 (handoff + V-1)
+```
+
+T-01 で「`codex` CLI native hook なし & `scripts/codex-local.sh` で fan-out 不可能」と判明した場合、CX-2 を本 PBI から外して別 PBI 化することを再 C-3 で人間確認する。
+
+## 8. exec 範囲予告 (参考)
+
+- T-01..T-10 + T-09b / 推定 10-12 ファイル変更
+- 主要 touch: bin/plangate, .codex/hooks/ (or scripts/codex-local.sh), tests/extras/, tests/hooks/, docs/rfc/provider-codex.md, README / README_en / docs/index.md
+- 既存テスト regression: tests/run-tests.sh 101/0 + tests/hooks/run-tests.sh 79/0 維持


### PR DESCRIPTION
## 概要

PR #322 (TASK-0108) と PR #323 (TASK-0109) の C-2 反映完了後、Human が C-3 ゲート判定を行うための材料 (c3-review-packet.md) を両 PBI に追加。

Codex 相談 (2026-05-24) で「優先順 G (C-3 承認用パケット準備)」と提案された範囲の自律実行。

## 含む内容

- Phase 状態サマリ
- plan_hash post-merge 予測値 (再算出ガイド付き)
- CI 結果 (全 PASS)
- C-2 proactive レビュー差分要約 (R-NNN 表)
- c3.json 発行 template (3 値選択)
- Exec 着手前 Human チェックリスト

## TASK-0109 特記

- CRITICAL R-005 (`--sandbox read-only`) 対応状況
- T-01 ハードゲート構造 (CX-2 凍結条件) 明示
- T-01 経路確定不能の場合の再 C-3 予告

## 境界

- AI は c3.json 自体を発行しない (Human-owned)
- merge は Human-owned
- 本 PR は **判定材料のみ追加** (実装変更なし、docs only)

Refs: #310, #315, PR #322, PR #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)