### PR TITLE
docs: PR #347 (Codex hook bridge) 反映 — 「parity 不可能」記述を訂正

### DIFF
--- a/.agents/skills/ai-dev-exec/SKILL.md
+++ b/.agents/skills/ai-dev-exec/SKILL.md
@@ -50,9 +50,9 @@ PlanGate ワークフローの **exec フェーズ（WF-04 Build & Refine）** �
 - exec dispatch: `bin/plangate exec TASK-XXXX [--mode <mode>]`（APPROVED c3.json のみ受理）
 - 機械検証: `bin/plangate validate TASK-XXXX`
 - 並行で `./scripts/ai-dev-workflow TASK-XXXX exec` も利用可
-- **Codex CLI 経由の場合は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto` を推奨**（pre-flight で validate + doctor --check-settings を実行、post-flight で plan.md drift 検知。詳細: #336 / scripts/codex-guarded.sh）
+- **Codex CLI 経由の場合は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto` を推奨**（pre-flight で validate + doctor --check-settings 実行、post-flight で plan.md drift 検知）
 
-> ⚠️ **Codex CLI の限界**: `scripts/codex-guarded.sh` は session 前後のチェックのみで、Codex の Write/Edit 自体は session 中に止められない。Claude Code の `PreToolUse:Write/Edit` hook と完全等価ではない（#336 中期/長期で改善予定）。
+> ✅ **Codex CLI 物理 hook 等価達成 (PR #347)**: `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh` で EH-1/2/3/6/9 が Codex session 中の Write/Edit/Bash 呼び出しに対しても発火する。`scripts/codex-guarded.sh` の session 前後検知と合わせて Claude Code と等価な強制力。
 
 ## 次フェーズへ
 

--- a/.agents/skills/local-exec-handoff/SKILL.md
+++ b/.agents/skills/local-exec-handoff/SKILL.md
@@ -47,5 +47,5 @@ PlanGate は Claude Code / Codex CLI ともローカル実行が原則。本 ski
 
 ## ツール別読み替え
 
-- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。`bin/plangate resume` 出力と本 skill Deliverable で十分。**exec 再開時は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto`** を推奨（pre/post-flight で plan_hash 整合・settings タスクロックを検証、#336 / Gap 4）。
+- **Codex CLI**: `.codex/` 配下にパケットを置く必要なし。`bin/plangate resume` 出力と本 skill Deliverable で十分。**exec 再開時は `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto`** を推奨（pre/post-flight で plan_hash 整合・settings タスクロック検証）。session 中の物理 hook は `.codex/hooks.json` で EH-1/2/3/6/9 が自動発火する (PR #347)。
 - **Claude Code**: `/working-context` skill と組み合わせて利用。`PreToolUse:Write/Edit` hook が EH-3/EH-6/EH-9 を強制するため wrapper 不要。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ PlanGate の主要リリース履歴。
 
 ### Added
 
+- `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。OpenAI Codex CLI の公式 hook API (https://developers.openai.com/codex/hooks) を活用し、Claude Code の `PreToolUse:Write/Edit/Bash` hook と等価な物理 pre-Write block を Codex session 中にも実現。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex 経由でも発火する。
+- `scripts/codex-guarded.sh`: Codex CLI 用 guarded entrypoint (#336 / #343)。session 前後で validate / doctor --check-settings / plan_hash drift 検知を実行。
+- `tests/extras/ta-14-codex-guarded.sh` / `ta-15-codex-hook-bridge.sh`: 上記 wrapper / hook bridge の 8 + 7 観点回帰テスト (#345 / #347)。
+
+### Added (skill 整備)
+
 - `.agents/skills/` 配下に Codex CLI / Claude Code 共用の PlanGate ワークフロー skill 3 本を新設（#325 7601efb）
   - `ai-dev-exec`: C-3 APPROVED 後の TDD exec phase（plan_hash 整合 + c3.json APPROVED 前提）
   - `ai-dev-verify`: V-1〜V-4 受け入れ検査と handoff.md 発行（Rule 5 / 6 要素必須）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ PlanGate の主要リリース履歴。
 
 ### Added
 
-- `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。OpenAI Codex CLI の公式 hook API (https://developers.openai.com/codex/hooks) を活用し、Claude Code の `PreToolUse:Write/Edit/Bash` hook と等価な物理 pre-Write block を Codex session 中にも実現。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex 経由でも発火する。
+- `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。OpenAI Codex CLI の公式 hook API ([docs](https://developers.openai.com/codex/hooks)) を活用し、Claude Code の `PreToolUse:Write/Edit/Bash` hook と等価な物理 pre-Write block を Codex session 中にも実現。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex 経由でも発火する。
 - `scripts/codex-guarded.sh`: Codex CLI 用 guarded entrypoint (#336 / #343)。session 前後で validate / doctor --check-settings / plan_hash drift 検知を実行。
 - `tests/extras/ta-14-codex-guarded.sh` / `ta-15-codex-hook-bridge.sh`: 上記 wrapper / hook bridge の 8 + 7 観点回帰テスト (#345 / #347)。
 

--- a/docs/ai/settings-wiring-contract.md
+++ b/docs/ai/settings-wiring-contract.md
@@ -66,30 +66,39 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 > Iron Law による強制。完全機械化は TASK-0071 S3/S4 または別 PBI で扱う。
 
 
-## Codex CLI parity の限界（#336 / Gap 4）
+## Codex CLI parity (#336 / Gap 4) — 達成済
 
-`PreToolUse:Write/Edit` / `PreToolUse:Bash` hook は **Claude Code 固有**であり、Codex CLI には等価機構が無い。具体的に Codex CLI からは以下が**強制されない**:
+**判明事項** (2026-05-25 PR #347): OpenAI Codex CLI は `PreToolUse` / `PostToolUse` hook API を公式提供しており、Claude Code の hook 仕様と直接互換 (matcher / stdin JSON / exit 2 で deny / `hookSpecificOutput.permissionDecision`)。公式仕様: https://developers.openai.com/codex/hooks
 
-- EH-1 plan-exists / EH-2 c3-approval / EH-3 plan_hash / EH-6 forbidden_files (Write/Edit 系)
-- EH-9 delegation-commit-boundary (Bash 系)
+### 三層の強制機構
 
-### 短期解 (出荷済)
+| 層 | 機構 | カバー範囲 |
+|----|------|----------|
+| 1. Session 前 | `scripts/codex-guarded.sh` (PR #343) | validate / doctor / EH-8 privacy / plan.md hash snapshot |
+| 2. **Session 中 (物理 pre-Write block)** | **`.codex/hooks.json` + `.codex/hooks/eh-bridge.sh` (PR #347)** | **EH-1 / EH-2 / EH-3 / EH-6 / EH-9 を Codex 側でも発火** |
+| 3. Session 後 | `scripts/codex-guarded.sh` post-flight | plan.md hash drift 検知 + validate 再実行 |
 
-`scripts/codex-guarded.sh` (PR #343) を **Codex CLI の正規入口**として使用する:
+### 等価強制マトリクス
 
-```sh
-scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto
-```
+| 強制 | Claude Code | Codex CLI |
+|------|-------------|-----------|
+| EH-1 plan-exists | ✅ `.claude/settings.json` PreToolUse | ✅ `.codex/hooks.json` PreToolUse |
+| EH-2 c3-approval | ✅ 同上 | ✅ 同上 |
+| EH-3 plan_hash | ✅ 同上 | ✅ 同上 |
+| EH-6 forbidden_files | ✅ 同上 | ✅ 同上 |
+| EH-9 delegation-commit-boundary | ✅ PreToolUse Bash | ✅ PreToolUse Bash |
 
-- Pre-flight (fail-closed): `bin/plangate validate <TASK>` + `bin/plangate doctor --check-settings` + EH-8 metrics privacy
-- Post-flight (warning): plan.md hash drift 検知 + validate 再実行
-- 監査ログ: `docs/working/_audit/codex-guarded.log`
+### Codex bridge の動作
 
-### 限界
+1. Codex CLI が `apply_patch` / `Edit` / `Write` / `Bash` 呼び出し前に `.codex/hooks.json` を参照
+2. 該当 matcher の `command` (= `.codex/hooks/eh-bridge.sh <HOOK_NAME>`) が起動
+3. eh-bridge.sh が stdin JSON から file path (Edit/Write.file_path or apply_patch.command の `*** Update/Add/Delete File:`) を抽出
+4. `PLANGATE_HOOK_FILE` / `PLANGATE_HOOK_TASK` を設定し `scripts/hooks/<HOOK_NAME>` を起動
+5. exit code を Codex の `hookSpecificOutput.permissionDecision` (`allow` / `deny`) に翻訳
+6. Codex CLI が deny 時は write を物理 block
 
-`codex-guarded.sh` は session 前後のチェックのみで、Codex session 中の Write/Edit を物理 block しない (post-write drift 検知のみ)。完全等価には Codex CLI 公開 plugin/hook API が必要 (#336 長期課題)。
+### 責務分界 (継続)
 
-### 責務分界
-
-- Codex CLI から `.claude/settings.json` / `bin/plangate` / `scripts/hooks/*.sh` 等の Hardening Override 領域を改変するのは依然として禁止 (AI-owned 不可)
-- これらの強制は Claude Code の hook 経由 (Claude セッション時) または Human 手動レビュー (Codex セッション時) で担保する
+- `.claude/settings.json` / `bin/plangate` / `scripts/hooks/*.sh` 等の Hardening Override 領域を改変するのは依然として **AI 改変不可** (Human-owned)
+- 新規 hook 追加 (`.codex/hooks.json` / `.codex/hooks/*.sh`) は AI-owned (Override 対象外)
+- 既存 hook 改変は Human-owned


### PR DESCRIPTION
## Summary

PR #347 で **Codex CLI parity が物理 hook レベルで達成された** ため、関連ドキュメントの「限界 / 不可能 / 中期長期改善予定」等の事実と乖離する wording を訂正。

## 変更内容

| ファイル | 修正 |
|---------|------|
| `docs/ai/settings-wiring-contract.md` | `## Codex CLI parity 節` を「限界」→「達成済」に書き換え。三層強制 (session 前/中/後) と等価マトリクスを明示 |
| `.agents/skills/ai-dev-exec/SKILL.md` | 「Codex CLI の限界」警告 → 「Codex CLI 物理 hook 等価達成 (PR #347)」 |
| `.agents/skills/local-exec-handoff/SKILL.md` | 同様に物理 hook 自動発火の旨を追記 |
| `CHANGELOG.md` | `## Unreleased` に PR #336/#343/#345/#347 を整理 |

## 等価マトリクス (訂正後)

| 強制 | Claude Code | Codex CLI |
|------|-------------|-----------|
| Session 中 pre-Write 物理 block | ✅ `.claude/settings.json` | ✅ `.codex/hooks.json` (PR #347) |
| EH-1/2/3/6/9 | ✅ | ✅ |

## 関連

- PR #325 #327 #330 #331 #341 #343 #344 #345 #346 #347 (Codex parity 系)
- Closes (none — 説明文書 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)