### PR TITLE
docs(#310): UX 改善 5 項目 (Codex+Gemini 外部評価ベース)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ PlanGate は、AI コーディングエージェントのためのガバナン�
 
 ![PlanGate overview](docs/assets/harness-plangate-readme-dark-v2.png)
 
+## 新規利用者: 最初に読む 3 ページ
+
+PlanGate を初めて知った方は、以下の順に **15-30 分** で読むことを推奨します。
+
+1. **[PlanGate ガイド](docs/plangate.md)** — 全体像・5 フェーズ・解決する問題（約 5 分）
+2. **[段階的導入ガイド](docs/staged-adoption-guide.md)** — Level 1 (Day 1) から始める具体手順（約 10 分）
+3. **[10 分チュートリアル（本 README 後半）](#10-分チュートリアル)** — 実際に手を動かす最小例（約 10 分）
+
+「自分のチームに合うか」を判断したい方は [思想と問題設定](docs/philosophy.md) と [When NOT to use](docs/when-not-to-use.md) を参照。略号 (EH-X / WF-XX / V-X / C-X) は [用語クイックリファレンス](docs/glossary.md) を参照。
+
 ## PlanGate の本質的価値
 
 PlanGate が配布するのは **「AI 開発の安全な型」** です。AI に何でも自動でやらせる枠組みではありません。
@@ -130,9 +140,11 @@ cp -r plangate/.claude/ your-project/.claude/
 > 既存利用者や段階的移行を行う場合、plugin と `.claude/` のデュアル運用は技術的に可能ですが、同名 Skill / コマンドの解決順に注意してください。
 > plugin 側を明示的に呼び出す場合は `plangate:<skill-or-agent>` prefix を使用します。詳細は [plugin 移行ガイド](docs/plangate-plugin-migration.md) を参照してください。
 
-### 導入後: hook 強制を有効化する
+### 導入後: hook 強制を有効化する 🚨 必須
 
-clone / plugin 導入だけでは hook 強制（ゲートの不変条件検査）は配線されません。導入先で次の 1 コマンドを実行して、`.claude/settings.json` への hook 配線を確立します。
+> ⚠️ **重要**: clone / plugin 導入だけでは **hook 強制（EH-1〜EH-9 のゲート不変条件検査）が配線されません**。本コマンドを実行しないと PlanGate の核となる承認境界保護が無効状態のままになります。
+
+clone / plugin 導入直後に、必ず次の 1 コマンドを実行して `.claude/settings.json` への hook 配線を確立してください:
 
 ```bash
 bin/plangate doctor --fix
@@ -421,6 +433,8 @@ PlanGate のガバナンスワークフローはプロバイダに依存しな�
 | [docs/rfc/provider-cursor.md](docs/rfc/provider-cursor.md) | Cursor Provider RFC |
 | [docs/plangate-plugin-migration.md](docs/plangate-plugin-migration.md) | Claude Code plugin としての利用・移行 |
 | [docs/oss-governance.md](docs/oss-governance.md) | OSS 公開設定・運用判断 |
+| [docs/glossary.md](docs/glossary.md) | **用語クイックリファレンス** — EH-X / WF-XX / V-X / C-X / mode 5 段階等の略号 (#310) |
+| [docs/when-not-to-use.md](docs/when-not-to-use.md) | **When NOT to use / Trade-offs** — PlanGate を採用しない方が良いケース (#310) |
 | [CHANGELOG.md](CHANGELOG.md) | 主要リリース履歴 |
 | [docs/working/discussions/](docs/working/discussions/) | Claude × Codex × Gemini の戦略ディスカッションログ（5 ラウンド、v8.7.0 主軸の根拠） |
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,76 @@
+# PlanGate 用語クイックリファレンス
+
+PlanGate ドキュメントで頻出する略号の一覧。初見の方はこのページをブックマーク推奨。
+
+## ゲート / 承認境界 (C-X)
+
+| 略号 | 名称 | 説明 |
+|------|------|------|
+| **C-1** | セルフレビュー | 17 項目チェック (Plan 7 + ToDo 5 + TestCases 3 + 結合 2)。AI 自身が plan/todo/test-cases を構造的に検証。 |
+| **C-2** | 外部 AI レビュー | gemini / codex 等の外部モデルが指摘 R-NNN を付与。`bin/plangate review --phase c2` |
+| **C-3** | 人間承認ゲート（plan） | C-1/C-2 を踏まえ人間が APPROVED / CONDITIONAL / REJECT 三値で判定。`approvals/c3.json` 発行。 |
+| **C-4** | 人間承認ゲート（PR） | GitHub 上で PR レビュー。APPROVE / REQUEST CHANGES / REJECT 三値。 |
+
+## 検証フェーズ (V-X)
+
+| 略号 | 名称 | 適用 mode | 説明 |
+|------|------|----------|------|
+| **V-1** | 受け入れ検査 | 全 mode | test-cases.md 各 AC を機械的に PASS/FAIL 突合 |
+| **V-2** | コード最適化 | high-risk / critical | 動作不変で可読性・効率性改善 |
+| **V-3** | 外部モデルレビュー | standard 以上 | 5 観点 + Severity 判定、R-NNN 採番 |
+| **V-4** | リリース前チェック | critical のみ | ドキュメント整合 / マイグレーション / セキュリティ |
+
+## Workflow フェーズ (WF-XX)
+
+| 略号 | 名称 | 旧呼称 |
+|------|------|--------|
+| **WF-01** | Brainstorm | A: PBI INPUT PACKAGE |
+| **WF-02** | Requirement Expansion | A→B 中間 |
+| **WF-03** | Solution Design | B: Plan + ToDo + Test Cases |
+| **WF-04** | Build & Refine | D: Agent 実行 (exec) |
+| **WF-05** | Verify & Handoff | V-1〜V-4 + handoff |
+
+## Hook 識別子 (EH-X)
+
+PlanGate の PreToolUse hook 群 (`scripts/hooks/check-*.sh` + `.claude/settings.json` または `.codex/hooks.json` で配線)。
+
+| 略号 | 役割 | 発火条件 |
+|------|------|---------|
+| **EH-1** | plan-exists | plan.md 存在検証 |
+| **EH-2** | c3-approval | c3.json APPROVED 検証 |
+| **EH-3** | plan_hash | C-3 承認後の plan.md 改竄検知 |
+| **EH-6** | forbidden_files | scope 越境禁止 |
+| **EH-8** | metrics-privacy | events.ndjson の Forbidden field 検出 |
+| **EH-9** | delegation-commit-boundary | 委譲時の commit 境界違反検出 |
+| **EH-10** | self-set-gate-enforcement | AI 自己設置 Gate の Hook 強制（[RFC Draft](rfc/ai-self-set-gate-hook-enforcement.md)）|
+
+## モード分類 (5 段階)
+
+| 略号 | 名称 | 対象例 |
+|------|------|--------|
+| **ultra-light** | 超低 | typo / 設定値変更 / コメント修正 |
+| **light** | 低 | バグ修正 / 1 ファイル小修正 |
+| **standard** | 中 | 小機能追加 / 数ファイル変更 |
+| **high-risk** | 高 | 機能追加 / 複数レイヤー変更 |
+| **critical** | 超高 | アーキテクチャ変更 / 横断的リファクタ |
+
+詳細: [`.claude/rules/mode-classification.md`](https://github.com/s977043/PlanGate/blob/main/.claude/rules/mode-classification.md)
+
+## 派生属性
+
+| 属性 | 説明 |
+|------|------|
+| `lite_eligible` | C-3 を非同期降格してよいかの真偽属性。`C-1 PASS` & `C-2 critical/major=0` & light/standard 相当でのみ true 候補。critical mode は原則 false (AC-11)。判定不能は安全側 false (AC-8)。 |
+| **Hardening Override** | AI 改変不可ファイル群 (`.claude/settings*.json` / `.claude/rules/*.md` / `.claude/agents/*.md` / `.claude/commands/*.md` / `scripts/hooks/*.sh` / `bin/plangate` / `AGENTS.md` / `CLAUDE.md` 等)。Human-owned 適用のみ。 |
+
+## 指摘 ID
+
+| ID | 用途 |
+|----|------|
+| **R-NNN** | C-2 / V-3 外部レビューで採番する指摘 ID。`review-external.md` に追記専用集約。反映コミットに `Refs: R-NNN` |
+
+## 関連
+
+- 全体像: [PlanGate ガイド](plangate.md)
+- 段階的導入: [Staged Adoption Guide](staged-adoption-guide.md)
+- 設定契約: [settings-wiring-contract.md](ai/settings-wiring-contract.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ PlanGate を初めて知った方は、以下の順に **15-30 分** で読む�
 2. **[段階的導入ガイド](./staged-adoption-guide.md)** — Level 1 (Day 1) から始める具体手順（約 10 分）
 3. **[10 分チュートリアル（GitHub README）](https://github.com/s977043/PlanGate#10-分チュートリアル)** — 実際に手を動かす最小例（約 10 分）
 
-「自分のチームに合うか」を判断したい方は [思想と問題設定](./philosophy.md) も参照。
+「自分のチームに合うか」を判断したい方は [思想と問題設定](./philosophy.md) と [When NOT to use](./when-not-to-use.md) を参照。略号 (EH-X / WF-XX / V-X / C-X) は [用語クイックリファレンス](./glossary.md) を参照。
 
 ## Requirements
 

--- a/docs/when-not-to-use.md
+++ b/docs/when-not-to-use.md
@@ -1,0 +1,74 @@
+# When NOT to use PlanGate (採用しない方が良いケース)
+
+PlanGate は **すべての AI コーディング** に向くわけではありません。以下のケースでは導入コストの方が便益を上回ります。
+
+## ✗ 採用しない方が良いケース
+
+### 1. 探索的プロトタイピング (throwaway code)
+
+- 30 分以内に書き捨てる検証コード
+- Notebook での data exploration
+- ワンショットの bug repro
+
+**理由**: PBI INPUT PACKAGE → plan → C-3 承認 → exec の正規フローが overhead になる。
+**代替**: 直接 AI に依頼 (Cursor / Copilot)、後で正規化が必要なら PBI 化。
+
+### 2. 完全自律エージェントを目指す開発
+
+- AutoGPT / agentic AI system 開発
+- 人間承認を介さずに目標達成する agent loop の構築
+
+**理由**: PlanGate の中核は **人間承認ゲート (C-3 / C-4)** であり「承認なしで AI に書かせない」を絶対化する。完全自律と相反。
+**代替**: LangGraph / AutoGen / 独自 agent framework。
+
+### 3. SaaS / 外部 store 前提のチーム
+
+- Linear / Jira / Notion を信頼の正本とするチーム
+- PR / Issue 中心の運用ではなくチケット ID で全てが回る組織
+
+**理由**: PlanGate は `docs/working/TASK-XXXX/` の Markdown を「正本」とする。外部 SaaS と二重管理になる。
+**代替**: SaaS の Webhook / API で承認境界を実装。
+
+### 4. 1 人開発 / 短期プロジェクト
+
+- Solo developer の personal project
+- 6 週間以内に終わる limited duration project
+
+**理由**: PlanGate のガバナンスコスト (PBI 記入 / C-3 承認 / handoff 発行) は **3 人以上のチーム & 3 ヶ月以上の継続運用** で元が取れる設計。
+**代替**: Cursor + git だけで十分。
+
+### 5. リアルタイム / 低レイテンシ要件のある AI 統合
+
+- Voice assistant / live coding 補助
+- Code completion の inline 体験
+
+**理由**: PlanGate の hook / gate は秒〜分単位の人間判断を介在させる。millisec オーダーでは不適。
+**代替**: GitHub Copilot / Cursor の inline completion。
+
+## ⚠ Trade-offs (使う場合の覚悟)
+
+PlanGate を採用する場合、以下のコストを受け入れる必要があります。
+
+| コスト | 内容 | 緩和策 |
+|-------|------|--------|
+| **PBI 記入コスト** | Why / What / AC / Constraints / Non-goals を毎タスクで明文化 | テンプレ化、`bin/plangate brainstorm` で対話的生成 |
+| **C-3 承認の同期遅延** | 人間が plan を読んで判定するまで exec 待機 | `lite_eligible` で非同期降格 (条件付き)、light mode で簡略化 |
+| **学習負荷** | EH-X / WF-XX / V-X / C-X 略号、mode 分類、責務 4 分類 | [glossary.md](glossary.md) でクイックリファレンス、[Staged Adoption Guide](staged-adoption-guide.md) で段階導入 |
+| **handoff 維持コスト** | 全 PBI で 6 要素 handoff.md を発行・保管 | テンプレ自動生成 (`bin/plangate handoff`)、light mode で簡易版 |
+| **hook の摩擦** | EH-1〜EH-9 が誤検知する局面がある | `PLANGATE_BYPASS_HOOK=1` で一時 bypass (監査ログ記録) |
+
+## ✓ 採用が **特に有効** なケース
+
+参考までに、PlanGate が最も価値を出すシナリオ:
+
+- **3 人以上 & 3 ヶ月以上**のチーム開発
+- AI コーディングエージェント (Claude Code / Codex CLI / Cursor) を本格運用
+- **監査可能性 / 説明責任**が要求される業界 (regulated industry / 公共系)
+- **段階的に AI 自律度を上げたい**チーム (Level 1 → 5)
+- **Scrum / Agile** 運用との親和性を重視
+
+## 関連
+
+- [philosophy.md](philosophy.md) — 設計思想と問題設定
+- [staged-adoption-guide.md](staged-adoption-guide.md) — 段階的導入レベル 1〜5
+- [glossary.md](glossary.md) — 用語クイックリファレンス


### PR DESCRIPTION
## Summary

Issue #310 で集約された 7 改善項目のうち **AI 自律可能な小規模 5 項目** を一括対応。

## 変更内容

| # | 優先 | 項目 | 対応 |
|---|------|------|------|
| 1 | HIGH | トップに「最初に読む 3 ページ」順序明示 | ✅ README.md 上部に追加 (docs/index.md は既存) |
| 2 | HIGH | Requirements 明文化 | ✅ 既存 (README/docs/index 両方) |
| 4 | MEDIUM | `doctor --fix` 必須度強調 | ✅ 🚨 必須 マーク + 重要 callout |
| 5 | MEDIUM | When NOT to use / Trade-offs | ✅ `docs/when-not-to-use.md` 新設 |
| 6 | MEDIUM | 用語クイックリファレンス | ✅ `docs/glossary.md` 新設 |

## 未対応 (本 PR スコープ外・中規模)

- #3 30-minute first run を 1 本に統一 (README 10 分 vs Phase 0)
- #7 A/B/C/D ↔ WF-01..05 呼称統合

これらは Issue #310 の正規 PlanGate フロー (plan → C-3 → exec) で別 PR 推奨。

## 統計

4 files: README.md (+19 / -3), docs/index.md (+1 / -1), docs/glossary.md (新規 +76), docs/when-not-to-use.md (新規 +74)

Refs: #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)