### PR TITLE
fix(skills): Codex/Gemini レビュー指摘の skill ↔ 実 CLI 整合

### DIFF
--- a/.agents/skills/ai-dev-brainstorm/SKILL.md
+++ b/.agents/skills/ai-dev-brainstorm/SKILL.md
@@ -5,17 +5,16 @@ description: "アイデアや曖昧な要件を PlanGate の PBI INPUT PACKAGE �
 
 # AI-Driven Brainstorm (PlanGate / Codex 共用)
 
-PlanGate ワークフローの **brainstorm フェーズ（WF-01 / phase 0）** を Codex / Claude Code 両方で実行する skill。
+PlanGate ワークフローの **brainstorm フェーズ** を Codex / Claude Code 両方で実行する skill。
 
 ## Read First
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（PBI INPUT PACKAGE の必須要素・ディレクトリ構造）
-4. `.claude/rules/mode-classification.md`（後段の mode 判定材料を意識）
-5. `docs/ai-driven-development.md`
+3. `.claude/rules/working-context.md`（PBI INPUT PACKAGE の必須要素・ディレクトリ構造の正本）
+4. `docs/ai-driven-development.md`
    - 最低限: `## ワークフロー全体像`、`## ゲート条件`、`## 成果物の保存先`
-6. `docs/working/TASK-XXXX/status.md`（存在する場合）
+5. `docs/working/TASK-XXXX/status.md`（存在する場合）
 
 ## Output
 
@@ -25,20 +24,14 @@ PlanGate ワークフローの **brainstorm フェーズ（WF-01 / phase 0）** 
 ## Rules
 
 - 1 問ずつ進める（最大 3 問の確認質問・多肢選択推奨）
-- まだ `plan.md` / `todo.md` / `test-cases.md` は作成しない（plan フェーズの責務）
-- `pbi-input.md` には以下を明記:
-  - Context / Why（なぜやるか）
-  - What（Scope）: In scope / Out of scope
-  - 受入基準（Acceptance Criteria, AC-1, AC-2, ...）
-  - Notes from Refinement
-  - Estimation Evidence: Risks / Unknowns / Assumptions
+- まだ `plan.md` / `todo.md` / `test-cases.md` は作成しない
+- `pbi-input.md` の必須要素は `.claude/rules/working-context.md` の「pbi-input.md」節を参照
 - 既存コードや関連制約はコードベースを確認してから要約する
-- 設計が曖昧なまま実装へ進まない（plan フェーズへの handoff 品質を担保）
 
 ## CLI 呼び出し
 
-- 共通: `bin/plangate brainstorm TASK-XXXX` または `./scripts/ai-dev-workflow TASK-XXXX brainstorm`
-- skill 側はプロンプト規約のみ。実行ロジックは CLI 側（Rule 2 遵守）
+- 実コマンド: `./scripts/ai-dev-workflow TASK-XXXX brainstorm`
+- skill 側はプロンプト規約のみ（Rule 2 遵守）
 
 ## 次フェーズへ
 

--- a/.agents/skills/ai-dev-exec/SKILL.md
+++ b/.agents/skills/ai-dev-exec/SKILL.md
@@ -7,13 +7,15 @@ description: "PlanGate の exec フェーズを TDD で実行する。Use when: 
 
 PlanGate ワークフローの **exec フェーズ（WF-04 Build & Refine）** を Codex / Claude Code 両方で実行する skill。
 
-## 前提条件（必須）
+## 前提条件（exec 開始ゲート）
 
 - `docs/working/TASK-XXXX/approvals/c3.json` が存在し `c3_status: APPROVED`
-- `plan_hash` が現 plan.md の SHA-256 と一致（EH-3 PASS）
-- `bin/plangate doctor --check-settings` が PASS（settings タスクロック・Shadow Config 防止）
+- `bin/plangate validate TASK-XXXX` PASS（plan_hash 整合 / artifact 整合 / EH-3 整合）
+- `bin/plangate exec TASK-XXXX` は APPROVED c3.json のみ受理（CLI 側で機械チェック）
 
 これらが満たされなければ exec を**開始しない**。
+
+> **settings タスクロック** (`bin/plangate doctor --check-settings`) は **V-1 / handoff 完了の前提条件**（`.claude/rules/working-context.md` 正本）。exec 入口では block しない。詳細は `ai-dev-verify` skill。
 
 ## Read First
 
@@ -45,8 +47,10 @@ PlanGate ワークフローの **exec フェーズ（WF-04 Build & Refine）** �
 
 ## CLI 呼び出し
 
-- 共通: `bin/plangate exec TASK-XXXX`（APPROVED c3.json のみ受理）
+- exec dispatch: `bin/plangate exec TASK-XXXX [--mode <mode>]`（APPROVED c3.json のみ受理）
+- 機械検証: `bin/plangate validate TASK-XXXX`
+- 並行で `./scripts/ai-dev-workflow TASK-XXXX exec` も利用可
 
 ## 次フェーズへ
 
-exec 完了後は workflow-conductor が L-0（リンター）→ V-1（受け入れ検査）→ V-2/V-3/V-4 を自動進行。verify 観点は `ai-dev-verify` skill。
+exec 完了後は `ai-dev-verify` skill で V-1〜V-4 + handoff.md 発行。L-0〜V-4 は workflow-conductor が自動進行。

--- a/.agents/skills/ai-dev-plan/SKILL.md
+++ b/.agents/skills/ai-dev-plan/SKILL.md
@@ -5,14 +5,14 @@ description: "PBI INPUT PACKAGE から PlanGate の plan.md / todo.md / test-cas
 
 # AI-Driven Plan (PlanGate / Codex 共用)
 
-PlanGate ワークフローの **plan フェーズ（WF-02〜WF-03 相当）** を Codex / Claude Code 両方で実行する skill。実行ロジックは `bin/plangate` CLI に集約し、skill はプロンプト規約のみを担う。
+PlanGate ワークフローの **plan フェーズ（WF-02〜WF-03）** を Codex / Claude Code 両方で実行する skill。実行ロジックは `scripts/ai-dev-workflow` / `bin/plangate` CLI 側に集約し、skill は読む順序と入出力規約のみを担う。
 
 ## Read First
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（B フェーズ 3 ファイル同時生成・段階別出力・ゲート条件）
-4. `.claude/rules/mode-classification.md`（5 段階 mode + `lite_eligible` 派生属性）
+3. `.claude/rules/working-context.md`（B フェーズ 3 ファイル同時生成・段階別出力・ゲート条件の正本）
+4. `.claude/rules/mode-classification.md`（5 段階 mode + `lite_eligible` 派生属性の正本）
 5. `.claude/rules/hybrid-architecture.md`（Rule 1〜5 / handoff 必須化）
 6. `docs/ai-driven-development.md`
    - 最低限: `## ワークフロー全体像`、`### タスク規模によるモード分岐（5 モード）`、`## ゲート条件`、`### Prompt 1: Plan + ToDo + Test Cases生成`
@@ -28,49 +28,30 @@ PlanGate ワークフローの **plan フェーズ（WF-02〜WF-03 相当）** �
 
 ## Rules
 
-### B-1 → B-2 → B-3 フロー（必須）
+### フロー（詳細は正本参照）
 
-- **B-1**: PBI INPUT の曖昧点を最大 3 問の確認質問（多肢選択推奨）で解消。曖昧さがなければスキップ可。
-- **B-2**: 2〜3 アプローチ案を trade-off 付きで比較し推薦案を明示。比較結果は plan.md「アプローチ比較」セクションに記載。
-- **B-3**: 確定仕様で plan.md + todo.md + test-cases.md を**同時生成**。
-
-### plan.md 必須セクション
-
-- Goal / Constraints / Non-goals / Approach Overview
-- **確認事項**（B-1 の Q&A、無ければ「該当なし」明記）
-- **アプローチ比較**（B-2、無ければ「該当なし」明記）
-- Work Breakdown（Step ごとに Output / Owner / Risk / 🚩 checkpoint）
-- Files / Components to Touch
-- Testing Strategy
-- Risks & Mitigations
-- Questions / Unknowns
-- **Mode判定**: 5 段階（ultra-light / light / standard / high-risk / critical）+ 判定根拠
-- **lite_eligible**: true / false + 根拠（AC-8 安全側 / AC-11 critical 原則 false）
+- **B-1 / B-2 / B-3** フローおよび plan.md 必須セクション（確認事項 / アプローチ比較 / Mode判定 / lite_eligible 等）は `docs/ai-driven-development.md` の `### Prompt 1: Plan + ToDo + Test Cases生成` と `.claude/rules/mode-classification.md` を **正本** とする。skill は順序のみを示す。
+- B-1（最大 3 問の確認質問）→ B-2（2〜3 案の trade-off 比較）→ B-3（3 ファイル同時生成）
 
 ### todo.md 規約
 
-- タスク粒度 2-5 分
-- `Owner: agent / human` 必須
-- `depends_on` / `files` を必ず付ける
+- タスク粒度 2-5 分、`Owner: agent / human` 必須、`depends_on` / `files` 必須
 - L-0〜V-4・PR 作成は workflow-conductor が自動制御するため含めない
-- 🤖 Agent / 👤 Human のフェーズ分離を明示
 
 ### test-cases.md 規約
 
-- 各 AC → テストケースのマッピング必須
-- 前提条件 / 入力 / 期待出力 / 種別（unit / integration / e2e / verification）
-- Edge case を含める
+- 各 AC → テストケースのマッピング必須、Edge case を含める
 
-### 監査・整合
+### 監査
 
-- Unknowns は plan に明記（隠さない）
 - decision-log.jsonl に B-1/B-2/B-3 の主要判断を append-only で記録
-- mode が `critical` で `lite_eligible=true` の場合は人間の C-3 明示承認記録が前提（AC-11）
+- mode が `critical` で `lite_eligible=true` の場合は人間の C-3 明示承認記録が前提（`mode-classification.md` AC-11）
 
 ## CLI 呼び出し
 
-- 共通: `bin/plangate plan TASK-XXXX` または `./scripts/ai-dev-workflow TASK-XXXX plan`
+- 実コマンド: `./scripts/ai-dev-workflow TASK-XXXX plan`
+- 機械検証: `bin/plangate validate TASK-XXXX`（plan_hash 整合）
 
 ## 次フェーズへ
 
-plan 完了後は `plan-review-gate` skill で C-1（17 項目）→ C-2（R-NNN 集約）→ C-3（c3.json APPROVED）。exec は `ai-dev-exec` skill。
+plan 完了後は `plan-review-gate` skill で C-1 → C-2 → C-3（c3.json APPROVED）。exec は `ai-dev-exec` skill。

--- a/.agents/skills/ai-dev-verify/SKILL.md
+++ b/.agents/skills/ai-dev-verify/SKILL.md
@@ -11,51 +11,29 @@ PlanGate ワークフローの **verify & handoff フェーズ（WF-05）** を 
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（handoff 必須化・6 要素）
+3. `.claude/rules/working-context.md`（handoff 必須化・6 要素・settings タスクロックの正本）
 4. `.claude/rules/hybrid-architecture.md`（Rule 5）
 5. `.claude/rules/review-principles.md`（V-3 外部レビュー観点）
 6. `.claude/rules/mode-classification.md`（V-2/V-3/V-4 の mode 別適用）
 7. `docs/working/TASK-XXXX/plan.md` / `test-cases.md` / `status.md`
-8. `docs/working/templates/handoff.md`
+8. `docs/working/templates/handoff.md`（handoff.md 6 要素の正本テンプレート）
 
-## V-1 受け入れ検査（必須）
+## V-1〜V-4 の概要
 
-- test-cases.md の各 AC を機械的に PASS/FAIL 突合
-- 推測ではなく**実行結果のみで判定**
-- FAIL があれば exec へ差し戻し（修正後再検査）
-- evidence: `evidence/test-runs/`, `evidence/verification/`
+mode 別の適用範囲は `.claude/rules/mode-classification.md` フェーズ適用マトリクスを正本とする。各フェーズの趣旨:
 
-## V-2 コード最適化（high-risk / critical のみ）
+- **V-1 受け入れ検査**: test-cases.md の各 AC を機械的に PASS/FAIL 突合（推測ではなく実行結果のみ）。FAIL は exec へ差し戻し。evidence: `evidence/test-runs/`, `evidence/verification/`。
+- **V-2 コード最適化** (high-risk / critical): 動作不変で可読性・効率性改善。テスト再実行で回帰なしを保証。
+- **V-3 外部モデルレビュー** (standard 以上): 5 観点 + Severity 判定。R-NNN 採番で `review-external.md` 追記専用。
+- **V-4 リリース前チェック** (critical): ドキュメント整合 / マイグレーション / ロールバック / セキュリティ。
 
-- 動作を変えずに可読性・効率性を改善
-- テスト再実行で回帰がないことを保証
+## settings タスクロック（V-1 / handoff 完了の前提条件）
 
-## V-3 外部モデルレビュー（standard 以上）
-
-- 5 観点（可読性 / 拡張性 / Perf / Security / 保守性）+ Severity 判定
-- 指摘は R-NNN 採番、`review-external.md` に追記専用
-- critical / major は修正必須
-
-## V-4 リリース前チェック（critical のみ）
-
-- ドキュメント整合 / マイグレーション計画 / ロールバック手順 / セキュリティチェック
+`bin/plangate doctor --check-settings` PASS を **V-1 / handoff 完了の前提**として要求（`.claude/rules/working-context.md` 正本）。未配線時は **Shadow Configuration 防止**のため handoff を完了扱いにできない。settings 適用は Human-owned（`sh scripts/apply-claude-settings.sh` を Human が実行）。
 
 ## handoff.md 発行（必須・Rule 5）
 
-`docs/working/templates/handoff.md` を雛形に、以下 6 要素を必ず含める:
-
-1. **要件適合確認結果**: 各 AC の PASS / FAIL / WARN（V-1 出力）
-2. **既知課題一覧**: 残課題・回避策・影響範囲
-3. **V2 候補**: 今回 scope 外の改善候補
-4. **妥協点**: 採用しなかった選択肢と理由
-5. **引き継ぎ文書**: 5 分で状況把握できるサマリ
-6. **テスト結果サマリ**: ユニット / 統合 / E2E の結果
-
-light モード以下で簡易版を採用する場合も本 6 要素のテンプレートを踏襲（該当なしは「該当なし」明記）。PR マージ後も削除しない（完了資産として保管）。
-
-## settings タスクロック
-
-handoff 完了の前提条件として `bin/plangate doctor --check-settings` PASS。未配線時は handoff を完了扱いにできない。
+`docs/working/templates/handoff.md` を雛形に発行。**6 要素の正本**は `.claude/rules/working-context.md` の「handoff（WF-05 完了資産 / Rule 5）」節および `docs/working/templates/handoff.md` を参照。light モード以下で簡易版を採用する場合も本テンプレートを踏襲（該当なしは「該当なし」明記）。PR マージ後も削除しない（完了資産）。
 
 ## Output
 
@@ -65,8 +43,13 @@ handoff 完了の前提条件として `bin/plangate doctor --check-settings` PA
 
 ## CLI 呼び出し
 
-- V-1 実行: `bin/plangate verify TASK-XXXX`
-- handoff 発行: `bin/plangate handoff TASK-XXXX`
+- V-1 機械検証: `bin/plangate validate TASK-XXXX`
+- V-3 外部 AI レビュー: `bin/plangate review TASK-XXXX --phase v3`
+- settings 検証: `bin/plangate doctor --check-settings`
+- 8 観点 eval: `bin/plangate eval TASK-XXXX`
+- metrics 収集: `bin/plangate metrics TASK-XXXX --collect|--report`
+
+> **handoff.md 発行コマンドは未実装**。skill 利用者が `docs/working/templates/handoff.md` をコピーし手動で 6 要素を記載する。
 
 ## 次フェーズへ
 

--- a/.agents/skills/local-exec-handoff/SKILL.md
+++ b/.agents/skills/local-exec-handoff/SKILL.md
@@ -11,7 +11,7 @@ PlanGate は Claude Code / Codex CLI ともローカル実行が原則。本 ski
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（current-state.md / status.md 役割分担）
+3. `.claude/rules/working-context.md`（current-state.md / status.md 役割分担の正本）
 4. `docs/working/TASK-XXXX/INDEX.md`
 5. `docs/working/TASK-XXXX/current-state.md`
 6. `docs/working/TASK-XXXX/status.md`（最終セクション）
@@ -19,28 +19,33 @@ PlanGate は Claude Code / Codex CLI ともローカル実行が原則。本 ski
 
 ## Rules
 
-- C-3 未承認なら exec 再開を拒否（`approvals/c3.json` 必須）
+- C-3 未承認なら exec 再開を拒否（`approvals/c3.json` APPROVED 必須）
 - handoff packet は **次の担当者が 1 分で再開できる粒度**
 - 機密情報（events.ndjson / 個人情報 / 認証情報）を含めない（EH-8 Privacy 準拠）
-- ツール依存（Claude Code 固有コマンド等）を含めず、bin/plangate CLI 呼び出しに統一
+- ツール依存（Claude Code 固有コマンド等）を含めず、PlanGate 共通 CLI（`bin/plangate` / `scripts/ai-dev-workflow`）に統一
 
 ## Deliverable
 
 以下を含む短い再開指示（10〜30 行程度）:
 
-1. **TASK ID**: TASK-XXXX
-2. **現在のフェーズ**: exec / verify / handoff のどれか
-3. **直近の完了タスク**: todo.md 該当行
-4. **次にやること**: 1〜3 件の具体的な手順
-5. **触ってよいファイル範囲**: plan.md「Files / Components to Touch」抜粋
-6. **触ってはいけないファイル**: forbidden_files / Hardening Override 領域
-7. **再開コマンド**: `bin/plangate <phase> TASK-XXXX` の具体形
+- **TASK ID**
+- **現在のフェーズ**: exec / verify / handoff のどれか
+- **直近の完了タスク**: todo.md 該当行
+- **次にやること**: 1〜3 件の具体的な手順
+- **触ってよいファイル範囲**: plan.md「Files / Components to Touch」抜粋
+- **触ってはいけないファイル**: forbidden_files / Hardening Override 領域
+- **再開コマンド**: `bin/plangate resume TASK-XXXX` で current-state を表示後、フェーズに応じ `bin/plangate exec/validate TASK-XXXX`
 
 ## CLI 呼び出し
 
-- 共通: `bin/plangate handoff-local TASK-XXXX` または `./scripts/ai-dev-workflow TASK-XXXX handoff-local`（未実装なら docs/working/TASK-XXXX/current-state.md を参照して手動構築）
+- セッション再開時の current-state 表示: `bin/plangate resume TASK-XXXX`
+- フェーズ確認: `bin/plangate status TASK-XXXX`
+- exec 継続: `bin/plangate exec TASK-XXXX`
+- 検証: `bin/plangate validate TASK-XXXX`
+
+> packet 自体は手動構築。専用 CLI は未提供（`bin/plangate resume` + `bin/plangate status` の出力を整形する）。
 
 ## ツール別読み替え
 
-- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。current-state.md + 本 skill 出力で十分。
+- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。`bin/plangate resume` 出力と本 skill Deliverable で十分。
 - **Claude Code**: `/working-context` skill と組み合わせて利用。

--- a/.agents/skills/manual-cloud-task/SKILL.md
+++ b/.agents/skills/manual-cloud-task/SKILL.md
@@ -5,7 +5,7 @@ description: "tracked handoff packet を使って Codex Cloud task を手動起�
 
 # Manual Cloud Task (PlanGate / optional)
 
-> **PlanGate での位置付け**: PlanGate は Claude Code / Codex CLI どちらも**ローカル実行が原則**。Codex Cloud を使う場合のみ本 skill を使う（optional）。通常の Codex CLI ローカル実行は `local-exec-handoff` skill を参照。
+> **PlanGate での位置付け**: PlanGate は Claude Code / Codex CLI どちらも**ローカル実行が原則**。Codex Cloud を使う場合のみ本 skill を使う（optional）。ローカル exec 再開には `local-exec-handoff` skill を参照。
 
 ## Read First
 

--- a/.agents/skills/plan-review-gate/SKILL.md
+++ b/.agents/skills/plan-review-gate/SKILL.md
@@ -11,60 +11,49 @@ PlanGate の **plan ゲート（C-1 セルフレビュー / C-2 外部レビュ�
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（C-3 三値ゲート / 条件付き降格 / settings タスクロック）
-4. `.claude/rules/review-principles.md`（5 観点 / Severity / C-2 2 レーン責務契約）
+3. `.claude/rules/working-context.md`（C-1 17 項目 / C-3 三値ゲート / 条件付き降格 / settings タスクロック の正本）
+4. `.claude/rules/review-principles.md`（5 観点 / Severity / C-2 2 レーン責務契約の正本）
 5. `.claude/rules/mode-classification.md`（mode 別フェーズ適用マトリクス）
 6. `docs/working/TASK-XXXX/plan.md`
 7. `docs/working/TASK-XXXX/review-self.md`（C-1）
 8. `docs/working/TASK-XXXX/review-external.md`（C-2、存在すれば）
 9. `docs/working/TASK-XXXX/approvals/c3.json`（存在すれば）
-10. `docs/working/TASK-XXXX/status.md`
 
-## C-1 セルフレビュー（17 項目）
+## C-1 セルフレビュー
 
-mode に応じて適用範囲を切り替える（mode-classification.md フェーズ適用マトリクス）:
+mode に応じた適用範囲・項目数（17 項目構成）は `.claude/rules/working-context.md` の C-1 節および `.claude/rules/mode-classification.md` フェーズ適用マトリクスを正本とする。FAIL があれば修正後再実行。evidence は FAIL 時必須（`evidence/c1-review/`）。
 
-- **ultra-light**: スキップ
-- **light**: Plan 7 項目（C1-PLAN-01〜07）のみ
-- **standard 以上**: 17 項目（Plan 7 + ToDo 5 + TestCases 3 + 結合 2）
+## C-2 外部レビュー
 
-判定: PASS / WARN / FAIL。FAIL があれば plan/todo/test-cases を修正し再実行。evidence は FAIL 時必須（`evidence/c1-review/`）。
-
-## C-2 外部レビュー（2 レーン責務）
-
-- **設計妥当性レーン**: plan/todo/test-cases/pbi-input を読む。実装コードは原則読まない。
-- **コードベース整合レーン**: 既存パターン該当箇所のみ。1 エージェントに集約。
-- 指摘は **R-NNN** 採番で `review-external.md` に追記専用集約。指摘ゼロでも「指摘なし」を明示記録。
-- 実装詳細レビューは V-3 に寄せる（plan 段階の二重精読を解消）。
+- 2 レーン責務（設計妥当性 / コードベース整合）と R-NNN 採番・追記専用集約の規約は `.claude/rules/review-principles.md` §7-bis を正本とする
+- 実行コマンド: `bin/plangate review TASK-XXXX --phase c2`（外部 AI モデル呼び出し）
+- 指摘ゼロでも「指摘なし」を明示記録
 
 ## C-2 → 確定反映 → c3.json 発行（EH-3 整合・厳守順序）
 
-1. **R-NNN を review-external.md に集約**（追記専用）
-2. **1 回確定反映**（plan/todo/test-cases へ反映。コミットメッセージに `Refs: R-NNN`）
-3. **簡易 C-1 再実行**（反映分のみ）
+1. R-NNN を `review-external.md` に集約（追記専用）
+2. 1 回確定反映（plan/todo/test-cases へ反映、コミットメッセージに `Refs: R-NNN`）
+3. 簡易 C-1 再実行
 4. **人間が APPROVED c3.json 発行**（確定後 plan の `plan_hash: sha256:...` を含む）
-5. **exec 開始**（`bin/plangate exec` は APPROVED のみ受理）
+5. exec 開始
 
 > ⚠️ **c3.json 発行は確定反映の後**。順序を逆にすると EH-3 が plan_hash mismatch で block する。
 
 ## C-3 三値判定
 
-- **APPROVE**: status.md に `## C-3 Gate: APPROVED` 記録 + c3.json 発行 → exec
-- **CONDITIONAL**: R-NNN 反映 → 簡易 C-1 → c3.json APPROVED 発行 → exec
-- **REJECT**: plan 再生成
-
-## C-3 条件付き降格（opt-in・既定 OFF）
-
-`C-1 PASS` & `C-2 critical/major=0` & `lite_eligible=true` がすべて満たされる場合のみ非同期降格候補。判定不能なら必ず同期（AC-8 安全側）。`critical` mode は原則 `lite_eligible=false`（AC-11）。Hardening Override（settings / 責務 4 分類 / Critical Infra）抵触時は Standard・同期を強制（AC-10）。
+詳細は `.claude/rules/working-context.md` の C-3 ゲート節と条件付き降格節を正本とする。`bin/plangate exec` は APPROVED の c3.json のみ受理。
 
 ## settings タスクロック
 
-V-1 / handoff 完了の前提条件として `bin/plangate doctor --check-settings` PASS を要求。未配線時は **Shadow Configuration 防止**のため C-3 通過していても完了扱いにしない。settings 適用は Human-owned（AI 不可）。
+`bin/plangate doctor --check-settings` PASS は **V-1 / handoff 完了の前提条件**（`.claude/rules/working-context.md` 正本）。plan ゲート段階での block 対象ではないが、未配線なら verify フェーズ前に Human が `sh scripts/apply-claude-settings.sh` 実行が必要なことを認識しておく。
 
 ## CLI 呼び出し
 
-- C-1 セルフレビュー実行: `bin/plangate review TASK-XXXX` 相当
-- 最終判定の機械検証: `bin/plangate gate TASK-XXXX` 相当
+- 機械検証（plan_hash / artifact 整合）: `bin/plangate validate TASK-XXXX`
+- C-2 / V-3 外部 AI レビュー: `bin/plangate review TASK-XXXX --phase {c2|v3}`
+- gate 通過判定（artifact チェック）: `./scripts/ai-dev-workflow TASK-XXXX gate`
+
+> ⚠️ **`bin/plangate review` は外部 AI モデル（gemini/codex 等）を呼び出す**。C-1 セルフレビュー目的で誤起動するとコスト発生・機密送信のリスクがある。C-1 は本 skill の手順に従い手動で実施する。
 
 ## 判定
 

--- a/.agents/skills/working-context/SKILL.md
+++ b/.agents/skills/working-context/SKILL.md
@@ -5,50 +5,38 @@ description: "PlanGate の TASK-XXXX 作業コンテキストを Progressive Dis
 
 # Working Context (PlanGate / Codex 共用)
 
-PlanGate の `docs/working/TASK-XXXX/` 配下を **L0〜L3 の Progressive Disclosure プロトコル** で読み込み、更新する skill。
+PlanGate の `docs/working/TASK-XXXX/` 配下を **L0〜L3 の Progressive Disclosure プロトコル** で読み込み、更新する skill。プロトコル詳細は `.claude/rules/working-context.md` を正本とする。
 
 ## Read First (L0 / 常に読む)
 
 1. `CLAUDE.md`
 2. `AGENTS.md`
-3. `.claude/rules/working-context.md`（ディレクトリ構造・段階別出力・handoff 必須化の正本）
+3. `.claude/rules/working-context.md`（ディレクトリ構造・段階別出力・handoff 必須化・L0〜L3 プロトコルの正本）
 4. `docs/working/TASK-XXXX/INDEX.md`
 5. `docs/working/TASK-XXXX/current-state.md`
 
-## L1（フェーズに応じて）
+## L1 / L2 / L3 の読み込み対象
 
-- plan → `pbi-input.md`
-- exec → `plan.md`, `todo.md`, `test-cases.md`
-- review → `plan.md`, `review-self.md`, `review-external.md`
-- status → `status.md`, `todo.md`
-
-## L2（根拠が必要な時のみ）
-
-- `evidence/{c1-review,c2-review,test-runs,verification,e2e}/`
-- `decision-log.jsonl`
-
-## L3（横断分析が必要な時のみ）
-
-- `status.md` 全体、他チケットの working context
+`.claude/rules/working-context.md` の「コンテキスト読み込みプロトコル（Progressive Disclosure）」表を参照（重複を避けるため本 skill では再掲しない）。
 
 ## Output
 
 - `docs/working/TASK-XXXX/status.md`（フェーズ履歴・追記）
 - `docs/working/TASK-XXXX/current-state.md`（今の状態スナップショット・上書き）
-- `docs/working/TASK-XXXX/handoff.md`（WF-05 完了時のみ、Rule 5 / 6 要素必須）
+- `docs/working/TASK-XXXX/handoff.md`（WF-05 完了時のみ、Rule 5 / 6 要素は正本参照）
 
 ## Rules
 
 - INDEX.md が無ければフォールバックで status.md を直接読む（旧形式互換）
 - セッション開始は L0 → L1 の順で必要分だけ読む（不要 read を抑制）
 - 計画からの逸脱は status.md「計画からの変更点」セクションに記録
-- 完了タスクは todo.md と status.md の両方を更新
-- current-state.md は ~20 行のスナップショット、status.md は履歴アーカイブ
-- handoff.md は WF-05 完了時に 1 回発行（6 要素: 要件適合 / 既知課題 / V2 候補 / 妥協点 / 引き継ぎ文書 / テスト結果）
+- handoff.md は WF-05 完了時に 1 回発行（6 要素は `.claude/rules/working-context.md` および `docs/working/templates/handoff.md` を正本とする）
 
 ## CLI 呼び出し
 
-- 共通: `bin/plangate context TASK-XXXX` または `./scripts/ai-dev-workflow TASK-XXXX context`
+- セッション再開時の current-state 表示: `bin/plangate resume TASK-XXXX`
+- 動的 context 取得（opt-in / Issue #199）: `bin/plangate context TASK-XXXX --phase <plan|exec|review|status>`（**`--phase` 必須**）
+- 状態確認: `bin/plangate status TASK-XXXX`
 
 ## 次フェーズへ
 


### PR DESCRIPTION
## Summary

PR #325 post-merge の Codex / Gemini 独立レビューで判明した critical 1 + major 7 件を修正。**skill 側を実 CLI に寄せる方針** (小範囲改修)。

## 修正内容

### 🔴 critical
- **plan-review-gate**: \`bin/plangate review\` は実は外部 AI モデル呼び出し。C-1 セルフレビュー目的で誤起動するとコスト発生・機密送信。→ 警告追加、C-1 は手動実施と明記。

### 🟠 major
- 架空 CLI 6 件 (brainstorm/plan/gate/verify/handoff/handoff-local) を実在コマンドへ置換
- settings タスクロックを ai-dev-exec 開始条件 → ai-dev-verify (V-1/handoff 完了条件) へ移動 (正本整合)
- \`bin/plangate context\` の \`--phase\` 必須引数を明記
- \`gate\` vs \`validate\` 命名揺れを整理
- Rule 2 ドリフト圧縮: B-1〜B-3 / C-1 17 項目 / handoff 6 要素 / V-1〜V-4 詳細を正本参照に置換

## 残課題 (本 PR スコープ外)

- \`bin/plangate exec\` の plan_hash 照合・doctor チェック未実装 (Codex 指摘・CLI 側改修要)
- Shadow Prompting: \`scripts/ai-dev-plan.sh\` の古い命令が skill を上書きする (Gemini 指摘・CLI 側改修要)

## 統計

8 files changed, +94 / -151 (-57 net, Rule 2 ドリフト圧縮効果)

## レビュー

Codex / Gemini に独立レビュー依頼済 (PR #325 post-merge 時点)。本 PR は両者指摘の反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)