### PR TITLE
docs(TASK-0110): plan/todo/test-cases/review-self 新規生成 (#301 follow-up)

### DIFF
--- a/docs/working/TASK-0110/INDEX.md
+++ b/docs/working/TASK-0110/INDEX.md
@@ -1,0 +1,30 @@
+# TASK-0110 INDEX
+
+- **Title**: skip-decision-log.jsonl の一括 acknowledge と repo 保全
+- **Issue**: [#301](https://github.com/s977043/plangate/issues/301)
+- **Mode**: light
+- **Phase**: B 完了 (plan / todo / test-cases / review-self 揃った)
+- **Generated**: 2026-05-25
+- **Status**: C-3 待ち (Human-owned)
+
+## ファイル一覧
+
+| ファイル | 役割 | 状態 |
+|---------|------|------|
+| pbi-input.md | A: PBI INPUT PACKAGE | ✅ |
+| plan.md | B: EXECUTION PLAN | ✅ |
+| todo.md | B: EXECUTION TODO | ✅ |
+| test-cases.md | B: テストケース | ✅ |
+| review-self.md | C-1: セルフレビュー | ✅ PASS |
+| approvals/c3.json | C-3 ゲート判定 | ⏳ 未発行 (Human) |
+| handoff.md | WF-05 完了パッケージ | ⏳ exec 完了後 |
+
+## 次のステップ
+
+Human が plan/todo/test-cases/review-self をレビュー → C-3 ゲート (approvals/c3.json 発行) → AI が exec 着手 (T-01..T-06)。
+
+## plan_hash (post-merge 予測)
+
+```
+(merge 後に sha256sum docs/working/TASK-0110/plan.md で算出)
+```

--- a/docs/working/TASK-0110/current-state.md
+++ b/docs/working/TASK-0110/current-state.md
@@ -1,0 +1,24 @@
+# TASK-0110 current-state
+
+> 配置: `docs/working/TASK-0110/current-state.md`
+
+## Phase: B 完了
+
+- B: plan / todo / test-cases / review-self 生成済
+- 次: C-3 ゲート (Human-owned)
+
+## ブロッカー
+
+なし
+
+## 次の Step
+
+1. Human が C-3 ゲート判定
+2. C-3 APPROVED → AI が exec 着手 (T-01..T-06)
+3. exec 完了 → handoff → C-4 → merge
+4. merge 後 Human が `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by s977043` 実行
+
+## 関連
+
+- Issue: #301
+- 出自: #300 で除外された follow-up

--- a/docs/working/TASK-0110/pbi-input.md
+++ b/docs/working/TASK-0110/pbi-input.md
@@ -1,0 +1,56 @@
+# TASK-0110 PBI INPUT PACKAGE
+
+> Issue: [#301](https://github.com/s977043/plangate/issues/301)
+> 出自: #300 で除外された follow-up（gemini-code-assist critical 指摘実測確認）
+
+## Context / Why
+
+`docs/working/_audit/skip-decision-log.jsonl` (148 record / 2026-05-25 時点) は全 entry が `acknowledged_by:null` 状態で、`scripts/check-skip-acknowledged.sh` (CI required "SKIP_REASON 追認") が exit 1 となるため repo に保全できない。acknowledge 追記は Human-owned のため、AI は batch acknowledge **スクリプト + 適用手順 + 監査** の作成までを担当し、適用は Human が実施する。
+
+## What (Scope)
+
+### In scope
+
+- `scripts/batch-acknowledge-skip-decisions.py` (新規): jsonl を読んで `acknowledged_by` `acknowledged_at` を一括追記 (in-place atomic RMW)。AI 実装可
+- 適用前後の **CI "SKIP_REASON 追認" が PASS する** ことを検証する手順書
+- dry-run / production mode 分岐
+- 適用 dry-run 結果 (evidence/) と diff サマリ
+- documented limitation: AI は適用しない、Human が CLI 実行
+
+### Out of scope
+
+- `check-skip-acknowledged.sh` 仕様変更 (現行 strict 維持)
+- skip エントリの prune / deletion (#301 Approach (c) は将来)
+- 新規 SKIP 記録の都度追認フロー変更 (#301 (b) は将来)
+
+## 受入基準
+
+- AC-1: `scripts/batch-acknowledge-skip-decisions.py --dry-run` で全 `acknowledged_by:null` を検出、追記予定 entry 数 / sample 出力
+- AC-2: `--apply --acknowledged-by <name>` で実 jsonl を atomic 更新 (元 file は `.bak` 保持)
+- AC-3: 適用後の jsonl で `scripts/check-skip-acknowledged.sh` が PASS (exit 0)
+- AC-4: schema 互換性: 既存 entry の他フィールド (ts, run_id, hook, reason 等) が一切変更されない (byte-equal except 2 field)
+- AC-5: `--apply` は明示 `--acknowledged-by` 必須 (空文字 reject)
+- AC-6: dry-run 結果と evidence サマリを `docs/working/TASK-0110/evidence/` に保存
+- AC-7: `tests/extras/ta-14-skip-acknowledge.sh` で fixture jsonl に対する batch 動作を unit test
+
+## Notes from Refinement
+
+- Approach (a) 一括追認 を採用 (#301 候補のうち最も影響が予測可能)
+- 適用は Human-owned (AI 不可): スクリプト作成 + dry-run までが AI 担当
+- 適用後の `acknowledged_at` は **batch-timestamp** で統一 (個別の record timestamp とは区別)
+
+## Estimation
+
+### Risks
+
+- 既存 entry の意味喪失 (一括追認で個別 reason 点検が形骸化) → mitigation: dry-run 出力に reason 集計を含め、Human が点検対象を選別可能に
+- atomic RMW 失敗で jsonl 破損 → mitigation: `.bak` 保持 + os.replace + 適用前 schema 検証
+
+### Unknowns
+
+- 148 record の reason 分布 (EH-3 SKIP vs 他) — dry-run で測定
+
+### Assumptions
+
+- `check-skip-acknowledged.sh` 仕様は不変
+- 新規 SKIP 記録は今後 C-3/C-4 都度追認 (本 PBI 範囲外)

--- a/docs/working/TASK-0110/plan.md
+++ b/docs/working/TASK-0110/plan.md
@@ -1,0 +1,77 @@
+# TASK-0110 EXECUTION PLAN
+
+> Source: pbi-input.md / GitHub issue #301 / Mode: **light**
+> Generated: 2026-05-25 / Codex 提案順位 B (2026-05-25)
+
+## Goal
+
+`docs/working/_audit/skip-decision-log.jsonl` の 148 record (全 `acknowledged_by:null`) を一括追認するためのスクリプトと適用手順を整備し、CI "SKIP_REASON 追認" が PASS する状態に到達する。**適用は Human-owned**、AI はスクリプト + dry-run + 検証手順までを担当。
+
+## Constraints / Non-goals
+
+### Constraints
+- AI は `acknowledged_by` を発行しない (適用は Human の CLI 実行)
+- 既存 entry の `acknowledged_by` / `acknowledged_at` 以外のフィールドは一切変更しない (byte-equal except 2 field)
+- `check-skip-acknowledged.sh` 仕様変更しない (strict 維持)
+- 既存テスト regression なし (tests/run-tests.sh + tests/hooks/run-tests.sh)
+
+### Non-goals
+- skip エントリの prune / deletion (#301 (c))
+- 新規 SKIP 記録の都度追認 (#301 (b))
+- check-skip-acknowledged.sh 仕様変更
+
+## Approach Overview
+
+(1) `scripts/batch-acknowledge-skip-decisions.py` を新規作成 (dry-run / apply 分岐 / atomic RMW with .bak)、(2) `tests/extras/ta-14-skip-acknowledge.sh` で fixture jsonl に対する unit test、(3) dry-run を実 log で実行し reason 分布を evidence/ に保存、(4) `docs/ai/skip-acknowledge-cli.md` で Human 適用手順を documented。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 Checkpoint |
+|---|------|--------|-------|------|--------------|
+| 1 | **準備**: skip-decision-log.jsonl の現状調査、schema 確認、check-skip-acknowledged.sh 既存実装読解 | 調査メモ | AI | low | 既存資産マップ完成 |
+| 2 | **T-02**: `scripts/batch-acknowledge-skip-decisions.py` 新規。引数 `--dry-run` / `--apply --acknowledged-by NAME` / `--log PATH`。atomic RMW (.bak 保持 + os.replace) | scripts/batch-acknowledge-skip-decisions.py | AI | medium | dry-run / apply 両動作、fixture で byte-equal except 2 field |
+| 3 | **T-03**: `tests/extras/ta-14-skip-acknowledge.sh` unit test 追加 (fixture jsonl 3 case: 全 null / 一部 null / 全 ack 済) | tests/extras/ta-14-skip-acknowledge.sh | AI | low | tests/run-tests.sh PASS + 新 case 全 PASS |
+| 4 | **T-04**: 実 log で dry-run 実行 → evidence/ に reason 分布 + 追記予定 entry 数を保存 | docs/working/TASK-0110/evidence/dry-run-result.md | AI | low | 148 record 全件検出確認 |
+| 5 | **T-05**: `docs/ai/skip-acknowledge-cli.md` 運用ガイド作成 (Human が適用する手順、dry-run → review → apply → CI 確認) | docs/ai/skip-acknowledge-cli.md | AI | low | Human が見て適用できる |
+| 6 | **T-06**: handoff.md (Rule 5) + V-1 | docs/working/TASK-0110/handoff.md | AI | low | AC-1..7 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `scripts/batch-acknowledge-skip-decisions.py` | 新規 |
+| `tests/extras/ta-14-skip-acknowledge.sh` | 新規 |
+| `tests/run-tests.sh` | dispatcher 追記 |
+| `docs/ai/skip-acknowledge-cli.md` | 新規 (Human 適用ガイド) |
+| `docs/working/TASK-0110/evidence/dry-run-result.md` | 新規 |
+| `docs/working/TASK-0110/handoff.md` | WF-05 |
+
+> **適用される側** (`docs/working/_audit/skip-decision-log.jsonl`) は AI 不可。Human が `--apply` 実行時に変更。
+
+## Testing Strategy
+
+- **Unit**: fixture jsonl 3 case (全 null / 一部 null / 全 ack 済) で batch スクリプト動作
+- **Byte-equal 検証**: dry-run + apply で `--dry-run | sort` と適用後 `--check | sort` が一致 (acknowledged_by/at 2 field のみ差分)
+- **CI**: 既存 `tests/run-tests.sh` 維持、新 case 追加
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| atomic RMW 失敗で jsonl 破損 | medium | .bak 保持 + os.replace pattern (TASK-0106 で実証済) |
+| 既存 entry の他フィールド意図せず変更 | medium | byte-equal except 2 field を test で機械検証 |
+| 一括追認で個別 reason 点検が形骸化 | low | dry-run 出力に reason 集計を含め、Human が点検対象選別可能 |
+| Human が `--acknowledged-by` 空で実行 | low | 空文字 reject + 必須引数 validation |
+
+## Mode 判定
+
+**light**
+
+- 変更ファイル数: 5-6
+- 受入基準数: 7
+- 変更種別: スクリプト追加 + テスト + ドキュメント
+- リスク: 中 (atomic RMW + 監査ファイル変更スクリプト)
+- ロールバック: 容易 (.bak 復元)
+- 影響範囲: skip-decision-log.jsonl の整備のみ、承認境界不変
+
+→ light で進行。`lite_eligible=false` (新規スクリプト + 監査ファイル操作で完全な既存パターン踏襲ではない)

--- a/docs/working/TASK-0110/plan.md
+++ b/docs/working/TASK-0110/plan.md
@@ -11,6 +11,10 @@
 
 ### Constraints
 - AI は `acknowledged_by` を発行しない (適用は Human の CLI 実行)
+- **R-001 timing 確定**: Human は **PR ブランチで `--apply` 実行 → 変更を同一 PR にコミット (apply commit) → CI PASS 確認後 merge**。AC-3 は PR 上の最終 commit で評価
+- **R-002 byte-equal 実装契約**: JSON parse→dump せず、既存行を raw line として読み、`acknowledged_by` / `acknowledged_at` の 2 field のみを **既存 key 順を維持して置換/追加** する line-preserving 方式を採用 (key order / spacing / escape / trailing newline すべて保持)
+- **R-004 C-3 同期固定**: 監査ログ一括変更 CLI のため、mode=light でも **C-3 同期固定** (非同期降格なし)
+- **R-005**: `acknowledged_at` は ISO 8601 UTC `YYYY-MM-DDTHH:MM:SSZ`
 - 既存 entry の `acknowledged_by` / `acknowledged_at` 以外のフィールドは一切変更しない (byte-equal except 2 field)
 - `check-skip-acknowledged.sh` 仕様変更しない (strict 維持)
 - 既存テスト regression なし (tests/run-tests.sh + tests/hooks/run-tests.sh)
@@ -22,14 +26,16 @@
 
 ## Approach Overview
 
-(1) `scripts/batch-acknowledge-skip-decisions.py` を新規作成 (dry-run / apply 分岐 / atomic RMW with .bak)、(2) `tests/extras/ta-14-skip-acknowledge.sh` で fixture jsonl に対する unit test、(3) dry-run を実 log で実行し reason 分布を evidence/ に保存、(4) `docs/ai/skip-acknowledge-cli.md` で Human 適用手順を documented。
+(1) `scripts/batch-acknowledge-skip-decisions.py` を新規作成 (dry-run / apply 分岐 / **raw-line-preserving atomic RMW with .bak**)、(2) `tests/extras/ta-14-skip-acknowledge.sh` で fixture jsonl に対する unit test (**byte-equal except 2 field を機械検証**)、(3) dry-run を実 log で実行し reason 分布を evidence/ に保存 (**event: EH-3_SKIP 優先スキャン**)、(4) `docs/ai/skip-acknowledge-cli.md` で Human 適用手順を documented (**PR ブランチで --apply → コミット → CI → merge の順を明記**)。
+
+**R-001/R-002/R-003/R-004/R-005/R-006 反映済** (review-external.md 参照)。
 
 ## Work Breakdown
 
 | # | Step | Output | Owner | Risk | 🚩 Checkpoint |
 |---|------|--------|-------|------|--------------|
 | 1 | **準備**: skip-decision-log.jsonl の現状調査、schema 確認、check-skip-acknowledged.sh 既存実装読解 | 調査メモ | AI | low | 既存資産マップ完成 |
-| 2 | **T-02**: `scripts/batch-acknowledge-skip-decisions.py` 新規。引数 `--dry-run` / `--apply --acknowledged-by NAME` / `--log PATH`。atomic RMW (.bak 保持 + os.replace) | scripts/batch-acknowledge-skip-decisions.py | AI | medium | dry-run / apply 両動作、fixture で byte-equal except 2 field |
+| 2 | **T-02 (R-002/R-005)**: `scripts/batch-acknowledge-skip-decisions.py` 新規。引数 `--dry-run` / `--apply --acknowledged-by NAME` / `--log PATH`。**raw-line-preserving 方式**: 各行を文字列として読み、line-by-line で `acknowledged_by`/`acknowledged_at` 2 field のみ既存 key 順維持で置換/追加。**ISO 8601 UTC** (`YYYY-MM-DDTHH:MM:SSZ`)。atomic RMW (.bak + os.replace) | scripts/batch-acknowledge-skip-decisions.py | AI | medium | dry-run/apply 両動作、fixture で byte-equal except 2 field を機械検証 |
 | 3 | **T-03**: `tests/extras/ta-14-skip-acknowledge.sh` unit test 追加 (fixture jsonl 3 case: 全 null / 一部 null / 全 ack 済) | tests/extras/ta-14-skip-acknowledge.sh | AI | low | tests/run-tests.sh PASS + 新 case 全 PASS |
 | 4 | **T-04**: 実 log で dry-run 実行 → evidence/ に reason 分布 + 追記予定 entry 数を保存 | docs/working/TASK-0110/evidence/dry-run-result.md | AI | low | 148 record 全件検出確認 |
 | 5 | **T-05**: `docs/ai/skip-acknowledge-cli.md` 運用ガイド作成 (Human が適用する手順、dry-run → review → apply → CI 確認) | docs/ai/skip-acknowledge-cli.md | AI | low | Human が見て適用できる |
@@ -62,6 +68,9 @@
 | 既存 entry の他フィールド意図せず変更 | medium | byte-equal except 2 field を test で機械検証 |
 | 一括追認で個別 reason 点検が形骸化 | low | dry-run 出力に reason 集計を含め、Human が点検対象選別可能 |
 | Human が `--acknowledged-by` 空で実行 | low | 空文字 reject + 必須引数 validation |
+| **PR merge と --apply の timing 矛盾 (R-001)** | medium | Human は **PR ブランチで --apply → apply コミット追加 → CI PASS → merge** の順を遵守。docs/ai/skip-acknowledge-cli.md に明記 |
+| **JSON parse→dump で既存 key order/spacing 破壊 (R-002)** | medium | raw-line-preserving 方式採用、JSON parse は validation 用のみで write には使わない |
+| **C-3 非同期降格で監査 CLI が無監視で進む (R-004)** | medium | C-3 同期固定明記、lite_eligible=false 維持 |
 
 ## Mode 判定
 

--- a/docs/working/TASK-0110/review-external.md
+++ b/docs/working/TASK-0110/review-external.md
@@ -1,0 +1,29 @@
+# TASK-0110 review-external (C-2 proactive 外部レビュー集約)
+
+> 追記専用・差分管理用。R-NNN は指摘 ID。reflected_in = 確定反映コミット。
+
+## Sources
+
+- C-2 proactive (2026-05-25): Codex (設計妥当性レーン) + Gemini (コードベース整合レーン)
+
+## 集約 (R-001..R-006)
+
+| ID | Lane | Severity | 内容 | reflected_in | status |
+|----|------|----------|------|--------------|--------|
+| R-001 (codex#1) | 設計 | major | H-02 適用 timing と AC-3 (apply 後 CI PASS) の衝突 — merge 後 apply だと PR は CI 通らない。**設計選択固定**: Human が PR ブランチで --apply 実行 → 変更を同一 PR にコミット → CI 通った後 merge | _本コミット_ | reflected |
+| R-002 (codex#2) | 設計 | major | AC-4 byte-equal except 2 field の実装契約未明確 (JSON parse→dump で key order/spacing 変わるリスク) → **既存行 JSON object を読み、key 順維持で acknowledged_by/at だけ置換/追加する raw-line-preserving 方式**を plan/test-cases に明記 | _本コミット_ | reflected |
+| R-003 (codex#3) | 設計 | minor | --apply の Human 実行証跡 (commit message に "applied by <human-name>" 等) 明示要 | _本コミット_ | reflected |
+| R-004 (codex#4) | 設計 | minor | 監査ログ一括変更 CLI のため、mode=light でも C-3 同期固定 (非同期降格なし) を plan に明記 | _本コミット_ | reflected |
+| R-005 (gemini#1) | コードベース | minor | acknowledged_at は ISO 8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`) 統一 | _本コミット_ | reflected |
+| R-006 (gemini#2) | コードベース | minor | dry-run で `event: EH-3_SKIP` 優先スキャン (将来拡張堅牢性) | _本コミット_ | reflected |
+
+## 判定サマリ
+
+| Reviewer | 判定 | 内訳 |
+|----------|------|------|
+| Codex (設計妥当性) | CONDITIONAL | major 2 + minor 2 |
+| Gemini (コードベース整合) | APPROVE | minor 2 |
+
+## 反映方針
+
+`.claude/rules/working-context.md` #234-C に従い、本コミットで plan / todo / test-cases / review-self を **1 回確定反映**。

--- a/docs/working/TASK-0110/review-self.md
+++ b/docs/working/TASK-0110/review-self.md
@@ -32,6 +32,6 @@
 | C1-TC-02 | Edge case 網羅 | PASS (空 jsonl / 破損 entry / idempotent) |
 | C1-TC-03 | 自動化可否 | PASS (TC-01..TC-09 全 自動化可) |
 
-## 判定: **PASS** — C-3 ゲート提出可能
+## 判定: **PASS** — C-3 ゲート提出可能 (C-2 proactive R-001..R-006 確定反映後 v2)
 
-総合スコア: 92 / 100。blocker 0、major 0、minor 1 (Codex/Gemini 外部レビューで proactive C-2 推奨)。
+総合スコア: **95 / 100** (C-2 反映後)。blocker 0、major 0、minor 1 (Codex/Gemini 外部レビューで proactive C-2 推奨)。

--- a/docs/working/TASK-0110/review-self.md
+++ b/docs/working/TASK-0110/review-self.md
@@ -1,0 +1,37 @@
+# TASK-0110 C-1 セルフレビュー
+
+> Source: plan.md / todo.md / test-cases.md / 17 項目チェック (light mode は Plan 7 項目のみ必須だが、本 PBI では全 17 項目実施)
+
+## Plan チェック (7 項目)
+
+| # | 項目 | 判定 | コメント |
+|---|------|------|---------|
+| C1-PLAN-01 | 受入基準網羅性 | PASS | AC-1..AC-7 全て TC マッピングあり |
+| C1-PLAN-02 | Unknowns 処理 | PASS | reason 分布は dry-run で測定 (T-04) |
+| C1-PLAN-03 | スコープ制御 | PASS | Out of scope (#301 (b)(c)) 明示 |
+| C1-PLAN-04 | テスト戦略 | PASS | Unit (fixture 3 case) + byte-equal + CI |
+| C1-PLAN-05 | Work Breakdown Output | PASS | 各 Step に Output / Owner / Risk / 🚩 明示 |
+| C1-PLAN-06 | 依存関係 | PASS | T-02→T-03/T-04→T-05→T-06 / H-02 は merge 後 |
+| C1-PLAN-07 | 動作検証自動化 | PASS | TC-04/TC-05/TC-08 で機械検証可 |
+
+## ToDo チェック (5 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TODO-01 | タスク粒度 | PASS |
+| C1-TODO-02 | depends_on 設定 | PASS |
+| C1-TODO-03 | チェックポイント設定 | PASS |
+| C1-TODO-04 | Iron Law 遵守 | PASS (AI 不可作業 = H-02 適用 を明示) |
+| C1-TODO-05 | 完了条件 | PASS |
+
+## TestCases チェック (3 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TC-01 | 受入基準との紐付き | PASS |
+| C1-TC-02 | Edge case 網羅 | PASS (空 jsonl / 破損 entry / idempotent) |
+| C1-TC-03 | 自動化可否 | PASS (TC-01..TC-09 全 自動化可) |
+
+## 判定: **PASS** — C-3 ゲート提出可能
+
+総合スコア: 92 / 100。blocker 0、major 0、minor 1 (Codex/Gemini 外部レビューで proactive C-2 推奨)。

--- a/docs/working/TASK-0110/test-cases.md
+++ b/docs/working/TASK-0110/test-cases.md
@@ -22,11 +22,13 @@
 | TC-02 | fixture jsonl で apply → 2 field のみ追記 | `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by tester --log /tmp/test.jsonl` | exit 0 + ack 済化 |
 | TC-03 | apply 後に .bak が残存 | apply 後 `ls /tmp/test.jsonl.bak` | ファイル存在 |
 | TC-04 | apply 後 check-skip-acknowledged.sh PASS | `sh scripts/check-skip-acknowledged.sh` (LOG=/tmp/test.jsonl) | exit 0 |
-| TC-05 | byte-equal except 2 field | apply 前後の jsonl を diff、acknowledged_by/at の 2 field 以外不変 | diff で 2 field のみ差分 |
+| TC-05 (R-002) | **raw-line-preserving 検証**: apply 前後の jsonl で、各行を JSON parse して `acknowledged_by`/`acknowledged_at` 2 field を除いた object を比較、さらに raw byte レベルでも 2 field の置換/追加部分のみが差分であることを確認 | `python3 scripts/_byte_equal_except_2.py before.jsonl after.jsonl` (本 PBI で簡易検証 helper も提供 or test 内で直接) | 全行で 2 field のみ差分、他 key 順・spacing 不変 |
 | TC-06 | apply で --acknowledged-by 空文字 reject | `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by "" --log /tmp/test.jsonl` | exit !=0 + reject message |
 | TC-07 | dry-run 結果が evidence/dry-run-result.md に保存 | T-04 実行後 `ls docs/working/TASK-0110/evidence/dry-run-result.md` | ファイル存在 |
 | TC-08 | ta-14 が tests/run-tests.sh から自動 discovery + PASS | `sh tests/run-tests.sh` | 全 case PASS (count 増加) |
 | TC-09 | 既に ack 済 entry は触らない (idempotent) | fixture (全 ack 済) で apply → no-op | exit 0 + 変更 0 件 |
+| **TC-10 (R-005)** | acknowledged_at が ISO 8601 UTC 形式 (`YYYY-MM-DDTHH:MM:SSZ`) | apply 後 jsonl の acknowledged_at を regex 検証 | `grep -E 'acknowledged_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' fixture-applied.jsonl` 該当 |
+| **TC-11 (R-006)** | dry-run 出力に `event: EH-3_SKIP` 件数集計を含む | `--dry-run` 出力に "EH-3_SKIP: N 件" 等の集計 line | 該当 1 行以上 |
 
 ## エッジケース
 

--- a/docs/working/TASK-0110/test-cases.md
+++ b/docs/working/TASK-0110/test-cases.md
@@ -1,0 +1,35 @@
+# TASK-0110 TEST CASES
+
+> Source: plan.md / AC-1..AC-7
+
+## 受入基準 → テストケースマッピング
+
+| AC | TC |
+|----|-----|
+| AC-1: dry-run で全 null 検出 + sample 出力 | TC-01 |
+| AC-2: apply で atomic 更新 + .bak 保持 | TC-02, TC-03 |
+| AC-3: 適用後 check-skip-acknowledged.sh PASS | TC-04 |
+| AC-4: byte-equal except 2 field | TC-05 |
+| AC-5: --apply は --acknowledged-by 必須 | TC-06 |
+| AC-6: dry-run 結果 evidence 保存 | TC-07 |
+| AC-7: ta-14 unit test 追加 | TC-08 |
+
+## テストケース一覧
+
+| ID | 内容 | コマンド/手順 | 期待 |
+|----|------|-------------|------|
+| TC-01 | fixture jsonl (全 null) で dry-run → 全件検出 + reason 分布出力 | `python3 scripts/batch-acknowledge-skip-decisions.py --dry-run --log tests/fixtures/skip-log-all-null.jsonl` | exit 0 + 検出件数 + reason 集計 |
+| TC-02 | fixture jsonl で apply → 2 field のみ追記 | `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by tester --log /tmp/test.jsonl` | exit 0 + ack 済化 |
+| TC-03 | apply 後に .bak が残存 | apply 後 `ls /tmp/test.jsonl.bak` | ファイル存在 |
+| TC-04 | apply 後 check-skip-acknowledged.sh PASS | `sh scripts/check-skip-acknowledged.sh` (LOG=/tmp/test.jsonl) | exit 0 |
+| TC-05 | byte-equal except 2 field | apply 前後の jsonl を diff、acknowledged_by/at の 2 field 以外不変 | diff で 2 field のみ差分 |
+| TC-06 | apply で --acknowledged-by 空文字 reject | `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by "" --log /tmp/test.jsonl` | exit !=0 + reject message |
+| TC-07 | dry-run 結果が evidence/dry-run-result.md に保存 | T-04 実行後 `ls docs/working/TASK-0110/evidence/dry-run-result.md` | ファイル存在 |
+| TC-08 | ta-14 が tests/run-tests.sh から自動 discovery + PASS | `sh tests/run-tests.sh` | 全 case PASS (count 増加) |
+| TC-09 | 既に ack 済 entry は触らない (idempotent) | fixture (全 ack 済) で apply → no-op | exit 0 + 変更 0 件 |
+
+## エッジケース
+
+- 空 jsonl: dry-run / apply 共に no-op (exit 0)
+- jsonl 破損 (parse error) entry: スキップ + warning 出力 (apply は abort)
+- 1 行のみの jsonl: 正常処理

--- a/docs/working/TASK-0110/todo.md
+++ b/docs/working/TASK-0110/todo.md
@@ -8,7 +8,7 @@
 - [ ] **T-01**: skip-decision-log.jsonl の schema 把握 + check-skip-acknowledged.sh 読解 + entry 件数/サンプル抽出 (owner=agent / Risk=low / 🚩 既存資産マップ完成)
 
 ### Phase 2: 実装
-- [ ] **T-02**: `scripts/batch-acknowledge-skip-decisions.py` 新規。引数 `--dry-run` / `--apply --acknowledged-by NAME` / `--log PATH`。atomic RMW (.bak + os.replace) + byte-equal except 2 field (owner=agent / Risk=medium / depends_on=T-01 / 🚩 dry-run/apply 両動作)
+- [ ] **T-02 (R-002/R-005)**: `scripts/batch-acknowledge-skip-decisions.py` 新規。**raw-line-preserving 方式** (line-by-line で 2 field のみ既存 key 順維持で置換/追加)。**ISO 8601 UTC**。atomic RMW (.bak + os.replace) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 dry-run/apply 両動作 + byte-equal except 2 field 機械検証)
 
 ### Phase 3: 検証
 - [ ] **T-03**: `tests/extras/ta-14-skip-acknowledge.sh` 新規 (fixture jsonl 3 case) + tests/run-tests.sh dispatcher 追記 (owner=agent / Risk=low / depends_on=T-02 / 🚩 tests/run-tests.sh PASS + 新 case 全 PASS)
@@ -21,7 +21,7 @@
 ## 👤 Human タスク
 
 - [ ] **H-01**: **C-3 ゲート** — plan/todo/test-cases/review-self.md 確認 → APPROVE/CONDITIONAL/REJECT → `approvals/c3.json` 発行
-- [ ] **H-02**: **適用** — `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by s977043` 実行 (AI 不可)
+- [ ] **H-02 (R-001/R-003)**: **PR ブランチで適用** — `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by s977043` をローカルで実行 → 変更を同一 PR にコミット (commit message に `applied by s977043 (TASK-0110 H-02)`) → push → CI "SKIP_REASON 追認" PASS 確認 → C-4 承認 → merge (AI 不可)
 - [ ] **H-03**: 適用後 CI で "SKIP_REASON 追認" PASS 確認
 - [ ] **H-04**: **C-4 ゲート (PR レビュー)** + **merge** (Human-owned 固定)
 

--- a/docs/working/TASK-0110/todo.md
+++ b/docs/working/TASK-0110/todo.md
@@ -1,0 +1,36 @@
+# TASK-0110 EXECUTION TODO
+
+> Source: plan.md / Mode: light / Generated: 2026-05-25
+
+## 🤖 Agent タスク
+
+### Phase 1: 準備
+- [ ] **T-01**: skip-decision-log.jsonl の schema 把握 + check-skip-acknowledged.sh 読解 + entry 件数/サンプル抽出 (owner=agent / Risk=low / 🚩 既存資産マップ完成)
+
+### Phase 2: 実装
+- [ ] **T-02**: `scripts/batch-acknowledge-skip-decisions.py` 新規。引数 `--dry-run` / `--apply --acknowledged-by NAME` / `--log PATH`。atomic RMW (.bak + os.replace) + byte-equal except 2 field (owner=agent / Risk=medium / depends_on=T-01 / 🚩 dry-run/apply 両動作)
+
+### Phase 3: 検証
+- [ ] **T-03**: `tests/extras/ta-14-skip-acknowledge.sh` 新規 (fixture jsonl 3 case) + tests/run-tests.sh dispatcher 追記 (owner=agent / Risk=low / depends_on=T-02 / 🚩 tests/run-tests.sh PASS + 新 case 全 PASS)
+- [ ] **T-04**: 実 log で dry-run 実行 → evidence/dry-run-result.md に reason 分布保存 (owner=agent / Risk=low / depends_on=T-02 / 🚩 148 record 全件検出)
+
+### Phase 4: 完了
+- [ ] **T-05**: `docs/ai/skip-acknowledge-cli.md` Human 適用ガイド作成 (owner=agent / Risk=low / depends_on=T-04 / 🚩 Human が読んで適用可能)
+- [ ] **T-06**: handoff.md (Rule 5 必須 6 要素) + V-1 (test-cases 全件突合) (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..7 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: **C-3 ゲート** — plan/todo/test-cases/review-self.md 確認 → APPROVE/CONDITIONAL/REJECT → `approvals/c3.json` 発行
+- [ ] **H-02**: **適用** — `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by s977043` 実行 (AI 不可)
+- [ ] **H-03**: 適用後 CI で "SKIP_REASON 追認" PASS 確認
+- [ ] **H-04**: **C-4 ゲート (PR レビュー)** + **merge** (Human-owned 固定)
+
+## ⚠️ 依存関係
+
+- T-02..T-06 は H-01 (C-3) 通過後にのみ着手可
+- T-01 (read-only 調査) は C-3 前可
+- H-02 (適用) は本 PBI の merge 後に Human が実行
+
+## 完了条件
+
+全 T + handoff 6 要素 + AC-1..7 PASS + 既存テスト regression なし


### PR DESCRIPTION
Codex 提案順位 B (#301 plan 生成) として実施。skip-decision-log.jsonl の一括 acknowledge スクリプト作成と適用手順整備を扱う PBI を B フェーズまで完了。

## 範囲

- AI: batch スクリプト + dry-run + 検証手順 (実装可)
- Human: 適用 (`--apply --acknowledged-by`) (Iron Law)

## Mode

light (5-6 ファイル変更 / AC 7 件 / atomic RMW pattern は TASK-0106 で実証済を再利用)

## 次

Human が C-3 ゲート判定 → APPROVED で exec 着手可。

Refs: #301, #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)