### PR TITLE
feat(.codex/hooks): EH-1/2/3/6/9 PreToolUse 物理 hook bridge — Codex parity 完成 (#336)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,48 @@
+{
+  "$schema_note": "Codex CLI hook spec: https://developers.openai.com/codex/hooks",
+  "$note": "PlanGate hook 群 (EH-1/EH-2/EH-3/EH-6) を Codex CLI PreToolUse へ橋渡し。Claude Code の .claude/settings.json hooks と等価な強制力を Codex セッションで実現する。EH-9 (delegation-commit-boundary) は Bash matcher で別途配線。",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.codex/hooks/eh-bridge.sh\" check-plan-exists.sh",
+            "timeout": 10,
+            "statusMessage": "PlanGate EH-1 plan-exists"
+          },
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.codex/hooks/eh-bridge.sh\" check-c3-approval.sh",
+            "timeout": 10,
+            "statusMessage": "PlanGate EH-2 c3-approval"
+          },
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.codex/hooks/eh-bridge.sh\" check-plan-hash.sh",
+            "timeout": 15,
+            "statusMessage": "PlanGate EH-3 plan_hash"
+          },
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.codex/hooks/eh-bridge.sh\" check-forbidden-files.sh",
+            "timeout": 10,
+            "statusMessage": "PlanGate EH-6 forbidden_files"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$(git rev-parse --show-toplevel)/.codex/hooks/eh-bridge.sh\" check-delegation-commit-boundary.sh",
+            "timeout": 10,
+            "statusMessage": "PlanGate EH-9 delegation-commit-boundary"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/eh-bridge.sh
+++ b/.codex/hooks/eh-bridge.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# eh-bridge.sh — Codex CLI PreToolUse hook bridge to PlanGate scripts/hooks/*.sh
+#
+# Reads Codex stdin JSON, extracts file path(s) from tool_input (Edit/Write or
+# apply_patch), runs the named PlanGate hook with PLANGATE_HOOK_FILE /
+# PLANGATE_HOOK_TASK set, translates exit code / stdout JSON to Codex's
+# hookSpecificOutput {permissionDecision}.
+#
+# Usage:
+#   echo "<json>" | .codex/hooks/eh-bridge.sh <check-script-basename>
+#   e.g.   .codex/hooks/eh-bridge.sh check-plan-hash.sh
+#
+# Reference:
+# - Claude bridge precedent: scripts/hooks/cursor-adapter.sh
+# - Codex hooks spec: https://developers.openai.com/codex/hooks
+
+set -eu
+
+HOOK_NAME=${1:-}
+if [ -z "$HOOK_NAME" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"eh-bridge: hook name missing"}}\n'
+  exit 0
+fi
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HOOK_SCRIPT="$REPO_ROOT/scripts/hooks/$HOOK_NAME"
+
+if [ ! -f "$HOOK_SCRIPT" ]; then
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"eh-bridge: PlanGate hook %s not found"}}\n' "$HOOK_NAME"
+  exit 0
+fi
+
+INPUT=$(cat)
+
+# Extract file path(s) from Codex tool_input.
+#   - Edit/Write: tool_input.file_path
+#   - apply_patch: tool_input.command contains "*** Update File: <path>" /
+#     "*** Add File: <path>" / "*** Delete File: <path>"
+FILE_PATH=$(printf '%s' "$INPUT" | python3 -c '
+import json, re, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(0)
+ti = d.get("tool_input") or {}
+fp = ti.get("file_path") or ti.get("path")
+if fp:
+    print(fp); sys.exit(0)
+cmd = ti.get("command") or ""
+m = re.search(r"\*\*\* (?:Update|Add|Delete) File: (.+?)(?:\n|$)", cmd)
+if m:
+    print(m.group(1).strip())
+' 2>/dev/null || echo "")
+
+if [ -n "$FILE_PATH" ]; then
+  export PLANGATE_HOOK_FILE="$FILE_PATH"
+  case "$FILE_PATH" in
+    *docs/working/TASK-*/*)
+      _task=$(printf '%s\n' "$FILE_PATH" | sed -n 's|.*docs/working/\(TASK-[^/]*\)/.*|\1|p')
+      if [ -n "$_task" ] && [ -z "${PLANGATE_HOOK_TASK:-}" ]; then
+        export PLANGATE_HOOK_TASK="$_task"
+      fi
+      ;;
+  esac
+fi
+
+# Run PlanGate hook. Capture exit code; stderr stays visible for debugging.
+set +e
+sh "$HOOK_SCRIPT" >/tmp/eh-bridge-out.$$ 2>&1
+rc=$?
+set -e
+
+reason=""
+if [ -f /tmp/eh-bridge-out.$$ ]; then
+  reason=$(tail -n 5 /tmp/eh-bridge-out.$$ | tr '\n' ' ' | tr '"' "'" | head -c 400)
+  rm -f /tmp/eh-bridge-out.$$
+fi
+
+case "$rc" in
+  0)
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}\n'
+    ;;
+  2|1)
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"PlanGate %s blocked: %s"}}\n' "$HOOK_NAME" "$reason"
+    ;;
+  *)
+    # Unknown exit code: allow but flag in reason for debugging
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"PlanGate %s rc=%d (unexpected, allowing)"}}\n' "$HOOK_NAME" "$rc"
+    ;;
+esac
+exit 0

--- a/tests/extras/ta-15-codex-hook-bridge.sh
+++ b/tests/extras/ta-15-codex-hook-bridge.sh
@@ -1,0 +1,77 @@
+# tests/extras/ta-15-codex-hook-bridge.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# Gap 4 / #336: .codex/hooks/eh-bridge.sh と .codex/hooks.json の検証
+
+printf '\n=== TA-15: .codex/hooks/eh-bridge.sh (Gap 4 / #336) ===\n'
+
+PG_T15_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T15_BRIDGE="$PG_T15_ROOT/.codex/hooks/eh-bridge.sh"
+PG_T15_HOOKS_JSON="$PG_T15_ROOT/.codex/hooks.json"
+
+t15_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t15_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# === TC-01: bridge script 存在 + 実行権限 ===
+if [ -f "$PG_T15_BRIDGE" ] && [ -x "$PG_T15_BRIDGE" ]; then
+  t15_pass "TC-01 eh-bridge.sh exists and is executable"
+else
+  t15_fail "TC-01 eh-bridge.sh missing or not executable"
+fi
+
+# === TC-02: shell syntax ===
+if sh -n "$PG_T15_BRIDGE" 2>/dev/null; then
+  t15_pass "TC-02 eh-bridge.sh shell syntax OK"
+else
+  t15_fail "TC-02 eh-bridge.sh shell syntax error"
+fi
+
+# === TC-03: hooks.json valid JSON ===
+if [ -f "$PG_T15_HOOKS_JSON" ] && python3 -m json.tool "$PG_T15_HOOKS_JSON" >/dev/null 2>&1; then
+  t15_pass "TC-03 .codex/hooks.json is valid JSON"
+else
+  t15_fail "TC-03 .codex/hooks.json missing or invalid JSON"
+fi
+
+# === TC-04: hooks.json に PlanGate EH-1/2/3/6/9 hook 配線あり ===
+_tc04_count=0
+for eh in check-plan-exists check-c3-approval check-plan-hash check-forbidden-files check-delegation-commit-boundary; do
+  if grep -q "$eh" "$PG_T15_HOOKS_JSON" 2>/dev/null; then
+    _tc04_count=$((_tc04_count + 1))
+  fi
+done
+if [ "$_tc04_count" = "5" ]; then
+  t15_pass "TC-04 hooks.json wires all 5 PlanGate hooks (EH-1/2/3/6/9)"
+else
+  t15_fail "TC-04 hooks.json wires $_tc04_count/5 PlanGate hooks"
+fi
+
+# === TC-05: bridge が hook name 未指定で allow を返す (safety default) ===
+_tc05_out=$(echo '{}' | "$PG_T15_BRIDGE" 2>/dev/null || true)
+if printf '%s' "$_tc05_out" | grep -q '"permissionDecision":"allow"'; then
+  t15_pass "TC-05 bridge with missing hook name returns allow (safety default)"
+else
+  t15_fail "TC-05 bridge with missing hook name should return allow, got: $_tc05_out"
+fi
+
+# === TC-06: bridge が存在しない hook script 名で deny を返す ===
+_tc06_out=$(echo '{"tool_name":"Edit"}' | "$PG_T15_BRIDGE" check-nonexistent-xyz.sh 2>/dev/null || true)
+if printf '%s' "$_tc06_out" | grep -q '"permissionDecision":"deny"'; then
+  t15_pass "TC-06 bridge with nonexistent hook returns deny"
+else
+  t15_fail "TC-06 bridge with nonexistent hook should return deny, got: $_tc06_out"
+fi
+
+# === TC-07: bridge が JSON 出力するか (hookSpecificOutput 構造) ===
+_tc07_out=$(echo '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/safe.txt"}}' | "$PG_T15_BRIDGE" check-plan-exists.sh 2>/dev/null || true)
+if printf '%s' "$_tc07_out" | python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+assert 'hookSpecificOutput' in d
+assert d['hookSpecificOutput']['hookEventName'] == 'PreToolUse'
+assert d['hookSpecificOutput']['permissionDecision'] in ('allow', 'deny')
+print('OK')
+" 2>/dev/null | grep -q OK; then
+  t15_pass "TC-07 bridge outputs valid Codex hookSpecificOutput JSON"
+else
+  t15_fail "TC-07 bridge output invalid: $_tc07_out"
+fi


### PR DESCRIPTION
## Summary

OpenAI Codex CLI 公式仕様で **PreToolUse hook API が存在することを発見**（https://developers.openai.com/codex/hooks）。Claude Code の `.claude/settings.json` hooks と**直接互換** (matcher / stdin JSON / exit code 2 で deny / hookSpecificOutput.permissionDecision 形式)。

これにより従来 wrapper (`scripts/codex-guarded.sh`) では実現できなかった **session 中の物理 pre-write block** を Codex 側でも実装。

## 実装

| ファイル | 内容 |
|---------|------|
| `.codex/hooks/eh-bridge.sh` | stdin JSON → file path 抽出 (Edit/Write.file_path or apply_patch.command の `*** Update/Add/Delete File: <path>`) → PlanGate hook 実行 → Codex hookSpecificOutput 翻訳 |
| `.codex/hooks.json` | PreToolUse matcher `apply_patch\|Edit\|Write` で EH-1/2/3/6 配線、Bash matcher で EH-9 配線 |
| `tests/extras/ta-15-codex-hook-bridge.sh` | 7 観点回帰テスト |

## 検証

- ✅ 7/7 PASS (set -e 環境)
- ✅ 手動 E2E: stale plan_hash で `apply_patch` を block (deny 応答)

## 影響

**Codex parity Gap 4 (#336) の長期課題（案 C）が短期で実現**。
`codex-guarded.sh` (session 前後検知) と組み合わせ、Claude Code と**等価な強制力**を達成:

| 強制ポイント | Claude Code | Codex CLI |
|------------|-------------|-----------|
| Session 中 pre-Write block | ✅ PreToolUse hook | ✅ **本 PR で実装** |
| Session 前 validate / doctor | - | ✅ codex-guarded.sh |
| Session 後 plan_hash drift 検知 | - | ✅ codex-guarded.sh |

## 責務分界

Hardening Override 領域 (`scripts/hooks/*.sh` / `bin/plangate` / `.claude/settings.json`) には**触れず**、`.codex/` 配下のみで完結 (AI-owned 範囲)。

## 関連

- Closes #336 (Gap 4)
- 親 EPIC: #338 — Codex parity 完成へ大きく前進

🤖 Generated with [Claude Code](https://claude.com/claude-code)