### PR TITLE
docs(TASK-0114): plan 生成 — pre-push hook で main 直接 push 防止 (INC P-1)

### DIFF
--- a/docs/working/TASK-0114/INDEX.md
+++ b/docs/working/TASK-0114/INDEX.md
@@ -1,0 +1,7 @@
+# TASK-0114 INDEX
+
+- **Title**: pre-push hook で main 直接 push 防止 (INC-2026-05-26-001 P-1)
+- **出自**: INC-2026-05-26-001 Prevention P-1
+- **Mode**: standard
+- **Phase**: B 完了
+- **Status**: C-3 待ち

--- a/docs/working/TASK-0114/current-state.md
+++ b/docs/working/TASK-0114/current-state.md
@@ -1,0 +1,10 @@
+# TASK-0114 current-state
+
+## Phase: B 完了 / C-3 待ち
+
+INC-2026-05-26-001 P-1 対応。TASK-0113 (pre-commit hook) と並列構造。
+
+## 関連
+
+- INC-2026-05-26-001 / PR #359
+- TASK-0113 (#355 pre-commit hook)

--- a/docs/working/TASK-0114/pbi-input.md
+++ b/docs/working/TASK-0114/pbi-input.md
@@ -1,0 +1,58 @@
+# TASK-0114 PBI INPUT PACKAGE
+
+> 出自: [INC-2026-05-26-001](../incidents/2026-05-26-empty-commit-direct-push.md) Prevention P-1
+> 関連: PR #359
+
+## Context / Why
+
+INC-2026-05-26-001 で AI が main 直接 push (empty commit 49448c5) を実施。Prevention P-1 として **pre-push hook template** で main / master / release branch への直接 push を physical block する仕組みを PlanGate 標準テンプレとして提供する。
+
+`.git/hooks/` は repo にコミット不可のため、`scripts/templates/pre-push.sample` + `scripts/install-pre-push.sh` で Human が opt-in 配置する形式。TASK-0113 (#355 pre-commit hook) と並列構造。
+
+## What (Scope)
+
+### In scope
+
+- `scripts/templates/pre-push.sample` (新規) — protected branch を `main`/`master`/`release/*` で設定可能
+- `scripts/install-pre-push.sh` (新規) — Human opt-in 配置スクリプト
+- `docs/ai/direct-push-prevention.md` (新規) — 運用ガイド
+- `tests/extras/ta-17-pre-push-guard.sh` (新規) — fixture test
+- 既存 TASK-0113 templates/install パターンと一貫した設計
+- protected branch list 設定 (環境変数 `PLANGATE_PROTECTED_BRANCHES` で override 可)
+
+### Out of scope
+
+- GitHub branch protection 設定 (P-2、Human-owned GitHub admin)
+- `.claude/rules/` 追記 (P-3、TASK-0115 で別 PBI)
+- 全リポジトリへの自動配信 (各 repo Human opt-in)
+
+## 受入基準
+
+- AC-1: `scripts/templates/pre-push.sample` (POSIX sh) が protected branch (`main`/`master`/`release/*`) への push を exit 1 + 明確なメッセージで block
+- AC-2: `scripts/install-pre-push.sh` で `.git/hooks/pre-push` 配置可能 (既存 hook がある場合 `.bak` 保持)
+- AC-3: `PLANGATE_PROTECTED_BRANCHES` 環境変数 (space-separated) で protected list override 可能 (既定: `main master`)
+- AC-4: `docs/ai/direct-push-prevention.md` で運用ガイド (install / unprotect 手順 / bypass 方法 (緊急時 `--no-verify`))
+- AC-5: `tests/extras/ta-17-pre-push-guard.sh` fixture 5 case: protected push block / feature branch push OK / `--no-verify` bypass OK / 既存 hook 退避 / override env 動作
+- AC-6: 既存 tests/run-tests.sh + tests/hooks/run-tests.sh regression なし
+- AC-7: markdownlint + shellcheck PASS
+
+## Notes from Refinement
+
+- AI が `.git/hooks/` を repo にコミットできないため、template + install script 方式は唯一の選択肢
+- emergency bypass: `git push --no-verify` (慣行に準拠)
+- TASK-0113 (pre-commit hook) と同じ template ディレクトリ構造で並列化
+- P-2 (GitHub branch protection) と組み合わせで repo-wide + local の二段構え
+
+## Estimation
+
+### Risks
+- false positive で feature branch push が block → mitigation: protected list を明確化、override env 提供
+- 既存 hook 衝突 → mitigation: `.bak` 保持 + install スクリプトで明示警告
+- `--no-verify` で容易 bypass → 仕様 (緊急時の脱出弁)、監査は GitHub branch protection P-2 と組み合わせ
+
+### Unknowns
+- 各プロジェクトの release branch 命名揺れ (`release/*` / `prod` / `production` 等) → 設定 override で吸収
+
+### Assumptions
+- git pre-push hook が機能する環境
+- POSIX sh / `read` で stdin parsing 可能

--- a/docs/working/TASK-0114/plan.md
+++ b/docs/working/TASK-0114/plan.md
@@ -1,0 +1,68 @@
+# TASK-0114 EXECUTION PLAN
+
+> Source: pbi-input.md / INC-2026-05-26-001 P-1 / Mode: **standard**
+> Generated: 2026-05-26
+
+## Goal
+
+PlanGate 標準テンプレに pre-push hook を提供し、AI からの main / master / release branch 直接 push を **physical block**。INC-2026-05-26-001 寄与要因 C-3 を解消。
+
+## Constraints / Non-goals
+
+- GitHub branch protection (P-2) には触れない (Human-owned)
+- `.claude/rules/` 追記 (P-3 = TASK-0115) には触れない (orthogonal)
+- AI が `.git/hooks/` を repo にコミットしない (template + install script のみ)
+
+## Approach Overview
+
+TASK-0113 (#355 pre-commit hook、PR #358) と並列構造で pre-push 版を提供。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01 調査**: TASK-0113 template / install pattern 確認、git pre-push 仕様 (stdin format) 確認 | 調査メモ | AI | low | パターン把握 |
+| 2 | **T-02**: `scripts/templates/pre-push.sample` (POSIX sh、stdin parsing、protected check、エラーメッセージ) | scripts/templates/pre-push.sample | AI | medium | protected push 検出 + 明確メッセージ |
+| 3 | **T-03**: `scripts/install-pre-push.sh` (TASK-0113 install スクリプトと並列、`.bak` 保持) | scripts/install-pre-push.sh | AI | low | install 後 hook 発火 |
+| 4 | **T-04**: `docs/ai/direct-push-prevention.md` 運用ガイド | docs/ai/direct-push-prevention.md | AI | low | Human が読んで運用可能 |
+| 5 | **T-05**: `tests/extras/ta-17-pre-push-guard.sh` fixture 5 case | tests/extras/ta-17-pre-push-guard.sh | AI | low | tests/run-tests.sh + ta-17 PASS |
+| 6 | **T-06 handoff + V-1** | handoff.md | AI | low | AC-1..7 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `scripts/templates/pre-push.sample` | 新規 (POSIX sh) |
+| `scripts/install-pre-push.sh` | 新規 |
+| `docs/ai/direct-push-prevention.md` | 新規 |
+| `tests/extras/ta-17-pre-push-guard.sh` | 新規 |
+| `docs/working/TASK-0114/handoff.md` | WF-05 |
+
+`.claude/settings.json` / `.git/hooks/` (repo 内) には触れない。
+
+## Testing Strategy
+
+- Unit: fixture stdin で hook 単体動作 (5 case)
+- Integration: 一時 repo で `git push` 経由発火確認
+- 回帰: tests/run-tests.sh + tests/hooks/run-tests.sh
+- markdownlint + shellcheck
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| feature branch push false positive | low | protected list 明確化 + override env |
+| 既存 hook 衝突 | low | `.bak` 保持 + 明示警告 |
+| `--no-verify` で容易 bypass | acceptable | 緊急脱出弁、P-2 GitHub branch protection と組合せ |
+| stdin format の OS 差 | low | git 公式仕様準拠 (`<local ref> <local sha> <remote ref> <remote sha>`) |
+
+## Mode 判定
+
+**standard** (lite_eligible=false)
+
+- 変更ファイル数: 5 (新規)
+- 受入基準数: 7
+- 変更種別: 新規 template + install + doc + test
+- リスク: 中 (push 経路への介入、ただし opt-in install で影響限定)
+- 影響範囲: install するまで効果なし
+- 承認境界: `scripts/templates/` は新規パス、Hardening Override 対象外 → standard

--- a/docs/working/TASK-0114/review-self.md
+++ b/docs/working/TASK-0114/review-self.md
@@ -1,0 +1,13 @@
+# TASK-0114 C-1 セルフレビュー
+
+## Plan 7 項目: 全 PASS / ToDo 5 項目: PASS / TestCases 3 項目: PASS
+
+| # | 判定 |
+|---|------|
+| C1-PLAN-01..07 | PASS |
+| C1-TODO-01..05 | PASS |
+| C1-TC-01..03 | PASS |
+
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+
+総合スコア: 90/100。blocker 0、major 0、minor 1 (TASK-0113 と同じ install pattern なので C-2 で重複検出を期待)。

--- a/docs/working/TASK-0114/test-cases.md
+++ b/docs/working/TASK-0114/test-cases.md
@@ -1,0 +1,33 @@
+# TASK-0114 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1 protected block | TC-01, TC-02 |
+| AC-2 install + .bak | TC-03 |
+| AC-3 env override | TC-04 |
+| AC-4 ガイド | TC-05 |
+| AC-5 ta-17 fixture | TC-06 |
+| AC-6 regression | TC-07 |
+| AC-7 lint | TC-08 |
+
+## ケース
+
+| ID | 内容 | 手順 | 期待 |
+|----|------|------|------|
+| TC-01 | main push block | hook stdin に `refs/heads/main` push entry | exit 1 + メッセージ |
+| TC-02 | feature branch push OK | stdin に `refs/heads/feature/x` | exit 0 |
+| TC-03 | install + .bak 保持 | 既存 `.git/hooks/pre-push` 存在下で install | 既存→.bak + 新規配置 |
+| TC-04 | env override (carve out main) | `PLANGATE_PROTECTED_BRANCHES=release` + main push | exit 0 (main not protected) |
+| TC-05 | ガイド 主要セクション存在 | `grep -E '## install\|## bypass\|## emergency' docs/ai/direct-push-prevention.md` | 該当 |
+| TC-06 | ta-17 dispatcher 認識 | `sh tests/run-tests.sh` | TA-17 全 case PASS |
+| TC-07 | 既存テスト regression なし | `sh tests/run-tests.sh && sh tests/hooks/run-tests.sh` | 全 PASS |
+| TC-08 | shellcheck + markdownlint | `shellcheck scripts/templates/pre-push.sample scripts/install-pre-push.sh && npx markdownlint-cli docs/ai/direct-push-prevention.md` | exit 0 |
+| TC-09 | `--no-verify` bypass (emergency) | git push --no-verify でも block しない | exit 0 (git client が hook skip) |
+| TC-10 | release/* glob match | stdin に `refs/heads/release/v2.0.0` | exit 1 |
+
+## エッジケース
+
+- empty stdin (no push): exit 0
+- delete remote branch (`local_sha = 0...`): protected でも許可 (delete は別操作)

--- a/docs/working/TASK-0114/todo.md
+++ b/docs/working/TASK-0114/todo.md
@@ -1,0 +1,16 @@
+# TASK-0114 EXECUTION TODO
+
+## 🤖 Agent タスク
+
+- [ ] **T-01**: TASK-0113 template/install pattern + git pre-push 仕様確認 (owner=agent / Risk=low / 🚩 パターン把握)
+- [ ] **T-02**: `scripts/templates/pre-push.sample` (POSIX sh、protected branch block) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 protected push 検出)
+- [ ] **T-03**: `scripts/install-pre-push.sh` (`.bak` 保持) (owner=agent / Risk=low / depends_on=T-02 / 🚩 install 後 hook 発火)
+- [ ] **T-04**: `docs/ai/direct-push-prevention.md` 運用ガイド (owner=agent / Risk=low / depends_on=T-03 / 🚩 Human 運用可能)
+- [ ] **T-05**: `tests/extras/ta-17-pre-push-guard.sh` fixture 5 case (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-17 全 PASS)
+- [ ] **T-06**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..7 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: (opt-in) `sh scripts/install-pre-push.sh` で hook 配置
+- [ ] **H-03**: C-4 + merge


### PR DESCRIPTION
INC-2026-05-26-001 Prevention P-1 対応の PBI plan を B フェーズまで完了。

## Scope
- scripts/templates/pre-push.sample (POSIX sh)
- scripts/install-pre-push.sh (opt-in)
- docs/ai/direct-push-prevention.md
- tests/extras/ta-17-pre-push-guard.sh (5 case)

## Mode
standard (TASK-0113 と並列構造)

Refs: INC-2026-05-26-001 P-1, PR #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)