### PR TITLE
docs: PR #325/#327/#330 反映 — 新 skill 3 本・新 env var 言及追加

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,10 +10,13 @@
 | `ai-dev-plan` | PBI INPUT PACKAGE から `plan.md` `todo.md` `test-cases.md` を作る |
 | `plan-review-gate` | C-1 / C-2 / C-3 の判定と exec 可否を確認する |
 | `manual-cloud-task` | tracked handoff packet を使って手動 Cloud task を起動する |
-| `working-context` | ローカル ticket コンテキストと Cloud handoff packet の橋渡し |
+| `working-context` | ローカル ticket コンテキストと Cloud handoff packet の橋渡し（L0〜L3 Progressive Disclosure） |
+| `ai-dev-exec` | C-3 APPROVED 後の TDD 実行フェーズ（plan_hash 整合 + c3.json APPROVED が前提）|
+| `ai-dev-verify` | V-1〜V-4 受け入れ検査と handoff.md 発行（Rule 5 / 6 要素必須）|
+| `local-exec-handoff` | ローカル exec 再開・ツール間引き継ぎ用の短い指示パケット（Cloud 不使用時）|
 | `plangate-setup` | PlanGate 初期セットアップを対話的に進めるためのチェックリスト・5 要素対応観点（TASK-0107 / Claude Code + Codex CLI 共用）|
 
-Codex CLI の標準入口は `./scripts/ai-dev-workflow TASK-XXXX brainstorm|plan|gate|prepare-cloud|exec|status|sync-cloud`。
+Codex CLI の標準入口は `./scripts/ai-dev-workflow TASK-XXXX brainstorm|plan|gate|exec|prepare-cloud|sync-cloud`。verify 系は `bin/plangate validate|review|eval|metrics TASK-XXXX` を併用する。
 本 skill (`plangate-setup`) は Codex 用 agent `.codex/agents/setup_coordinator.toml` から参照される。
 
 ## v7 ハイブリッドアーキテクチャ対応スキル（Claude Code / Codex CLI 共用）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ PlanGate の主要リリース履歴。
 
 このファイルは各リリース時点の内容を記録するものであり、この pull request の差分一覧ではない。
 
+## Unreleased
+
+### Added
+
+- `.agents/skills/` 配下に Codex CLI / Claude Code 共用の PlanGate ワークフロー skill 3 本を新設（#325 7601efb）
+  - `ai-dev-exec`: C-3 APPROVED 後の TDD exec phase（plan_hash 整合 + c3.json APPROVED 前提）
+  - `ai-dev-verify`: V-1〜V-4 受け入れ検査と handoff.md 発行（Rule 5 / 6 要素必須）
+  - `local-exec-handoff`: ローカル exec 再開・ツール間引き継ぎ用の短い指示パケット
+- `scripts/ai-dev-plan.sh` に環境変数追加（#330 efd86d0）
+  - `PLANGATE_PLAN_LEGACY=1`: 旧挙動（C-2 同パス作成 + Cloud handoff draft 強制）を保持（後方互換）
+  - `PLANGATE_CLOUD_HANDOFF=1`: 新挙動でも Cloud handoff draft を生成（Codex Cloud 利用時のみ）
+
+### Changed
+
+- 既存 5 skill (`ai-dev-brainstorm` / `ai-dev-plan` / `plan-review-gate` / `working-context` / `manual-cloud-task`) を PlanGate 固有要素 (mode 5 段階 + lite_eligible / C-1 17 項目 / R-NNN / handoff 6 要素 / EH-3 順序 / settings タスクロック) に整合（#325 7601efb）
+- `scripts/ai-dev-plan.sh` の Shadow Prompting を解消し、`.agents/skills/ai-dev-plan/SKILL.md` の B-1 → B-2 → B-3 フローと整合（#330 efd86d0）
+  - C-2 (review-external.md) 作成を本 phase から除外し `plan-review-gate` skill / `bin/plangate review --phase c2` に委譲
+  - Mode 5 段階判定 + `lite_eligible` を plan.md 必須セクションに追加
+- skill ↔ 実 CLI 整合（#327 6e31845）
+  - 架空 CLI コマンド (brainstorm/plan/gate/verify/handoff/handoff-local) を実在コマンドに置換
+  - settings タスクロックの参照位置を `ai-dev-exec` 開始条件 → `ai-dev-verify` 完了条件に修正（正本整合）
+  - Rule 2 ドリフト圧縮: skill 本体の固有仕様を `.claude/rules` 参照に置き換え（-57 行）
+
+### Security
+
+- `plan-review-gate` skill に `bin/plangate review` 誤起動警告を追加（実は外部 AI モデル呼び出しのため、C-1 セルフレビュー目的で起動するとコスト発生・機密送信のリスク）（#327 6e31845）
+
 ## v8.9.0 - 2026-05-19
 
 feat: Reporting & Retrospective v1 + reporting 精度 follow-up — EPIC #193 完遂

--- a/docs/ai-driven-development.md
+++ b/docs/ai-driven-development.md
@@ -290,6 +290,9 @@ Prompt 3  Agent実行（workflow-conductor経由）
 
 ### Prompt 1: Plan + ToDo + Test Cases生成
 
+> **v8.9+ 補足 (#325 / #330)**: plan フェーズは `.agents/skills/ai-dev-plan/SKILL.md` の **B-1 → B-2 → B-3** フロー（B-1 確認質問 / B-2 アプローチ比較 / B-3 3 ファイル同時生成）で実行する。`scripts/ai-dev-plan.sh` は新 skill に整合済。後方互換のため `PLANGATE_PLAN_LEGACY=1` で旧挙動（C-2 同パス + Cloud handoff 強制）、`PLANGATE_CLOUD_HANDOFF=1` で新挙動 + Cloud handoff draft を選択可能。C-2 外部 AI レビューは plan フェーズ内では作成せず、`plan-review-gate` skill / `bin/plangate review --phase c2` で別実行する。
+
+
 **タイミング:** In Progressに移動した直後
 **入力:** PBI INPUT PACKAGE
 **出力:** EXECUTION PLAN + EXECUTION TODO + TEST CASES

--- a/docs/plangate.md
+++ b/docs/plangate.md
@@ -440,3 +440,28 @@ PlanGateのゲートは**PBI(チケット)1枚の中**に置きます。判断�
 - [メインコマンド定義](../.claude/commands/ai-dev-workflow.md) -- `/ai-dev-workflow`コマンド
 - [作業コンテキスト管理ルール](../.claude/rules/working-context.md) -- セッション管理
 - [レビュー判定フレーム](../.claude/rules/review-principles.md) -- レビュー原則
+
+
+## 関連環境変数
+
+### plan フェーズ (`scripts/ai-dev-plan.sh`)
+
+| 変数 | 既定 | 動作 |
+|------|------|------|
+| `PLANGATE_PLAN_LEGACY` | `0` | `1` で旧挙動（C-2 同パス作成 + Cloud handoff draft 強制）に切替（後方互換）|
+| `PLANGATE_CLOUD_HANDOFF` | `0` | `1` で新挙動でも Cloud handoff draft (`.codex/manual-cloud-task.md`) を生成 |
+
+詳細: `.agents/skills/ai-dev-plan/SKILL.md` と `scripts/ai-dev-plan.sh`。
+
+### Codex CLI / Claude Code 共用 skill
+
+`.agents/skills/` 配下に PlanGate ワークフロー専用 skill を配置:
+
+- `ai-dev-brainstorm` / `ai-dev-plan` / `plan-review-gate`: brainstorm → plan → C-1/C-2/C-3 gate
+- `ai-dev-exec`: exec phase (c3.json APPROVED + plan_hash 整合が前提)
+- `ai-dev-verify`: V-1〜V-4 + handoff.md 発行 (settings タスクロックは本 phase で検証)
+- `working-context`: L0〜L3 Progressive Disclosure
+- `manual-cloud-task`: Codex Cloud 利用時の handoff packet (optional)
+- `local-exec-handoff`: ローカル exec 再開パケット
+
+skill 一覧は `.agents/skills/README.md` を参照。


### PR DESCRIPTION
## Summary

Codex + Gemini 並列ドキュメント監査で判明した **major 4 件** を解消。直近 3 PR (#325/#327/#330) の skill 整備・CLI 整合・Shadow Prompting 修正の内容を、ユーザ向けドキュメントに反映。

## 変更内容

| ファイル | 内容 |
|---------|------|
| \`.agents/skills/README.md\` | ai-dev-exec / ai-dev-verify / local-exec-handoff の 3 行を skill テーブルに追加。Codex CLI 入口の説明に verify 系 CLI を追記 |
| \`CHANGELOG.md\` | \`## Unreleased\` セクション新設、PR #325/#327/#330 を Added/Changed/Security に整理 |
| \`docs/plangate.md\` | \`## 関連環境変数\` セクション新設、PLANGATE_PLAN_LEGACY / PLANGATE_CLOUD_HANDOFF の動作表 + 共用 skill 一覧 |
| \`docs/ai-driven-development.md\` | \`### Prompt 1\` に v8.9+ 補足追加 (B-1→B-2→B-3 / env var / C-2 別フェーズ化) |

## レビュー履歴

- Codex 独立レビュー: 観点 2/3/4/6 で MAJOR 確認 (本 PR で解消)
- Gemini 独立レビュー: 同 4 観点 + 観点 7 (handoff 要素数表現) を MAJOR と指摘
  - 観点 7 は v8.6.0+ Metrics summary が「任意」扱いで意味的乖離なし → wording cleanup のみ別 PBI に残置

## 残課題 (本 PR スコープ外)

- README.md / CLAUDE.md / AGENTS.md の top-level skill 言及 (Codex 監査で MAJOR 該当なし判定)
- handoff template の 6 vs 7 要素 wording cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)