### PR TITLE
docs(TASK-0111): plan/todo/test-cases/review-self 新規生成 (#295 follow-up)

### DIFF
--- a/docs/working/TASK-0111/INDEX.md
+++ b/docs/working/TASK-0111/INDEX.md
@@ -1,0 +1,24 @@
+# TASK-0111 INDEX
+
+- **Title**: pages/ の Pages 配信構造を恒久改善 (pages → docs/pages 移設)
+- **Issue**: [#295](https://github.com/s977043/plangate/issues/295)
+- **Mode**: standard
+- **Phase**: B 完了 (plan / todo / test-cases / review-self 揃った)
+- **Generated**: 2026-05-25
+- **Status**: C-3 待ち (Human-owned)。**proactive C-2 推奨** (structural change)
+
+## ファイル一覧
+
+| ファイル | 役割 | 状態 |
+|---------|------|------|
+| pbi-input.md | A: PBI INPUT PACKAGE | ✅ |
+| plan.md | B: EXECUTION PLAN | ✅ |
+| todo.md | B: EXECUTION TODO | ✅ |
+| test-cases.md | B: テストケース | ✅ |
+| review-self.md | C-1: セルフレビュー | ✅ PASS (88/100) |
+| approvals/c3.json | C-3 ゲート判定 | ⏳ 未発行 (Human) |
+| handoff.md | WF-05 完了パッケージ | ⏳ exec 完了後 |
+
+## 次のステップ
+
+(推奨) AI proactive C-2 (Codex+Gemini) → Human C-3 → exec (T-01..T-07) → Human Jekyll local build (T-06) → handoff → C-4 → merge → Human 公開サイト確認 (AC-4)

--- a/docs/working/TASK-0111/current-state.md
+++ b/docs/working/TASK-0111/current-state.md
@@ -1,0 +1,15 @@
+# TASK-0111 current-state
+
+## Phase: B 完了
+
+- B: plan / todo / test-cases / review-self 生成済
+- 次: (推奨) proactive C-2 → C-3 ゲート (Human-owned)
+
+## ブロッカー
+
+なし。ただし structural change のため proactive C-2 (Codex+Gemini 外部レビュー) を強く推奨。
+
+## 関連
+
+- Issue: #295
+- 出自: #293 暫定対応 follow-up

--- a/docs/working/TASK-0111/pbi-input.md
+++ b/docs/working/TASK-0111/pbi-input.md
@@ -1,0 +1,68 @@
+# TASK-0111 PBI INPUT PACKAGE
+
+> Issue: [#295](https://github.com/s977043/plangate/issues/295)
+> 出自: #293 暫定対応 (GitHub blob URL ハードコード) の gemini-code-assist 指摘 follow-up
+
+## Context / Why
+
+#293 で公開トップ `docs/index.md` の `../pages/...` リンク 404 を **GitHub blob URL (`s977043/main` ハードコード) への変更で暫定対応**した。gemini-code-assist が「フォーク・他ブランチで参照が壊れる保守性課題」を critical 指摘。
+
+GitHub Pages source は `/docs` (Jekyll) に設定済のため、リポジトリ root の `pages/` 配下は Pages 配信に含まれない。よって `docs/index.md` から `../pages/...` 相対パスで参照しても 404 になる構造的問題。
+
+## What (Scope)
+
+### Approach (3 候補から (a) を採用)
+
+| 案 | 内容 | 判定 |
+|----|------|------|
+| (a) | `pages/` を `docs/pages/` へ移設し相対パスで参照 | **採用** (AI 単独で実施可、Pages 設定変更不要) |
+| (b) | Pages source を `/docs` → `/` 変更 or GitHub Actions ビルドで pages/ も配信 | 採用しない (Pages 設定変更は Human-owned + リポジトリ全体の rebuild リスク) |
+| (c) | Jekyll `site.github.repository_url` で動的 URL 生成 | 採用しない (#293 で既に近い形を実装、依然 main/branch hardcode の variant が残る) |
+
+### In scope
+
+- `pages/` 配下 (`explanation/`, `guides/`, `reference/`, `index.md`) を `docs/pages/` に移設
+- 全 internal 参照を `../pages/...` ハードコード GitHub blob URL → 相対パス (`./pages/...`) に書き換え
+- `docs/_config.yml` で `pages/` を Pages 配信対象に含める確認 (Jekyll relative_links で配信)
+- 既存リダイレクト互換 (旧 `pages/explanation/...` URL からの遷移)
+- markdownlint pass + リンク健全性 CI pass
+
+### Out of scope
+
+- #293 暫定対応の差し戻し (暫定対応は維持。本 PBI で恒久版に置き換え後 cleanup)
+- root `pages/` 配下の独立配信 (採用しない)
+- Pages 設定の `/docs → /` 変更 (Human-owned + 副作用大)
+
+## 受入基準
+
+- AC-1: `docs/pages/` 配下に `explanation/`, `guides/`, `reference/`, `index.md` が存在し、root `pages/` は削除済 (or 旧位置への redirect frontmatter のみ残置)
+- AC-2: `docs/index.md` の `../pages/...` 全 GitHub blob URL 参照が `./pages/...` 相対パスに置換 (リンク健全性 CI pass)
+- AC-3: `docs/_config.yml` で `docs/pages/` が `relative_links` + `collections` 経由で配信される (markdownlint + Jekyll build 確認)
+- AC-4: 公開サイト https://s977043.github.io/PlanGate/ で docs/index.md 経由の pages/ リンクが 200 OK (Human が事後確認)
+- AC-5: フォーク / 他ブランチでも参照が壊れない (相対パスベースで `main` hardcode 不要)
+- AC-6: 旧 `pages/` 配下を参照していた他 docs (例: README, staged-adoption-guide) が新パスを参照
+- AC-7: markdownlint + reference 健全性 CI 全 PASS
+
+## Notes from Refinement
+
+- Approach (a) のみが AI 単独で実施可能 (b/c は Pages 設定変更 or 構造再設計)
+- 旧 root `pages/` を完全削除する場合、Cloudflare Pages / 他デプロイ経路の影響を確認する必要あり (調査 T-01)
+- 移設後の URL 経路 (`/pages/explanation/...` → `/docs/pages/explanation/...`) が変わるため、外部リンク被覆を grep で確認
+
+## Estimation
+
+### Risks
+
+- 外部からの旧 URL 参照 (issue/comment/blog 等) が 404 化 → mitigation: T-01 で grep 確認、必要なら redirect frontmatter で旧位置に薄 stub 残置
+- Jekyll build で collection / permalink 不整合 → mitigation: ローカル `bundle exec jekyll serve` で事前検証
+
+### Unknowns
+
+- Cloudflare Pages 等 secondary deploy がある場合の影響 (T-01 で調査)
+- pages/index.md と docs/pages/index.md の URL 経路差 (`/pages/` → `/docs/pages/` or permalink 制御)
+
+### Assumptions
+
+- GitHub Pages source は `/docs` 固定 (本 PBI で変更しない)
+- Jekyll plugins (relative_links / github_metadata) は不変
+- root `pages/` を参照する build/CI workflow は存在しない (T-01 で確認)

--- a/docs/working/TASK-0111/plan.md
+++ b/docs/working/TASK-0111/plan.md
@@ -25,18 +25,27 @@
 
 ## Approach Overview
 
-(1) T-01 影響調査 (root `pages/` 参照箇所 grep, 外部 link grep, Cloudflare 等 secondary deploy 確認)、(2) `pages/` → `docs/pages/` git mv、(3) `docs/index.md` 等の `../pages/...` を `./pages/...` 相対パスに置換、(4) `_config.yml` で配信確認、(5) Jekyll local build で事前検証 (optional)、(6) handoff。
+(1) T-01 影響調査 (root `pages/` 参照箇所 grep, 外部 link grep, `sidebars.js` / `.github/workflows/` / Cloudflare 等 secondary deploy 確認、`pages/guides/governance/documentation-management.md` の自己言及含む)、(2) `pages/` → `docs/pages/` git mv (history 保持)、(3) **全 `docs/**/*.md`** の `../pages/...` を `./pages/...` 相対パスに置換、(4) `_config.yml` で配信確認、(5) **Jekyll local build を pre-C-3 mandatory gate に格上げ** (Human が `bundle exec jekyll serve` で `/PlanGate/pages/...` 200 OK 確認)、(6) handoff。
+
+**R-001/R-002/R-003/R-004/R-005/R-006/R-007 反映済** (review-external.md 参照)。
+
+## Design Contract (R-001/R-002 確定)
+
+- **公開 URL**: GitHub Pages source=`/docs` のため、`docs/pages/foo.md` は `/PlanGate/pages/foo.html` で配信される (`/docs/` prefix なし、Jekyll permalink デフォルト挙動)
+- **旧 root `pages/` の扱い**: git mv で完全移設、root には残さない。GitHub HTTP redirect は GitHub Pages 制御外のため redirect stub は採用しない
+- **#293 GitHub blob URL の扱い**: 本 PBI で全削除して `./pages/...` 相対パスに置換 (s977043/main hardcode を除去)
+- **外部 (issue/blog) からの旧 URL 参照**: T-01 で grep 確認、影響あれば PR 本文に注記
 
 ## Work Breakdown
 
 | # | Step | Output | Owner | Risk | 🚩 Checkpoint |
 |---|------|--------|-------|------|--------------|
-| 1 | **T-01 調査**: root `pages/` 参照箇所全件 grep / Cloudflare 等 secondary deploy 確認 / 旧 URL 外部参照影響評価 | 調査メモ | AI | low | 全参照箇所マップ完成 |
+| 1 | **T-01 調査 (R-002/R-005/R-006)**: root `pages/` 参照箇所全件 grep (全 `docs/**/*.md` + `pages/guides/governance/documentation-management.md` 自己言及含む) / `sidebars.js` Docusaurus 想定参照 / `.github/workflows/` / Cloudflare 等 secondary deploy 確認 / 旧 URL 外部参照影響評価 | 調査メモ | AI | low | 全参照箇所マップ完成 |
 | 2 | **T-02**: `git mv pages/ docs/pages/` | mv 後 file 配置 | AI | low | git mv で history 保持 |
-| 3 | **T-03**: `docs/index.md` 等の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 | docs/index.md + 他参照 docs | AI | medium | 全 link が `./pages/...` 形式 + markdownlint pass |
+| 3 | **T-03 (R-004/R-005)**: **全 `docs/**/*.md`** の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 (T-01 で特定した全箇所、`pages/guides/governance/documentation-management.md` 自己言及含む) | 全 docs/**/*.md | AI | medium | 全 link が `./pages/...` 形式 + grep で blob URL ゼロ + markdownlint pass |
 | 4 | **T-04**: `docs/_config.yml` 確認 (relative_links / collections 既存設定で `docs/pages/` も配信されるか) + 必要なら microadjustment | docs/_config.yml | AI | low | Jekyll build で 200 OK 想定 |
 | 5 | **T-05 リンク健全性**: 既存 reference 健全性 CI で全 internal link 検証、外部参照は旧 URL を grep で除外 | reference 健全性 PASS | AI | medium | CI PASS |
-| 6 | **T-06 ローカル検証 (optional)**: `bundle exec jekyll serve` で事前確認 (CI 無いため AI 不可、Human 推奨) | (Human-only) | Human | low | 200 OK |
+| 6 | **T-06 ローカル検証 (R-003 mandatory pre-C-3 gate)**: Human が `bundle exec jekyll serve` で `/PlanGate/pages/...` 各 link が **200 OK を確認するまで C-3 ゲート進めない**。AI 不可、Human-owned mandatory | (Human-only) | Human | **medium** (gate 必須) | 全 link 200 OK |
 | 7 | **T-07**: handoff.md (Rule 5) + V-1 | docs/working/TASK-0111/handoff.md | AI | low | AC-1..7 PASS |
 
 ## Files / Components to Touch
@@ -66,6 +75,9 @@
 | git mv で history が失われる (rename 検出不可) | low | git mv コマンド使用 + `git log --follow` で確認 |
 | Cloudflare Pages 等 secondary deploy への影響 | low | T-01 で `.github/workflows/` 等 grep |
 | reference 健全性 CI が新パスを認識しない | low | scripts/check-reference-health.sh をローカル実行で事前確認 |
+| **公開 URL 期待が `/docs/pages/` か `/pages/` か不明 (R-001)** | resolved | Design Contract で `/PlanGate/pages/...` (Pages source=/docs ゆえ `/docs/` prefix なし) に確定 |
+| **旧 root pages/ 互換が T-01 結果依存 (R-002)** | resolved | Design Contract で git mv 完全移設、redirect stub 不採用、grep で外部参照確認 |
+| **Jekyll build optional で URL 検証なしのまま merge (R-003)** | resolved | T-06 mandatory pre-C-3 gate に格上げ |
 
 ## Mode 判定
 

--- a/docs/working/TASK-0111/plan.md
+++ b/docs/working/TASK-0111/plan.md
@@ -1,0 +1,81 @@
+# TASK-0111 EXECUTION PLAN
+
+> Source: pbi-input.md / GitHub issue #295 / Mode: **standard**
+> Generated: 2026-05-25 / Codex 提案順位 A (2026-05-25)
+
+## Goal
+
+`pages/` を `docs/pages/` へ移設し、`docs/index.md` の `../pages/...` GitHub blob URL ハードコードを相対パスに置換することで、フォーク / 他ブランチでも壊れない pages 配信構造を恒久化する。
+
+## Constraints / Non-goals
+
+### Constraints
+
+- GitHub Pages source 設定 (`/docs`) を変更しない (Human-owned 領域)
+- Jekyll plugins / `_config.yml` の plugin 構成を破壊しない
+- 既存テスト regression なし
+- markdownlint + reference 健全性 CI が PASS する範囲で実施
+
+### Non-goals
+
+- root `pages/` の独立配信
+- Pages source 変更 (#295 (b))
+- 動的 URL 生成戦略の追加 (#295 (c))
+- #293 暫定対応自体の roll back (本 PBI で natural に上書き)
+
+## Approach Overview
+
+(1) T-01 影響調査 (root `pages/` 参照箇所 grep, 外部 link grep, Cloudflare 等 secondary deploy 確認)、(2) `pages/` → `docs/pages/` git mv、(3) `docs/index.md` 等の `../pages/...` を `./pages/...` 相対パスに置換、(4) `_config.yml` で配信確認、(5) Jekyll local build で事前検証 (optional)、(6) handoff。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 Checkpoint |
+|---|------|--------|-------|------|--------------|
+| 1 | **T-01 調査**: root `pages/` 参照箇所全件 grep / Cloudflare 等 secondary deploy 確認 / 旧 URL 外部参照影響評価 | 調査メモ | AI | low | 全参照箇所マップ完成 |
+| 2 | **T-02**: `git mv pages/ docs/pages/` | mv 後 file 配置 | AI | low | git mv で history 保持 |
+| 3 | **T-03**: `docs/index.md` 等の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 | docs/index.md + 他参照 docs | AI | medium | 全 link が `./pages/...` 形式 + markdownlint pass |
+| 4 | **T-04**: `docs/_config.yml` 確認 (relative_links / collections 既存設定で `docs/pages/` も配信されるか) + 必要なら microadjustment | docs/_config.yml | AI | low | Jekyll build で 200 OK 想定 |
+| 5 | **T-05 リンク健全性**: 既存 reference 健全性 CI で全 internal link 検証、外部参照は旧 URL を grep で除外 | reference 健全性 PASS | AI | medium | CI PASS |
+| 6 | **T-06 ローカル検証 (optional)**: `bundle exec jekyll serve` で事前確認 (CI 無いため AI 不可、Human 推奨) | (Human-only) | Human | low | 200 OK |
+| 7 | **T-07**: handoff.md (Rule 5) + V-1 | docs/working/TASK-0111/handoff.md | AI | low | AC-1..7 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `pages/` (root) | 削除 (`git mv` → `docs/pages/`) |
+| `docs/pages/` (新規 from mv) | 配置 (内容変更なし) |
+| `docs/index.md` | `../pages/...` blob URL → `./pages/...` 相対パスに置換 |
+| `docs/_config.yml` | 必要なら microadjustment (collections 等) |
+| `README.md` / `README_en.md` / `staged-adoption-guide.md` 等 | 旧 `pages/` 参照箇所があれば置換 (T-01 で特定) |
+| `docs/working/TASK-0111/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- **Reference 健全性 CI**: 既存 `scripts/check-reference-health.sh` 等で internal link 検証
+- **markdownlint**: 全変更ファイル
+- **Jekyll local build (Human)**: `bundle exec jekyll serve` で `/docs/pages/...` 200 OK 確認 (CI 化は別 PBI)
+- **AC-4 公開サイト Human 事後確認**: merge + Pages rebuild 後 200 OK
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| 外部 (issue/blog) の旧 URL 参照が 404 化 | medium | T-01 で grep + 旧位置に redirect frontmatter 薄 stub 残置検討 |
+| Jekyll permalink / collection 不整合 | medium | T-04/T-06 で `_config.yml` microadjust + Human local build 検証 |
+| git mv で history が失われる (rename 検出不可) | low | git mv コマンド使用 + `git log --follow` で確認 |
+| Cloudflare Pages 等 secondary deploy への影響 | low | T-01 で `.github/workflows/` 等 grep |
+| reference 健全性 CI が新パスを認識しない | low | scripts/check-reference-health.sh をローカル実行で事前確認 |
+
+## Mode 判定
+
+**standard**
+
+- 変更ファイル数: 移設 +相対パス置換で 10-20 ファイル相当
+- 受入基準数: 7 件
+- 変更種別: ディレクトリ移設 + リンク置換 (構造変更)
+- リスク: 中 (公開サイト構造変更、外部リンク被覆)
+- ロールバック: 可能 (git revert で復元)
+- 影響範囲: docs/ 配下 + 公開サイト + 外部参照 URL
+
+→ standard で進行。`lite_eligible=false` (構造変更 + 公開サイト影響)

--- a/docs/working/TASK-0111/review-external.md
+++ b/docs/working/TASK-0111/review-external.md
@@ -1,0 +1,30 @@
+# TASK-0111 review-external (C-2 proactive 外部レビュー集約)
+
+> 追記専用・差分管理用。R-NNN は指摘 ID。
+
+## Sources
+
+- C-2 proactive (2026-05-25): Codex (設計妥当性レーン) + Gemini (コードベース整合レーン)
+
+## 集約 (R-001..R-007)
+
+| ID | Lane | Severity | 内容 | reflected_in | status |
+|----|------|----------|------|--------------|--------|
+| R-001 (codex#1) | 設計 | major | `docs/pages/` 配置後の公開 URL 期待が不整合 (`/docs/pages/...` と `/pages/...` 混在)。**確定**: Pages source=`/docs` のため公開 URL は `/PlanGate/pages/...` (Jekyll permalink で `/docs/` prefix なし)。AC-4/TC-04 をこの前提に修正 | _本コミット_ | reflected |
+| R-002 (codex#2) | 設計 | major | 旧 root `pages/` 互換方針が T-01 結果依存で未確定。**確定方針**: (i) git mv で完全移設、(ii) T-01 で外部参照 (issue/blog/comment) を grep、(iii) GitHub blob URL の旧 `pages/` 参照は #293 で既に `s977043/main` hardcode 済 → **本 PBI で全削除**、(iv) redirect stub は採用しない (Pages source=/docs のため root pages/ への HTTP redirect は GitHub Pages 制御外) | _本コミット_ | reflected |
+| R-003 (codex#3) | 設計 | major | Jekyll build を Human optional ではなく **mandatory pre-C-3 gate** に格上げ。`bundle exec jekyll serve` で /docs/pages/ 各 link が 200 OK を確認するまで C-3 ゲート進めない | _本コミット_ | reflected |
+| R-004 (codex#4) | 設計 | minor | TC-02 が `docs/index.md` 限定 → 全 `docs/**/*.md` で `../pages/` および blob URL の grep を TC-06 で実施 | _本コミット_ | reflected |
+| R-005 (gemini#1) | コードベース | minor | `pages/guides/governance/documentation-management.md` 内の自己言及 (pages/ パス例) も T-03 置換対象 | _本コミット_ | reflected |
+| R-006 (gemini#2) | コードベース | minor | `sidebars.js` (Docusaurus 想定) の参照確認を T-01 に追加 | _本コミット_ | reflected |
+| R-007 (gemini#3) | コードベース | info | `git mv` 後 `git log --follow docs/pages/index.md` で履歴継続を PR 本文に記載 | _本コミット_ | reflected |
+
+## 判定サマリ
+
+| Reviewer | 判定 | 内訳 |
+|----------|------|------|
+| Codex (設計妥当性) | CONDITIONAL | major 3 + minor 1 |
+| Gemini (コードベース整合) | APPROVE | minor 2 + info 1 |
+
+## 反映方針
+
+`.claude/rules/working-context.md` #234-C に従い、本コミットで pbi-input / plan / todo / test-cases / review-self を **1 回確定反映**。Codex major 3 件が design contract 確定に直結するため最重要。

--- a/docs/working/TASK-0111/review-self.md
+++ b/docs/working/TASK-0111/review-self.md
@@ -1,0 +1,39 @@
+# TASK-0111 C-1 セルフレビュー
+
+> Source: plan.md / todo.md / test-cases.md / 17 項目チェック (standard mode は全 17 項目必須)
+
+## Plan チェック (7 項目)
+
+| # | 項目 | 判定 | コメント |
+|---|------|------|---------|
+| C1-PLAN-01 | 受入基準網羅性 | PASS | AC-1..AC-7 全て TC マッピング |
+| C1-PLAN-02 | Unknowns 処理 | PASS | secondary deploy 影響は T-01 で測定 |
+| C1-PLAN-03 | スコープ制御 | PASS | Approach (b)(c) を Out of scope 明示 |
+| C1-PLAN-04 | テスト戦略 | PASS | reference 健全性 + markdownlint + Jekyll build (Human) |
+| C1-PLAN-05 | Work Breakdown Output | PASS | 各 Step に Output / Owner / Risk / 🚩 |
+| C1-PLAN-06 | 依存関係 | PASS | T-01→T-02→T-03/T-04→T-05→T-07 / H-02/H-04 は AI 不可 |
+| C1-PLAN-07 | 動作検証自動化 | WARN | TC-04 (公開サイト 200 OK) は AI 不可 = Human 事後確認、ローカル Jekyll build も Human 推奨 |
+
+## ToDo チェック (5 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TODO-01 | タスク粒度 | PASS |
+| C1-TODO-02 | depends_on 設定 | PASS |
+| C1-TODO-03 | チェックポイント設定 | PASS |
+| C1-TODO-04 | Iron Law 遵守 | PASS (承認境界に触れない明示) |
+| C1-TODO-05 | 完了条件 | PASS |
+
+## TestCases チェック (3 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TC-01 | 受入基準との紐付き | PASS |
+| C1-TC-02 | Edge case 網羅 | PASS |
+| C1-TC-03 | 自動化可否 | WARN (TC-04 のみ Human) |
+
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+
+総合スコア: 88 / 100。blocker 0、major 0、minor 2 (TC-04 自動化困難 / TASK-0108/0109 同様 proactive C-2 推奨)。
+
+structural change のため、C-3 前に Codex+Gemini proactive 外部レビュー (#295 (a) 採用妥当性 / secondary deploy 影響 / Jekyll permalink) を推奨。

--- a/docs/working/TASK-0111/review-self.md
+++ b/docs/working/TASK-0111/review-self.md
@@ -32,8 +32,8 @@
 | C1-TC-02 | Edge case 網羅 | PASS |
 | C1-TC-03 | 自動化可否 | WARN (TC-04 のみ Human) |
 
-## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+## 判定: **PASS** — C-3 ゲート提出可能 (C-2 proactive R-001..R-007 確定反映後 v2)
 
-総合スコア: 88 / 100。blocker 0、major 0、minor 2 (TC-04 自動化困難 / TASK-0108/0109 同様 proactive C-2 推奨)。
+総合スコア: **92 / 100** (C-2 反映後)。Codex major 3 (R-001/R-002/R-003) は design contract 確定 + T-06 mandatory pre-C-3 gate 格上げで解消。blocker 0、major 0、minor 2 (TC-04 自動化困難 / TASK-0108/0109 同様 proactive C-2 推奨)。
 
 structural change のため、C-3 前に Codex+Gemini proactive 外部レビュー (#295 (a) 採用妥当性 / secondary deploy 影響 / Jekyll permalink) を推奨。

--- a/docs/working/TASK-0111/test-cases.md
+++ b/docs/working/TASK-0111/test-cases.md
@@ -19,12 +19,15 @@
 | ID | 内容 | コマンド/手順 | 期待 |
 |----|------|-------------|------|
 | TC-01 | docs/pages/ 配下に explanation/guides/reference/index.md / root pages/ 不存在 | `test -d docs/pages/explanation && test ! -d pages/` | exit 0 |
-| TC-02 | docs/index.md に `../pages/` または GitHub blob URL なし、`./pages/` のみ | `grep -nE '\\.\\./pages/\\|github\\.com/.*/blob/.*/pages' docs/index.md` | no match (exit 1) |
+| TC-02 (R-004) | **全 `docs/**/*.md`** に `../pages/` または GitHub blob URL なし | `grep -rnE '\.\./pages/\|github\.com/.*/blob/.*/pages' docs/ | grep -v 'docs/working/'` | no match |
 | TC-03 | _config.yml で docs/pages/ が collections / relative_links 経由で配信される設定 | `cat docs/_config.yml` で確認 + Jekyll build 想定 | 設定 OK |
-| TC-04 | 公開サイト https://s977043.github.io/PlanGate/ から docs/pages/ リンクが 200 OK | manual (Human) | 全 link 200 OK |
+| TC-04 (R-001/R-003) | 公開 URL `/PlanGate/pages/...` (Pages source=/docs ゆえ `/docs/` prefix なし) で 200 OK。pre-C-3: Human が `bundle exec jekyll serve` で local 検証 / post-merge: 公開サイトで再確認 | manual (Human) | 全 link 200 OK |
 | TC-05 | docs/index.md の link が main hardcode を含まない (相対パスのみ) | `grep -nE 's977043/main\\|s977043/PlanGate/blob' docs/index.md` | no match |
-| TC-06 | README.md, staged-adoption-guide.md 等の旧 `pages/` 参照が docs/pages/ に置換済 | T-01 で特定した全 docs を grep | 全置換 確認 |
+| TC-06 (R-004/R-005) | 全 `docs/**/*.md` + `documentation-management.md` 自己言及含む全箇所が新パス参照 | `grep -rn 'pages/' docs/ | grep -v 'docs/working/' | grep -v 'docs/pages/' | grep -v './pages/'` | no match |
 | TC-07 | markdownlint + reference 健全性 CI PASS | `npx markdownlint-cli '**/*.md' && sh scripts/check-reference-health.sh` (or 同等) | exit 0 |
+
+| **TC-08 (R-006)** | `sidebars.js` 等 Docusaurus 参照ファイルが旧 pages/ を参照していないこと | `grep -n 'pages/' sidebars.js 2>/dev/null || true` | 該当なし or 新パス |
+| **TC-09 (R-007)** | git mv 後 history 継続 | `git log --follow docs/pages/index.md | head` | 移設前 commit 表示 |
 
 ## エッジケース
 

--- a/docs/working/TASK-0111/test-cases.md
+++ b/docs/working/TASK-0111/test-cases.md
@@ -1,0 +1,33 @@
+# TASK-0111 TEST CASES
+
+> Source: plan.md / AC-1..AC-7
+
+## 受入基準 → テストケースマッピング
+
+| AC | TC |
+|----|-----|
+| AC-1: docs/pages/ 存在 + root pages/ 削除 | TC-01 |
+| AC-2: ../pages/... blob URL → ./pages/... 相対パス | TC-02 |
+| AC-3: _config.yml で docs/pages/ 配信 | TC-03 |
+| AC-4: 公開サイト 200 OK | TC-04 (Human) |
+| AC-5: フォーク / 他ブランチで壊れない | TC-05 |
+| AC-6: 他 docs の旧 pages/ 参照置換 | TC-06 |
+| AC-7: markdownlint + reference 健全性 CI PASS | TC-07 |
+
+## テストケース一覧
+
+| ID | 内容 | コマンド/手順 | 期待 |
+|----|------|-------------|------|
+| TC-01 | docs/pages/ 配下に explanation/guides/reference/index.md / root pages/ 不存在 | `test -d docs/pages/explanation && test ! -d pages/` | exit 0 |
+| TC-02 | docs/index.md に `../pages/` または GitHub blob URL なし、`./pages/` のみ | `grep -nE '\\.\\./pages/\\|github\\.com/.*/blob/.*/pages' docs/index.md` | no match (exit 1) |
+| TC-03 | _config.yml で docs/pages/ が collections / relative_links 経由で配信される設定 | `cat docs/_config.yml` で確認 + Jekyll build 想定 | 設定 OK |
+| TC-04 | 公開サイト https://s977043.github.io/PlanGate/ から docs/pages/ リンクが 200 OK | manual (Human) | 全 link 200 OK |
+| TC-05 | docs/index.md の link が main hardcode を含まない (相対パスのみ) | `grep -nE 's977043/main\\|s977043/PlanGate/blob' docs/index.md` | no match |
+| TC-06 | README.md, staged-adoption-guide.md 等の旧 `pages/` 参照が docs/pages/ に置換済 | T-01 で特定した全 docs を grep | 全置換 確認 |
+| TC-07 | markdownlint + reference 健全性 CI PASS | `npx markdownlint-cli '**/*.md' && sh scripts/check-reference-health.sh` (or 同等) | exit 0 |
+
+## エッジケース
+
+- pages/ 配下に隠しファイル (.gitignore 等) がある場合: git mv で全件移設
+- 旧 pages/ 参照を含む issue / comment: redirect frontmatter で薄 stub 残置 (T-01 結果次第)
+- Jekyll permalink 衝突: T-04 で _config.yml microadjustment

--- a/docs/working/TASK-0111/todo.md
+++ b/docs/working/TASK-0111/todo.md
@@ -1,0 +1,41 @@
+# TASK-0111 EXECUTION TODO
+
+> Source: plan.md / Mode: standard / Generated: 2026-05-25
+
+## 🤖 Agent タスク
+
+### Phase 1: 準備
+- [ ] **T-01**: root `pages/` 参照箇所 (`grep -rn "pages/" --include="*.md"` 等) 全件抽出、Cloudflare Pages / .github/workflows/ 等 secondary deploy 影響評価、外部 link 影響メモ作成 (owner=agent / Risk=low / 🚩 全参照マップ完成)
+
+### Phase 2: 実装
+- [ ] **T-02**: `git mv pages/ docs/pages/` (history 保持) (owner=agent / Risk=low / depends_on=T-01 / 🚩 git log --follow で履歴追跡可)
+- [ ] **T-03**: `docs/index.md` 他の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 (T-01 で特定した全箇所) (owner=agent / Risk=medium / depends_on=T-02 / 🚩 全 link が `./pages/...` 形式 + markdownlint pass)
+- [ ] **T-04**: `docs/_config.yml` で `docs/pages/` 配信確認 (relative_links / collections 既存設定で動作するか) + 必要なら microadjustment (owner=agent / Risk=low / depends_on=T-02 / 🚩 _config.yml で `docs/pages/` 認識)
+
+### Phase 3: 検証
+- [ ] **T-05**: reference 健全性 CI を local 実行で事前確認 (`sh scripts/check-reference-health.sh` 等)、markdownlint 全 PASS (owner=agent / Risk=medium / depends_on=T-03 / 🚩 全 CI PASS)
+
+### Phase 4: 完了
+- [ ] **T-07**: handoff.md (Rule 5) + V-1 (test-cases 全件突合) (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..7 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: **C-3 ゲート** — plan/todo/test-cases/review-self.md 確認 → APPROVE/CONDITIONAL/REJECT → `approvals/c3.json` 発行
+- [ ] **H-02 (T-06)**: ローカル Jekyll build 検証 (optional, AI 不可) — `bundle exec jekyll serve` で `/docs/pages/...` 200 OK 確認
+- [ ] **H-03**: **C-4 ゲート (PR レビュー)** + **merge** (Human-owned 固定)
+- [ ] **H-04 (AC-4)**: merge 後 公開サイト https://s977043.github.io/PlanGate/ で 200 OK 確認
+
+## ⚠️ 依存関係
+
+- T-02..T-07 は H-01 (C-3) 通過後にのみ着手可
+- T-01 (read-only 調査) は C-3 前可
+- H-02 / H-04 は AI 不可、Human が個別実施
+
+## Iron Law 遵守
+
+- Edit/Write 前に PLANGATE_HOOK_TASK=TASK-0111 設定
+- docs/ 配下のみ操作、承認境界 (.claude/, scripts/hooks/, bin/plangate) には触れない
+
+## 完了条件
+
+全 T + handoff 6 要素 + AC-1..7 PASS + markdownlint pass + reference 健全性 CI PASS

--- a/docs/working/TASK-0111/todo.md
+++ b/docs/working/TASK-0111/todo.md
@@ -5,11 +5,11 @@
 ## 🤖 Agent タスク
 
 ### Phase 1: 準備
-- [ ] **T-01**: root `pages/` 参照箇所 (`grep -rn "pages/" --include="*.md"` 等) 全件抽出、Cloudflare Pages / .github/workflows/ 等 secondary deploy 影響評価、外部 link 影響メモ作成 (owner=agent / Risk=low / 🚩 全参照マップ完成)
+- [ ] **T-01 (R-002/R-005/R-006)**: root `pages/` 参照箇所 (`grep -rn "pages/" --include="*.md"` 等) 全件抽出、Cloudflare Pages / .github/workflows/ 等 secondary deploy 影響評価、外部 link 影響メモ作成 (owner=agent / Risk=low / 🚩 全参照マップ完成)
 
 ### Phase 2: 実装
 - [ ] **T-02**: `git mv pages/ docs/pages/` (history 保持) (owner=agent / Risk=low / depends_on=T-01 / 🚩 git log --follow で履歴追跡可)
-- [ ] **T-03**: `docs/index.md` 他の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 (T-01 で特定した全箇所) (owner=agent / Risk=medium / depends_on=T-02 / 🚩 全 link が `./pages/...` 形式 + markdownlint pass)
+- [ ] **T-03 (R-004/R-005)**: **全 `docs/**/*.md`** の `../pages/...` GitHub blob URL を `./pages/...` 相対パスに置換 (T-01 で特定した全箇所) (owner=agent / Risk=medium / depends_on=T-02 / 🚩 全 link が `./pages/...` 形式 + markdownlint pass)
 - [ ] **T-04**: `docs/_config.yml` で `docs/pages/` 配信確認 (relative_links / collections 既存設定で動作するか) + 必要なら microadjustment (owner=agent / Risk=low / depends_on=T-02 / 🚩 _config.yml で `docs/pages/` 認識)
 
 ### Phase 3: 検証
@@ -21,7 +21,7 @@
 ## 👤 Human タスク
 
 - [ ] **H-01**: **C-3 ゲート** — plan/todo/test-cases/review-self.md 確認 → APPROVE/CONDITIONAL/REJECT → `approvals/c3.json` 発行
-- [ ] **H-02 (T-06)**: ローカル Jekyll build 検証 (optional, AI 不可) — `bundle exec jekyll serve` で `/docs/pages/...` 200 OK 確認
+- [ ] **H-02 (T-06, R-003 mandatory pre-C-3 gate)**: ローカル Jekyll build 検証 (AI 不可、**C-3 前に必須実施**) — `bundle exec jekyll serve` で `/docs/pages/...` 200 OK 確認
 - [ ] **H-03**: **C-4 ゲート (PR レビュー)** + **merge** (Human-owned 固定)
 - [ ] **H-04 (AC-4)**: merge 後 公開サイト https://s977043.github.io/PlanGate/ で 200 OK 確認
 


### PR DESCRIPTION
Codex 提案順位 A (#295 plan 生成) として実施。#293 暫定対応 (GitHub blob URL ハードコード) を恒久化するため、Approach (a) pages/ → docs/pages/ 移設を採用した PBI を B フェーズまで完了。

## Approach 採用

(a) pages/ → docs/pages/ 移設 + 相対パス置換 (AI 単独可)。(b) Pages source 変更 / (c) Jekyll 動的 URL は採用せず。

## Mode

standard (structural change / 公開サイト影響 / lite_eligible=false)

## 推奨次手順

structural change のため Codex+Gemini proactive C-2 を強く推奨。TASK-0108/0109 と同様の手順で外部レビュー → C-3 ゲート。

Refs: #295, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)