### PR TITLE
docs(TASK-0117): Codex 最終確認 NEEDS_FIX 反映漏れ修正 (3 件、PR #364 follow-up)

### DIFF
--- a/docs/working/TASK-0117/INDEX.md
+++ b/docs/working/TASK-0117/INDEX.md
@@ -1,7 +1,7 @@
 # TASK-0117 INDEX
 
 - **Title**: plan 段階に「事前メトリクス検証」step 追加 (#351)
-- **Mode**: light (Hardening Override)
+- **Mode**: standard (R-002 反映、.agents/skills/ は Hardening Override 対象外)
 - **Phase**: B 完了
-- **Status**: C-3 + maintenance window 待ち
+- **Status**: C-3 待ち (maintenance window 不要 / R-001)
 - **意義**: process drift (前 session review 最大 risk) への構造的対応、#352 codex-mvp-split の前提

--- a/docs/working/TASK-0117/pbi-input.md
+++ b/docs/working/TASK-0117/pbi-input.md
@@ -46,7 +46,7 @@ PlanGate A → B 遷移 (PBI INPUT → plan 生成) で AI が **規模見積も
 
 ## Notes from Refinement
 
-- `.claude/skills/ai-dev-plan/` 配下は Hardening Override 対象 (`.claude/` 配下) → C-3 APPROVED + maintenance window 経由
+- **実体は `.agents/skills/ai-dev-plan/SKILL.md`** (R-001 反映)。`.agents/skills/` は `.claude/` 配下と異なり Hardening Override 対象外 → maintenance window 不要
 - PocketEitan PR #371 の該当セクションを参考に最小ポート
 - 「事前メトリクス検証」は AI 判定の客観化であり、process drift (前回 session review 最大 risk) に直接効く
 - #352 codex-mvp-split は本 PBI 完了後に着手する前提
@@ -59,9 +59,9 @@ PlanGate A → B 遷移 (PBI INPUT → plan 生成) で AI が **規模見積も
 - skill 構造変更で既存 ai-dev-plan 動作 regression → mitigation: 追記のみ (additive)、既存 step を破壊しない
 
 ### Unknowns
-- 既存 `.claude/skills/ai-dev-plan/` の正確な構造 → T-01 で調査
+- 既存 `.agents/skills/ai-dev-plan/SKILL.md` の正確な構造 → T-01 で調査 (R-001 確定済)
 - skill / commands 配置の選択 (本 PBI 段階) → T-01 で決定
 
 ### Assumptions
-- `ai-dev-plan` 等の skill が `.claude/skills/` または `.claude/commands/` 配下に存在
-- Hardening Override 対象のため maintenance window 必須
+- `ai-dev-plan` skill は `.agents/skills/ai-dev-plan/SKILL.md` (実体確認済、R-001)
+- Hardening Override 対象外、maintenance window 不要

--- a/docs/working/TASK-0117/plan.md
+++ b/docs/working/TASK-0117/plan.md
@@ -1,6 +1,6 @@
 # TASK-0117 EXECUTION PLAN
 
-> Source: pbi-input.md / Issue #351 / Mode: **light**
+> Source: pbi-input.md / Issue #351 / Mode: **standard** (R-002 反映)
 > Generated: 2026-05-26 / Codex 推奨
 
 ## Goal
@@ -21,11 +21,11 @@
 
 | # | Step | Output | Owner | Risk | 🚩 |
 |---|------|--------|-------|------|----|
-| 1 | **T-01 調査**: `.claude/skills/ai-dev-plan/` (or `.claude/commands/`) 構造把握、PocketEitan PR #371 該当セクション参照 | 調査メモ | AI | low | 既存構造マップ |
+| 1 | **T-01 調査**: `.agents/skills/ai-dev-plan/SKILL.md` (実体、R-001) 構造把握、PocketEitan PR #371 該当セクション参照 | 調査メモ | AI | low | 既存構造マップ |
 | 2 | **T-02 skill 追記 (R-001/R-003)**: `.agents/skills/ai-dev-plan/SKILL.md` に「事前メトリクス検証」セクション追加 (検証コマンド例 / 判定基準 / 実例 link / **B-1 → B-2 mandatory gate 配置**) | `.agents/skills/ai-dev-plan/SKILL.md` | AI | medium | markdownlint pass (Hardening Override 対象外) |
 | 3 | **T-03 doc (R-003)**: `docs/ai/plan-metrics-verification.md` 新規 (運用ガイド + PocketEitan 実例 + 判定基準数値 + **plan.md `## Metrics Evidence` 欄テンプレート**) | docs/ai/plan-metrics-verification.md | AI | low | plan.md template 例含む |
 | 4 | **T-04 test**: `tests/extras/ta-19-plan-metrics-verification.sh` (skill に該当セクション含むことを grep で機械検証) | tests/extras/ta-19-plan-metrics-verification.sh | AI | low | ta-19 PASS |
-| 5 | **T-05 handoff + V-1** | handoff.md | AI | low | AC-1..7 PASS |
+| 5 | **T-05 handoff + V-1** | handoff.md | AI | low | AC-1..8 PASS (AC-8 追加 / R-003) |
 
 ## Files / Components to Touch
 

--- a/docs/working/TASK-0117/test-cases.md
+++ b/docs/working/TASK-0117/test-cases.md
@@ -11,6 +11,7 @@
 | AC-5 TASK-0112 相互参照 | TC-05 |
 | AC-6 ta-19 機械検証 | TC-06 |
 | AC-7 markdownlint + regression | TC-07, TC-08 |
+| **AC-8 Metrics Evidence 欄** | **TC-09** (R-003 反映) |
 
 ## ケース
 

--- a/docs/working/TASK-0117/todo.md
+++ b/docs/working/TASK-0117/todo.md
@@ -2,11 +2,11 @@
 
 ## 🤖 Agent タスク
 
-- [ ] **T-01**: `.claude/skills/ai-dev-plan/` 構造把握 + PocketEitan PR #371 該当セクション参照 (owner=agent / Risk=low / 🚩 構造マップ)
+- [ ] **T-01**: `.agents/skills/ai-dev-plan/SKILL.md` 構造把握 (実体、R-001) + PocketEitan PR #371 該当セクション参照 (owner=agent / Risk=low / 🚩 構造マップ)
 - [ ] **T-02 (R-001/R-003)**: `.agents/skills/ai-dev-plan/SKILL.md` に「事前メトリクス検証」セクション追加 (B-1→B-2 mandatory gate 配置) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 markdownlint pass + plan.md template に Metrics Evidence 欄サンプル)
 - [ ] **T-03**: `docs/ai/plan-metrics-verification.md` 運用ガイド (owner=agent / Risk=low / depends_on=T-02 / 🚩 Human/AI 参照可能)
 - [ ] **T-04**: `tests/extras/ta-19-plan-metrics-verification.sh` (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-19 PASS)
-- [ ] **T-05**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..7 PASS)
+- [ ] **T-05**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..8 PASS)
 
 ## 👤 Human タスク
 


### PR DESCRIPTION
PR #364 merged 後に Codex 再確認で反映漏れ 3 件検出。本 PR で main に取り込む。

## 経緯

PR #364 で R-001..R-005 を反映したが、修正コミット 9c689c8 が PR merge 直後の push となり main に未取り込みだった。本 PR で完全反映。

## 反映 (3 件)

| ID | 修正 |
|----|------|
| R-002 | plan.md header / INDEX.md の Mode を light → standard、Hardening Override 表記除去 |
| R-001/R-004 | pbi-input.md / plan.md T-01 / todo.md T-01 の旧 .claude/skills/ 記述 → .agents/skills/ |
| R-003 | test-cases.md AC→TC mapping に AC-8 行追加、plan.md / todo.md 完了条件を AC-1..8 に |

## 結果

Codex 最終確認 (2026-05-27) で挙がった反映漏れ 3 件すべて解消。APPROVE 想定。

Refs: Codex C-2 最終確認 (2026-05-27), PR #364 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)