### PR TITLE
fix(ci): Metrics Privacy Check でテストフィクスチャを誤検知しないよう除外

### DIFF
--- a/.github/workflows/metrics-privacy.yml
+++ b/.github/workflows/metrics-privacy.yml
@@ -55,9 +55,11 @@ jobs:
           set -eu
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git diff --name-only --diff-filter=ACM "$BASE_SHA" "$HEAD_SHA" \
-              | grep -E '\.(json|ndjson)$' > .scan-files.txt || true
+              | grep -E '\.(json|ndjson)$' \
+              | grep -v '^tests/fixtures/' > .scan-files.txt || true
           else
-            git ls-files '*.json' '*.ndjson' > .scan-files.txt || true
+            git ls-files '*.json' '*.ndjson' \
+              | grep -v '^tests/fixtures/' > .scan-files.txt || true
           fi
           count=$(wc -l < .scan-files.txt | tr -d ' ')
           echo "count=$count" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- main push 時の Metrics Privacy Check（EH-8 strict）が `tests/fixtures/hooks/check-metrics-privacy/bad-forbidden/sample.json` を誤検知して failure になっていた問題を修正

## 原因

PR 時は差分スキャン（`git diff`）、main push 時は `git ls-files` で全 JSON を対象にするため、EH-8 の動作テスト用に**意図的に** forbidden field を含むフィクスチャファイルが拾われていた。

## 修正内容

`Determine files to scan` ステップの両パス（PR・main push）に `grep -v '^tests/fixtures/'` を追加し、テストフィクスチャをスキャン対象から除外。

```diff
- git diff ... | grep -E '\.(json|ndjson)$' > .scan-files.txt
+ git diff ... | grep -E '\.(json|ndjson)$' \
+   | grep -v '^tests/fixtures/' > .scan-files.txt

- git ls-files '*.json' '*.ndjson' > .scan-files.txt
+ git ls-files '*.json' '*.ndjson' \
+   | grep -v '^tests/fixtures/' > .scan-files.txt
```

## 影響範囲

- CI ワークフロー修正のみ。プロダクトコード・フィクスチャ自体の変更なし
- `good/` フィクスチャもスキャン対象外になるが、テスト用サンプルであり実メトリクスではないため問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)