### PR TITLE
fix(tests/ta-14): set -e サブシェル exit code 取得を修正 (CI 復旧)

### DIFF
--- a/tests/extras/ta-14-codex-guarded.sh
+++ b/tests/extras/ta-14-codex-guarded.sh
@@ -34,11 +34,11 @@ fi
 
 # === TC-04: TASK ID 未指定で error 終了 (exit 1) ===
 # Run from a directory that does NOT match docs/working/TASK-*/ to avoid cwd auto-detection
+_tc04_rc=0
 (
   cd "$PG_T14_ROOT"
   "$PG_T14_WRAPPER" >/dev/null 2>&1
-)
-_tc04_rc=$?
+) || _tc04_rc=$?
 if [ "$_tc04_rc" = "1" ]; then
   t14_pass "TC-04 missing TASK ID exits with code 1"
 else
@@ -46,11 +46,11 @@ else
 fi
 
 # === TC-05: 不正な TASK ID 形式で error 終了 (exit 1) ===
+_tc05_rc=0
 (
   cd "$PG_T14_ROOT"
   "$PG_T14_WRAPPER" --task "INVALID-XXX" >/dev/null 2>&1
-)
-_tc05_rc=$?
+) || _tc05_rc=$?
 if [ "$_tc05_rc" = "1" ]; then
   t14_pass "TC-05 invalid TASK ID format exits with code 1"
 else


### PR DESCRIPTION
## Summary

PR #345 で追加した TA-14 が CI (`set -e`) 下で TC-04/TC-05 のサブシェル exit 1 を捕捉できず、`run-tests.sh` 全体を abort させていた。**CI 全体 fail の原因のためホットフィックス**。

## 修正

```sh
# Before (set -e で abort)
(
  cd ...
  "$PG_T14_WRAPPER" ...
)
_tc04_rc=$?

# After (|| で捕捉)
_tc04_rc=0
(
  cd ...
  "$PG_T14_WRAPPER" ...
) || _tc04_rc=$?
```

## 検証

`FIXTURES_DIR=... pass=0 fail=0 sh -e -c '. ta-14-codex-guarded.sh; echo "pass=$pass fail=$fail"'` → **8/8 PASS**

## 影響

- main ブランチの CI 復旧
- 全 OPEN PR (#339/#340/#341/#342) が rebase 後に CI green になる前提条件

🤖 Generated with [Claude Code](https://claude.com/claude-code)