### PR TITLE
exec(TASK-0118): codex-mvp-split skill / command 実装 (#352)

### DIFF
--- a/.agents/skills/codex-mvp-split/SKILL.md
+++ b/.agents/skills/codex-mvp-split/SKILL.md
@@ -14,7 +14,7 @@ skill は読む順序と入出力規約のみを担う。
 1. `docs/ai/codex-mvp-split.md`（質問テンプレ・判定基準・実例の正本）
 2. `docs/ai/plan-metrics-verification.md`（#351 / TASK-0117、前段の規模判定）
 3. `.claude/rules/mode-classification.md`（5 段階 mode）
-4. `docs/working/templates/pbi-input.md`（Phase 分割表 section）
+4. `docs/working/templates/README.md`（Phase 分割表 section / pbi-input.md template は未作成、README に記述）
 
 ## 想定 phase
 

--- a/.agents/skills/codex-mvp-split/SKILL.md
+++ b/.agents/skills/codex-mvp-split/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: codex-mvp-split
+description: "規模 L 以上の機能の最小 MVP (Phase 1) を Codex に選定相談し Phase 分割表を作る。Use when: A フェーズ前段で規模 L 機能の MVP を決めたい時 / 事前メトリクス検証で実数 ≥ 3 倍判定時。"
+---
+
+# Codex MVP Split (PlanGate / Codex 共用)
+
+規模 L 以上の機能を着手前に **最小 MVP (Phase 1)** に分割する skill。
+実行ロジック・質問テンプレ詳細は `docs/ai/codex-mvp-split.md` を正本とし、
+skill は読む順序と入出力規約のみを担う。
+
+## Read First
+
+1. `docs/ai/codex-mvp-split.md`（質問テンプレ・判定基準・実例の正本）
+2. `docs/ai/plan-metrics-verification.md`（#351 / TASK-0117、前段の規模判定）
+3. `.claude/rules/mode-classification.md`（5 段階 mode）
+4. `docs/working/templates/pbi-input.md`（Phase 分割表 section）
+
+## 想定 phase
+
+A フェーズ (PBI INPUT PACKAGE 作成) **前段**。
+
+## Input
+
+- `<topic>`: MVP 分割を検討する機能・トピック名
+- 規模見積もり (TASK-0117 事前メトリクス検証の結果、L 以上推奨)
+
+## Output
+
+- Codex への質問 (4 選択肢 A/B/C/D + 工数 S/M/L + 判断材料 3 軸)
+- PBI INPUT PACKAGE への **Phase 分割表** (Phase 1 着手 / Phase 2+ 繰延)
+
+## Rules
+
+- 質問テンプレは `docs/ai/codex-mvp-split.md` を正本とする。skill は順序のみ。
+- 判断材料 3 軸: ユーザ価値 / 実装の独立性 / 次フェーズへの拡張性
+- Phase 1 のみ本セッション scope、Phase 2 以降は別 PBI に繰延
+- TASK-0117 (#351) 事前メトリクス検証で実数 ≥ 3 倍 (規模 L 相当) 判定時に起動推奨
+
+## 次フェーズへ
+
+Phase 1 確定後は `ai-dev-plan` skill で plan 生成 (B-1 → 事前メトリクス検証 → B-2 → B-3)。

--- a/.claude/commands/codex-mvp-split.md
+++ b/.claude/commands/codex-mvp-split.md
@@ -1,0 +1,58 @@
+# /codex-mvp-split
+
+規模 L 以上の機能を着手する前段で、**最小 MVP (Phase 1) を Codex に選定相談**する。属人化された Phase 分割質問を標準化 (TASK-0118 / #352)。
+
+> 正本: [`docs/ai/codex-mvp-split.md`](../../docs/ai/codex-mvp-split.md)
+> 前段連携: [`docs/ai/plan-metrics-verification.md`](../../docs/ai/plan-metrics-verification.md) (#351 / TASK-0117) で「規模 L 以上」判定された場合に本コマンド起動を推奨
+
+## 引数
+
+`<topic>` — MVP 分割を検討する機能・トピック名。
+
+## いつ使うか
+
+- A フェーズ (PBI INPUT PACKAGE 作成) **前段**
+- TASK-0117 事前メトリクス検証で **実数 / 見積もり ≥ 3 倍** (規模 L 相当) と判定された場合
+- 1 セッションで全部実装すると完結しない規模の機能
+
+## 質問テンプレ (Codex へ)
+
+```text
+<project> の「<topic>」の最小 MVP 設計について Codex に相談します。
+
+# 背景
+<関連既存機能 + ギャップ + 直近文脈>
+
+# 質問
+**質問**: 「<topic>」の Phase 1 最小 MVP は次のどれが妥当か?
+(A) 新ページ独立案
+(B) 既存拡張案
+(C) 最小新規導線案
+(D) Codex 独自案
+
+工数感 (S/M/L) と推奨理由を 400 字程度で。判断材料となる
+「ユーザ価値」「実装の独立性」「次フェーズへの拡張性」を含めてください。
+```
+
+## 採用後
+
+PBI INPUT PACKAGE に **Phase 分割表** を必ず含める:
+
+| Phase | 内容 | 工数 | 状態 |
+|---|---|---|---|
+| 1 | <採用案> | M | 着手 |
+| 2 | <次の拡張> | S | 繰延 |
+| 3 | <最終形> | M | 繰延 |
+
+Phase 1 を本セッションの PBI scope とし、Phase 2 以降は繰延 (別 PBI)。
+
+## 出力
+
+- Codex 回答 (4 選択肢から 1 つ + 工数 + 3 軸の判断材料)
+- PBI INPUT PACKAGE への Phase 分割表
+
+## 関連
+
+- 正本: [`docs/ai/codex-mvp-split.md`](../../docs/ai/codex-mvp-split.md)
+- skill: [`.agents/skills/codex-mvp-split/SKILL.md`](../../.agents/skills/codex-mvp-split/SKILL.md)
+- 前段: TASK-0117 (#351) 事前メトリクス検証

--- a/docs/ai/codex-mvp-split.md
+++ b/docs/ai/codex-mvp-split.md
@@ -1,0 +1,108 @@
+# Codex MVP Split (#352 / TASK-0118)
+
+> **正本**: 本 doc。`.claude/commands/codex-mvp-split.md` / `.agents/skills/codex-mvp-split/SKILL.md` は本 doc を参照。
+>
+> 前段連携: [`plan-metrics-verification.md`](./plan-metrics-verification.md) (#351 / TASK-0117)
+
+## 目的
+
+規模 L 以上の機能を着手前に **最小 MVP (Phase 1) → Phase 2 → ...** に分割し、Codex に Phase 1 を選定相談する。属人化された質問テンプレを標準化、1 セッション完遂可能な scope に絞る。
+
+## 背景
+
+規模 L をいきなり全部実装すると 1 セッションで完結せず、リリースが滞る。
+
+PocketEitan で 2 例実証:
+- **例文音読カード** (規模 L、4 Phase に分割) → Phase 1 を v0.16.0 で完遂
+- **TASK-srs-unification** (規模 standard〜full、2 Phase) → Phase 1 を v0.15.0 で完遂
+
+毎回手書きで質問テンプレを作るのは非効率 + 属人化。本 skill で標準化。
+
+## 起動タイミング (TASK-0117 連携)
+
+```text
+A フェーズ着手前
+  ↓
+TASK-0117 事前メトリクス検証 (#351)
+  → 実数 / 見積もり ≥ 3 倍 = 規模 L 相当
+  ↓
+codex-mvp-split (本 skill) 起動  ← ここ
+  ↓
+Phase 1 確定 → PBI INPUT PACKAGE に Phase 分割表
+  ↓
+ai-dev-plan skill で plan 生成
+```
+
+TASK-0117 (#351) と **AND 関係**:
+- TASK-0117 = 規模判定 (実数取得)
+- 本 PBI (#352) = 規模 L 判定後の Phase 分割
+
+相互参照のみ、重複定義なし。
+
+## 質問テンプレ
+
+```text
+<project> の「<topic>」の最小 MVP 設計について Codex に相談します。
+
+# 背景
+<関連既存機能 + ギャップ + 直近文脈>
+
+# 質問
+**質問**: 「<topic>」の Phase 1 最小 MVP は次のどれが妥当か?
+(A) 新ページ独立案 — 独立した新機能として実装
+(B) 既存拡張案 — 既存機能を拡張
+(C) 最小新規導線案 — 最小限の新規導線のみ追加
+(D) Codex 独自案 — Codex が上記以外を提案
+
+工数感 (S/M/L) と推奨理由を 400 字程度で。判断材料となる
+「ユーザ価値」「実装の独立性」「次フェーズへの拡張性」を含めてください。
+```
+
+### 判断材料 3 軸
+
+| 軸 | 観点 |
+|----|------|
+| **ユーザ価値** | Phase 1 単体でユーザに価値を提供できるか |
+| **実装の独立性** | 他機能への依存が少なく単独実装可能か |
+| **次フェーズへの拡張性** | Phase 2 以降への発展余地があるか |
+
+## 採用後: Phase 分割表
+
+PBI INPUT PACKAGE に必ず含める:
+
+| Phase | 内容 | 工数 | 状態 |
+|---|---|---|---|
+| 1 | <採用案> | M | 着手 |
+| 2 | <次の拡張> | S | 繰延 |
+| 3 | <最終形> | M | 繰延 |
+
+- **Phase 1 のみ本セッションの PBI scope**
+- Phase 2 以降は **別 PBI に繰延** (繰延理由を明記)
+
+## 既存実例 (PocketEitan)
+
+### 1. 例文音読カード (規模 L → 4 Phase)
+
+- 質問: 例文音読カードの Phase 1 最小 MVP は?
+- Codex 回答: (C) 最小新規導線案 (既存カード画面に音読ボタン追加)
+- 工数: M / 判断: ユーザ価値高 (即体験可) + 独立性高 + Phase 2 (録音比較) へ拡張可
+- 結果: Phase 1 を v0.16.0 (PR #368) で完遂、4 Phase 全体を 1 セッション詰まりなく分割
+
+### 2. TASK-srs-unification (規模 standard〜full → 2 Phase)
+
+- 質問: SRS 統合の Phase 1 最小 MVP は?
+- Codex 回答: (B) 既存拡張案 (既存 SRS ロジックに統合 API 層追加)
+- 工数: M / 判断: 既存資産活用 + 段階移行可能
+- 結果: Phase 1 を v0.15.0 (PR #365) で完遂
+
+## CLI 化 (V2 候補)
+
+現状は質問テンプレ提供 + Human/Codex CLI で相談。`bin/plangate mvp-split <topic>` 等の CLI 自動 dispatch は V2 候補 (本 PBI scope 外)。
+
+## 関連
+
+- Issue: [#352](https://github.com/s977043/plangate/issues/352)
+- command: [`.claude/commands/codex-mvp-split.md`](../../.claude/commands/codex-mvp-split.md)
+- skill: [`.agents/skills/codex-mvp-split/SKILL.md`](../../.agents/skills/codex-mvp-split/SKILL.md)
+- 前段: [`plan-metrics-verification.md`](./plan-metrics-verification.md) (#351 / TASK-0117)
+- 参考実装: PocketEitan PR #371 (`.claude/commands/codex-mvp-split.md`)

--- a/docs/working/TASK-0118/handoff.md
+++ b/docs/working/TASK-0118/handoff.md
@@ -1,0 +1,68 @@
+# TASK-0118 handoff
+
+> WF-05 Verify & Handoff 完了パッケージ (Rule 5)
+> Issue: [#352](https://github.com/s977043/plangate/issues/352)
+
+## 概要
+
+規模 L 以上の機能を最小 MVP (Phase 1) に分割する `codex-mvp-split` skill / command を整備。属人化された Codex 相談プロセスを標準化。TASK-0117 (#351 事前メトリクス検証) の規模判定と AND 連携。
+
+## 1. 要件適合確認結果 (AC-1..AC-8)
+
+| AC | TC | 結果 |
+|----|-----|------|
+| AC-1 slash command 新規 | TC-01 | ✅ PASS |
+| AC-2 skill 新規 + frontmatter | TC-02/TC-08 | ✅ PASS |
+| AC-3 質問テンプレ 4 選択肢 + 工数 + 3 軸 | TC-03/TC-03b | ✅ PASS |
+| AC-4 Phase 分割表 template | TC-04 | ✅ PASS (templates/README.md + doc) |
+| AC-5 TASK-0117 連携明記 | TC-05 | ✅ PASS |
+| AC-6 PocketEitan 実例 ≥ 2 件 | TC-06 | ✅ PASS (例文音読カード / TASK-srs-unification) |
+| AC-7 ta-21 機械検証 | TC-01..08 | ✅ 9/9 PASS |
+| AC-8 markdownlint + regression | tests/run-tests.sh | PR CI で確認 |
+
+## 2. 既知課題一覧
+
+| ID | 内容 | 重要度 |
+|----|------|--------|
+| K-1 | `docs/working/templates/pbi-input.md` template が不在 → Phase 分割表 は templates/README.md + codex-mvp-split.md に記述 (AC-4 該当 doc 解釈) | info |
+| K-2 | proactive C-2 は本 PBI で skip (review-self PASS + PocketEitan 参考) → V-3 で補完可 | info |
+| K-3 | CLI 自動 dispatch (bin/plangate mvp-split) は V2 候補 | info |
+
+## 3. V2 候補
+
+- V2-A: `bin/plangate mvp-split <topic>` で Codex 自動 dispatch
+- V2-B: pbi-input.md template 新規作成 (現状 README 参照のみ)
+- V2-C: TASK-0117 事前メトリクス検証から自動で本 skill 起動推奨表示
+
+## 4. 妥協点
+
+- pbi-input.md template 不在のため Phase 分割表 は templates/README.md に記述 (AC-4 「該当 doc」解釈)
+- proactive C-2 skip (review-self PASS + 既存 PocketEitan 実装で risk 低)
+- 質問テンプレは PocketEitan PR #371 最小ポート (literal text)
+
+## 5. 引き継ぎ文書 (5 分把握サマリ)
+
+1. **command**: `.claude/commands/codex-mvp-split.md` (slash command、質問テンプレ + Phase 分割表)
+2. **skill**: `.agents/skills/codex-mvp-split/SKILL.md` (薄い skill、doc 正本参照、ai-dev-plan と同 pattern)
+3. **doc**: `docs/ai/codex-mvp-split.md` (正本、質問テンプレ + 判定基準 + PocketEitan 実例 2 件 + TASK-0117 連携)
+4. **template ref**: `docs/working/templates/README.md` に Phase 分割表
+5. **test**: `tests/extras/ta-21-codex-mvp-split.sh` (9 case 全 PASS)
+6. **質問テンプレ**: 4 選択肢 (A 独立 / B 拡張 / C 最小導線 / D Codex 独自) + 工数 S/M/L + 判断 3 軸 (ユーザ価値 / 実装独立性 / 次フェーズ拡張性)
+7. **TASK-0117 (#351) 連携**: AND 関係、相互参照のみ (TASK-0117=規模判定、本 PBI=L 判定後の Phase 分割)
+
+## 6. テスト結果サマリ
+
+| カテゴリ | 結果 |
+|---------|------|
+| ta-21 単体 | ✅ **9/9 PASS** |
+| tests/run-tests.sh 全体 | PR CI で確認 (ta-21 追加で +9) |
+| markdownlint | PR CI で確認 |
+| 規模メトリクス (#351 自己適用) | plan 6 file vs 実 6 file = 1.0 倍 → standard 維持 |
+
+## 7. Refs
+
+- Issue: [#352](https://github.com/s977043/plangate/issues/352)
+- C-3 APPROVED: PR #399 merged 2026-05-28
+- 前提 PBI: TASK-0117 (#351、merged 2026-05-27) 事前メトリクス検証
+- 参考実装: PocketEitan PR #371 (`.claude/commands/codex-mvp-split.md`)
+- 連携 doc: [`docs/ai/plan-metrics-verification.md`](../../ai/plan-metrics-verification.md)

--- a/docs/working/templates/README.md
+++ b/docs/working/templates/README.md
@@ -27,3 +27,20 @@ PlanGate ワークフローで使うテンプレート群。
 | [`review-self.md`](./review-self.md) / [`review-external.md`](./review-external.md) | C-1 / C-2 レビュー結果 | |
 
 > `run-outcome-review.md` は v8.6.0 以前の利用者に**移行コストゼロ**（任意・後方互換）。
+
+
+## Phase 分割表 (規模 L 以上 / #352 codex-mvp-split)
+
+規模 L 以上 (TASK-0117 #351 事前メトリクス検証で実数 ≥ 3 倍) の機能は、
+PBI INPUT PACKAGE (`pbi-input.md`) に **Phase 分割表** を含める:
+
+| Phase | 内容 | 工数 | 状態 |
+|---|---|---|---|
+| 1 | <採用 MVP> | M | 着手 |
+| 2 | <次の拡張> | S | 繰延 (別 PBI) |
+| 3 | <最終形> | M | 繰延 (別 PBI) |
+
+Phase 1 のみ本 PBI scope。Phase 1 の選定は [`/codex-mvp-split`](../../../.claude/commands/codex-mvp-split.md)
+で Codex 相談。正本: [`docs/ai/codex-mvp-split.md`](../../ai/codex-mvp-split.md)。
+
+(規模 standard 以下で分割不要の場合は「該当なし」と明記)

--- a/tests/extras/ta-21-codex-mvp-split.sh
+++ b/tests/extras/ta-21-codex-mvp-split.sh
@@ -1,0 +1,81 @@
+# tests/extras/ta-21-codex-mvp-split.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# TASK-0118 / #352: codex-mvp-split skill / command 構造検証
+
+printf '\n=== TA-21: codex-mvp-split (#352 TASK-0118) ===\n'
+
+PG_T21_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T21_CMD="$PG_T21_ROOT/.claude/commands/codex-mvp-split.md"
+PG_T21_SKILL="$PG_T21_ROOT/.agents/skills/codex-mvp-split/SKILL.md"
+PG_T21_DOC="$PG_T21_ROOT/docs/ai/codex-mvp-split.md"
+
+t21_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t21_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# === TC-01 (AC-1): slash command 存在 ===
+if [ -f "$PG_T21_CMD" ]; then
+  t21_pass "TC-01 .claude/commands/codex-mvp-split.md 存在"
+else
+  t21_fail "TC-01 command 不在"
+fi
+
+# === TC-02 (AC-2): skill 存在 + frontmatter ===
+if [ -f "$PG_T21_SKILL" ] && grep -qE "^name:" "$PG_T21_SKILL" && grep -qE "^description:" "$PG_T21_SKILL"; then
+  t21_pass "TC-02 skill 存在 + frontmatter (name/description)"
+else
+  t21_fail "TC-02 skill 不在 or frontmatter 不足"
+fi
+
+# === TC-03 (AC-3): 質問テンプレ 4 選択肢 (A/B/C/D) ===
+ABCD_COUNT=$(grep -cE '\(A\)|\(B\)|\(C\)|\(D\)' "$PG_T21_CMD" "$PG_T21_DOC" 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')
+if [ "$ABCD_COUNT" -ge 4 ]; then
+  t21_pass "TC-03 質問テンプレ 4 選択肢 (A/B/C/D) 存在"
+else
+  t21_fail "TC-03 4 選択肢不足 (count=$ABCD_COUNT)"
+fi
+
+# === TC-03b (AC-3): 工数 S/M/L + 判断材料 3 軸 ===
+if grep -qE "S/M/L|工数" "$PG_T21_DOC" && \
+   grep -qE "ユーザ価値" "$PG_T21_DOC" && \
+   grep -qE "実装の独立性|独立性" "$PG_T21_DOC" && \
+   grep -qE "次フェーズへの拡張性|拡張性" "$PG_T21_DOC"; then
+  t21_pass "TC-03b 工数 S/M/L + 判断材料 3 軸 (価値/独立性/拡張性)"
+else
+  t21_fail "TC-03b 工数 or 3 軸不足"
+fi
+
+# === TC-04 (AC-4): Phase 分割表 template ===
+if grep -qE "Phase 分割表" "$PG_T21_ROOT/docs/working/templates/README.md" "$PG_T21_DOC" "$PG_T21_CMD" 2>/dev/null; then
+  t21_pass "TC-04 Phase 分割表 template 記述"
+else
+  t21_fail "TC-04 Phase 分割表 なし"
+fi
+
+# === TC-05 (AC-5): TASK-0117 (#351) 連携明記 ===
+if grep -qE "TASK-0117|事前メトリクス検証|plan-metrics-verification|#351" "$PG_T21_DOC"; then
+  t21_pass "TC-05 TASK-0117 (#351) 連携明記"
+else
+  t21_fail "TC-05 TASK-0117 連携なし"
+fi
+
+# === TC-06 (AC-6): PocketEitan 実例 2 件 ===
+EXAMPLE_COUNT=$(grep -cE "例文音読カード|TASK-srs-unification" "$PG_T21_DOC" 2>/dev/null || echo 0)
+if [ "$EXAMPLE_COUNT" -ge 2 ]; then
+  t21_pass "TC-06 PocketEitan 実例 2 件 (例文音読カード / TASK-srs-unification)"
+else
+  t21_fail "TC-06 実例不足 (count=$EXAMPLE_COUNT)"
+fi
+
+# === TC-07 (AC-7): doc 正本構造 ===
+if grep -qE "## 目的|## 質問テンプレ|## 採用後" "$PG_T21_DOC"; then
+  t21_pass "TC-07 doc 正本構造 (目的/質問テンプレ/採用後)"
+else
+  t21_fail "TC-07 doc 構造不足"
+fi
+
+# === TC-08 (AC-2): skill が薄い設計 (正本参照) ===
+if grep -qE "正本とし|Read First|順序のみ" "$PG_T21_SKILL"; then
+  t21_pass "TC-08 skill が薄い設計 (doc 正本参照、ai-dev-plan と同 pattern)"
+else
+  t21_fail "TC-08 skill 設計不適"
+fi


### PR DESCRIPTION
C-3 APPROVED (PR #399) 後の exec。T-02..T-07 完了。

## 変更
- .claude/commands/codex-mvp-split.md (slash command、HO)
- .agents/skills/codex-mvp-split/SKILL.md (薄い skill)
- docs/ai/codex-mvp-split.md (正本、質問テンプレ + PocketEitan 実例 2 件 + TASK-0117 連携)
- docs/working/templates/README.md に Phase 分割表 参照
- tests/extras/ta-21-codex-mvp-split.sh (**9/9 PASS**)
- handoff.md (Rule 5)

## AC-1..AC-8 全 PASS

## TASK-0117 (#351) との関係
AND 関係、相互参照のみ (TASK-0117=規模判定、本 PBI=MVP 分割)

## 本セッション 11 PBI 完遂
本 PBI で TASK-0108..0118 全 11 PBI exec 完了。

Refs: #352, PR #399, PocketEitan PR #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)