### PR TITLE
docs(TASK-0118): plan 生成 — codex-mvp-split skill / command (#352)

### DIFF
--- a/docs/working/TASK-0118/INDEX.md
+++ b/docs/working/TASK-0118/INDEX.md
@@ -1,0 +1,8 @@
+# TASK-0118 INDEX
+
+- **Title**: codex-mvp-split skill / command を A フェーズ前段に追加 (#352)
+- **Issue**: [#352](https://github.com/s977043/plangate/issues/352)
+- **Mode**: standard (HO)
+- **Phase**: B 完了
+- **Status**: C-3 待ち
+- **意義**: 規模 L 機能の Phase 分割を Codex 相談で標準化、属人化解消、TASK-0117 (#351) と相互補完

--- a/docs/working/TASK-0118/current-state.md
+++ b/docs/working/TASK-0118/current-state.md
@@ -1,0 +1,16 @@
+# TASK-0118 current-state
+
+## Phase: B 完了
+
+#352 codex-mvp-split を PBI 化。TASK-0117 (#351 事前メトリクス検証) の完了で前提達成。
+
+## ブロッカー
+
+なし。
+
+## 関連
+
+- Issue: #352
+- 前提 PBI: TASK-0117 (#351、merged 2026-05-27)
+- 参考実装: PocketEitan PR #371
+- 並列 PBI なし

--- a/docs/working/TASK-0118/pbi-input.md
+++ b/docs/working/TASK-0118/pbi-input.md
@@ -1,0 +1,63 @@
+# TASK-0118 PBI INPUT PACKAGE
+
+> Issue: [#352](https://github.com/s977043/plangate/issues/352)
+> Codex 推奨優先順 A (2026-05-28): #352 codex-mvp-split を PBI 化
+> 出自: PocketEitan で 2 例の MVP 分割を Codex 相談で実施、属人化解消
+
+## Context / Why
+
+PlanGate A フェーズ (PBI INPUT PACKAGE 作成) に着手する前段で、**規模 L 以上の機能は最小 MVP (Phase 1) を Codex に選定相談する** プロセスを標準化する。
+
+属人化された質問テンプレを skill / command 化し、Phase 分割設計を再現可能にする。
+
+PocketEitan で 2 例実証済:
+- 例文音読カード (規模 L、4 Phase に分割) → v0.16.0
+- TASK-srs-unification (規模 standard〜full、2 Phase) → v0.15.0
+
+## What (Scope)
+
+### In scope
+
+- **`.claude/commands/codex-mvp-split.md`** (新規) — Claude Code slash command
+- **`.agents/skills/codex-mvp-split/SKILL.md`** (新規) — Codex / 他 provider 共用 skill
+- 質問テンプレ標準化:
+  - 背景 / 質問 / 工数感 (S/M/L) / 判断材料 3 軸 (ユーザ価値 / 実装独立性 / 次フェーズ拡張性)
+- 採用後の **Phase 分割表** を PBI INPUT PACKAGE 必須要素に追加
+- TASK-0117 (#351 事前メトリクス検証) との接続: 規模見積もりで L 以上判定 → 本 skill 起動
+- `docs/ai/codex-mvp-split.md` 運用ガイド
+- `tests/extras/ta-21-codex-mvp-split.sh` (skill 構造検証 + テンプレ含有確認)
+
+### Out of scope
+
+- Codex への自動 dispatch (本 skill は質問テンプレ提供のみ、Codex 起動は Human / CLI 側)
+- L 未満の規模での自動起動 (現状: Human 判断 or TASK-0117 規模判定で起動推奨)
+
+## 受入基準
+
+- AC-1: `.claude/commands/codex-mvp-split.md` (slash command 形式) 新規
+- AC-2: `.agents/skills/codex-mvp-split/SKILL.md` (frontmatter + Read First + 入出力規約) 新規
+- AC-3: 質問テンプレに 4 選択肢 (A/B/C/D) + 工数感 (S/M/L) + 判断材料 3 軸 含む
+- AC-4: 採用後の Phase 分割表 template が PBI INPUT PACKAGE に追加される旨を `docs/working/templates/pbi-input.md` で記述 (or 該当 doc)
+- AC-5: TASK-0117 (#351) 事前メトリクス検証で「規模 L 以上」判定された場合、本 skill 起動推奨を skill / doc に明記
+- AC-6: 既存実例 ≥ 2 件 (PocketEitan 例文音読カード / TASK-srs-unification) を doc に literal text で記載
+- AC-7: `tests/extras/ta-21-codex-mvp-split.sh` で skill 構造を機械検証 (該当セクション grep)
+- AC-8: markdownlint + 既存テスト regression なし
+
+## Notes from Refinement
+
+- `.claude/commands/` も `.agents/skills/` も Hardening Override 対象なので C-3 APPROVED + Human-owned patch 設計 (TASK-0112 と同方針)
+- 質問テンプレは PocketEitan 実装を最小ポート (案 A/B/C/D + 工数 S/M/L + 判断 3 軸)
+- TASK-0117 との連携は相互参照のみ (重複定義なし、AND 関係)
+
+## Estimation
+
+### Risks
+- LLM 解釈依存のソフトルール (本 skill は質問テンプレ提供のみ、回答品質は Codex 次第) → mitigation: 質問テンプレで 3 軸明示
+- L 規模判定が曖昧 → mitigation: TASK-0117 事前メトリクス検証と連携
+
+### Unknowns
+- `.agents/skills/` 配下に置くか `.claude/commands/` 配下か → T-01 で確定 (両方推奨)
+
+### Assumptions
+- PocketEitan PR #371 (`.claude/commands/codex-mvp-split.md`) を参考実装として利用可能 (外部 repo)
+- TASK-0117 (#351、merged) の事前メトリクス検証で「実数 / 見積もり ≥ 3 倍」判定が L 規模相当

--- a/docs/working/TASK-0118/plan.md
+++ b/docs/working/TASK-0118/plan.md
@@ -1,0 +1,70 @@
+# TASK-0118 EXECUTION PLAN
+
+> Source: pbi-input.md / Issue #352 / Mode: **standard**
+> Generated: 2026-05-28 / Codex 推奨 A
+
+## Goal
+
+規模 L 以上の機能を **最小 MVP (Phase 1) → Phase 2 → ...** に分割する skill / command を整備し、A フェーズ前段で利用可能化。属人化された Codex 相談プロセスを標準化。
+
+## Constraints / Non-goals
+
+- Hardening Override 対象パス (`.claude/commands/` `.agents/skills/`) → Human-owned patch 設計 (本 PBI exec は AI 直接書き込み、c3.json APPROVED + plan_hash 一致で EH-3 通過)
+- 既存 ai-dev-plan skill / B-1/B-2/B-3 フローを破壊しない (additive)
+- TASK-0117 (#351 事前メトリクス検証) と重複定義しない (相互参照のみ)
+- Codex 自動 dispatch は scope 外 (質問テンプレ提供のみ)
+
+## Approach Overview
+
+(1) T-01 既存 skill / command pattern 把握、(2) T-02 `.claude/commands/codex-mvp-split.md` 新規、(3) T-03 `.agents/skills/codex-mvp-split/SKILL.md` 新規、(4) T-04 `docs/ai/codex-mvp-split.md` 運用ガイド、(5) T-05 `tests/extras/ta-21-codex-mvp-split.sh`、(6) T-06 handoff + V-1。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | **T-01 調査**: 既存 `.claude/commands/` / `.agents/skills/ai-dev-plan/` 構造 + PocketEitan PR #371 該当 commands 参照 | 調査メモ | AI | low | 既存 pattern マップ |
+| 2 | **T-02 slash command**: `.claude/commands/codex-mvp-split.md` (frontmatter + 質問テンプレ + 4 選択肢 + 工数 S/M/L + 判断 3 軸 + Phase 分割表 template) | `.claude/commands/codex-mvp-split.md` (HO) | AI | medium (HO) | slash command 動作 |
+| 3 | **T-03 skill**: `.agents/skills/codex-mvp-split/SKILL.md` (薄い skill、入出力規約のみ、詳細は doc 参照) | `.agents/skills/codex-mvp-split/SKILL.md` | AI | low | skill 構造 (ai-dev-plan と同 pattern) |
+| 4 | **T-04 doc**: `docs/ai/codex-mvp-split.md` 運用ガイド (質問テンプレ詳細 + 採用フロー + PocketEitan 実例 2 件 + TASK-0117 連携) | docs/ai/codex-mvp-split.md | AI | low | Human/AI 双方が参照可能 |
+| 5 | **T-05 template**: `docs/working/templates/pbi-input.md` に「Phase 分割表」section 追加 (AC-4 反映) | docs/working/templates/pbi-input.md | AI | low | 既存 template 整合 |
+| 6 | **T-06 test**: `tests/extras/ta-21-codex-mvp-split.sh` (skill / command / doc / template 構造検証) | tests/extras/ta-21-codex-mvp-split.sh | AI | low | ta-21 全 PASS |
+| 7 | **T-07 handoff + V-1** | handoff.md | AI | low | AC-1..8 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| `.claude/commands/codex-mvp-split.md` | 新規 (**Hardening Override**) |
+| `.agents/skills/codex-mvp-split/SKILL.md` | 新規 (HO 対象外、`.agents/` 配下) |
+| `docs/ai/codex-mvp-split.md` | 新規 |
+| `docs/working/templates/pbi-input.md` | 追記 (Phase 分割表 section) |
+| `tests/extras/ta-21-codex-mvp-split.sh` | 新規 |
+| `docs/working/TASK-0118/handoff.md` | WF-05 |
+
+## Testing Strategy
+
+- 機械検証: ta-21 で skill / command / doc に必須要素 (4 選択肢 / 工数 / 3 軸 / 実例) 含有確認
+- markdownlint
+- 既存テスト regression なし
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| Hardening Override (`.claude/commands/`) 改修が EH-3 で block | high | c3.json APPROVED + plan_hash 一致で EH-3 通過 (TASK-0112/0113/0115/0117 で実証済) |
+| LLM 解釈依存のソフトルール効果薄 | medium | 質問テンプレ + 4 選択肢 + 工数 + 3 軸で具体性確保 |
+| TASK-0117 (#351) との重複感 | low | 本 PBI = MVP Phase 分割 (規模 L 以上)、TASK-0117 = 事前メトリクス検証 (規模判定)。AND 関係、相互参照のみ |
+| PocketEitan 外部参照が不安定 | low | literal text として記録 (リンクではなく内容引用) |
+
+## Mode 判定
+
+**standard** (lite_eligible=false、`.claude/commands/` は HO)
+
+- 変更ファイル数: 6
+- 受入基準数: 8
+- 変更種別: 新規 skill + command + docs + template + test
+- リスク: 中 (HO 対象を含む、ただし TASK-0112 例外ルールで standard が下限)
+- ロールバック: 容易
+- 影響範囲: A フェーズ前段の AI workflow に波及
+
+TASK-0117 (#351) 自己適用: 想定 6 file vs 実 6 file = 1.0 倍 → standard 維持。

--- a/docs/working/TASK-0118/review-self.md
+++ b/docs/working/TASK-0118/review-self.md
@@ -1,0 +1,9 @@
+# TASK-0118 C-1 セルフレビュー
+
+## Plan 7 項目: 全 PASS / ToDo 5 項目: PASS / TestCases 3 項目: PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能 (proactive C-2 推奨)
+
+総合スコア: 90/100。blocker 0、major 0、minor 2 (`.claude/commands/` か `.agents/skills/` どちらが正本か T-01 で確定 / PocketEitan PR #371 外部参照のため literal text で記載)。
+
+TASK-0117 (#351) と相互参照のみ、重複定義なし。MVP 分割は属人化解消のため標準化、AC-1..AC-8 全て TC マッピング済。

--- a/docs/working/TASK-0118/test-cases.md
+++ b/docs/working/TASK-0118/test-cases.md
@@ -1,0 +1,31 @@
+# TASK-0118 TEST CASES
+
+## マッピング
+
+| AC | TC |
+|----|-----|
+| AC-1 slash command 新規 | TC-01 |
+| AC-2 skill 新規 | TC-02 |
+| AC-3 質問テンプレ 4 選択肢 + 工数 + 3 軸 | TC-03 |
+| AC-4 Phase 分割表 template | TC-04 |
+| AC-5 TASK-0117 連携明記 | TC-05 |
+| AC-6 PocketEitan 実例 ≥ 2 件 | TC-06 |
+| AC-7 ta-21 機械検証 | TC-07 |
+| AC-8 markdownlint + regression | TC-08 |
+
+## ケース
+
+| ID | 内容 | コマンド | 期待 |
+|----|------|---------|------|
+| TC-01 | slash command 存在 | `test -f .claude/commands/codex-mvp-split.md` | exit 0 |
+| TC-02 | skill 存在 + frontmatter | `grep -E '^name:|^description:' .agents/skills/codex-mvp-split/SKILL.md` | 両 field 該当 |
+| TC-03 | 質問テンプレに 4 選択肢 (A/B/C/D) + 工数 (S/M/L) + 判断 3 軸 | `grep -cE '\(A\).*独立\|\(B\).*拡張\|\(C\).*導線\|\(D\).*独自' .claude/commands/codex-mvp-split.md docs/ai/codex-mvp-split.md` | ≥ 4 |
+| TC-04 | Phase 分割表 template が PBI INPUT PACKAGE template に追加 | `grep -nE 'Phase 分割表\|Phase.*工数\|Phase.*状態' docs/working/templates/pbi-input.md` | 該当 |
+| TC-05 | TASK-0117 (#351) 連携明記 | `grep -nE 'TASK-0117\|事前メトリクス検証' docs/ai/codex-mvp-split.md` | 該当 |
+| TC-06 | PocketEitan 実例 2 件 | `grep -cE 'PocketEitan\|例文音読カード\|TASK-srs-unification' docs/ai/codex-mvp-split.md` | ≥ 2 |
+| TC-07 | ta-21 dispatcher 認識 + PASS | `sh tests/run-tests.sh` | TA-21 全 case PASS |
+| TC-08 | markdownlint + regression | `npx markdownlint-cli docs/ai/codex-mvp-split.md && sh tests/run-tests.sh` | exit 0 |
+
+## エッジケース
+
+- skill / command が `.claude/commands/` か `.claude/skills/` か不確実 (TASK-0117 と同様の R-001 リスク) → T-01 で実体確認、本 PBI plan は `.claude/commands/` 優先 (slash command 用途)

--- a/docs/working/TASK-0118/todo.md
+++ b/docs/working/TASK-0118/todo.md
@@ -1,0 +1,16 @@
+# TASK-0118 EXECUTION TODO
+
+## 🤖 Agent タスク
+
+- [ ] **T-01**: 既存 `.claude/commands/` / `.agents/skills/ai-dev-plan/` 構造 + PocketEitan PR #371 参照 (owner=agent / Risk=low / 🚩 既存 pattern マップ)
+- [ ] **T-02 (HO)**: `.claude/commands/codex-mvp-split.md` 新規 (slash command + 質問テンプレ) (owner=agent / Risk=medium / depends_on=T-01 / 🚩 動作確認)
+- [ ] **T-03**: `.agents/skills/codex-mvp-split/SKILL.md` 新規 (薄い skill、入出力規約のみ) (owner=agent / Risk=low / depends_on=T-01 / 🚩 ai-dev-plan と同 pattern)
+- [ ] **T-04**: `docs/ai/codex-mvp-split.md` 運用ガイド (PocketEitan 実例 2 件 + TASK-0117 連携) (owner=agent / Risk=low / depends_on=T-02/T-03 / 🚩 Human/AI 参照可能)
+- [ ] **T-05**: `docs/working/templates/pbi-input.md` に Phase 分割表 section 追加 (owner=agent / Risk=low / depends_on=T-04 / 🚩 既存 template 整合)
+- [ ] **T-06**: `tests/extras/ta-21-codex-mvp-split.sh` 機械検証 (owner=agent / Risk=low / depends_on=T-02/T-03/T-04 / 🚩 ta-21 全 PASS)
+- [ ] **T-07**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..8 PASS)
+
+## 👤 Human タスク
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: C-4 + merge


### PR DESCRIPTION
Codex 推奨優先順 A (2026-05-28) で #352 codex-mvp-split を新規 PBI 化。TASK-0117 (#351、merged) の完了で前提達成。

## Goal
規模 L 以上の機能を最小 MVP (Phase 1) → Phase 2 に分割する skill / command を整備、A フェーズ前段で利用可能化。

## Scope
- .claude/commands/codex-mvp-split.md (HO)
- .agents/skills/codex-mvp-split/SKILL.md
- docs/ai/codex-mvp-split.md
- docs/working/templates/pbi-input.md に Phase 分割表 section 追加
- tests/extras/ta-21-codex-mvp-split.sh

## 質問テンプレ
- 4 選択肢 (A/B/C/D)
- 工数 S/M/L
- 判断 3 軸 (ユーザ価値 / 実装独立性 / 次フェーズ拡張性)

## TASK-0117 (#351) との関係
AND 関係、相互参照のみ (本 PBI = MVP 分割、TASK-0117 = 規模判定)

Refs: #352, TASK-0117 (#351), PocketEitan PR #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)