### PR TITLE
docs(TASK-0116): plan 生成 — NO RELEASE WITHOUT TAG-MAIN PARITY Iron Law (#354)

### DIFF
--- a/docs/working/TASK-0116/INDEX.md
+++ b/docs/working/TASK-0116/INDEX.md
@@ -1,0 +1,6 @@
+# TASK-0116 INDEX
+
+- **Title**: NO RELEASE WITHOUT TAG-MAIN PARITY Iron Law + 機械検証 (#354)
+- **Mode**: standard (stretch AC-7 採否で high 可)
+- **Phase**: B 完了
+- **Status**: C-3 + maintenance window 待ち

--- a/docs/working/TASK-0116/current-state.md
+++ b/docs/working/TASK-0116/current-state.md
@@ -1,0 +1,12 @@
+# TASK-0116 current-state
+
+## Phase: B 完了
+
+Governance hardening 系列 (INC / TASK-0114 P-1 / TASK-0115 P-3) の release プロセス版。
+
+## 関連
+
+- #354
+- INC-2026-05-26-001 / TASK-0114 / TASK-0115 (同系 governance)
+- PocketEitan `.claude/commands/release.md` Phase 5 (参考実装)
+- s977043 memory `feedback_release_tag_collision_verify.md`

--- a/docs/working/TASK-0116/pbi-input.md
+++ b/docs/working/TASK-0116/pbi-input.md
@@ -1,0 +1,63 @@
+# TASK-0116 PBI INPUT PACKAGE
+
+> Issue: [#354](https://github.com/s977043/plangate/issues/354)
+> 同系の governance hardening: INC-2026-05-26-001 / TASK-0114 (P-1) / TASK-0115 (P-3)
+
+## Context / Why
+
+annotated tag を打った後、tag が指す commit と `origin/main` の最新が一致しない事態が過去に発生 (s977043 memory `feedback_release_tag_collision_verify.md`、PocketEitan の `.claude/commands/release.md` Phase 5 で既に対策実装済)。
+
+PlanGate workflow にも **NO RELEASE WITHOUT TAG-MAIN PARITY** Iron Law を追加し、tag push → 検証 → 不一致時 force update → 再検証 のフローを必須化する。
+
+INC-2026-05-26-001 / TASK-0114 / TASK-0115 と同じ governance hardening 系列。
+
+## What (Scope)
+
+### In scope
+
+- PlanGate workflow docs (`docs/workflows/` or `docs/release-process.md`) に Iron Law 追記
+- `.claude/rules/responsibility-classes.md` §「対外公開アーティファクト publish 責務分界」に検証手順 link
+- `scripts/check-tag-main-parity.sh` (新規) — `[ "$(git rev-parse <tag>^{commit})" = "$(git rev-parse origin/main)" ]` で機械検証
+- `bin/plangate doctor` 統合 (option): 最新 tag vs main の整合確認
+- `docs/ai/release-process.md` (新規 or 既存追記) — 検証フロー手順書 + 失敗時 `-f` 貼り替え手順
+- `tests/extras/ta-18-tag-main-parity.sh` (新規) fixture test
+
+### Out of scope
+
+- 既存 release skill (`.claude/commands/release.md` 等) の本体改修 (本 PBI は Iron Law + 検証 script 追加のみ、skill 統合は follow-up)
+- `git tag` 自動化 (Iron Law は AI 自律 tag を許可しない、Human オペレーション)
+
+## 受入基準
+
+- AC-1: `docs/release-process.md` (新規 or 既存) に **NO RELEASE WITHOUT TAG-MAIN PARITY** Iron Law が追加
+- AC-2: `scripts/check-tag-main-parity.sh` (新規) で `git rev-parse <tag>^{commit}` vs `git rev-parse origin/main` の機械検証、不一致時 exit 1
+- AC-3: `.claude/rules/responsibility-classes.md` §publish 責務分界 に本検証手順への link
+- AC-4: 検証失敗時の `-f` 貼り替え手順が docs に明示 (Human オペレーション)
+- AC-5: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case: 一致 / 不一致 / tag 不在
+- AC-6: 既存テスト regression なし + markdownlint + shellcheck PASS
+- AC-7: `bin/plangate doctor` で latest tag vs main の事後確認 section を追加 (任意、stretch goal)
+
+## Notes from Refinement
+
+- PocketEitan 実装 (`.claude/commands/release.md` Phase 5) を参考に最小ポート
+- `.claude/rules/` 追記は Hardening Override 対象 → C-3 APPROVED + maintenance window
+- `bin/plangate` 追記も Hardening Override 対象 → 同上 (AC-7 は stretch、必須化しない)
+- annotated tag のオブジェクト SHA vs commit SHA の混同を `^{commit}` で吸収
+
+## Estimation
+
+### Risks
+
+- 既存 release skill との重複定義 → mitigation: 本 PBI は Iron Law + 検証 script のみ、skill 改修は follow-up
+- force push (`git push -f`) の濫用リスク → mitigation: 検証失敗時のみ + Human オペレーション固定 + 監査ログ
+- ローカル test で実 tag/main を弄れない → mitigation: fixture tmp git repo で再現
+
+### Unknowns
+
+- doctor 統合 (AC-7) の要否 (stretch goal で C-3 判断)
+- annotated tag 以外 (lightweight tag) の扱い (`^{commit}` で吸収するが test で確認)
+
+### Assumptions
+
+- `git rev-parse` の `^{commit}` peeling 仕様は不変
+- release は Human-owned (tag push / GitHub Release create は AI 不可、TASK-0114 P-1 と整合)

--- a/docs/working/TASK-0116/plan.md
+++ b/docs/working/TASK-0116/plan.md
@@ -1,0 +1,70 @@
+# TASK-0116 EXECUTION PLAN
+
+> Source: pbi-input.md / Issue #354 / Mode: **standard**
+> Generated: 2026-05-26
+
+## Goal
+
+PlanGate workflow に **NO RELEASE WITHOUT TAG-MAIN PARITY** Iron Law と機械検証 script を追加し、tag-main mismatch を構造的に防ぐ。`scripts/check-tag-main-parity.sh` の機械検証で release 直前の人間オペレーションを支援。
+
+## Constraints / Non-goals
+
+- 既存 release skill の本体改修なし (follow-up)
+- AI 自律 tag push 禁止 (TASK-0114 P-1 と整合)
+- `.claude/rules/` 追記は Hardening Override 経由
+
+## Approach Overview
+
+PocketEitan `.claude/commands/release.md` Phase 5 の最小ポート + PlanGate 既存 `.claude/rules/responsibility-classes.md` §publish 責務分界 への統合。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01 調査**: 既存 release 関連 docs / `.claude/commands/` / scripts 把握、PocketEitan 実装パターン参照 | 調査メモ | AI | low | 既存資産マップ |
+| 2 | **T-02 script**: `scripts/check-tag-main-parity.sh` (POSIX sh、引数 tag、`^{commit}` peel、exit 0/1) | scripts/check-tag-main-parity.sh | AI | medium | tag/main 比較動作 |
+| 3 | **T-03 doc**: `docs/release-process.md` (新規 or 既存追記) Iron Law + 検証フロー + 失敗時 `-f` 貼り替え手順 | docs/release-process.md | AI | low | Human 運用可能 |
+| 4 | **T-04 rule link**: `.claude/rules/responsibility-classes.md` §publish 責務分界 に検証手順 link 追記 | .claude/rules/responsibility-classes.md | AI | medium (Hardening Override) | maintenance window 経由 + markdownlint |
+| 5 | **T-05 test**: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case (一致/不一致/tag 不在) | tests/extras/ta-18-tag-main-parity.sh | AI | low | ta-18 全 PASS |
+| 6 | **T-06 (stretch)**: `bin/plangate doctor` 統合 (AC-7、optional) | bin/plangate | AI | medium (Hardening Override) | C-3 判断 |
+| 7 | **T-07 handoff + V-1** | handoff.md | AI | low | AC-1..6 PASS (AC-7 任意) |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `scripts/check-tag-main-parity.sh` | 新規 (POSIX sh) |
+| `docs/release-process.md` | 新規 or 既存追記 |
+| `.claude/rules/responsibility-classes.md` | 追記 (**Hardening Override**) |
+| `bin/plangate` | 追記 (**Hardening Override / stretch**) |
+| `tests/extras/ta-18-tag-main-parity.sh` | 新規 |
+| `docs/working/TASK-0116/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- Unit: fixture tmp git repo で tag/main 比較 (3 case)
+- Integration: 実 PlanGate repo の最新 tag で動作確認 (read-only)
+- 回帰: tests/run-tests.sh + tests/hooks/run-tests.sh
+- markdownlint + shellcheck
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| 既存 release skill と重複定義 | low | 本 PBI は Iron Law + 検証 script のみ、skill 改修は follow-up |
+| force push (`git push -f`) 濫用 | medium | 検証失敗時のみ + Human オペレーション固定 + 監査ログ docs に明示 |
+| Hardening Override 対象改修が EH-3 で block | high | C-3 APPROVED + maintenance window (TASK-0106/0112/0115 で実証済) |
+| lightweight tag vs annotated tag 揺れ | low | `^{commit}` peel で吸収、TC-03 で確認 |
+
+## Mode 判定
+
+**standard** (lite_eligible=false)
+
+- 変更ファイル数: 5-6 (新規 + 既存追記)
+- 受入基準数: 6 (+1 stretch)
+- 変更種別: script + docs + rule + (stretch: doctor)
+- リスク: 中 (Hardening Override 対象を含む)
+- ロールバック: 容易
+- 影響範囲: release プロセス全般、AI 自律 tag は元々禁止のため AI 行動への影響限定
+
+→ standard、ただし `.claude/rules/` / `bin/plangate` 改修部分は TASK-0112 例外ルール「承認境界周辺→最低 高」該当の見込み。**stretch goal AC-7 (doctor 統合) を外せば light 相当**、含めると standard or high。本 plan は標準 standard で提出、C-3 判断で stretch 採否を決める。

--- a/docs/working/TASK-0116/review-self.md
+++ b/docs/working/TASK-0116/review-self.md
@@ -1,0 +1,7 @@
+# TASK-0116 C-1 セルフレビュー
+
+## Plan/ToDo/TestCases: 全 PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+
+総合スコア: 90/100。blocker 0、major 0、minor 2 (stretch goal AC-7 採否を C-3 で判断 / TASK-0115 (P-3) との rule 重複領域を C-2 で確認推奨)。

--- a/docs/working/TASK-0116/test-cases.md
+++ b/docs/working/TASK-0116/test-cases.md
@@ -1,0 +1,34 @@
+# TASK-0116 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1 Iron Law doc 追加 | TC-01 |
+| AC-2 機械検証 script | TC-02, TC-03, TC-04 |
+| AC-3 rule link | TC-05 |
+| AC-4 失敗時 `-f` 手順 doc | TC-06 |
+| AC-5 ta-18 fixture | TC-07 |
+| AC-6 regression + lint | TC-08, TC-09 |
+| AC-7 doctor 統合 (stretch) | TC-10 |
+
+## ケース
+
+| ID | 内容 | コマンド | 期待 |
+|----|------|---------|------|
+| TC-01 | `docs/release-process.md` に Iron Law | `grep -nE 'NO RELEASE WITHOUT TAG-MAIN PARITY' docs/release-process.md` | 該当 |
+| TC-02 | script: tag = main 一致時 exit 0 | fixture repo で tag を HEAD に + script 実行 | exit 0 |
+| TC-03 | script: tag != main 不一致時 exit 1 | fixture で tag を別 commit に + script | exit 1 + メッセージ |
+| TC-04 | script: tag 不在時 exit 1 + 明確メッセージ | 存在しない tag を引数 | exit 1 |
+| TC-05 | `.claude/rules/responsibility-classes.md` に検証 link | `grep -nE 'check-tag-main-parity\|release-process' .claude/rules/responsibility-classes.md` | 該当 |
+| TC-06 | docs に `-f` 貼り替え手順 (Human オペレーション) | `grep -nE 'git push -f.*tag\|tag -fa' docs/release-process.md` | 該当 |
+| TC-07 | ta-18 dispatcher 認識 + 3 case PASS | `sh tests/run-tests.sh` | TA-18 全 case PASS |
+| TC-08 | 既存テスト regression なし | `sh tests/run-tests.sh && sh tests/hooks/run-tests.sh` | 全 PASS |
+| TC-09 | shellcheck + markdownlint | `shellcheck scripts/check-tag-main-parity.sh && npx markdownlint-cli docs/release-process.md` | exit 0 |
+| TC-10 (stretch) | `bin/plangate doctor` で latest tag vs main 表示 | `bin/plangate doctor --scope release` (or 同等) | tag/main parity 表示 |
+
+## エッジケース
+
+- lightweight tag (annotated でない): `^{commit}` peel で吸収、TC-02/03 で確認
+- detached HEAD で実行: 警告 + exit 1
+- remote main fetch 失敗 (offline): 警告 + skip (exit 0 ではなく明確メッセージで abort)

--- a/docs/working/TASK-0116/todo.md
+++ b/docs/working/TASK-0116/todo.md
@@ -1,0 +1,18 @@
+# TASK-0116 EXECUTION TODO
+
+## 🤖 Agent タスク
+
+- [ ] **T-01**: 既存 release 関連 docs / commands / scripts 把握、PocketEitan Phase 5 参照 (owner=agent / Risk=low / 🚩 既存資産マップ)
+- [ ] **T-02**: `scripts/check-tag-main-parity.sh` (POSIX sh、`^{commit}` peel) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 比較動作)
+- [ ] **T-03**: `docs/release-process.md` Iron Law + 検証フロー (owner=agent / Risk=low / depends_on=T-02 / 🚩 Human 運用可能)
+- [ ] **T-04**: `.claude/rules/responsibility-classes.md` §publish 責務分界 link 追記 (owner=agent / Risk=medium / depends_on=T-03 / 🚩 maintenance window 経由)
+- [ ] **T-05**: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-18 全 PASS)
+- [ ] **T-06 (stretch)**: `bin/plangate doctor` 統合 (owner=agent / Risk=medium / depends_on=T-02 / 🚩 C-3 判断)
+- [ ] **T-07**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..6 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行、stretch AC-7 採否決定)
+- [ ] **H-02**: T-04 + T-06 (stretch) のため maintenance window 発行 (`scripts/check-tag-main-parity.sh` は新規ファイルで Hardening Override 対象外)
+- [ ] **H-03**: C-4 + merge
+- [ ] **H-04**: 次回 release で実運用 (Iron Law 適用)


### PR DESCRIPTION
#354 release tag 整合 Iron Law を governance hardening 系列 (INC / P-1 / P-3) として B フェーズまで完了。

## Scope
- scripts/check-tag-main-parity.sh
- docs/release-process.md (Iron Law)
- .claude/rules/responsibility-classes.md link 追記 (Hardening Override)
- tests/extras/ta-18-tag-main-parity.sh (3 case)
- (stretch) bin/plangate doctor 統合

## Mode
standard。.claude/rules/ + bin/plangate 部分は high 補正の可能性、C-3 で確定。

参考: PocketEitan release.md Phase 5

Refs: #354, INC-2026-05-26-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)