### PR TITLE
docs(TASK-0112): plan/todo/test-cases/review-self 新規生成 (Codex 推奨 C / 承認境界 mode 引き上げ)

### DIFF
--- a/docs/working/TASK-0112/INDEX.md
+++ b/docs/working/TASK-0112/INDEX.md
@@ -1,0 +1,7 @@
+# TASK-0112 INDEX
+
+- **Title**: mode-classification.md 例外ルール拡張 (承認境界周辺→最低 高)
+- **出自**: TASK-0106 Retrospective Try / Codex 推奨優先順 C
+- **Mode**: light (lite_eligible=false)
+- **Phase**: B 完了
+- **Status**: C-3 + maintenance window 待ち (Human-owned)

--- a/docs/working/TASK-0112/current-state.md
+++ b/docs/working/TASK-0112/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0112 current-state
+
+## Phase: B 完了
+
+次: C-3 ゲート + maintenance window (Human-owned) → AI exec (T-02)
+
+## ブロッカー
+
+なし。
+
+## 関連
+
+- TASK-0106 Retrospective Try / Codex 推奨 C

--- a/docs/working/TASK-0112/pbi-input.md
+++ b/docs/working/TASK-0112/pbi-input.md
@@ -1,0 +1,57 @@
+# TASK-0112 PBI INPUT PACKAGE
+
+> Codex 推奨優先順 C (2026-05-26): mode-classification.md 例外ルール拡張
+> 出自: TASK-0106 Retrospective Try アクション
+
+## Context / Why
+
+TASK-0106 (#289 EH-3 maintenance CLI) の retrospective で、**承認境界周辺の改修が mode=standard と判定されたが実態は high-risk 相当だった**ことが Problem として記録された ([`docs/working/TASK-0106/retrospective.md`](../TASK-0106/retrospective.md) §2 Problem)。
+
+現行 `.claude/rules/mode-classification.md` の例外ルールは「セキュリティ関連→最低 中」「DB スキーマ変更→最低 高」「公開 API 破壊的変更→最低 超高」の 3 種のみで、**承認境界 (Hardening Override 対象パス) 周辺の改修** に対する mode 自動補正ルールが不在。本 PBI で例外ルールに追加し、自動推定の安全側を構造化する。
+
+## What (Scope)
+
+### In scope
+
+- `.claude/rules/mode-classification.md` の例外ルールに「承認境界周辺の変更 → 最低でも『高』」を追加
+- 対象パスを Hardening Override 対象と一致させて明示（`scripts/hooks/check-plan-hash.sh` の検出パターンと整合）
+- 監査ログ (`docs/working/_audit/`) のデータ一括変更 CLI も承認境界相当として扱う旨（TASK-0110 を踏まえる）
+- `working-context.md` AC-10 Hardening Override（`lite_eligible=false` 強制）との整合明示
+- 自動推定の安全側（該当不確実→該当扱い）を AC-8 と一貫させる
+
+### Out of scope
+
+- mode 自動推定の実装変更（本 PBI は文言追加のみ）
+- 既存の 3 例外ルール（セキュリティ/DB/公開 API）の改変
+- EH-10 self-set gate hook 実装（PR #339 RFC とは orthogonal）
+
+## 受入基準
+
+- AC-1: `.claude/rules/mode-classification.md` の例外ルールに「承認境界周辺の変更 → 最低でも『高』」が追加されている
+- AC-2: 対象パス一覧が Hardening Override 対象（`.claude/`, `scripts/hooks/`, `bin/plangate`, `schemas/`, `.github/workflows/`, `AGENTS.md`, `CLAUDE.md`）と一致
+- AC-3: `working-context.md` AC-10 / AC-8 安全側と整合する記述（重複定義ではなく相互参照）
+- AC-4: 監査ログ一括変更 CLI も承認境界相当（TASK-0110 を例示）
+- AC-5: 自動推定の安全側ルール（不確実→該当扱い）が明記
+- AC-6: markdownlint pass + リンク健全性 CI pass
+
+## Notes from Refinement
+
+- `.claude/rules/` は Hardening Override 対象で AI 直接編集不可 → 本 PBI で c3.json APPROVED + EH-3 maintenance window 経由で適用
+- 既存例外ルール 3 種は破壊しない（additive change）
+- TASK-0110 (#301) と関連: 監査ログ一括変更 CLI のため最低「高」適用＝TASK-0110 を Standard で進めることへの軽微な是正は出るが、本 PBI merge 時点での「以降の PBI から適用」とする
+
+## Estimation
+
+### Risks
+
+- 既存 PBI が「standard 想定」で進行中の場合、ルール拡張で再評価が必要 → mitigation: 「本 PBI merge 後着手の PBI から適用」と明記
+- 例外ルール乱立で運用負担増 → mitigation: 対象パスは Hardening Override と完全一致させて単一情報源化
+
+### Unknowns
+
+- mode 自動推定の実装側 (plan-health 等) が本ルール追加を機械的に反映するか → 本 PBI 範囲外、follow-up で対応
+
+### Assumptions
+
+- `.claude/rules/mode-classification.md` の例外ルール構造が変わらない
+- Hardening Override 対象パスは `scripts/hooks/check-plan-hash.sh` の現行検出パターンを正本とする

--- a/docs/working/TASK-0112/plan.md
+++ b/docs/working/TASK-0112/plan.md
@@ -1,0 +1,61 @@
+# TASK-0112 EXECUTION PLAN
+
+> Source: pbi-input.md / Codex 推奨 C / Mode: **light**
+> Generated: 2026-05-26
+
+## Goal
+
+`.claude/rules/mode-classification.md` の例外ルールに「承認境界周辺の変更 → 最低でも『高』」を追加し、自動推定の安全側ルールと整合させる。TASK-0106 Retrospective Try アクションを構造化。
+
+## Constraints / Non-goals
+
+- 既存の 3 例外ルール（セキュリティ/DB/公開 API）を破壊しない（additive change）
+- mode 自動推定の実装変更を含まない（文言追加のみ）
+- `working-context.md` AC-10/AC-8 と重複定義せず相互参照
+- 既存テスト regression なし
+
+## Approach Overview
+
+`.claude/rules/mode-classification.md` の例外ルールセクション 1 箇所への追記のみ。`.claude/rules/` は Hardening Override 対象のため、本 PBI の C-3 APPROVED + maintenance window 経由で適用。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01**: 既存例外ルール構造確認 + Hardening Override 対象パスの単一情報源（check-plan-hash.sh）抽出 | 調査メモ | AI | low | パス一覧確定 |
+| 2 | **T-02**: `.claude/rules/mode-classification.md` 例外ルール追記 (承認境界周辺→最低「高」 + 対象パス一覧 + 監査ログ CLI 例外 + 自動推定安全側) | mode-classification.md | AI | medium (Hardening Override) | maintenance window 経由 + markdownlint pass |
+| 3 | **T-03**: handoff.md (Rule 5) + V-1 | handoff.md | AI | low | AC-1..6 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `.claude/rules/mode-classification.md` | 例外ルール追記（**Hardening Override 対象**） |
+| `docs/working/TASK-0112/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- **markdownlint**: `.claude/rules/mode-classification.md`
+- **リンク健全性 CI**: 既存 reference 健全性 check で `working-context.md` への相互参照確認
+- **CI**: settings wiring drift / Markdown lint / SKIP_REASON 追認 / check 全 PASS
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| Hardening Override 対象パス改変が EH-3 で block | high | C-3 APPROVED + maintenance window 経由で適用（TASK-0106 で実証済の運用） |
+| 既存進行中 PBI の mode 判定再評価リクエスト | low | 「本 PBI merge 後着手の PBI から適用」を文言に含める |
+| 例外ルール乱立 | low | 対象パスを Hardening Override と完全一致させて単一情報源化 |
+
+## Mode 判定
+
+**light** (`lite_eligible=false` 強制)
+
+- 変更ファイル数: 1（+handoff 1）
+- 受入基準数: 6
+- 変更種別: docs (rule) 追記
+- リスク: 中 (Hardening Override 対象だが内容は additive 文言追加)
+- ロールバック: 容易 (git revert)
+- 影響範囲: `.claude/rules/mode-classification.md` のみ、以降の PBI mode 推定に波及
+
+→ light で進行、ただし `lite_eligible=false` 強制（承認境界周辺自体）。**自己適用**（本 PBI 自体が新ルール対象なら最低「高」になるが、文言追加のみで影響範囲が rule 文言に限定されるため light で C-3 判定を仰ぐ）

--- a/docs/working/TASK-0112/review-self.md
+++ b/docs/working/TASK-0112/review-self.md
@@ -1,0 +1,19 @@
+# TASK-0112 C-1 セルフレビュー
+
+## Plan 7 項目
+
+| # | 判定 | コメント |
+|---|------|---------|
+| C1-PLAN-01 受入基準網羅性 | PASS | AC-1..6 全 TC マッピング |
+| C1-PLAN-02 Unknowns | PASS | 自動推定実装は out of scope |
+| C1-PLAN-03 スコープ制御 | PASS | additive 文言追加のみ |
+| C1-PLAN-04 テスト戦略 | PASS | grep + markdownlint で機械検証 |
+| C1-PLAN-05 Work Breakdown | PASS | T-01..T-03 Output 明示 |
+| C1-PLAN-06 依存関係 | PASS | T-02 は C-3 + maintenance window 後 |
+| C1-PLAN-07 動作検証自動化 | PASS | 全 TC が grep + markdownlint |
+
+## ToDo 5 項目: PASS / TestCases 3 項目: PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能
+
+総合スコア: 94/100。blocker 0、major 0、minor 1 (TASK-0110 を例示したことで TASK-0110 の mode 再評価示唆が発生するが、本 PBI で「以降の PBI から適用」と明記済)。

--- a/docs/working/TASK-0112/test-cases.md
+++ b/docs/working/TASK-0112/test-cases.md
@@ -1,0 +1,27 @@
+# TASK-0112 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1: 例外ルール追記 | TC-01 |
+| AC-2: 対象パス一覧 = Hardening Override | TC-02 |
+| AC-3: working-context.md AC-10/AC-8 相互参照 | TC-03 |
+| AC-4: 監査ログ CLI 例外 | TC-04 |
+| AC-5: 自動推定安全側 | TC-05 |
+| AC-6: markdownlint + リンク健全性 | TC-06 |
+
+## ケース
+
+| ID | 内容 | コマンド | 期待 |
+|----|------|---------|------|
+| TC-01 | 「承認境界周辺の変更 → 最低でも『高』」追加 | `grep -n '承認境界周辺の変更.*最低でも.*高' .claude/rules/mode-classification.md` | 該当 1 件 |
+| TC-02 | 対象パス一覧が Hardening Override と一致 (.claude/, scripts/hooks/, bin/plangate, schemas/, .github/workflows/, AGENTS.md, CLAUDE.md) | `grep -nE '\.claude/.*scripts/hooks/.*bin/plangate' .claude/rules/mode-classification.md \|\| true` および手動比較 | 全 path 言及 |
+| TC-03 | working-context.md AC-10/AC-8 への相互参照 | `grep -nE 'AC-10\|AC-8\|working-context' .claude/rules/mode-classification.md` | 該当 |
+| TC-04 | 監査ログ一括変更 CLI 例外 (TASK-0110 を例示) | `grep -nE '監査ログ.*一括\|TASK-0110' .claude/rules/mode-classification.md` | 該当 |
+| TC-05 | 自動推定安全側 (不確実→該当扱い) | `grep -nE '安全側\|不確実.*該当' .claude/rules/mode-classification.md` | 該当 |
+| TC-06 | markdownlint pass | `npx markdownlint-cli '.claude/rules/mode-classification.md'` | exit 0 |
+
+## エッジケース
+
+- 既存 3 例外ルール (セキュリティ/DB/公開 API) は不変 (`grep -A3 '例外ルール' .claude/rules/mode-classification.md` で 3 項目残存)

--- a/docs/working/TASK-0112/todo.md
+++ b/docs/working/TASK-0112/todo.md
@@ -1,0 +1,24 @@
+# TASK-0112 EXECUTION TODO
+
+> Source: plan.md / Mode: light
+
+## 🤖 Agent タスク
+
+- [ ] **T-01**: 既存例外ルール構造確認 + Hardening Override 対象パス抽出 (check-plan-hash.sh) (owner=agent / Risk=low / 🚩 パス一覧確定)
+- [ ] **T-02**: `.claude/rules/mode-classification.md` 例外ルール追記 (owner=agent / Risk=medium / depends_on=T-01 / 🚩 maintenance window 経由 + markdownlint pass)
+- [ ] **T-03**: handoff.md (Rule 5 必須 6 要素) + V-1 (owner=agent / Risk=low / depends_on=T-02 / 🚩 AC-1..6 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: maintenance window 発行 (`bin/plangate maintenance start --paths .claude/rules/mode-classification.md --minutes 5`) — exec 直前
+- [ ] **H-03**: C-4 ゲート (PR レビュー) + merge
+
+## ⚠️ 依存関係
+
+- T-02 は H-01 (C-3) + H-02 (maintenance) 両通過後にのみ着手可
+- T-01 は C-3 前可
+
+## 完了条件
+
+全 T + handoff 6 要素 + AC-1..6 PASS + CI 全 PASS


### PR DESCRIPTION
Codex 推奨優先順 C として実施。TASK-0106 Retrospective Try アクション「承認境界周辺は最低 high-risk」を mode-classification.md 例外ルールに追加する PBI の plan を生成。

## Goal

`.claude/rules/mode-classification.md` の例外ルールに「承認境界周辺の変更 → 最低でも『高』」を追加。

## 設計判断

- 対象パスは Hardening Override 対象と一致 (single source of truth)
- 監査ログ一括変更 CLI も承認境界相当 (TASK-0110 を例示)
- working-context.md AC-10/AC-8 と相互参照 (重複定義しない)
- additive 変更 (既存 3 例外ルールは不変)

## Mode

light (lite_eligible=false 強制)。Hardening Override 対象パス改修のため C-3 APPROVED + maintenance window 経由で適用 (TASK-0106 実証済)。

## PR #339 (EH-10 RFC) との関係

orthogonal: D=AI 自己 Gate Hook 強制、C=mode 自動推定の安全側補強。補完関係。

Refs: TASK-0106 Retrospective Try

🤖 Generated with [Claude Code](https://claude.com/claude-code)