### PR TITLE
docs(TASK-0120): plan 生成 — gh account pinning helper (Retro Try #2)

### DIFF
--- a/docs/working/TASK-0120/INDEX.md
+++ b/docs/working/TASK-0120/INDEX.md
@@ -1,0 +1,5 @@
+# TASK-0120 INDEX
+- **Title**: gh account pinning helper (Session Retro Try #2)
+- **Mode**: light (HO 対象外)
+- **Phase**: B 完了
+- **Status**: C-3 待ち

--- a/docs/working/TASK-0120/current-state.md
+++ b/docs/working/TASK-0120/current-state.md
@@ -1,0 +1,6 @@
+# TASK-0120 current-state
+## Phase: B 完了
+Session Retrospective Try #2 由来。gh account 切替による権限エラーの構造対策。
+## 関連
+- Session Retro (PR #401)
+- memory feedback_github_account_switch

--- a/docs/working/TASK-0120/pbi-input.md
+++ b/docs/working/TASK-0120/pbi-input.md
@@ -1,0 +1,53 @@
+# TASK-0120 PBI INPUT PACKAGE
+
+> 出自: Session Retrospective 2026-05-24〜28 (PR #401) Try #2
+> 関連: feedback_github_account_switch memory
+
+## Context / Why
+
+本セッションで `gh` の active account が意図せず kominem-unilabo にスイッチし、`gh pr create` / GraphQL mutation (resolveReviewThread) が `must be a collaborator` / `FORBIDDEN` で失敗する事例が 5+ 回発生。都度 `gh auth switch --user s977043` で復旧したが属人的。
+
+PlanGate ルール: コミット / PR / merge は s977043 アカウント固定 (sockpuppet 禁止、`feedback_github_account_switch` / `feedback_no_sockpuppet_merge`)。
+
+## What (Scope)
+
+### In scope
+
+- `scripts/gh-s977043.sh` (新規) — gh 操作前に active account を s977043 に強制するラッパ
+  - `gh auth switch --user s977043` を冒頭で実行してから引数を gh に渡す
+- `docs/ai/github-account-pinning.md` (新規 or 既存追記) — 運用ガイド (commit/PR/merge は s977043 固定)
+- SessionStart hook 連携確認 (既存 `gh-pin-account` hook が「already pinned to s977043」を出力していた → 本ラッパとの責務整理)
+- `tests/extras/ta-23-gh-account-pin.sh` (ラッパ存在 + s977043 switch ロジック検証)
+
+### Out of scope
+
+- gh CLI 本体の改修
+- 認証情報 (token) の管理 (既存 keyring 利用)
+- sockpuppet 禁止ルール自体 (既存 memory / responsibility-classes で規定済)
+
+## 受入基準
+
+- AC-1: `scripts/gh-s977043.sh` が `gh auth switch --user s977043` 後に gh 引数を実行
+- AC-2: active account が既に s977043 ならスイッチ skip (冪等)
+- AC-3: `docs/ai/github-account-pinning.md` で運用ガイド (commit/PR/merge 固定)
+- AC-4: 既存 SessionStart `gh-pin-account` hook との責務整理を doc に明記
+- AC-5: `tests/extras/ta-23-gh-account-pin.sh` で検証
+- AC-6: markdownlint + shellcheck + 既存テスト regression なし
+
+## Notes from Refinement
+
+- scripts/ ルート直下は Hardening Override 対象外 (scripts/hooks/ ではない)
+- 既存 SessionStart hook `gh-pin-account` が pinning を試みているが、セッション中の mutation 操作前には効かない → 本ラッパで補完
+- C (ツール運用変更) 分類
+
+## Estimation
+
+### Risks
+- gh auth switch の権限不足環境 → mitigation: switch 失敗時 warning + 続行
+- 既存 hook との二重 pinning → mitigation: 責務整理 doc
+
+### Unknowns
+- SessionStart hook の実装場所 (.claude/settings.json or scripts/hooks/) → T-01
+
+### Assumptions
+- s977043 アカウントが gh auth に登録済 (keyring)

--- a/docs/working/TASK-0120/plan.md
+++ b/docs/working/TASK-0120/plan.md
@@ -1,0 +1,55 @@
+# TASK-0120 EXECUTION PLAN
+
+> Source: pbi-input.md / Session Retro Try #2 / Mode: **light**
+> Generated: 2026-05-28
+
+## Goal
+
+gh 操作前に active account を s977043 に強制するラッパを整備し、本セッションで多発した account 切替による権限エラーを構造的に防ぐ。
+
+## Constraints / Non-goals
+
+- gh CLI 本体改修しない
+- sockpuppet 禁止ルール自体は既存規定 (本 PBI はツール運用補助)
+- scripts/ ルート直下は HO 対象外
+
+## Approach Overview
+
+(1) T-01 既存 SessionStart gh-pin-account hook 実装場所確認、(2) T-02 scripts/gh-s977043.sh 新規、(3) T-03 doc、(4) T-04 ta-23、(5) T-05 handoff。
+
+## Work Breakdown
+
+| # | Step | Output | Owner | Risk | 🚩 |
+|---|------|--------|-------|------|----|
+| 1 | T-01 調査: SessionStart gh-pin-account hook 実装場所 + 責務確認 | 調査メモ | AI | low | 責務整理 |
+| 2 | T-02: scripts/gh-s977043.sh (auth switch + 冪等) | scripts/gh-s977043.sh | AI | low | switch + gh 実行 |
+| 3 | T-03: docs/ai/github-account-pinning.md | docs/ai/github-account-pinning.md | AI | low | 運用ガイド |
+| 4 | T-04: tests/extras/ta-23-gh-account-pin.sh | tests/extras/ta-23-gh-account-pin.sh | AI | low | ta-23 PASS |
+| 5 | T-05: handoff + V-1 | handoff.md | AI | low | AC-1..6 PASS |
+
+## Files / Components to Touch
+
+| ファイル | 性質 |
+|---------|------|
+| scripts/gh-s977043.sh | 新規 (HO 対象外、scripts/ ルート) |
+| docs/ai/github-account-pinning.md | 新規 |
+| tests/extras/ta-23-gh-account-pin.sh | 新規 |
+| docs/working/TASK-0120/handoff.md | WF-05 |
+
+## Testing Strategy
+
+- ラッパ存在 + switch ロジック grep 検証
+- shellcheck + markdownlint + 既存テスト regression
+
+## Risks & Mitigations
+
+| Risk | Sev | Mitigation |
+|------|-----|------------|
+| switch 権限不足環境 | low | switch 失敗時 warning + 続行 |
+| SessionStart hook と二重 pinning | low | 責務整理 doc |
+
+## Mode 判定
+
+**light** (HO 対象外、scripts/ ルート直下)
+
+Session Retro Try #2 由来。TASK-0117 事前メトリクス: 想定 4 file、light 維持。

--- a/docs/working/TASK-0120/plan.md
+++ b/docs/working/TASK-0120/plan.md
@@ -48,6 +48,12 @@ gh 操作前に active account を s977043 に強制するラッパを整備し�
 | switch 権限不足環境 | low | switch 失敗時 warning + 続行 |
 | SessionStart hook と二重 pinning | low | 責務整理 doc |
 
+## Questions / Unknowns
+
+- **SessionStart hook の実装場所**: `gh-pin-account` hook が `.claude/settings.json` か `scripts/hooks/` か → **T-01 で確定**
+- **二重 pinning の影響**: 既存 SessionStart hook と本ラッパの責務分界 → T-01 + T-03 doc で整理
+- **switch 権限不足環境の挙動**: switch 失敗時 warning + 続行で許容するか → plan で warning + 続行を仮採用
+
 ## Mode 判定
 
 **light** (HO 対象外、scripts/ ルート直下)

--- a/docs/working/TASK-0120/review-self.md
+++ b/docs/working/TASK-0120/review-self.md
@@ -1,0 +1,7 @@
+# TASK-0120 C-1 セルフレビュー
+
+## Plan/ToDo/TestCases: PASS
+
+## 判定: **PASS** — C-3 ゲート提出可能
+
+総合 90/100。blocker 0、major 0、minor 1 (SessionStart hook との責務整理 T-01 確定)。Session Retro Try #2 由来。scripts/ ルート直下で HO 対象外、maintenance window 不要。

--- a/docs/working/TASK-0120/review-self.md
+++ b/docs/working/TASK-0120/review-self.md
@@ -1,6 +1,34 @@
 # TASK-0120 C-1 セルフレビュー
 
-## Plan/ToDo/TestCases: PASS
+## Plan チェック (7 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-PLAN-01 受入基準網羅性 | AC-1..6 全 TC マッピング | PASS |
+| C1-PLAN-02 Unknowns 処理 | SessionStart hook 実装場所 = T-01 | PASS |
+| C1-PLAN-03 スコープ制御 | gh 本体改修 / sockpuppet ルール自体は Out of scope | PASS |
+| C1-PLAN-04 テスト戦略 | ラッパ存在 + switch ロジック grep + shellcheck | PASS |
+| C1-PLAN-05 Work Breakdown Output | 各 Step に Output/Owner/Risk/🚩 | PASS |
+| C1-PLAN-06 依存関係 | T-01→T-02→T-03/T-04→T-05 | PASS |
+| C1-PLAN-07 動作検証自動化 | ta-23 で grep 機械検証 | PASS |
+
+## ToDo チェック (5 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TODO-01 タスク粒度 | PASS |
+| C1-TODO-02 depends_on 設定 | PASS |
+| C1-TODO-03 チェックポイント設定 | PASS |
+| C1-TODO-04 Iron Law 遵守 | PASS (scripts/ ルートで HO 対象外、c3 後 exec) |
+| C1-TODO-05 完了条件 | PASS |
+
+## TestCases チェック (3 項目)
+
+| # | 項目 | 判定 |
+|---|------|------|
+| C1-TC-01 受入基準との紐付き | PASS |
+| C1-TC-02 Edge case 網羅 | PASS (switch 失敗 / 既 s977043) |
+| C1-TC-03 自動化可否 | PASS (grep / shellcheck) |
 
 ## 判定: **PASS** — C-3 ゲート提出可能
 

--- a/docs/working/TASK-0120/test-cases.md
+++ b/docs/working/TASK-0120/test-cases.md
@@ -1,0 +1,19 @@
+# TASK-0120 TEST CASES
+
+| AC | TC |
+|----|-----|
+| AC-1 switch 後 gh 実行 | TC-01 |
+| AC-2 冪等 (既に s977043 なら skip) | TC-02 |
+| AC-3 doc | TC-03 |
+| AC-4 SessionStart hook 責務整理 | TC-04 |
+| AC-5 ta-23 | TC-05 |
+| AC-6 shellcheck + regression | TC-06 |
+
+| ID | 内容 | 期待 |
+|----|------|------|
+| TC-01 | ラッパが gh auth switch --user s977043 を含む | grep 該当 |
+| TC-02 | 既に s977043 active なら switch skip (冪等ロジック) | grep 該当 |
+| TC-03 | doc 主要 section (運用 / 責務整理) | grep 該当 |
+| TC-04 | doc に SessionStart gh-pin-account との責務整理 | grep 該当 |
+| TC-05 | ta-23 dispatcher 認識 | PASS |
+| TC-06 | shellcheck scripts/gh-s977043.sh + regression | exit 0 |

--- a/docs/working/TASK-0120/test-cases.md
+++ b/docs/working/TASK-0120/test-cases.md
@@ -1,5 +1,7 @@
 # TASK-0120 TEST CASES
 
+## マッピング
+
 | AC | TC |
 |----|-----|
 | AC-1 switch 後 gh 実行 | TC-01 |
@@ -9,11 +11,19 @@
 | AC-5 ta-23 | TC-05 |
 | AC-6 shellcheck + regression | TC-06 |
 
-| ID | 内容 | 期待 |
-|----|------|------|
-| TC-01 | ラッパが gh auth switch --user s977043 を含む | grep 該当 |
-| TC-02 | 既に s977043 active なら switch skip (冪等ロジック) | grep 該当 |
-| TC-03 | doc 主要 section (運用 / 責務整理) | grep 該当 |
-| TC-04 | doc に SessionStart gh-pin-account との責務整理 | grep 該当 |
-| TC-05 | ta-23 dispatcher 認識 | PASS |
-| TC-06 | shellcheck scripts/gh-s977043.sh + regression | exit 0 |
+## テストケース一覧
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|----------|------|----------|------|
+| TC-01 | gh CLI install 済 | `grep 'gh auth switch --user s977043' scripts/gh-s977043.sh` | 該当 1 件以上 | 構造 |
+| TC-02 | active account 取得可能 | ラッパ内に「既に s977043 なら switch skip」の冪等ロジック | grep 該当 | 構造 |
+| TC-03 | doc 存在 | `grep -E '## 運用\|## 責務整理' docs/ai/github-account-pinning.md` | 該当 | 構造 |
+| TC-04 | SessionStart hook 把握 | doc に gh-pin-account hook との責務整理記述 | grep 該当 | 構造 |
+| TC-05 | tests/run-tests.sh 実行 | `sh tests/run-tests.sh` | TA-23 全 case PASS | 統合 |
+| TC-06 | shellcheck install 済 | `shellcheck scripts/gh-s977043.sh && sh tests/run-tests.sh` | exit 0 | 統合 |
+
+## エッジケース
+
+- s977043 が gh auth に未登録: switch 失敗 → warning + 続行 (権限不足環境)
+- 既に s977043 active: switch skip (冪等)
+- gh CLI 未 install: ラッパ冒頭で error + exit

--- a/docs/working/TASK-0120/todo.md
+++ b/docs/working/TASK-0120/todo.md
@@ -1,12 +1,22 @@
 # TASK-0120 EXECUTION TODO
 
+> Source: plan.md / Mode: light
+
 ## 🤖 Agent タスク
-- [ ] **T-01**: SessionStart gh-pin-account hook 実装場所 + 責務確認 (owner=agent / Risk=low)
-- [ ] **T-02**: scripts/gh-s977043.sh (auth switch + 冪等) (owner=agent / Risk=low / depends_on=T-01)
-- [ ] **T-03**: docs/ai/github-account-pinning.md (owner=agent / Risk=low / depends_on=T-02)
-- [ ] **T-04**: tests/extras/ta-23-gh-account-pin.sh (owner=agent / Risk=low / depends_on=T-02)
-- [ ] **T-05**: handoff + V-1 (owner=agent / Risk=low / depends_on=全完了)
+
+- [ ] **T-01**: SessionStart gh-pin-account hook 実装場所 + 責務確認 (owner=agent / Risk=low / 🚩 責務整理完了)
+- [ ] **T-02**: scripts/gh-s977043.sh (auth switch + 冪等) (owner=agent / Risk=low / depends_on=T-01 / 🚩 switch + gh 実行 + 冪等)
+- [ ] **T-03**: docs/ai/github-account-pinning.md (owner=agent / Risk=low / depends_on=T-02 / 🚩 運用ガイド + 責務整理)
+- [ ] **T-04**: tests/extras/ta-23-gh-account-pin.sh (owner=agent / Risk=low / depends_on=T-02 / 🚩 ta-23 全 PASS)
+- [ ] **T-05**: handoff.md + V-1 (owner=agent / Risk=low / depends_on=全完了 / 🚩 AC-1..6 PASS)
 
 ## 👤 Human タスク
-- [ ] **H-01**: C-3 ゲート
-- [ ] **H-02**: C-4 + merge
+
+- [ ] **H-01**: C-3 ゲート (`approvals/c3.json` 発行)
+- [ ] **H-02**: C-4 ゲート (PR レビュー) + merge
+
+## ⚠️ 依存関係
+
+- T-02..T-05 は H-01 (C-3) 通過後に着手可
+- T-01 (read-only 調査) は C-3 前可
+- H-02 (merge) は Human-owned 固定

--- a/docs/working/TASK-0120/todo.md
+++ b/docs/working/TASK-0120/todo.md
@@ -1,0 +1,12 @@
+# TASK-0120 EXECUTION TODO
+
+## 🤖 Agent タスク
+- [ ] **T-01**: SessionStart gh-pin-account hook 実装場所 + 責務確認 (owner=agent / Risk=low)
+- [ ] **T-02**: scripts/gh-s977043.sh (auth switch + 冪等) (owner=agent / Risk=low / depends_on=T-01)
+- [ ] **T-03**: docs/ai/github-account-pinning.md (owner=agent / Risk=low / depends_on=T-02)
+- [ ] **T-04**: tests/extras/ta-23-gh-account-pin.sh (owner=agent / Risk=low / depends_on=T-02)
+- [ ] **T-05**: handoff + V-1 (owner=agent / Risk=low / depends_on=全完了)
+
+## 👤 Human タスク
+- [ ] **H-01**: C-3 ゲート
+- [ ] **H-02**: C-4 + merge


### PR DESCRIPTION
Session Retrospective (PR #401) Try #2 の PBI 化。gh account 切替による権限エラーの構造対策。

## Scope
- scripts/gh-s977043.sh (auth switch + 冪等、HO 対象外)
- docs/ai/github-account-pinning.md
- SessionStart gh-pin-account hook 責務整理
- tests/extras/ta-23-gh-account-pin.sh

Mode: light (HO 対象外)

Refs: PR #401 Try #2, memory feedback_github_account_switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)