### PR TITLE
feat(plangate): Hardening Override patches 4 件適用 — Codex parity 完成 (#333/#334/#337)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - PlanGate のワークフロー / 設定 / 運用ドキュメント管理
 - `package.json` なし → 一般的な lint / test / typecheck コマンドは未定義
 - 実行入口: `./scripts/ai-dev-workflow` / `./scripts/codex-local.sh` / `bin/plangate`
+- **推奨ガード入口**: `scripts/codex-guarded.sh` (PR #343 / #347。session 前後の plan_hash drift 検知と物理 hook bridge を有効化)
 
 ## Cursor 固有参照
 
@@ -27,6 +28,7 @@
 ## Codex 固有参照
 
 - 実行設定: `.codex/config.toml` / `.codex/instructions.md` / `.codex/agents/*.toml`
+- **Agent Bridge**: `.codex/agents/` の各 agent は Claude Code 側の agent 定義を `instructions` で参照する bridge 構成 (#341)。
 - 共有スキル: `.agents/skills/`（Claude Code と共用）
 - 役割分担: `docs/ai/tool-roles.md`
 - 作業コンテキストプロトコル（Progressive Disclosure）: `.claude/rules/working-context.md`
@@ -35,3 +37,45 @@
 ## 出力
 
 - 日本語（コミットメッセージ・PR 文面含む）
+
+
+
+
+## Codex CLI 固有参照 (PR #343/#347)
+
+- 正規入口: `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto`
+- 物理 hook: `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh` (EH-1/2/3/6/9 を Codex 側でも発火)
+- 強制等価: `docs/ai/settings-wiring-contract.md` §Codex CLI parity
+
+
+<claude-mem-context>
+# Memory Context
+
+# [plangate] recent context, 2026-05-26 5:20am GMT+9
+
+Legend: 🎯session 🔴bugfix 🟣feature 🔄refactor ✅change 🔵discovery ⚖️decision 🚨security_alert 🔐security_note
+Format: ID TIME TYPE TITLE
+Fetch details: get_observations([IDs]) | Search: mem-search skill
+
+Stats: 12 obs (4,335t read) | 410,476t work | 99% savings
+
+### May 24, 2026
+S1704 PlanGate skill review and full CLI alignment — reviewing .codex/runtime-home-v2/skills/ai-dev-plan/SKILL.md and fixing all identified issues across 4 PRs (May 24 at 3:32 PM)
+### May 25, 2026
+S1705 PlanGate skill review and full CLI alignment — reviewing ai-dev-plan/SKILL.md, fixing all identified issues across 4 PRs, filing remaining PBIs as GitHub Issues (May 25 at 7:00 AM)
+S1707 PlanGate skill review and full CLI alignment — all AI-autonomous work complete; two Human-owned patches designed, tested, and ready for application (May 25 at 7:10 AM)
+6233 9:00a 🔵 PlanGate PR #325/#327/#330 Documentation Verification (Read-Only Audit)
+6234 " 🔵 PlanGate Doc Verification: Most Target Files Unreadable or Empty
+6236 9:01a 🔵 PlanGate PR #325/#327/#330 Doc Audit: Concrete Findings Per Checklist Item
+6237 9:02a 🔵 PlanGate Doc Audit: Definitive Findings — New Skills Unregistered, Env Vars Undocumented, B-1→B-3 Flow Gap
+6276 11:04a ⚖️ PlanGate Codex Parity Gap #336 — 設計調査タスク発行
+6277 " 🔵 PlanGate hook 配線の実体確認 — .claude/settings.json 全構造
+6278 " 🔵 Codex CLI の sandbox_mode と forbidden_files 相当制御の確認結果
+6279 " 🔵 PlanGate リポジトリ構成 — .claude/.codex/.agents 三層アーキテクチャの確認
+6286 11:05a ⚖️ TASK-0111: pages/ → docs/pages/ 移設設計レビュー (C-2 外部レビュー)
+6280 " 🔵 hook スクリプト全体構造と Codex parity gap の技術的詳細
+6281 11:06a 🔵 bin/plangate exec の Codex 経路は情報表示のみ — 実行ゲートなし
+6287 11:11a 🔵 TASK-0111 C-2レビュー用リポジトリ現状調査結果
+
+Access 410k tokens of past work via get_observations([IDs]) or mem-search skill.
+</claude-mem-context>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,15 @@
 - **Roadmap**: [`docs/ai/harness-improvement-roadmap.md`](docs/ai/harness-improvement-roadmap.md) — Phase 0-6 + Governance + #213 全 ✅ Done（EPIC #193 CLOSED/COMPLETED）
 - **Templates**: [`docs/working/templates/handoff.md`](docs/working/templates/handoff.md) §7 / [`docs/working/templates/current-state.md`](docs/working/templates/current-state.md) で metrics スナップショットを記載可能（任意）
 
+
+
+## Codex CLI 固有参照 (PR #343/#347)
+
+- 正規入口: `scripts/codex-guarded.sh --task TASK-XXXX exec --full-auto` (pre/post-flight 強制)
+- 物理 hook 配線: [`.codex/hooks.json`](.codex/hooks.json) + [`.codex/hooks/eh-bridge.sh`](.codex/hooks/eh-bridge.sh) — EH-1/2/3/6/9 を Codex session 中の `apply_patch|Edit|Write|Bash` に対し物理発火
+- Codex 用 agent: [`.codex/agents/*.toml`](.codex/agents/) (Claude `.claude/agents/<name>.md` への thin pointer)
+- 強制等価マトリクス: [`docs/ai/settings-wiring-contract.md`](docs/ai/settings-wiring-contract.md) §Codex CLI parity
+
 <language>Japanese</language>
 <character_code>UTF-8</character_code>
 <law>

--- a/bin/plangate
+++ b/bin/plangate
@@ -120,6 +120,11 @@ cmd_help() {
     "" \
     "Commands:" \
     "  init <TASK-XXXX>               Create task folder and template files" \
+    "  brainstorm <TASK-XXXX>         Brainstorm PBI INPUT PACKAGE (wraps ai-dev-workflow)" \
+    "  plan <TASK-XXXX>               Generate plan.md/todo.md/test-cases.md (B-1->B-2->B-3)" \
+    "  gate <TASK-XXXX>               Check C-1/C-2/C-3 gate readiness" \
+    "  verify <TASK-XXXX> [--mode]    Run V-1 (validate) + settings lock + V-3 + eval + metrics" \
+    "  handoff <TASK-XXXX>            Copy handoff.md template into TASK working dir" \
     "  doctor [--json] [--scope <v>] [--fix [--dry-run] [--yes]] [--check-settings]" \
     "                                 Check environment; --fix wires hooks (TASK-0069)" \
     "  status <TASK-XXXX>             Show current phase and next action" \
@@ -1613,6 +1618,36 @@ cmd_exec() {
     return 1
   fi
 
+  # Gate check: plan_hash integrity (EH-3 integration at exec entry)
+  # plan.md must not have been modified after C-3 approval.
+  plan_file="$work_dir/plan.md"
+  c3_file="$work_dir/approvals/c3.json"
+  if [ -f "$plan_file" ]; then
+    recorded_hash=$(python3 -c "import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception:
+    print(''); sys.exit(0)
+if not isinstance(d,dict):
+    print(''); sys.exit(0)
+v=d.get('plan_hash','')
+print(v[7:] if isinstance(v,str) and v.startswith('sha256:') else '')" "$c3_file" 2>/dev/null || echo "")
+    if [ -n "$recorded_hash" ]; then
+      if command -v sha256sum >/dev/null 2>&1; then
+        current_hash=$(sha256sum "$plan_file" | awk '{print $1}')
+      else
+        current_hash=$(shasum -a 256 "$plan_file" | awk '{print $1}')
+      fi
+      if [ "$recorded_hash" != "$current_hash" ]; then
+        printf 'error: plan_hash mismatch -- plan.md modified after C-3 approval\n' >&2
+        printf '  Recorded: sha256:%s\n' "$recorded_hash" >&2
+        printf '  Current : sha256:%s\n' "$current_hash" >&2
+        printf '  Action  : Re-approval required (update c3.json plan_hash) or revert plan.md.\n' >&2
+        return 1
+      fi
+    fi
+  fi
+
   # Record session start
   ts=$(plangate_now)
   plangate_append_ndjson "$run_log" \
@@ -1647,6 +1682,97 @@ cmd_exec() {
   esac
 }
 
+
+cmd_brainstorm() {
+  task_id="${1:-}"
+  if [ -z "$task_id" ]; then
+    printf 'Usage: plangate brainstorm <TASK-XXXX>\n' >&2
+    return 2
+  fi
+  shift
+  exec "$plangate_root/scripts/ai-dev-workflow" "$task_id" brainstorm "$@"
+}
+
+cmd_plan() {
+  task_id="${1:-}"
+  if [ -z "$task_id" ]; then
+    printf 'Usage: plangate plan <TASK-XXXX>\n' >&2
+    return 2
+  fi
+  shift
+  exec "$plangate_root/scripts/ai-dev-workflow" "$task_id" plan "$@"
+}
+
+cmd_gate() {
+  task_id="${1:-}"
+  if [ -z "$task_id" ]; then
+    printf 'Usage: plangate gate <TASK-XXXX>\n' >&2
+    return 2
+  fi
+  shift
+  exec "$plangate_root/scripts/ai-dev-workflow" "$task_id" gate "$@"
+}
+
+cmd_verify() {
+  task_id="${1:-}"
+  if [ -z "$task_id" ]; then
+    printf 'Usage: plangate verify <TASK-XXXX>\n' >&2
+    return 2
+  fi
+  shift
+  mode_flag=""
+  for arg in "$@"; do
+    case "$arg" in
+      --mode=*) mode_flag="${arg#--mode=}" ;;
+    esac
+  done
+  printf '[verify] Running V-1 (validate)...\n'
+  if ! "$0" validate "$task_id"; then
+    printf '[verify] V-1 FAILED — stop\n' >&2
+    return 1
+  fi
+  printf '[verify] Running settings task-lock check...\n'
+  if ! "$0" doctor --check-settings; then
+    printf '[verify] settings task-lock FAILED — Human must run sh scripts/apply-claude-settings.sh\n' >&2
+    return 1
+  fi
+  case "$mode_flag" in
+    standard|high-risk|critical)
+      printf '[verify] Running V-3 (external review)...\n'
+      "$0" review "$task_id" --phase v3 || printf '[verify] V-3 returned non-zero\n' >&2
+      ;;
+  esac
+  printf '[verify] Running 8-aspect eval...\n'
+  "$0" eval "$task_id" || printf '[verify] eval returned non-zero\n' >&2
+  printf '[verify] Collecting metrics...\n'
+  "$0" metrics "$task_id" --collect || printf '[verify] metrics returned non-zero\n' >&2
+  printf '[verify] Complete. Next: plangate handoff %s\n' "$task_id"
+}
+
+cmd_handoff() {
+  task_id="${1:-}"
+  if [ -z "$task_id" ]; then
+    printf 'Usage: plangate handoff <TASK-XXXX>\n' >&2
+    return 2
+  fi
+  work_dir="$plangate_working_dir/$task_id"
+  template="$plangate_root/docs/working/templates/handoff.md"
+  target="$work_dir/handoff.md"
+  if [ ! -f "$template" ]; then
+    printf 'error: handoff template not found: %s\n' "$template" >&2
+    return 1
+  fi
+  if [ -f "$target" ]; then
+    printf 'handoff.md already exists: %s (skip)\n' "$target"
+    return 0
+  fi
+  mkdir -p "$work_dir"
+  cp "$template" "$target"
+  printf 'Created: %s\n' "$target"
+  printf 'Fill the 6 required sections (要件適合 / 既知課題 / V2 / 妥協点 / 引き継ぎ / テスト結果).\n'
+  printf 'Verify settings task-lock: plangate doctor --check-settings\n'
+}
+
 # ── dispatch ──────────────────────────────────────────────────────────────────
 
 if [ $# -eq 0 ]; then
@@ -1659,6 +1785,11 @@ shift
 
 case "$command" in
   init)        cmd_init "$@" ;;
+  brainstorm)  cmd_brainstorm "$@" ;;
+  plan)        cmd_plan "$@" ;;
+  gate)        cmd_gate "$@" ;;
+  verify)      cmd_verify "$@" ;;
+  handoff)     cmd_handoff "$@" ;;
   doctor)      cmd_doctor "$@" ;;
   status)      cmd_status "$@" ;;
   validate)    cmd_validate "$@" ;;


### PR DESCRIPTION
## Summary

ユーザ明示承認 (2026-05-26 "(bin/plangate / CLAUDE.md / AGENTS.md) の対応を行って") のもと、本セッション全体で設計・E2E 検証済の **4 patch を Hardening Override 領域に適用**。これで Codex parity EPIC (#338) の Gap 1/2/5 を完全解消し、残 OPEN Issue (#333/#334/#337) も本 PR merge で同時 close。

## 適用内容

| # | patch | 対象ファイル | 効果 |
|---|-------|-----------|------|
| 1 | `/tmp/gap1-subcommands.patch` | bin/plangate | brainstorm / plan / gate / verify / handoff サブコマンド追加 (#333 #337) |
| 2 | `/tmp/cmd-exec-plan-hash-check.patch` | bin/plangate | cmd_exec に plan_hash 整合検証追加 (#334) |
| 3 | `/tmp/claude-md-codex-section.patch` | CLAUDE.md | Codex CLI 固有参照節追加 |
| 4 | `/tmp/agents-md-codex-section.patch` | AGENTS.md | 同上 |

差分: 3 files, +184 insertions

## 検証 (ローカル E2E)

- ✓ `sh -n bin/plangate` syntax OK
- ✓ `bin/plangate --help` に 5 新サブコマンド表示
- ✓ TEST 1: plan_hash 一致時 exec 通過確認
- ✓ TEST 2: plan_hash 不一致時 block + 明示エラー (Recorded / Current / Action) で return 1
- ✓ TEST 3: handoff template copy 動作確認

## 責務分界

- bin/plangate / CLAUDE.md / AGENTS.md は Hardening Override (`scripts/hooks/check-plan-hash.sh:130-133`) で平時 AI 改変不可
- 本 PR はユーザの明示承認に基づく **per-scope 例外実行** (`responsibility-classes.md` 「対外公開アーティファクト publish 責務分界」例外条項に準拠)

## 関連

- Closes #333 (Gap 1)
- Closes #334 (Gap 2)
- Closes #337 (Gap 5)
- EPIC #338 100% 完成へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)