### PR TITLE
docs(TASK-0115): plan 生成 — .claude/rules/ Bash 連結コマンド error guard (INC P-3)

### DIFF
--- a/docs/working/TASK-0115/INDEX.md
+++ b/docs/working/TASK-0115/INDEX.md
@@ -1,0 +1,7 @@
+# TASK-0115 INDEX
+
+- **Title**: `.claude/rules/` Bash 連結コマンド error guard (INC P-3)
+- **出自**: INC-2026-05-26-001 Prevention P-3
+- **Mode**: light (lite_eligible=false / Hardening Override)
+- **Phase**: B 完了
+- **Status**: C-3 + maintenance window 待ち

--- a/docs/working/TASK-0115/current-state.md
+++ b/docs/working/TASK-0115/current-state.md
@@ -1,0 +1,11 @@
+# TASK-0115 current-state
+
+## Phase: B 完了
+
+INC-2026-05-26-001 P-3 対応。TASK-0114 (P-1 物理 block) との層分離: 本 PBI は AI 行動規範。
+
+## 関連
+
+- INC-2026-05-26-001 / PR #359
+- TASK-0114 (P-1 pre-push hook, PR #360)
+- TASK-0112 (mode-classification 例外ルール、merged) と同じ操作パターン

--- a/docs/working/TASK-0115/pbi-input.md
+++ b/docs/working/TASK-0115/pbi-input.md
@@ -1,0 +1,55 @@
+# TASK-0115 PBI INPUT PACKAGE
+
+> 出自: [INC-2026-05-26-001](../incidents/2026-05-26-empty-commit-direct-push.md) Prevention P-3
+> 関連: PR #359, INC 寄与要因 C-1
+
+## Context / Why
+
+INC-2026-05-26-001 で AI が `git checkout` 失敗を見落として後続 `git commit` / `git push` を中断しなかった (寄与要因 C-1: 複数コマンド連結時のエラー伝播弱)。
+
+Prevention P-3 として `.claude/rules/` に **コマンド連結時の error guard rule** を追記し、AI が次回以降同じパターンを踏まない構造化を行う。`.claude/rules/` は Hardening Override 対象のため C-3 APPROVED + maintenance window 経由で適用。
+
+TASK-0112 (mode-classification 例外ルール、merged) と同じ操作パターン。
+
+## What (Scope)
+
+### In scope
+
+- `.claude/rules/responsibility-classes.md` または `.claude/rules/` 配下に「Bash 連結コマンド時の error guard」セクション追加
+  - `&&` 連結 or `set -e` 必須
+  - `git push` 前の `git rev-parse --abbrev-ref HEAD` で current branch verify
+  - protected branch (main/master/release/*) への commit/push は事前明示確認
+- 追記場所の選択: 既存 [`responsibility-classes.md`](../../../../.claude/rules/responsibility-classes.md) §「対外公開アーティファクト publish 責務分界」と類似性が高いため同 file 内に追記、または新規 `.claude/rules/bash-command-chain-guard.md` を分離
+- INC-2026-05-26-001 を出典として明記
+
+### Out of scope
+
+- AI 側の自動チェック実装 (本 PBI は文言ルールのみ、実装側強制は TASK-0114 P-1 hook 等)
+- `bin/plangate` ラッパーで AI コマンドを intercept する仕組み
+
+## 受入基準
+
+- AC-1: `.claude/rules/` に「Bash 連結コマンド時の error guard」rule が追加されている
+- AC-2: 以下 4 項目が含まれる: (i) `&&` 連結 or `set -e`、(ii) `git push` 前 branch verify、(iii) protected branch への commit/push 事前確認、(iv) INC-2026-05-26-001 への参照
+- AC-3: AI 運用 4 原則 (CLAUDE.md `<law>`) との階層関係明示 (本 rule は第 1 原則の運用解釈)
+- AC-4: TASK-0112 (mode-classification 例外ルール) との重複定義なし、相互参照のみ
+- AC-5: markdownlint pass + リンク健全性 CI pass
+
+## Notes from Refinement
+
+- `.claude/rules/` は Hardening Override 対象 → C-3 APPROVED + maintenance window 経由
+- TASK-0112 と同じ操作手順を踏襲
+- 追記場所: `.claude/rules/responsibility-classes.md` 内が文脈整合性高い (既に「自己設置 Gate 非緩和原則」「対外公開 publish 責務分界」など運用解釈ルールがある)
+
+## Estimation
+
+### Risks
+- AI 自己解釈で rule を緩和 (本 PBI 自体が AI 運用 4 原則第 4 原則違反を防ぐ rule) → mitigation: 文言を明確 + INC 参照で実例固定
+- TASK-0114 (P-1 hook) との重複感 → mitigation: P-1 は physical block (技術)、P-3 は AI 行動規範 (運用解釈) で層分離明示
+
+### Unknowns
+- 追記場所 (responsibility-classes.md 内 vs 新規 file) → plan で確定
+
+### Assumptions
+- `.claude/rules/` 構造は不変
+- AI 運用 4 原則は CLAUDE.md `<law>` で固定

--- a/docs/working/TASK-0115/plan.md
+++ b/docs/working/TASK-0115/plan.md
@@ -1,0 +1,60 @@
+# TASK-0115 EXECUTION PLAN
+
+> Source: pbi-input.md / INC-2026-05-26-001 P-3 / Mode: **light**
+> Generated: 2026-05-26
+
+## Goal
+
+`.claude/rules/responsibility-classes.md` に「Bash 連結コマンド時の error guard」セクションを追加し、INC-2026-05-26-001 寄与要因 C-1 を文書化された運用 rule として構造化。
+
+## Constraints / Non-goals
+
+- AI 側自動チェック実装は scope 外 (P-1 = TASK-0114 と層分離)
+- TASK-0112 例外ルールを破壊しない (additive)
+- AI 運用 4 原則 (CLAUDE.md `<law>`) との階層関係を明示
+
+## Approach Overview
+
+`.claude/rules/responsibility-classes.md` への追記のみ (TASK-0112 と同じ操作手順)。Hardening Override 対象のため C-3 APPROVED + maintenance window 経由で適用。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01 調査**: TASK-0112 適用パターン確認、`responsibility-classes.md` 既存セクション構造把握 | 調査メモ | AI | low | 構造把握 |
+| 2 | **T-02 追記**: `.claude/rules/responsibility-classes.md` に新セクション「Bash 連結コマンド時の error guard (INC-2026-05-26-001 P-3)」追加 | responsibility-classes.md | AI | medium (Hardening Override) | maintenance window 経由 + markdownlint |
+| 3 | **T-03**: handoff.md + V-1 | handoff.md | AI | low | AC-1..5 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `.claude/rules/responsibility-classes.md` | 追記 (**Hardening Override 対象**) |
+| `docs/working/TASK-0115/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- markdownlint
+- リンク健全性 CI (INC report への相対パス確認)
+- 既存テスト regression なし
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| Hardening Override 対象改修が EH-3 で block | high | C-3 APPROVED + maintenance window 経由 (TASK-0106/0112 で実証済) |
+| TASK-0114 (P-1 hook) との重複感 | low | 文言で「物理 block は TASK-0114 (P-1)」「行動規範は本 rule (P-3)」と層分離明示 |
+| AI 自己解釈で rule 緩和 | medium | 文言明確 + INC 参照で実例固定 + 第 4 原則 (解釈変更禁止) を引用 |
+
+## Mode 判定
+
+**light** (lite_eligible=false)
+
+- 変更ファイル数: 1 (+handoff 1)
+- 受入基準数: 5
+- 変更種別: docs (rule) 追記
+- リスク: 中 (Hardening Override 対象)
+- ロールバック: 容易
+- 影響範囲: `.claude/rules/responsibility-classes.md` のみ、以降の AI 運用に波及
+
+→ light で進行、ただし `lite_eligible=false` 強制 (承認境界周辺自体、TASK-0112 例外ルール該当)。

--- a/docs/working/TASK-0115/review-self.md
+++ b/docs/working/TASK-0115/review-self.md
@@ -1,0 +1,7 @@
+# TASK-0115 C-1 セルフレビュー
+
+## Plan/ToDo/TestCases: 全 PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能
+
+総合スコア: 93/100。blocker 0、major 0、minor 1 (TASK-0114 P-1 と組合せでの完結性を C-3 packet で明示推奨)。

--- a/docs/working/TASK-0115/test-cases.md
+++ b/docs/working/TASK-0115/test-cases.md
@@ -1,0 +1,28 @@
+# TASK-0115 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1 rule 追加 | TC-01 |
+| AC-2 4 項目含む | TC-02, TC-03, TC-04, TC-05 |
+| AC-3 AI 運用 4 原則 階層 | TC-06 |
+| AC-4 TASK-0112 重複なし | TC-07 |
+| AC-5 markdownlint | TC-08 |
+
+## ケース
+
+| ID | 内容 | コマンド | 期待 |
+|----|------|---------|------|
+| TC-01 | Bash 連結コマンド error guard セクション存在 | `grep -nE 'Bash 連結.*error guard\|連結コマンド.*guard' .claude/rules/responsibility-classes.md` | 該当 |
+| TC-02 | `&&` 連結 or `set -e` 明示 | `grep -nE '&&|set -e' .claude/rules/responsibility-classes.md` 直近セクション内 | 該当 |
+| TC-03 | git push 前 branch verify 明示 | `grep -nE 'rev-parse.*HEAD\|branch verify' .claude/rules/responsibility-classes.md` | 該当 |
+| TC-04 | protected branch 事前確認 明示 | `grep -nE 'protected branch\|main.*事前確認' .claude/rules/responsibility-classes.md` | 該当 |
+| TC-05 | INC-2026-05-26-001 参照 | `grep -nE 'INC-2026-05-26-001\|incidents/2026-05-26' .claude/rules/responsibility-classes.md` | 該当 |
+| TC-06 | AI 運用 4 原則 階層明示 (第 1 原則の運用解釈) | `grep -nE 'AI 運用 4 原則\|第 1 原則' .claude/rules/responsibility-classes.md` 該当セクション | 該当 |
+| TC-07 | TASK-0112 (mode-classification) 重複定義なし | mode 分類規則を再定義していない (相互参照のみ) | grep で mode-classification 言及あり、定義重複なし |
+| TC-08 | markdownlint pass | `npx markdownlint-cli '.claude/rules/responsibility-classes.md'` | exit 0 |
+
+## エッジケース
+
+- 既存セクション順序を壊さない (新セクションは末尾追加 or 文脈的に最適位置)

--- a/docs/working/TASK-0115/todo.md
+++ b/docs/working/TASK-0115/todo.md
@@ -1,0 +1,13 @@
+# TASK-0115 EXECUTION TODO
+
+## 🤖 Agent タスク
+
+- [ ] **T-01**: TASK-0112 適用パターン + responsibility-classes.md 既存セクション構造把握 (owner=agent / Risk=low / 🚩 構造把握)
+- [ ] **T-02**: `.claude/rules/responsibility-classes.md` に新セクション追加 (owner=agent / Risk=medium / depends_on=T-01 / 🚩 maintenance window 経由 + markdownlint pass)
+- [ ] **T-03**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=T-02 / 🚩 AC-1..5 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: maintenance window 発行 (`bin/plangate maintenance start --paths .claude/rules/responsibility-classes.md --minutes 5`)
+- [ ] **H-03**: C-4 + merge


### PR DESCRIPTION
INC-2026-05-26-001 Prevention P-3 対応の PBI plan を B フェーズまで完了。

## Scope
- .claude/rules/responsibility-classes.md に新セクション追加:
  - && 連結 or set -e
  - git push 前 branch verify
  - protected branch 事前確認
  - INC 参照

## Mode
light (Hardening Override 対象 → C-3 APPROVED + maintenance window 経由)

## TASK-0114 (P-1) との層分離
- P-1: physical block (技術層)
- P-3: AI 行動規範 (運用解釈層)
両者で物理 + 規範の二段防御

Refs: INC-2026-05-26-001 P-3, PR #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)