### PR TITLE
fix(.codex/agents): 18/23 agent TOML に Claude markdown 参照を追加 (#335)

### DIFF
--- a/.codex/agents/acceptance_tester.toml
+++ b/.codex/agents/acceptance_tester.toml
@@ -16,4 +16,6 @@ developer_instructions = """
 - evidence を test-runs/ に保存
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/acceptance-tester.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/agile_coach.toml
+++ b/.codex/agents/agile_coach.toml
@@ -17,4 +17,6 @@ developer_instructions = """
 
 スタック: Scrum / Kanban / PlanGate v5-v6
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/agile-coach.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/claude_code_reviewer.toml
+++ b/.codex/agents/claude_code_reviewer.toml
@@ -25,4 +25,6 @@ developer_instructions = """
 - Codexのread-onlyサンドボックスではclaude CLIがAPI接続できない
 - そのためsandbox_modeはworkspace-writeに設定済み
 - それでもAPI接続がブロックされる場合は、エラーメッセージをそのまま返す
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/claude-code-reviewer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/code_optimizer.toml
+++ b/.codex/agents/code_optimizer.toml
@@ -15,4 +15,6 @@ developer_instructions = """
 - テスト再実行で回帰がないことを保証
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/code-optimizer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/documentation_writer.toml
+++ b/.codex/agents/documentation_writer.toml
@@ -22,4 +22,6 @@ developer_instructions = """
 - 冗長な説明を避け、実用的な内容を優先する
 
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/documentation-writer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/explorer_agent.toml
+++ b/.codex/agents/explorer_agent.toml
@@ -20,4 +20,6 @@ developer_instructions = """
 - .codex/ 配下のCodex設定
 
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/explorer-agent.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -16,4 +16,6 @@ developer_instructions = """
 - スコープ外の改善・リファクタリングは禁止
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/implementer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/linter_fixer.toml
+++ b/.codex/agents/linter_fixer.toml
@@ -16,4 +16,6 @@ developer_instructions = """
 - テスト回帰がないことを確認
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/linter-fixer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/migration_agent.toml
+++ b/.codex/agents/migration_agent.toml
@@ -16,4 +16,6 @@ developer_instructions = """
 - テスト回帰がないことをステップごとに確認
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/migration-agent.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/orchestrator.toml
+++ b/.codex/agents/orchestrator.toml
@@ -23,4 +23,6 @@ developer_instructions = """
 - explorer_agent: コードベース探索・調査（読み取り専用）
 
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/orchestrator.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/project_planner.toml
+++ b/.codex/agents/project_planner.toml
@@ -18,4 +18,6 @@ developer_instructions = """
 
 成果物: plan.md / todo.md（docs/working/TASK-XXXX/ 配下）
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/project-planner.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/prompt_engineer.toml
+++ b/.codex/agents/prompt_engineer.toml
@@ -15,4 +15,6 @@ developer_instructions = """
 - skill-designer が新規作成、prompt-engineer が既存改善を担当
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/prompt-engineer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/research_analyst.toml
+++ b/.codex/agents/research_analyst.toml
@@ -15,4 +15,6 @@ developer_instructions = """
 - 候補比較テーブルと推奨・リスク・次のアクションを含むレポートを出力
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/research-analyst.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/retrospective_analyst.toml
+++ b/.codex/agents/retrospective_analyst.toml
@@ -15,4 +15,6 @@ developer_instructions = """
 - 具体的な改善アクションを提案（次回 plan 向け）
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/retrospective-analyst.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/scrum_master.toml
+++ b/.codex/agents/scrum_master.toml
@@ -18,4 +18,6 @@ developer_instructions = """
 
 スタック: Scrum Guide 2020 / PlanGate v5-v6
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/scrum-master.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/setup_coordinator.toml
+++ b/.codex/agents/setup_coordinator.toml
@@ -77,4 +77,6 @@ cwd が `*/docs/working/TASK-[0-9]+` 配下なら抽出。それ以外は `ls -d
 - doctor 単一検証源: `bin/plangate doctor --json` / `bin/plangate doctor --check-settings`
 
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/setup-coordinator.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/skill_designer.toml
+++ b/.codex/agents/skill_designer.toml
@@ -23,4 +23,6 @@ developer_instructions = """
 - Claude Code 側の参考資産: .claude/skills/（テンプレートは .claude/skills/skill-creator/ を参照）
 
 プロジェクト指示は docs/ai/project-rules.md（正本）を第一に参照し、その上で AGENTS.md を入口として参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/skill-designer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """

--- a/.codex/agents/spec_writer.toml
+++ b/.codex/agents/spec_writer.toml
@@ -16,4 +16,6 @@ developer_instructions = """
 - brainstorming スキルと連携可能
 
 プロジェクト指示は AGENTS.md と CLAUDE.md を参照。日本語でやり取りする。
+
+詳細定義 (rich content / Iron Law / Common Rationalizations / Allowed Context): `.claude/agents/spec-writer.md` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
 """


### PR DESCRIPTION
## Summary

Codex parity Gap 3 (#335) の真の課題 — `.codex/agents/*.toml` の thin pointer 設計で **18/23 agent が Claude 側 rich content への明示参照を欠いていた** — を解消。

## 背景

#335 当初は「ファイル欠落」と推測していたが、検証で 23 agent 定義が既に存在することが判明。ただし Codex 側は Claude markdown の **7-15% の thin pointer** であり、Iron Law / Common Rationalizations / Allowed Context 等の詳細指示は Claude 側にしかない。

| agent | Claude 行数 | Codex 行数 | 比 |
|------|-----------|-----------|---|
| workflow_conductor | 516 | 39 | 7% |
| project_planner | 177 | 21 | 11% |
| (他 21 agent も同様) | | | 13-15% |

## 修正

- 全 18 stub TOML の `developer_instructions` 末尾に Claude markdown 参照行を追加
- 既に参照済の 5 agent (implementation_agent / qa_reviewer / requirements_analyst / solution_architect / workflow_conductor) は skip
- TOML 構文 (python3 tomllib) PASS

## 検証

- ✅ 全 23 agent が `.claude/agents/<name>.md` への参照を持つ
- ✅ TOML 構文 23/23 PASS

## 関連

- Closes #335 (再評価後の scope に対応)
- 親 EPIC: #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)