### PR TITLE
chore: TASK-0059 eval result タイムスタンプ更新

### DIFF
--- a/docs/working/TASK-0059/eval-result.json
+++ b/docs/working/TASK-0059/eval-result.json
@@ -1,6 +1,6 @@
 {
   "task_id": "TASK-0059",
-  "evaluated_at": "2026-05-06T09:43:58Z",
+  "evaluated_at": "2026-05-28T09:13:28Z",
   "evaluator_version": "1.2.0",
   "schema_compliance": {
     "json_files_validated": 0,

--- a/docs/working/TASK-0059/eval-result.md
+++ b/docs/working/TASK-0059/eval-result.md
@@ -1,6 +1,6 @@
 # Eval Result: TASK-0059
 
-> Evaluated at: 2026-05-06T09:43:58Z
+> Evaluated at: 2026-05-28T09:13:28Z
 > Runner version: 1.2.0
 
 ## サマリ


### PR DESCRIPTION
## Summary
- TASK-0059 eval を 2026-05-28 に再実行した際の `generated_at` タイムスタンプ更新のみ
- 内容・判定に変更なし

## 変更内容
- `docs/working/TASK-0059/eval-result.json` / `eval-result.md`: タイムスタンプ更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)