### PR TITLE
chore: docs/script 内の kominem-unilabo 文字列参照を中立表現へ置換

### DIFF
--- a/docs/working/TASK-0052/handoff.md
+++ b/docs/working/TASK-0052/handoff.md
@@ -52,7 +52,7 @@ related_issue: 171
 
 ### 概要
 
-plangate での作業中に gh CLI active account が想定外に kominem-unilabo へ切り戻る現象（retrospective 2026-05-01 P-1、本セッションで 4 回以上発生）への workaround。`scripts/gh-pin-account.sh` で現在 user を確認し、必要時のみ `s977043` に切替。SessionStart hook として `.claude/settings.example.json` に opt-in 登録。
+plangate での作業中に gh CLI active account が想定外に 別アカウント へ切り戻る現象（retrospective 2026-05-01 P-1、本セッションで 4 回以上発生）への workaround。`scripts/gh-pin-account.sh` で現在 user を確認し、必要時のみ `s977043` に切替。SessionStart hook として `.claude/settings.example.json` に opt-in 登録。
 
 主要成果:
 - `scripts/gh-pin-account.sh`（POSIX sh、冪等、`PLANGATE_GH_USER` で override 可能）

--- a/docs/working/TASK-0052/pbi-input.md
+++ b/docs/working/TASK-0052/pbi-input.md
@@ -5,7 +5,7 @@
 
 ## Context / Why
 
-retrospective 2026-04-30 T-5 / 2026-05-01 P-1。plangate での作業中に gh CLI の active account が `kominem-unilabo` へ勝手に切り戻る現象が頻発。本セッションだけで 4 回以上、共有 mutation が `does not have the correct permissions` で失敗 → 手動 `gh auth switch` 必要。
+retrospective 2026-04-30 T-5 / 2026-05-01 P-1。plangate での作業中に gh CLI の active account が `別アカウント` へ勝手に切り戻る現象が頻発。本セッションだけで 4 回以上、共有 mutation が `does not have the correct permissions` で失敗 → 手動 `gh auth switch` 必要。
 
 ## What
 

--- a/docs/working/TASK-0120/pbi-input.md
+++ b/docs/working/TASK-0120/pbi-input.md
@@ -5,7 +5,7 @@
 
 ## Context / Why
 
-本セッションで `gh` の active account が意図せず kominem-unilabo にスイッチし、`gh pr create` / GraphQL mutation (resolveReviewThread) が `must be a collaborator` / `FORBIDDEN` で失敗する事例が 5+ 回発生。都度 `gh auth switch --user s977043` で復旧したが属人的。
+本セッションで `gh` の active account が意図せず 別アカウント にスイッチし、`gh pr create` / GraphQL mutation (resolveReviewThread) が `must be a collaborator` / `FORBIDDEN` で失敗する事例が 5+ 回発生。都度 `gh auth switch --user s977043` で復旧したが属人的。
 
 PlanGate ルール: コミット / PR / merge は s977043 アカウント固定 (sockpuppet 禁止、`feedback_github_account_switch` / `feedback_no_sockpuppet_merge`)。
 

--- a/docs/working/_reports/session-retro-2026-05-24-to-28.md
+++ b/docs/working/_reports/session-retro-2026-05-24-to-28.md
@@ -32,7 +32,7 @@
 - **claude-mem 自動挿入の実害**: PR #376/#383 で AGENTS.md / skip-decision-log が `git add -A` に巻き込まれた。→ TASK-0113 検知 hook + 根本削除で解消
 - **plan の前提崩れ**: TASK-0109 (CX-2 既達)、TASK-0108 (#356 で 5 項目先行完了)、TASK-0112 (skill path `.claude/skills/` 誤認 → `.agents/skills/`)。**plan 生成時の実数検証不足** → TASK-0117 (事前メトリクス検証) で構造化
 - **commit への noise 混入** (AGENTS.md / skip-decision-log / TASK-0059): `git add -A` の多用で複数回発生。→ 個別 `git add <path>` + `git restore --staged` で対処したが規律が緩んだ
-- **gh アカウント切替の頻発**: GraphQL mutation / PR create で kominem-unilabo にスイッチ、権限エラー多発。→ 各操作前 `gh auth switch --user s977043` 必須化
+- **gh アカウント切替の頻発**: GraphQL mutation / PR create で 別アカウント にスイッチ、権限エラー多発。→ 各操作前 `gh auth switch --user s977043` 必須化
 - **PR 量産による Human gate bottleneck**: 一時 4+ PR 同時 open。Codex が複数回「process drift」「停止」を警告
 
 ### Try (次に試す)

--- a/docs/working/retrospective-2026-04-30.md
+++ b/docs/working/retrospective-2026-04-30.md
@@ -44,7 +44,7 @@ Phase A の Explore エージェントが以下を誤検出していた:
 **対策**: 監査エージェントに「**判断保留項目**」を明示的に分類させるプロンプトに改善。今回は方針 A を採用し、`hybrid-architecture.md` に補足として明文化したため、次回以降は誤検出として扱える。
 
 ### P-3. gh auth account 切り替えで PR 作成が一度失敗した
-作業開始時のアクティブアカウントが `kominem-unilabo` のままで、PR 作成が collaborator 権限エラーで失敗。auto-memory に記録された「GitHub アカウント切り替え」メモで原因即特定し復旧したが、**着手前に `gh auth status` を確認する手順が抜けていた**。
+作業開始時のアクティブアカウントが `別アカウント` のままで、PR 作成が collaborator 権限エラーで失敗。auto-memory に記録された「GitHub アカウント切り替え」メモで原因即特定し復旧したが、**着手前に `gh auth status` を確認する手順が抜けていた**。
 
 **対策**: メモリ記載通り「plangate 作業開始時に `gh auth switch -u s977043` を必ず実行」する hook 化を検討（別 PBI）。
 

--- a/docs/working/retrospective-2026-05-01.md
+++ b/docs/working/retrospective-2026-05-01.md
@@ -59,9 +59,9 @@ light → standard → high-risk → critical → high-risk の順で、ノウ�
 
 ## Problem（課題・反省）
 
-### P-1. gh アカウントが session 内で複数回 kominem-unilabo に勝手に戻った
+### P-1. gh アカウントが session 内で複数回 別アカウント に勝手に戻った
 
-`gh auth switch -u s977043` を実行しても、`gh pr update-branch` 後に kominem-unilabo に切り戻されるケースが複数回発生。memory には対策（毎回 active 確認）はあったが、自動切り戻しが起きる原因は不明。回数は 4 回以上、各回で `gh auth switch` を再実行する手間が発生。
+`gh auth switch -u s977043` を実行しても、`gh pr update-branch` 後に 別アカウント に切り戻されるケースが複数回発生。memory には対策（毎回 active 確認）はあったが、自動切り戻しが起きる原因は不明。回数は 4 回以上、各回で `gh auth switch` を再実行する手間が発生。
 
 **対策**: gh CLI の挙動仕様を調査、または session 起動時に固定する shim（前回 retrospective T-5 で記載済、未着手）。本 retrospective で **再起候補として強調**。
 

--- a/docs/working/retrospective-2026-05-06-v860-improvement.md
+++ b/docs/working/retrospective-2026-05-06-v860-improvement.md
@@ -54,7 +54,7 @@ v8.6.0 milestone を Phase A (#194 Baseline / #201 Governance / #202 Privacy) �
 - `**モード**: light` 形式しか拾えず、`## Mode 判定` / `## Mode\nlight` 形式（最近の TASK で多数）から mode が抽出できなかった
 - PR #220 で 3 形式対応 + fallback regex に強化、TASK-0059/0061 で正しく抽出可能に
 
-#### P-4: gh auth の自動切替で kominem-unilabo になる場面
+#### P-4: gh auth の自動切替で 別アカウント になる場面
 - `git push` 後に `gh pr create` / `gh pr merge` で 2 回 `must be a collaborator` / `does not have permissions` エラー
 - 都度 `gh auth switch -u s977043` で復旧、影響は軽微だが手数が増える
 - memory には三点セット必須と記録済み（auth switch + git config + remote SSH）

--- a/scripts/gh-pin-account.sh
+++ b/scripts/gh-pin-account.sh
@@ -2,7 +2,7 @@
 # gh-pin-account.sh — plangate 作業時に gh CLI active account を s977043 に固定
 #
 # 背景: retrospective 2026-05-01 P-1 — plangate での作業中に gh CLI の active
-# account が想定外に kominem-unilabo へ切り戻る現象（本セッションで 4 回以上発生）。
+# account が想定外に 別アカウント へ切り戻る現象（本セッションで 4 回以上発生）。
 # 共有 mutation（pr merge / pr comment / issue create）が 403 で失敗する原因。
 #
 # Usage:


### PR DESCRIPTION
## Summary
コード/コメント上から誤コミットアカウント名 `kominem-unilabo` を除去。8 ファイルの参照を「別アカウント」へ一括置換 (意味=gh active account の想定外切替現象 は保存)。

## 対象ファイル (8)
- docs/working/TASK-0052/{handoff,pbi-input}.md
- docs/working/TASK-0120/pbi-input.md
- docs/working/_reports/session-retro-2026-05-24-to-28.md
- docs/working/retrospective-2026-04-30.md / -2026-05-01.md / -2026-05-06-v860-improvement.md
- scripts/gh-pin-account.sh (コメント)

## 検証
- `git grep -in kominem -- . ':(exclude).mailmap'` → **0 件**

## 備考: .mailmap (#406) の扱い
`.mailmap` には `kominem-unilabo@users.noreply.github.com` が**機能上必須** (再マッピングの key) のため本 PR では除外。.mailmap 自体の要否は別途判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)