### PR TITLE
docs: codex-guarded.sh (#343) 参照を skill / settings-wiring-contract に反映

### DIFF
--- a/.agents/skills/ai-dev-exec/SKILL.md
+++ b/.agents/skills/ai-dev-exec/SKILL.md
@@ -50,6 +50,9 @@ PlanGate ワークフローの **exec フェーズ（WF-04 Build & Refine）** �
 - exec dispatch: `bin/plangate exec TASK-XXXX [--mode <mode>]`（APPROVED c3.json のみ受理）
 - 機械検証: `bin/plangate validate TASK-XXXX`
 - 並行で `./scripts/ai-dev-workflow TASK-XXXX exec` も利用可
+- **Codex CLI 経由の場合は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto` を推奨**（pre-flight で validate + doctor --check-settings を実行、post-flight で plan.md drift 検知。詳細: #336 / scripts/codex-guarded.sh）
+
+> ⚠️ **Codex CLI の限界**: `scripts/codex-guarded.sh` は session 前後のチェックのみで、Codex の Write/Edit 自体は session 中に止められない。Claude Code の `PreToolUse:Write/Edit` hook と完全等価ではない（#336 中期/長期で改善予定）。
 
 ## 次フェーズへ
 

--- a/.agents/skills/local-exec-handoff/SKILL.md
+++ b/.agents/skills/local-exec-handoff/SKILL.md
@@ -47,5 +47,5 @@ PlanGate は Claude Code / Codex CLI ともローカル実行が原則。本 ski
 
 ## ツール別読み替え
 
-- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。`bin/plangate resume` 出力と本 skill Deliverable で十分。
-- **Claude Code**: `/working-context` skill と組み合わせて利用。
+- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。`bin/plangate resume` 出力と本 skill Deliverable で十分。**exec 再開時は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto`** を推奨（pre/post-flight で plan_hash 整合・settings タスクロックを検証、#336 / Gap 4）。
+- **Claude Code**: `/working-context` skill と組み合わせて利用。`PreToolUse:Write/Edit` hook が EH-3/EH-6/EH-9 を強制するため wrapper 不要。

--- a/docs/ai/settings-wiring-contract.md
+++ b/docs/ai/settings-wiring-contract.md
@@ -64,3 +64,32 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 > 既知の限界（V2 候補）: 完全な PreToolUse-hook レベルの機械 block（V-1
 > 実行経路への物理結線）は本スライス範囲外。現状は DoD + doctor FAIL +
 > Iron Law による強制。完全機械化は TASK-0071 S3/S4 または別 PBI で扱う。
+
+
+## Codex CLI parity の限界（#336 / Gap 4）
+
+`PreToolUse:Write/Edit` / `PreToolUse:Bash` hook は **Claude Code 固有**であり、Codex CLI には等価機構が無い。具体的に Codex CLI からは以下が**強制されない**:
+
+- EH-1 plan-exists / EH-2 c3-approval / EH-3 plan_hash / EH-6 forbidden_files (Write/Edit 系)
+- EH-9 delegation-commit-boundary (Bash 系)
+
+### 短期解 (出荷済)
+
+`scripts/codex-guarded.sh` (PR #343) を **Codex CLI の正規入口**として使用する:
+
+```sh
+scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto
+```
+
+- Pre-flight (fail-closed): `bin/plangate validate <TASK>` + `bin/plangate doctor --check-settings` + EH-8 metrics privacy
+- Post-flight (warning): plan.md hash drift 検知 + validate 再実行
+- 監査ログ: `docs/working/_audit/codex-guarded.log`
+
+### 限界
+
+`codex-guarded.sh` は session 前後のチェックのみで、Codex session 中の Write/Edit を物理 block しない (post-write drift 検知のみ)。完全等価には Codex CLI 公開 plugin/hook API が必要 (#336 長期課題)。
+
+### 責務分界
+
+- Codex CLI から `.claude/settings.json` / `bin/plangate` / `scripts/hooks/*.sh` 等の Hardening Override 領域を改変するのは依然として禁止 (AI-owned 不可)
+- これらの強制は Claude Code の hook 経由 (Claude セッション時) または Human 手動レビュー (Codex セッション時) で担保する


### PR DESCRIPTION
Same content as previous attempt. See branch commit msg.

## Summary
PR #343 出荷の `scripts/codex-guarded.sh` を関連ドキュメントから参照。

## 変更
- `.agents/skills/ai-dev-exec/SKILL.md`: Codex CLI 経由の推奨入口を明記
- `.agents/skills/local-exec-handoff/SKILL.md`: exec 再開時の Codex 入口を統一
- `docs/ai/settings-wiring-contract.md`: `## Codex CLI parity の限界 (#336 / Gap 4)` 新設

## 関連
- #336 / #338 / PR #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)