### PR TITLE
chore: .mailmap で s977043 へ非破壊再マッピング

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# .mailmap — commit author/committer の表示正規化
+#
+# 目的: 過去に誤って kominem-unilabo アカウントで作成された commit を、
+#       正規アカウント s977043 (mine_take) として表示に再マッピングする。
+#       履歴 (commit hash) は書き換えず、git log/shortlog/blame および
+#       GitHub の contributor 表示上で正規化のみ行う (非破壊)。
+#
+# format: Proper-Name <proper-email> Commit-Name <commit-email>
+mine_take <s977043@users.noreply.github.com> kominem-unilabo <kominem-unilabo@users.noreply.github.com>


### PR DESCRIPTION
## Summary
誤って kominem-unilabo アカウントで作成された 11 commit (2026-04-24〜26、main 履歴深部) を、正規アカウント s977043 (mine_take) へ **非破壊で再マッピング**する `.mailmap` を追加。

## なぜ filter-repo ではなく .mailmap か
- 対象 commit は HEAD から 334〜349 commit 前にあり、author 書き換えには 349 commit の hash 全変更 + main force-push (ruleset 解除/Human admin) が必要
- 全 clone 再取得・closed PR リンク破壊・tag/SHA 参照破壊・本リポジトリ Iron Law (main 直接 push 禁止/INC-2026-05-26-001) と矛盾
- .mailmap は **hash 不変・force-push 不要**で git log/shortlog/blame・GitHub contributor 表示を正規化

## 検証
- `git shortlog -es origin/main` → kominem-unilabo が消え全件 mine_take に集約 (381 commit)

## 備考
- 個別 commit ページの author 表記は GitHub 側仕様で元表示が残る場合あり (表示正規化の限界)
- 完全な hash 書き換えが必要なら別途 Human admin 操作 (ruleset 解除+force-push) が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)