### PR TITLE
docs(TASK-0114/0116): Codex 9 PBI review NEEDS_FIX 解消 (c3 発行可化)

### DIFF
--- a/docs/working/TASK-0114/review-self.md
+++ b/docs/working/TASK-0114/review-self.md
@@ -8,6 +8,21 @@
 | C1-TODO-01..05 | PASS |
 | C1-TC-01..03 | PASS |
 
-## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 試行、Codex usage 上限のため deferred / TASK-0113 install pattern 重複は本 PBI で明示整理済)
 
-総合スコア: 90/100。blocker 0、major 0、minor 1 (TASK-0113 と同じ install pattern なので C-2 で重複検出を期待)。
+総合スコア: 90/100。blocker 0、major 0、minor 1 (proactive C-2 は Codex usage 上限により 2026-05-27 時点で deferred、c3.json 発行直前または exec 後の V-3 で再試行)。
+
+## TASK-0113 install pattern 重複整理 (Codex 9 PBI review 指摘反映)
+
+TASK-0113 (pre-commit hook for claude-mem 検知) と本 PBI (TASK-0114, pre-push hook for main 直接 push 防止) は **異なる git hook 階層** だが、`scripts/templates/<hook>.sample` + `scripts/install-<hook>.sh` の **install pattern が同型**:
+
+| 項目 | TASK-0113 (pre-commit) | TASK-0114 (pre-push) |
+|------|------------------------|----------------------|
+| Hook 階層 | git pre-commit (commit 前) | git pre-push (push 前) |
+| 目的 | claude-mem 自動挿入の **staged diff 検出** | main 直接 push の **branch protection** |
+| Template path | `scripts/templates/pre-commit.sample` | `scripts/templates/pre-push.sample` |
+| Install script | `scripts/install-pre-commit.sh` | `scripts/install-pre-push.sh` |
+| Bypass | allowlist marker | `--no-verify` (emergency) |
+| 重複領域 | install script の `.bak` 保持 / 既存 hook 検出 | 同 (本 PBI 実装で意図的に踏襲) |
+
+**確定方針**: 両 PBI は **並行存在**、install script は別 file (重複コードは V2 候補で抽象化検討)。本 PBI で TASK-0113 を破壊しない (additive)。

--- a/docs/working/TASK-0116/pbi-input.md
+++ b/docs/working/TASK-0116/pbi-input.md
@@ -35,7 +35,7 @@ INC-2026-05-26-001 / TASK-0114 / TASK-0115 と同じ governance hardening 系列
 - AC-4: 検証失敗時の `-f` 貼り替え手順が docs に明示 (Human オペレーション)
 - AC-5: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case: 一致 / 不一致 / tag 不在
 - AC-6: 既存テスト regression なし + markdownlint + shellcheck PASS
-- AC-7: `bin/plangate doctor` で latest tag vs main の事後確認 section を追加 (任意、stretch goal)
+- ~~AC-7 (stretch / 削除)~~: `bin/plangate doctor` 統合は **本 PBI から除外**。bin/plangate は Hardening Override で改修コスト高く、scripts/check-tag-main-parity.sh の機械検証で代替可。**doctor 統合は V2 候補に降格** (Codex 9 PBI review 反映)
 
 ## Notes from Refinement
 

--- a/docs/working/TASK-0116/plan.md
+++ b/docs/working/TASK-0116/plan.md
@@ -26,7 +26,7 @@ PocketEitan `.claude/commands/release.md` Phase 5 の最小ポート + PlanGate 
 | 3 | **T-03 doc**: `docs/release-process.md` (新規 or 既存追記) Iron Law + 検証フロー + 失敗時 `-f` 貼り替え手順 | docs/release-process.md | AI | low | Human 運用可能 |
 | 4 | **T-04 rule link**: `.claude/rules/responsibility-classes.md` §publish 責務分界 に検証手順 link 追記 | .claude/rules/responsibility-classes.md | AI | medium (Hardening Override) | maintenance window 経由 + markdownlint |
 | 5 | **T-05 test**: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case (一致/不一致/tag 不在) | tests/extras/ta-18-tag-main-parity.sh | AI | low | ta-18 全 PASS |
-| 6 | **T-06 (stretch)**: `bin/plangate doctor` 統合 (AC-7、optional) | bin/plangate | AI | medium (Hardening Override) | C-3 判断 |
+| ~~T-06 (stretch)~~ | ~~bin/plangate doctor 統合~~ | — | — | **本 PBI から除外** | V2 候補に降格 (Codex 9 PBI review 反映、bin/plangate は HO で改修コスト高) |
 | 7 | **T-07 handoff + V-1** | handoff.md | AI | low | AC-1..6 PASS (AC-7 任意) |
 
 ## Files / Components to Touch
@@ -35,8 +35,8 @@ PocketEitan `.claude/commands/release.md` Phase 5 の最小ポート + PlanGate 
 |---------|------|
 | `scripts/check-tag-main-parity.sh` | 新規 (POSIX sh) |
 | `docs/release-process.md` | 新規 or 既存追記 |
-| `.claude/rules/responsibility-classes.md` | 追記 (**Hardening Override**) |
-| `bin/plangate` | 追記 (**Hardening Override / stretch**) |
+| `.claude/rules/responsibility-classes.md` | 追記 (**Hardening Override**) — TASK-0115 (INC P-3) が編集する section と同 file。**順序**: TASK-0115 が先 (Bash 連結 error guard) → 本 PBI が後 (publish 責務分界 link 追記) で衝突回避 (Codex 9 PBI review 反映) |
+| ~~bin/plangate~~ | ~~stretch~~ | **削除**: V2 候補に降格 (HO 改修コスト高、機械検証 script で代替可) |
 | `tests/extras/ta-18-tag-main-parity.sh` | 新規 |
 | `docs/working/TASK-0116/handoff.md` | WF-05 |
 
@@ -56,15 +56,20 @@ PocketEitan `.claude/commands/release.md` Phase 5 の最小ポート + PlanGate 
 | Hardening Override 対象改修が EH-3 で block | high | C-3 APPROVED + maintenance window (TASK-0106/0112/0115 で実証済) |
 | lightweight tag vs annotated tag 揺れ | low | `^{commit}` peel で吸収、TC-03 で確認 |
 
-## Mode 判定
+## Mode 判定 (Codex 9 PBI review 反映)
 
 **standard** (lite_eligible=false)
 
-- 変更ファイル数: 5-6 (新規 + 既存追記)
-- 受入基準数: 6 (+1 stretch)
-- 変更種別: script + docs + rule + (stretch: doctor)
-- リスク: 中 (Hardening Override 対象を含む)
+- 変更ファイル数: 5 (新規 + 既存追記、stretch AC-7 削除)
+- 受入基準数: **6** (旧 stretch AC-7 削除済)
+- 変更種別: script + docs + rule (bin/plangate なし)
+- リスク: 中 (Hardening Override 対象 `.claude/rules/` を含む)
 - ロールバック: 容易
 - 影響範囲: release プロセス全般、AI 自律 tag は元々禁止のため AI 行動への影響限定
 
-→ standard、ただし `.claude/rules/` / `bin/plangate` 改修部分は TASK-0112 例外ルール「承認境界周辺→最低 高」該当の見込み。**stretch goal AC-7 (doctor 統合) を外せば light 相当**、含めると standard or high。本 plan は標準 standard で提出、C-3 判断で stretch 採否を決める。
+→ **standard** 確定。`.claude/rules/responsibility-classes.md` 改修は TASK-0112 例外ルールに該当する見込みだが、本 PBI 内では TASK-0115 (INC P-3) と同 file への追記順序で衝突回避 (TASK-0115 が先)。
+
+**TASK-0115 との重複整理 (Codex review 反映)**:
+- TASK-0115 (INC P-3): `.claude/rules/responsibility-classes.md` に「Bash 連結コマンド error guard」セクション追加
+- 本 PBI (TASK-0116): 同 file の §「対外公開アーティファクト publish 責務分界」に検証手順 link 追記
+- **順序**: TASK-0115 が先で base section 確立、本 PBI が後で link 追加 (rebase 不要、conflict なし設計)

--- a/docs/working/TASK-0116/review-self.md
+++ b/docs/working/TASK-0116/review-self.md
@@ -2,6 +2,10 @@
 
 ## Plan/ToDo/TestCases: 全 PASS
 
-## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+## 判定: **PASS** — C-3 ゲート提出可能 (Codex 9 PBI review 反映後 v2)
 
-総合スコア: 90/100。blocker 0、major 0、minor 2 (stretch goal AC-7 採否を C-3 で判断 / TASK-0115 (P-3) との rule 重複領域を C-2 で確認推奨)。
+総合スコア: **92/100** (NEEDS_FIX 解消後)。Codex 9 PBI review (2026-05-27) で「AC-7 stretch 採否未確定 / TASK-0115 との rule 重複未整理」を指摘 → 両者解消:
+- AC-7 stretch (bin/plangate doctor 統合) を本 PBI から **削除**、V2 候補に降格
+- TASK-0115 との `.claude/rules/responsibility-classes.md` 追記順序確定 (TASK-0115 先 → 本 PBI 後で衝突回避)
+
+blocker 0、major 0、minor 1 (V-3 で実 release flow との整合確認推奨)。

--- a/docs/working/TASK-0116/test-cases.md
+++ b/docs/working/TASK-0116/test-cases.md
@@ -10,7 +10,7 @@
 | AC-4 失敗時 `-f` 手順 doc | TC-06 |
 | AC-5 ta-18 fixture | TC-07 |
 | AC-6 regression + lint | TC-08, TC-09 |
-| AC-7 doctor 統合 (stretch) | TC-10 |
+| ~~AC-7 doctor 統合~~ | ~~TC-10~~ (削除済) |
 
 ## ケース
 
@@ -25,7 +25,7 @@
 | TC-07 | ta-18 dispatcher 認識 + 3 case PASS | `sh tests/run-tests.sh` | TA-18 全 case PASS |
 | TC-08 | 既存テスト regression なし | `sh tests/run-tests.sh && sh tests/hooks/run-tests.sh` | 全 PASS |
 | TC-09 | shellcheck + markdownlint | `shellcheck scripts/check-tag-main-parity.sh && npx markdownlint-cli docs/release-process.md` | exit 0 |
-| TC-10 (stretch) | `bin/plangate doctor` で latest tag vs main 表示 | `bin/plangate doctor --scope release` (or 同等) | tag/main parity 表示 |
+| ~~TC-10 (stretch)~~ | ~~doctor 統合~~ — V2 候補に降格 (Codex 9 PBI review 反映) | — | — |
 
 ## エッジケース
 

--- a/docs/working/TASK-0116/todo.md
+++ b/docs/working/TASK-0116/todo.md
@@ -7,12 +7,12 @@
 - [ ] **T-03**: `docs/release-process.md` Iron Law + 検証フロー (owner=agent / Risk=low / depends_on=T-02 / 🚩 Human 運用可能)
 - [ ] **T-04**: `.claude/rules/responsibility-classes.md` §publish 責務分界 link 追記 (owner=agent / Risk=medium / depends_on=T-03 / 🚩 maintenance window 経由)
 - [ ] **T-05**: `tests/extras/ta-18-tag-main-parity.sh` fixture 3 case (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-18 全 PASS)
-- [ ] **T-06 (stretch)**: `bin/plangate doctor` 統合 (owner=agent / Risk=medium / depends_on=T-02 / 🚩 C-3 判断)
+- [ ] ~~T-06 stretch~~ (本 PBI から削除、V2 候補に降格 / Codex 9 PBI review 反映)
 - [ ] **T-07**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..6 PASS)
 
 ## 👤 Human タスク
 
-- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行、stretch AC-7 採否決定)
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行) — stretch AC-7 削除済、scope 確定
 - [ ] **H-02**: T-04 + T-06 (stretch) のため maintenance window 発行 (`scripts/check-tag-main-parity.sh` は新規ファイルで Hardening Override 対象外)
 - [ ] **H-03**: C-4 + merge
 - [ ] **H-04**: 次回 release で実運用 (Iron Law 適用)


### PR DESCRIPTION
Codex 9 PBI batch review (2026-05-27) で NEEDS_FIX 2 件指摘の解消。

## TASK-0114 NEEDS_FIX → 解消
- proactive C-2 状況現実化 (Codex usage 上限 deferred、c3 直前 or V-3 で再試行)
- TASK-0113 install pattern 重複を比較表で明示整理

## TASK-0116 NEEDS_FIX → 解消
- AC-7 stretch (bin/plangate doctor) を本 PBI から削除 → V2 降格
- TASK-0115 との .claude/rules/responsibility-classes.md 追記順序確定 (0115→0116)
- Mode standard 確定、受入基準 6 件

両 PBI 共 APPROVE_FOR_C3 想定。

Refs: Codex 9 PBI batch review (2026-05-27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)