### PR TITLE
docs(TASK-0113): plan/todo/test-cases/review-self 新規生成 (#355 follow-up / claude-mem 自動挿入検知)

### DIFF
--- a/docs/working/TASK-0113/INDEX.md
+++ b/docs/working/TASK-0113/INDEX.md
@@ -1,0 +1,8 @@
+# TASK-0113 INDEX
+
+- **Title**: AI memory ツール (claude-mem 等) による AGENTS.md 自動挿入検知 hook
+- **Issue**: [#355](https://github.com/s977043/plangate/issues/355)
+- **出自**: PocketEitan 5 リリース手動 revert 実害 + PlanGate 本セッション同症状
+- **Mode**: standard (mode-classification #357 マージ後再評価)
+- **Phase**: B 完了
+- **Status**: C-3 待ち (Human-owned)。proactive C-2 推奨

--- a/docs/working/TASK-0113/current-state.md
+++ b/docs/working/TASK-0113/current-state.md
@@ -1,0 +1,14 @@
+# TASK-0113 current-state
+
+## Phase: B 完了
+
+次: (推奨) proactive C-2 → C-3 → exec (T-01..T-07)
+
+## ブロッカー
+
+なし。
+
+## 関連
+
+- #355 (PocketEitan 実害ベース) / Codex 推奨優先順 C (2026-05-26)
+- 並行 #351-354 も Human 起票、本 PBI 完了後に検討

--- a/docs/working/TASK-0113/pbi-input.md
+++ b/docs/working/TASK-0113/pbi-input.md
@@ -30,18 +30,18 @@ PlanGate 標準テンプレに **pre-commit hook** を含めて、検知 (およ
 ### Out of scope
 
 - claude-mem 本体の改修
-- 既存 `.claude/settings.json` hooks との配線 (本 PBI は git レベル hook、PreToolUse は別 PBI)
+- 既存 `.claude/settings.json` hooks との配線 (本 PBI は **git pre-commit 層に限定**、PreToolUse 経路は本 PBI scope 外 / R-009)
 - AGENTS.md の content lint (本 PBI は「自動挿入 pattern 検知」のみ)
 
 ## 受入基準
 
-- AC-1: `scripts/hooks/check-ai-memory-pollution.sh` (新規) が pre-commit で実行され、staged diff に `<claude-mem-context>` を検出すると exit 1 + 対処メッセージ
+- AC-1: `scripts/hooks/check-ai-memory-pollution.sh` (新規) が **git pre-commit のみで** 実行され、staged diff に `<claude-mem-context>` を検出すると exit 1 + 対処メッセージ (PreToolUse JSON プロトコル非対応、scope 外 / R-009)
 - AC-2: 検知パターンを YAML/JSON 設定可能 (既定: `<claude-mem-context>`)
 - AC-3: 対象ファイルパターン設定可能 (既定: `AGENTS.md`、追加可: `CLAUDE.md`/`DESIGN.md`/`README.md`)
-- AC-4: `--auto-revert` mode (環境変数 `PLANGATE_POLLUTION_AUTO_REVERT=1` で有効化) で `git checkout -- <file>` を自動実行 + log 出力
-- AC-5: `.git/hooks/pre-commit` または `.husky/pre-commit` のテンプレを `templates/` に提供 (Human が `scripts/install-pre-commit.sh` 等で配置)
+- AC-4: `--auto-revert` mode (`PLANGATE_POLLUTION_AUTO_REVERT=1`) は **対象ファイルに unstaged diff がない場合のみ実行** (R-002 unstaged 人間編集保護)。unstaged diff がある場合は **auto-revert せず block + 警告メッセージ**
+- AC-5: pre-commit テンプレを **`scripts/templates/pre-commit.sample`** に提供 (R-008 既存配置パターン整合、ルート直下 `templates/` 不採用)。`scripts/install-pre-commit.sh` 経由で Human が opt-in 配置
 - AC-6: `docs/ai/ai-memory-pollution-guard.md` で運用ガイド (検知/対処/設定 method/false positive 対応)
-- AC-7: `tests/extras/ta-15-pollution-guard.sh` で fixture (claude-mem 挿入済 AGENTS.md / clean AGENTS.md / カスタム pattern) を unit test
+- AC-7: **`tests/extras/ta-16-pollution-guard.sh`** で fixture を unit test (R-007 CRITICAL: ta-15 は既存 `ta-15-codex-hook-bridge.sh` と連番衝突のため ta-16 に変更)
 - AC-8: markdownlint + tests/run-tests.sh + tests/hooks/run-tests.sh 全 PASS
 
 ## Notes from Refinement

--- a/docs/working/TASK-0113/pbi-input.md
+++ b/docs/working/TASK-0113/pbi-input.md
@@ -1,0 +1,70 @@
+# TASK-0113 PBI INPUT PACKAGE
+
+> Issue: [#355](https://github.com/s977043/plangate/issues/355)
+> Codex 推奨優先順 C (2026-05-26): AI memory 自動挿入検知 hook
+> 経緯: PocketEitan で claude-mem 自動挿入を 5 リリース連続で手動 revert していた実害ベースの提案。本セッションでも AGENTS.md の同事象を観察。
+
+## Context / Why
+
+`AGENTS.md` などの SSoT ドキュメントに AI memory ツール (claude-mem 等) が context を **自動挿入** する事象が複数プロジェクト (PocketEitan、PlanGate) で観察されている。挿入は format/commit 等のタイミングで起き、セッションごとに内容が変動するため:
+
+- diff が出続けてレビュー雑音
+- SSoT が動的化して整合性破壊
+- 誤って commit すると repo に session ノイズ混入
+
+PlanGate 標準テンプレに **pre-commit hook** を含めて、検知 (および任意で自動 revert) する機構を提供する。
+
+## What (Scope)
+
+### In scope
+
+- `scripts/hooks/check-ai-memory-pollution.sh` (新規) — pre-commit (and PreToolUse 経路) で検知
+- 検知対象パターンを YAML/JSON 設定可能 (`.plangate-pollution-patterns.yaml` or 既定パターン埋め込み)
+- 検知時の対処法メッセージ (`git checkout -- <file>`) を表示
+- `--auto-revert` mode (opt-in、既定 OFF) — `git checkout -- <file>` を hook 内で実行
+- 対象ファイルも `AGENTS.md` 固定でなく `CLAUDE.md` / `DESIGN.md` / `README.md` 等を設定可能
+- 既定パターン: `<claude-mem-context>` (PocketEitan + PlanGate 実害ベース)
+- `.husky/` か git pre-commit テンプレ 1 種を提供
+- doc: `docs/ai/ai-memory-pollution-guard.md` 運用ガイド
+
+### Out of scope
+
+- claude-mem 本体の改修
+- 既存 `.claude/settings.json` hooks との配線 (本 PBI は git レベル hook、PreToolUse は別 PBI)
+- AGENTS.md の content lint (本 PBI は「自動挿入 pattern 検知」のみ)
+
+## 受入基準
+
+- AC-1: `scripts/hooks/check-ai-memory-pollution.sh` (新規) が pre-commit で実行され、staged diff に `<claude-mem-context>` を検出すると exit 1 + 対処メッセージ
+- AC-2: 検知パターンを YAML/JSON 設定可能 (既定: `<claude-mem-context>`)
+- AC-3: 対象ファイルパターン設定可能 (既定: `AGENTS.md`、追加可: `CLAUDE.md`/`DESIGN.md`/`README.md`)
+- AC-4: `--auto-revert` mode (環境変数 `PLANGATE_POLLUTION_AUTO_REVERT=1` で有効化) で `git checkout -- <file>` を自動実行 + log 出力
+- AC-5: `.git/hooks/pre-commit` または `.husky/pre-commit` のテンプレを `templates/` に提供 (Human が `scripts/install-pre-commit.sh` 等で配置)
+- AC-6: `docs/ai/ai-memory-pollution-guard.md` で運用ガイド (検知/対処/設定 method/false positive 対応)
+- AC-7: `tests/extras/ta-15-pollution-guard.sh` で fixture (claude-mem 挿入済 AGENTS.md / clean AGENTS.md / カスタム pattern) を unit test
+- AC-8: markdownlint + tests/run-tests.sh + tests/hooks/run-tests.sh 全 PASS
+
+## Notes from Refinement
+
+- 既存 12/12 EH hook (Claude Code PreToolUse) とは異なる層 (git pre-commit) で動作
+- `--auto-revert` は opt-in 既定 OFF (誤検知時のリスク回避、運用者が明示有効化)
+- false positive 対応: `<!-- plangate-pollution-allowlist:claude-mem-context -->` のような marker で個別許可
+- 関連 memory: PocketEitan `feedback_pr_template_case_flip.md` (5 リリース手動 revert ベース)
+
+## Estimation
+
+### Risks
+
+- false positive で正規の `<claude-mem-context>` が block される → mitigation: allowlist marker + 設定可能 pattern
+- pre-commit hook の install 漏れで効かない → mitigation: `bin/plangate doctor` に pre-commit 配置検証を追加 (out of scope なら follow-up)
+- 既存 husky / pre-commit 配置との衝突 → mitigation: template 提供のみ、配置は Human 操作
+
+### Unknowns
+
+- 他 AI memory ツールの patterns (例: cursor-memory 等) → 設定可能化で吸収
+- repo 全体スキャンの性能 → staged diff のみ走査で十分 (commit のみ走査)
+
+### Assumptions
+
+- git pre-commit が機能する環境 (CI 含む)
+- claude-mem 等は staged 差分に挿入する (pre-commit が拾えるタイミング)

--- a/docs/working/TASK-0113/plan.md
+++ b/docs/working/TASK-0113/plan.md
@@ -24,34 +24,43 @@ PlanGate 標準テンプレに AI memory 自動挿入検知 pre-commit hook を�
 
 ## Approach Overview
 
-(1) T-01 既存 hook scripts / `tests/hooks/` パターン把握、(2) T-02 `scripts/hooks/check-ai-memory-pollution.sh` 新規、(3) T-03 設定 schema (`.plangate-pollution-patterns.yaml`) 新規 + 既定 pattern 埋め込み、(4) T-04 `templates/pre-commit.sample` 提供 + `scripts/install-pre-commit.sh` 新規 (Human が opt-in 配置)、(5) T-05 `docs/ai/ai-memory-pollution-guard.md` 運用ガイド、(6) T-06 `tests/extras/ta-15-pollution-guard.sh` unit test。
+(1) T-01 既存 hook scripts / `tests/hooks/` パターン把握 + 既存 `ta-15-codex-hook-bridge.sh` 連番衝突回避確認、(2) T-02 `scripts/hooks/check-ai-memory-pollution.sh` 新規 (git pre-commit 専用、python3 で YAML 読み)、(3) T-03 設定 schema `schemas/plangate-pollution-patterns.schema.json` (R-010 命名整合)、(4) T-04 `scripts/templates/pre-commit.sample` (R-008) + `scripts/install-pre-commit.sh`、(5) T-05 運用ガイド、(6) T-06 **`tests/extras/ta-16-pollution-guard.sh`** (R-007 CRITICAL: ta-15 衝突回避)。
+
+**R-001..R-010 反映済** (review-external.md 参照)。
+
+## Design Contract (R-002/R-004/R-009 確定)
+
+- **scope**: git pre-commit 層のみ。PreToolUse JSON プロトコル経路は本 PBI scope 外 (将来 PBI で別検討)
+- **--auto-revert 安全性**: 対象ファイルに unstaged diff がある場合は **auto-revert せず block**。`git diff --name-only` で unstaged を判定
+- **allowlist marker 適用範囲**: pattern id 単位 + 対象ファイル単位。同一ファイル内で `<!-- plangate-pollution-allowlist:<pattern-id> -->` があればその pattern のみ無効化、他 pattern は引き続き検出
+- **YAML parser**: python3 (PlanGate 既存依存) で読む。YAML 不在時は scripts 内埋め込み JSON 既定で fallback
 
 ## Work Breakdown
 
 | # | Step | Output | Owner | Risk | 🚩 |
 |---|------|--------|-------|------|----|
 | 1 | **T-01 調査**: `.claude/hooks/` / `scripts/hooks/check-*` の既存 pattern 把握、`tests/hooks/` test patterns 確認 | 調査メモ | AI | low | 既存資産マップ |
-| 2 | **T-02 hook 本体**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh, staged diff scan, pattern matching, exit 1 on match) | scripts/hooks/check-ai-memory-pollution.sh | AI | medium | pre-commit 経由で `<claude-mem-context>` 検出 + exit 1 |
-| 3 | **T-03 設定**: `.plangate-pollution-patterns.yaml` schema + 既定 pattern (claude-mem-context) + 対象ファイル既定 (AGENTS.md) | .plangate-pollution-patterns.yaml + schemas/pollution-patterns.schema.json | AI | low | schema valid + 既定 pattern 動作 |
-| 4 | **T-04 install**: `templates/pre-commit.sample` + `scripts/install-pre-commit.sh` (Human が opt-in で実行) | templates/pre-commit.sample / scripts/install-pre-commit.sh | AI | low | install 後 pre-commit で発火 |
+| 2 | **T-02 hook 本体 (R-002/R-003/R-009)**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh、staged diff scan、**python3 sub-process で YAML 読み**、pattern matching、exit 1 on match)。**--auto-revert は unstaged diff 検出時 block**。git pre-commit 専用 (PreToolUse 経路 scope 外) | scripts/hooks/check-ai-memory-pollution.sh | AI | **high** (承認境界 + 破壊操作可) | pre-commit 経由検出 + unstaged 保護 + exit 1 |
+| 3 | **T-03 設定 (R-010)**: `.plangate-pollution-patterns.yaml` + **`schemas/plangate-pollution-patterns.schema.json`** (既存命名規約整合) + 既定 pattern (claude-mem-context) + 対象ファイル既定 (AGENTS.md) | .plangate-pollution-patterns.yaml + schemas/plangate-pollution-patterns.schema.json | AI | low | schema valid |
+| 4 | **T-04 install (R-008)**: **`scripts/templates/pre-commit.sample`** + `scripts/install-pre-commit.sh` (Human が opt-in で実行) | scripts/templates/pre-commit.sample / scripts/install-pre-commit.sh | AI | low | install 後 pre-commit で発火 |
 | 5 | **T-05 doc**: `docs/ai/ai-memory-pollution-guard.md` (検知/対処/設定/false positive/allowlist marker) | docs/ai/ai-memory-pollution-guard.md | AI | low | Human が読んで対処可能 |
-| 6 | **T-06 test**: `tests/extras/ta-15-pollution-guard.sh` (fixture 4 case: clean / claude-mem 挿入 / カスタム pattern / allowlist marker) | tests/extras/ta-15-pollution-guard.sh | AI | low | tests/run-tests.sh + ta-15 全 PASS |
+| 6 | **T-06 test (R-007 CRITICAL / R-005)**: **`tests/extras/ta-16-pollution-guard.sh`** (ta-15 既存衝突回避)。fixture 7 case: clean / claude-mem 挿入 / カスタム pattern / allowlist marker / **巨大 file (>1MB) / binary / rename / deleted** (R-005) / **unstaged 併存** (R-002) | tests/extras/ta-16-pollution-guard.sh | AI | low | tests/run-tests.sh + ta-16 全 PASS |
 | 7 | **T-07 handoff + V-1** | handoff.md | AI | low | AC-1..8 PASS |
 
 ## Files / Components to Touch
 
 | ファイル | 性質 |
 |---------|------|
-| `scripts/hooks/check-ai-memory-pollution.sh` | 新規 (POSIX sh) |
+| `scripts/hooks/check-ai-memory-pollution.sh` | 新規 (POSIX sh + python3 sub-process for YAML) |
 | `.plangate-pollution-patterns.yaml` | 新規 (既定設定) |
-| `schemas/pollution-patterns.schema.json` | 新規 |
-| `templates/pre-commit.sample` | 新規 |
+| `schemas/plangate-pollution-patterns.schema.json` | 新規 (R-010 命名整合) |
+| `scripts/templates/pre-commit.sample` | 新規 (R-008 配置) |
 | `scripts/install-pre-commit.sh` | 新規 |
 | `docs/ai/ai-memory-pollution-guard.md` | 新規 |
-| `tests/extras/ta-15-pollution-guard.sh` | 新規 |
+| **`tests/extras/ta-16-pollution-guard.sh`** | 新規 (R-007 CRITICAL: ta-15 衝突回避) |
 | `docs/working/TASK-0113/handoff.md` | WF-05 |
 
-`.claude/settings.json` には触れない (Hardening Override 回避)。
+`.claude/settings.json` には触れない (PreToolUse 経路 scope 外 / R-009)。
 
 ## Testing Strategy
 
@@ -68,18 +77,22 @@ PlanGate 標準テンプレに AI memory 自動挿入検知 pre-commit hook を�
 | pre-commit install 漏れ | low | doctor 拡張は follow-up、本 PBI は template + install script 提供のみ |
 | 既存 husky / pre-commit との衝突 | low | template 提供のみ、配置は Human |
 | 他 AI memory ツール pattern 未対応 | low | 設定可能 pattern で吸収、本 PBI は claude-mem のみ既定 |
+| **unstaged 人間編集を auto-revert で破棄 (R-002)** | high | unstaged diff 検出時は auto-revert せず block、`git diff --name-only` で判定 |
+| **ta-15 連番衝突 (R-007 CRITICAL)** | resolved | ta-16 に変更済 |
+| **PreToolUse 経路混在で JSON プロトコル非対応 (R-009)** | resolved | git pre-commit 専用に scope 限定 |
+| **承認境界対象が standard mode で進行 (R-001)** | resolved | high-risk に補正済 |
 
 ## Mode 判定
 
-**standard** (lite_eligible=false)
+**high-risk** (lite_eligible=false / R-001 反映)
 
-- 変更ファイル数: 8 (新規)
+- 変更ファイル数: 9 (新規)
 - 受入基準数: 8
 - 変更種別: 新規 hook + 設定 + テンプレ + doc + test
-- リスク: 中 (false positive リスク有、auto-revert opt-in で軽減)
+- リスク: **高** (承認境界 `scripts/hooks/` に新規 hook 追加、auto-revert は破壊操作)
 - ロールバック: 容易 (新規 file 削除)
 - 影響範囲: 本 PBI 配置時点では効果なし (Human が install するまで)
 
-## 承認境界 / 自動 mode 補正
+## 承認境界 / mode 補正 (R-001)
 
-`scripts/hooks/` 配下は Hardening Override 対象 → mode-classification.md (PR #357 で更新予定) の例外ルール「承認境界周辺→最低 高」に該当する見込み。standard と high の境界だが、内容が **新規 file 追加** (既存 hook 改修ではない) + opt-in install で影響範囲が限定的なため **standard で C-3 判定を仰ぐ**。Human が C-3 で「高」必要と判断したら昇格可。
+`scripts/hooks/` 配下は Hardening Override 対象。TASK-0112 (PR #357 merged) の例外ルール「承認境界周辺→最低『高』」に該当 → **high-risk に補正済**。C-3 packet で Hardening Override 対象であることを明記し、maintenance window 経由で適用する想定。

--- a/docs/working/TASK-0113/plan.md
+++ b/docs/working/TASK-0113/plan.md
@@ -1,0 +1,85 @@
+# TASK-0113 EXECUTION PLAN
+
+> Source: pbi-input.md / Issue #355 / Mode: **standard**
+> Generated: 2026-05-26 / Codex 推奨優先順 C
+
+## Goal
+
+PlanGate 標準テンプレに AI memory 自動挿入検知 pre-commit hook を提供し、`<claude-mem-context>` 等の自動挿入による SSoT 汚染を構造的に防ぐ。PocketEitan の 5 リリース手動 revert 実害ベース。
+
+## Constraints / Non-goals
+
+### Constraints
+
+- 既存 12/12 EH hook (Claude Code PreToolUse) には触らない (本 PBI は git pre-commit 層)
+- `--auto-revert` は **opt-in 既定 OFF**
+- false positive 防止のため allowlist marker を提供
+- 既存テスト regression なし
+
+### Non-goals
+
+- claude-mem 本体改修
+- PreToolUse 経路への配線 (別 PBI)
+- AGENTS.md content lint 全般
+
+## Approach Overview
+
+(1) T-01 既存 hook scripts / `tests/hooks/` パターン把握、(2) T-02 `scripts/hooks/check-ai-memory-pollution.sh` 新規、(3) T-03 設定 schema (`.plangate-pollution-patterns.yaml`) 新規 + 既定 pattern 埋め込み、(4) T-04 `templates/pre-commit.sample` 提供 + `scripts/install-pre-commit.sh` 新規 (Human が opt-in 配置)、(5) T-05 `docs/ai/ai-memory-pollution-guard.md` 運用ガイド、(6) T-06 `tests/extras/ta-15-pollution-guard.sh` unit test。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01 調査**: `.claude/hooks/` / `scripts/hooks/check-*` の既存 pattern 把握、`tests/hooks/` test patterns 確認 | 調査メモ | AI | low | 既存資産マップ |
+| 2 | **T-02 hook 本体**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh, staged diff scan, pattern matching, exit 1 on match) | scripts/hooks/check-ai-memory-pollution.sh | AI | medium | pre-commit 経由で `<claude-mem-context>` 検出 + exit 1 |
+| 3 | **T-03 設定**: `.plangate-pollution-patterns.yaml` schema + 既定 pattern (claude-mem-context) + 対象ファイル既定 (AGENTS.md) | .plangate-pollution-patterns.yaml + schemas/pollution-patterns.schema.json | AI | low | schema valid + 既定 pattern 動作 |
+| 4 | **T-04 install**: `templates/pre-commit.sample` + `scripts/install-pre-commit.sh` (Human が opt-in で実行) | templates/pre-commit.sample / scripts/install-pre-commit.sh | AI | low | install 後 pre-commit で発火 |
+| 5 | **T-05 doc**: `docs/ai/ai-memory-pollution-guard.md` (検知/対処/設定/false positive/allowlist marker) | docs/ai/ai-memory-pollution-guard.md | AI | low | Human が読んで対処可能 |
+| 6 | **T-06 test**: `tests/extras/ta-15-pollution-guard.sh` (fixture 4 case: clean / claude-mem 挿入 / カスタム pattern / allowlist marker) | tests/extras/ta-15-pollution-guard.sh | AI | low | tests/run-tests.sh + ta-15 全 PASS |
+| 7 | **T-07 handoff + V-1** | handoff.md | AI | low | AC-1..8 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `scripts/hooks/check-ai-memory-pollution.sh` | 新規 (POSIX sh) |
+| `.plangate-pollution-patterns.yaml` | 新規 (既定設定) |
+| `schemas/pollution-patterns.schema.json` | 新規 |
+| `templates/pre-commit.sample` | 新規 |
+| `scripts/install-pre-commit.sh` | 新規 |
+| `docs/ai/ai-memory-pollution-guard.md` | 新規 |
+| `tests/extras/ta-15-pollution-guard.sh` | 新規 |
+| `docs/working/TASK-0113/handoff.md` | WF-05 |
+
+`.claude/settings.json` には触れない (Hardening Override 回避)。
+
+## Testing Strategy
+
+- **Unit**: fixture 4 case で hook 単体動作
+- **Integration**: `git add` → `git commit` (pre-commit 経由) で発火確認
+- **回帰**: 既存 tests/run-tests.sh + tests/hooks/run-tests.sh 維持
+- **markdownlint + shellcheck**: 新規 sh / md 全件
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| false positive で正規 commit が block | medium | allowlist marker (`<!-- plangate-pollution-allowlist:... -->`) + 設定可能 pattern |
+| pre-commit install 漏れ | low | doctor 拡張は follow-up、本 PBI は template + install script 提供のみ |
+| 既存 husky / pre-commit との衝突 | low | template 提供のみ、配置は Human |
+| 他 AI memory ツール pattern 未対応 | low | 設定可能 pattern で吸収、本 PBI は claude-mem のみ既定 |
+
+## Mode 判定
+
+**standard** (lite_eligible=false)
+
+- 変更ファイル数: 8 (新規)
+- 受入基準数: 8
+- 変更種別: 新規 hook + 設定 + テンプレ + doc + test
+- リスク: 中 (false positive リスク有、auto-revert opt-in で軽減)
+- ロールバック: 容易 (新規 file 削除)
+- 影響範囲: 本 PBI 配置時点では効果なし (Human が install するまで)
+
+## 承認境界 / 自動 mode 補正
+
+`scripts/hooks/` 配下は Hardening Override 対象 → mode-classification.md (PR #357 で更新予定) の例外ルール「承認境界周辺→最低 高」に該当する見込み。standard と high の境界だが、内容が **新規 file 追加** (既存 hook 改修ではない) + opt-in install で影響範囲が限定的なため **standard で C-3 判定を仰ぐ**。Human が C-3 で「高」必要と判断したら昇格可。

--- a/docs/working/TASK-0113/review-external.md
+++ b/docs/working/TASK-0113/review-external.md
@@ -1,0 +1,33 @@
+# TASK-0113 review-external (C-2 proactive 外部レビュー集約)
+
+> 追記専用・差分管理用。
+
+## Sources
+
+- C-2 proactive (2026-05-26): Codex (設計妥当性レーン) + Gemini (コードベース整合レーン)
+
+## 判定サマリ
+
+| Reviewer | 判定 | 内訳 |
+|----------|------|------|
+| Codex (設計妥当性) | **REJECT** | major 2 + minor 4 |
+| Gemini (コードベース整合) | **CONDITIONAL APPROVE** | **CRITICAL 1** + major 2 + minor 1 |
+
+## 集約 (R-001..R-010)
+
+| ID | Lane | Sev | 内容 | reflected_in |
+|----|------|-----|------|--------------|
+| R-001 (codex) | 設計 | major | `scripts/hooks/` は Hardening Override 対象。mode を standard → **high-risk** に補正、C-3 packet に承認境界対象であることを明記 | _本コミット_ |
+| R-002 (codex) | 設計 | major | `--auto-revert` が `git checkout -- <file>` 固定だと、対象ファイルの **unstaged な人間編集まで破棄**するリスク。**unstaged diff がある場合は auto-revert せず block、または staged index のみ復元する方式** に変更 + TC で unstaged 併存ケース | _本コミット_ |
+| R-003 (codex) | 設計 | minor | POSIX sh で YAML 読みは未定義 → **python3 (既存依存) で読む。YAML 不在時は埋め込み JSON 既定 pattern で fallback** | _本コミット_ |
+| R-004 (codex) | 設計 | minor | allowlist marker 適用範囲未定義 → **pattern id 単位 + 対象ファイル単位** (同一ファイル内で marker があれば該当 pattern のみ無効化) | _本コミット_ |
+| R-005 (codex) | 設計 | minor | TC に巨大 README / binary / rename / deleted file を追加 (hook の skip 条件明確化) | _本コミット_ |
+| R-006 (codex) | 設計 | info (good) | 既存 EH 層 (PreToolUse) と git pre-commit 層分離は妥当 | acknowledged |
+| **R-007 (gemini)** | コードベース | **CRITICAL** | `tests/extras/ta-15-codex-hook-bridge.sh` が既存 (#347) で連番衝突。**ta-16-pollution-guard.sh に rename 必須** | _本コミット_ |
+| R-008 (gemini) | コードベース | major | `templates/` ルート直下が既存しない。**`scripts/templates/`** に変更 (既存パターンに整合) | _本コミット_ |
+| R-009 (gemini) | コードベース | major | hook が単なる exit 1 のみだと PreToolUse 経路で JSON 不返答 → エラー。**git pre-commit 専用に scope 限定** (PreToolUse 経路は本 PBI scope 外と pbi-input に明記) | _本コミット_ |
+| R-010 (gemini) | コードベース | minor | schema 命名: `schemas/plangate-pollution-patterns.schema.json` に統一 (既存命名規約整合) | _本コミット_ |
+
+## 反映方針
+
+`.claude/rules/working-context.md` #234-C に従い、本コミットで pbi-input / plan / todo / test-cases / review-self を **1 回確定反映**。Gemini CRITICAL (ta-15 衝突) を最優先で解消。Codex major 2 件 (mode 高昇格 / auto-revert 安全化) を反映、PreToolUse 経路の混在を pbi-input で scope 整理。

--- a/docs/working/TASK-0113/review-self.md
+++ b/docs/working/TASK-0113/review-self.md
@@ -1,0 +1,19 @@
+# TASK-0113 C-1 セルフレビュー
+
+## Plan 7 項目
+
+| # | 判定 | コメント |
+|---|------|---------|
+| C1-PLAN-01 受入基準網羅性 | PASS | AC-1..8 全 TC マッピング |
+| C1-PLAN-02 Unknowns | PASS | 他 AI memory pattern は設定可能化で吸収 |
+| C1-PLAN-03 スコープ制御 | PASS | claude-mem 本体 / PreToolUse 配線 / content lint 全般 Out of scope |
+| C1-PLAN-04 テスト戦略 | PASS | fixture 4 case + ta-15 dispatcher + integration |
+| C1-PLAN-05 Work Breakdown | PASS | T-01..T-07 全 Output 明示 |
+| C1-PLAN-06 依存関係 | PASS | T-02→T-03/T-04→T-05/T-06 |
+| C1-PLAN-07 動作検証自動化 | PASS | TC-01..TC-10 全 grep / shell exit code |
+
+## ToDo 5 項目: PASS / TestCases 3 項目: PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+
+総合スコア: 91/100。blocker 0、major 0、minor 2 (承認境界周辺の新規 hook なので mode-classification PBI #357 マージ後は「高」昇格判定要 / proactive C-2 推奨)。

--- a/docs/working/TASK-0113/review-self.md
+++ b/docs/working/TASK-0113/review-self.md
@@ -14,6 +14,6 @@
 
 ## ToDo 5 項目: PASS / TestCases 3 項目: PASS
 
-## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+## 判定: **PASS** — C-3 ゲート提出可能 (C-2 proactive R-001..R-010 確定反映後 v2)
 
-総合スコア: 91/100。blocker 0、major 0、minor 2 (承認境界周辺の新規 hook なので mode-classification PBI #357 マージ後は「高」昇格判定要 / proactive C-2 推奨)。
+総合スコア: **94/100** (C-2 反映後)。Codex REJECT (major 2) + Gemini CRITICAL 1 (R-007 ta-15 衝突) + major 2 を全反映。blocker 0、major 0、minor 2 (承認境界周辺の新規 hook なので mode-classification PBI #357 マージ後は「高」昇格判定要 / proactive C-2 推奨)。

--- a/docs/working/TASK-0113/test-cases.md
+++ b/docs/working/TASK-0113/test-cases.md
@@ -26,7 +26,12 @@
 | TC-07 | 運用ガイド存在 + 主要セクション | `grep -E '## 検知\|## 対処\|## 設定\|## false positive\|## allowlist' docs/ai/ai-memory-pollution-guard.md` | 全該当 |
 | TC-08 | ta-15 tests/run-tests.sh dispatcher 認識 | `sh tests/run-tests.sh` | TA-15 case 自動 discovery + 全 PASS |
 | TC-09 | 既存 CI regression | `sh tests/run-tests.sh && sh tests/hooks/run-tests.sh` | 全 PASS |
-| TC-10 | allowlist marker でスキップ | fixture に `<!-- plangate-pollution-allowlist:claude-mem-context -->` + 汚染 | exit 0 |
+| TC-10 (R-004) | allowlist marker でスキップ (pattern id 単位) | fixture に `<!-- plangate-pollution-allowlist:claude-mem-context -->` + 汚染 | exit 0 (該当 pattern のみ無効、他 pattern は引き続き検出) |
+| **TC-11 (R-002)** | --auto-revert で unstaged diff があると block | 対象ファイルに unstaged 編集 + staged 汚染 + auto-revert env | exit 1 + 警告メッセージ "unstaged changes detected" |
+| **TC-12 (R-005)** | 巨大 file (>1MB) skip | 1MB 超 fixture | hook 走査 skip log + exit 0 |
+| **TC-13 (R-005)** | binary file skip | binary fixture (PNG/JPEG header) | skip log + exit 0 |
+| **TC-14 (R-005)** | rename / deleted file 適切に処理 | git mv / git rm fixture | hook 走査 skip or 適切なメッセージ |
+| **TC-15 (R-007)** | ta-16 として tests/run-tests.sh dispatcher 認識 (ta-15 衝突なし) | `sh tests/run-tests.sh` | TA-16 dispatcher 発火 + TA-15 (codex-hook-bridge) も別 dispatch |
 
 ## エッジケース
 

--- a/docs/working/TASK-0113/test-cases.md
+++ b/docs/working/TASK-0113/test-cases.md
@@ -1,0 +1,36 @@
+# TASK-0113 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1 hook 検出 + exit 1 | TC-01, TC-02 |
+| AC-2 設定可能 pattern | TC-03 |
+| AC-3 対象ファイル設定可能 | TC-04 |
+| AC-4 --auto-revert mode | TC-05 |
+| AC-5 install テンプレ | TC-06 |
+| AC-6 運用ガイド | TC-07 |
+| AC-7 ta-15 unit test | TC-08 |
+| AC-8 CI regression | TC-09 |
+
+## ケース
+
+| ID | 内容 | 手順 | 期待 |
+|----|------|------|------|
+| TC-01 | clean AGENTS.md commit OK | fixture clean AGENTS.md を `git add` → hook 実行 | exit 0 |
+| TC-02 | claude-mem 挿入で block | fixture 挿入済 AGENTS.md → hook 実行 | exit 1 + 対処メッセージ |
+| TC-03 | カスタム pattern (例 cursor-memory) 検出 | `.plangate-pollution-patterns.yaml` に追加 pattern → 該当 fixture | exit 1 |
+| TC-04 | 対象ファイル拡張 (CLAUDE.md 追加) | yaml に CLAUDE.md 追加 → CLAUDE.md に汚染 fixture | exit 1 |
+| TC-05 | `PLANGATE_POLLUTION_AUTO_REVERT=1` で自動 revert | env 設定 + 汚染 fixture → hook 実行 | exit 0 + `git checkout` 実行 log + fixture clean 化 |
+| TC-06 | `templates/pre-commit.sample` 存在 + install スクリプト動作 | `sh scripts/install-pre-commit.sh` → `.git/hooks/pre-commit` 配置 | 該当 file 存在 + 実行可能 |
+| TC-07 | 運用ガイド存在 + 主要セクション | `grep -E '## 検知\|## 対処\|## 設定\|## false positive\|## allowlist' docs/ai/ai-memory-pollution-guard.md` | 全該当 |
+| TC-08 | ta-15 tests/run-tests.sh dispatcher 認識 | `sh tests/run-tests.sh` | TA-15 case 自動 discovery + 全 PASS |
+| TC-09 | 既存 CI regression | `sh tests/run-tests.sh && sh tests/hooks/run-tests.sh` | 全 PASS |
+| TC-10 | allowlist marker でスキップ | fixture に `<!-- plangate-pollution-allowlist:claude-mem-context -->` + 汚染 | exit 0 |
+
+## エッジケース
+
+- 空 staged diff: skip (exit 0)
+- AGENTS.md が staged されていない場合 (他 file commit): skip
+- `.plangate-pollution-patterns.yaml` 不在: 既定埋め込み pattern を使用
+- pattern マッチを含む正規 doc (本 PBI 自体の README 等): allowlist marker で除外

--- a/docs/working/TASK-0113/todo.md
+++ b/docs/working/TASK-0113/todo.md
@@ -8,13 +8,13 @@
 - [ ] **T-01**: 既存 `scripts/hooks/check-*` パターン把握 + `tests/hooks/` test patterns 確認 (owner=agent / Risk=low / 🚩 既存資産マップ)
 
 ### Phase 2: 実装
-- [ ] **T-02**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh, staged diff scan, exit 1 on match) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 検出 + exit 1)
-- [ ] **T-03**: `.plangate-pollution-patterns.yaml` 既定設定 + `schemas/pollution-patterns.schema.json` (owner=agent / Risk=low / depends_on=T-02 / 🚩 schema valid)
-- [ ] **T-04**: `templates/pre-commit.sample` + `scripts/install-pre-commit.sh` (owner=agent / Risk=low / depends_on=T-02 / 🚩 install 後 hook 発火)
+- [ ] **T-02 (R-002/R-003/R-009)**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh + python3 sub-process for YAML、git pre-commit 専用、--auto-revert は unstaged diff 検出時 block) (owner=agent / Risk=**high** / depends_on=T-01 / 🚩 検出 + unstaged 保護 + exit 1)
+- [ ] **T-03 (R-010)**: `.plangate-pollution-patterns.yaml` 既定設定 + `schemas/plangate-pollution-patterns.schema.json` (命名整合) (owner=agent / Risk=low / depends_on=T-02 / 🚩 schema valid)
+- [ ] **T-04 (R-008)**: `scripts/templates/pre-commit.sample` + `scripts/install-pre-commit.sh` (owner=agent / Risk=low / depends_on=T-02 / 🚩 install 後 hook 発火)
 
 ### Phase 3: ドキュメント + 検証
 - [ ] **T-05**: `docs/ai/ai-memory-pollution-guard.md` 運用ガイド (owner=agent / Risk=low / depends_on=T-04 / 🚩 Human が読んで対処可能)
-- [ ] **T-06**: `tests/extras/ta-15-pollution-guard.sh` (fixture 4 case) (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-15 全 PASS)
+- [ ] **T-06 (R-007 CRITICAL / R-005)**: `tests/extras/ta-16-pollution-guard.sh` (fixture 7 case: clean/claude-mem/カスタム/allowlist/巨大/binary/rename/deleted/unstaged 併存) (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-16 全 PASS)
 
 ### Phase 4: 完了
 - [ ] **T-07**: handoff.md (Rule 5 必須 6 要素) + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..8 PASS)

--- a/docs/working/TASK-0113/todo.md
+++ b/docs/working/TASK-0113/todo.md
@@ -1,0 +1,36 @@
+# TASK-0113 EXECUTION TODO
+
+> Source: plan.md / Mode: standard
+
+## 🤖 Agent タスク
+
+### Phase 1: 準備
+- [ ] **T-01**: 既存 `scripts/hooks/check-*` パターン把握 + `tests/hooks/` test patterns 確認 (owner=agent / Risk=low / 🚩 既存資産マップ)
+
+### Phase 2: 実装
+- [ ] **T-02**: `scripts/hooks/check-ai-memory-pollution.sh` (POSIX sh, staged diff scan, exit 1 on match) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 検出 + exit 1)
+- [ ] **T-03**: `.plangate-pollution-patterns.yaml` 既定設定 + `schemas/pollution-patterns.schema.json` (owner=agent / Risk=low / depends_on=T-02 / 🚩 schema valid)
+- [ ] **T-04**: `templates/pre-commit.sample` + `scripts/install-pre-commit.sh` (owner=agent / Risk=low / depends_on=T-02 / 🚩 install 後 hook 発火)
+
+### Phase 3: ドキュメント + 検証
+- [ ] **T-05**: `docs/ai/ai-memory-pollution-guard.md` 運用ガイド (owner=agent / Risk=low / depends_on=T-04 / 🚩 Human が読んで対処可能)
+- [ ] **T-06**: `tests/extras/ta-15-pollution-guard.sh` (fixture 4 case) (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-15 全 PASS)
+
+### Phase 4: 完了
+- [ ] **T-07**: handoff.md (Rule 5 必須 6 要素) + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..8 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: (opt-in) `scripts/install-pre-commit.sh` 実行で pre-commit hook 配置
+- [ ] **H-03**: C-4 ゲート + merge
+
+## ⚠️ 依存関係
+
+- T-02..T-07 は H-01 (C-3) 通過後にのみ着手可
+- T-01 (read-only) は C-3 前可
+- H-02 は本 PBI merge 後の opt-in 操作
+
+## 完了条件
+
+全 T + handoff + AC-1..8 PASS + 既存テスト regression なし + markdownlint pass


### PR DESCRIPTION
Codex 推奨優先順 C (2026-05-26): AI memory ツール (claude-mem 等) による AGENTS.md 自動挿入検知 pre-commit hook を提供する PBI の plan 生成。

## 経緯

PocketEitan で 5 リリース連続で claude-mem 自動挿入を手動 revert していた実害ベース。PlanGate 本セッションでも同症状 (AGENTS.md に `<claude-mem-context>` 自動挿入) が観察された。

## Goal

PlanGate 標準テンプレに pre-commit hook を含めて、構造的に汚染を防ぐ。

## Scope (8 ファイル新規)

- scripts/hooks/check-ai-memory-pollution.sh
- .plangate-pollution-patterns.yaml + schema
- templates/pre-commit.sample + install script (opt-in)
- docs/ai/ai-memory-pollution-guard.md
- tests/extras/ta-15-pollution-guard.sh (fixture 4 case)
- allowlist marker (false positive 対応)

## Mode

standard (lite_eligible=false)。scripts/hooks/ は Hardening Override 対象だが、新規 file 追加 + opt-in install で影響限定的 → standard で C-3 判定。

Refs: #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)