### PR TITLE
docs: 公開ページ品質向上 — 相互リンク・Quickstart・OSS準備

### DIFF
--- a/docs/pages/explanation/product/before-after.md
+++ b/docs/pages/explanation/product/before-after.md
@@ -1,6 +1,6 @@
 # Before / After: PlanGate
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
 
 ## 目的
@@ -67,3 +67,10 @@ AI development becomes manageable product delivery.
 PlanGate の価値は、AI の速度を落とすことではない。
 
 AI が速く動く前に、何を作るか、なぜ作るか、どう検証するかを固定することで、速さをプロダクト価値に接続することである。
+
+## 関連ページ
+
+- [Product Overview](./overview.md) — PlanGate の全体像と対象ユーザー
+- [Positioning](./positioning.md) — 競合・代替手段との差別化
+- [高品質な実行計画ができるまで](./plan-creation-process.md) — 計画フェーズの詳細
+- [はじめる（Getting Started）](../../guides/getting-started.md) — 実際に使い始める

--- a/docs/pages/explanation/product/overview.md
+++ b/docs/pages/explanation/product/overview.md
@@ -1,6 +1,6 @@
 # Product Overview: PlanGate
 
-> **Status**: v0（Product narrative draft）
+> **Status**: Stable
 > **Review cadence**: Monthly
 > **Owner**: Product / Maintainer
 
@@ -121,3 +121,11 @@ PlanGate は、AI coding agents の代替ではなく、それらをプロダク
 ## Main message
 
 PlanGate は、AI が速くコードを書く時代に、PM / PO が守るべき「何を作るか」「なぜ作るか」「Done とは何か」を失わないためのゲート型ハーネスである。
+
+## 関連ページ
+
+- [高品質な実行計画ができるまで](./plan-creation-process.md) — PBI INPUT から C-3 承認まで、計画を生むプロセスの詳細
+- [Before / After](./before-after.md) — 導入前後で何が変わるか
+- [Positioning](./positioning.md) — 競合・代替手段との差別化
+- [Product FAQ](../../reference/product-faq.md) — 導入検討時のよくある質問
+- [はじめる（Getting Started）](../../guides/getting-started.md) — 実際に使い始める

--- a/docs/pages/explanation/product/plan-creation-process.md
+++ b/docs/pages/explanation/product/plan-creation-process.md
@@ -142,4 +142,11 @@ PlanGate の計画品質を支える要のひとつ。「全部 / 全件 / 残�
 - レビュー原則: [review-principles.md](https://github.com/s977043/PlanGate/blob/main/.claude/rules/review-principles.md)
 - plan 生成 skill: [ai-dev-plan SKILL](https://github.com/s977043/PlanGate/blob/main/.agents/skills/ai-dev-plan/SKILL.md)
 - ワークフロー全体像 / プロンプト: [ai-driven-development.md](https://github.com/s977043/PlanGate/blob/main/docs/ai-driven-development.md)
+- 段階的導入ガイド: [staged-adoption-guide.md](https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md)
 - Workflow 定義（WF-02 / WF-03）: [workflows/README.md](https://github.com/s977043/PlanGate/blob/main/docs/workflows/README.md)
+
+## 関連ページ
+
+- [はじめる（Getting Started）](../../guides/getting-started.md) — 実際に使い始める
+- [Product Overview](./overview.md) — PlanGate の全体像
+- [Product FAQ](../../reference/product-faq.md) — よくある質問

--- a/docs/pages/explanation/product/pm-po-elevator-pitch.md
+++ b/docs/pages/explanation/product/pm-po-elevator-pitch.md
@@ -1,6 +1,6 @@
 # PM / PO Elevator Pitch
 
-> **Status**: v0（Pitch Draft）
+> **Status**: Stable
 > **Review cadence**: Monthly
 > **Owner**: Product / Maintainer
 
@@ -114,3 +114,10 @@ PlanGate では、AI が実装する前に plan と test-cases を作り、人�
 ## 現時点の推奨メインメッセージ
 
 PlanGate は、AI が速くコードを書く時代に、PM / PO が守るべき「何を作るか」「なぜ作るか」「Done とは何か」を失わないためのゲート型ハーネスである。
+
+## 次のステップ
+
+- [Before / After](./before-after.md) — 導入前後の変化を視覚的に説明
+- [Value Proposition Canvas](./value-proposition-canvas.md) — PM/PO 向けの詳細な価値整理
+- [Product FAQ](../../reference/product-faq.md) — よくある反論・質問への回答
+- [はじめる（Getting Started）](../../guides/getting-started.md) — チームへの導入を始める

--- a/docs/pages/explanation/product/positioning.md
+++ b/docs/pages/explanation/product/positioning.md
@@ -1,6 +1,6 @@
 # Positioning: PlanGate
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
 
 ## Category
@@ -36,6 +36,8 @@ AI が本番コードを書く前に、PBI、計画、受入条件、人間承�
 | Autonomous agent frameworks | Autonomy and task completion | PlanGate prioritizes approval boundaries and auditability |
 | Manual process docs | Human-readable guidance | PlanGate aims to make gate, artifact, hook, eval, and metrics operational |
 | CI only | Post-implementation checks | PlanGate adds pre-implementation approval and acceptance clarity |
+
+> 競合に関する詳細な Q&A は [Product FAQ](../../reference/product-faq.md#競合・代替ツールに関する質問) を参照。
 
 ## Core tagline candidates
 
@@ -85,3 +87,10 @@ PlanGate は、AI コーディングエージェントをプロダクト開発�
 AI が本番コードを書く前に、PBI、計画、受入条件、人間承認を必須化します。
 これにより、AI 開発でもスコープ、Done の定義、検証証拠を守れます。
 ```
+
+## 関連ページ
+
+- [Product Overview](./overview.md) — PlanGate の概要と価値
+- [Before / After](./before-after.md) — 導入前後の変化
+- [Product FAQ](../../reference/product-faq.md) — 競合・代替手段の詳細 Q&A
+- [Value Proposition Canvas](./value-proposition-canvas.md) — Customer Jobs / Pains / Gains

--- a/docs/pages/explanation/product/positioning.md
+++ b/docs/pages/explanation/product/positioning.md
@@ -37,7 +37,7 @@ AI が本番コードを書く前に、PBI、計画、受入条件、人間承�
 | Manual process docs | Human-readable guidance | PlanGate aims to make gate, artifact, hook, eval, and metrics operational |
 | CI only | Post-implementation checks | PlanGate adds pre-implementation approval and acceptance clarity |
 
-> 競合に関する詳細な Q&A は [Product FAQ](../../reference/product-faq.md#競合・代替ツールに関する質問) を参照。
+> 競合に関する詳細な Q&A は [Product FAQ](../../reference/product-faq.md#競合代替手段に関する質問) を参照。
 
 ## Core tagline candidates
 

--- a/docs/pages/explanation/product/value-proposition-canvas.md
+++ b/docs/pages/explanation/product/value-proposition-canvas.md
@@ -1,13 +1,13 @@
 # Value Proposition Canvas: PlanGate
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
 
 ## 目的
 
 PlanGate が誰のどんな課題に効くのかを Value Proposition Canvas として整理する。
 
-Product Overview、Positioning、FAQ、Pitch Deck、README の材料として使う。
+[Product Overview](./overview.md)、[Positioning](./positioning.md)、[FAQ](../../reference/product-faq.md)、Pitch Deck、README の材料として使う。
 
 ## Customer segments
 
@@ -127,3 +127,10 @@ AI が本番コードを書く前に、人間が承認した計画と受入条�
 - Pain relievers が誇張になっていないか
 - Roadmap 進捗により新しい gain creator が増えていないか
 - PM / PO / EM / CTO の message fit は適切か
+
+## 関連ページ
+
+- [Product Overview](./overview.md) — PlanGate の全体像
+- [Positioning](./positioning.md) — ポジショニングと差別化
+- [PM / PO Elevator Pitch](./pm-po-elevator-pitch.md) — ピッチ構成
+- [Product FAQ](../../reference/product-faq.md) — 導入検討時の FAQ

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -1,0 +1,68 @@
+# はじめる（Getting Started）
+
+> **Status**: v0
+> **Review cadence**: Monthly
+> **Owner**: Product / Maintainer
+
+## PlanGate とは
+
+PlanGate は、AI コーディングエージェントをプロダクト開発に安全に組み込むためのゲート型ワークフローハーネスです。AI がいきなりコードを書くのではなく、まず計画と受入条件を作り、人間が承認してから実装へ進む `No approved plan, no code.` の原則を実現します。
+
+詳しくは [Product Overview](../explanation/product/overview.md) を参照してください。
+
+## 前提条件
+
+- Claude Code または Codex CLI
+- Git リポジトリ
+- GitHub アカウント
+
+## 3ステップで始める（Phase 0 体験）
+
+Phase 0 は「Day 1 で体験する」フェーズです。ultra-light モードで 1 タスクを最後まで完了し、PlanGate の基本的な流れを体感します。plan / C-1〜C-4 / V-1〜V-4 / エージェント / フック / metrics はすべて不要です。まず動かすことが目的です。
+
+### ステップ 1: リポジトリに PlanGate を設定する
+
+```bash
+bin/plangate init <TASK-番号>
+```
+
+`init` コマンドは `docs/working/TASK-<番号>/` ディレクトリを作成し、作業コンテキスト管理の起点となるファイルを配置します。Phase 0 では `.claude/settings.json` の hooks 未配線でも問題ありません。
+
+### ステップ 2: 最初のタスクを ultra-light で実行する
+
+ultra-light モードは typo 修正・設定値変更・コメント修正など、影響範囲が最小のタスクに使います。
+
+1. 変更したいファイルを直接編集する（plan.md は任意）
+2. 変更をコミットする
+3. `bin/plangate doctor` でハーネスの健全性を確認する
+
+```bash
+# doctor で現在の設定状態を確認する
+bin/plangate doctor
+```
+
+Phase 0 では plan.md や C-1〜C-4 のゲートはスキップして構いません。成果物は変更そのものです。
+
+### ステップ 3: plan → exec → PR の流れを確認する
+
+ultra-light での体験後、次の流れが PlanGate の基本サイクルです。
+
+```text
+PBI INPUT → plan.md 生成 → C-3 人間承認 → exec（実装）→ PR → C-4 レビュー → Done
+```
+
+この流れを意識した上で、次のフェーズ（Phase 1: 計画導入）へ進むと、`pbi-input.md → plan.md` の生成を体験できます。
+
+## 次のステップ
+
+- **段階的導入ガイド**: [https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md](https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md) — Phase 0 〜 Phase 3 の成長パスと、各フェーズで使うコンポーネントの詳細
+- **高品質な実行計画ができるまで**: [../explanation/product/plan-creation-process.md](../explanation/product/plan-creation-process.md) — PBI INPUT から C-3 承認まで、計画を生むプロセスの解説
+- **Product Overview**: [../explanation/product/overview.md](../explanation/product/overview.md) — PlanGate の概要、対象ユーザー、価値、仕組み
+
+## 関連ページ
+
+- [Product Overview](../explanation/product/overview.md)
+- [高品質な実行計画ができるまで](../explanation/product/plan-creation-process.md)
+- [Demo Script](./product-demo-script.md)
+- [Product FAQ](../reference/product-faq.md)
+- [段階的導入ガイド（GitHub）](https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md)

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -1,6 +1,6 @@
 # はじめる（Getting Started）
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
 > **Owner**: Product / Maintainer
 

--- a/docs/pages/guides/governance/documentation-management.md
+++ b/docs/pages/guides/governance/documentation-management.md
@@ -45,7 +45,7 @@ Kiro 前提の配置ではなく、River-Reviewer を参考に、公開説明ド
 
 ### `docs/pages/guides/` に置くもの
 
-- Quickstart
+- [はじめる（Getting Started）](../getting-started.md) — Quickstart に相当するガイド（`docs/pages/guides/getting-started.md`）
 - Setup guide
 - Demo Script
 - Workflow usage guide
@@ -228,18 +228,9 @@ PlanGate では Product narrative を `解説 > プロダクト` に置く。
 
 ## 7. Current migration
 
-今回のプロダクト説明資料は、以下のように `docs/pages/` へ移動する。
-
-| Old path | New path |
-| --- | --- |
-| `docs/product/README.md` | `docs/pages/index.md` / `docs/pages/explanation/product/overview.md` |
-| `docs/product/product-brief.md` | `docs/pages/explanation/product/overview.md` |
-| `docs/product/before-after.md` | `docs/pages/explanation/product/before-after.md` |
-| `docs/product/positioning.md` | `docs/pages/explanation/product/positioning.md` |
-| `docs/product/value-proposition-canvas.md` | `docs/pages/explanation/product/value-proposition-canvas.md` |
-| `docs/product/faq.md` | `docs/pages/reference/product-faq.md` |
-| `docs/product/demo-script.md` | `docs/pages/guides/product-demo-script.md` |
-| `docs/pm-po-elevator-pitch.md` | `docs/pages/explanation/product/pm-po-elevator-pitch.md` |
+> **Migration completed (2026-05)**
+>
+> `docs/product/` は存在しない。上記テーブルに記載されていた全ファイルは `docs/pages/` への移動が完了している。このセクションは履歴記録として残す。
 
 ## 8. Monthly review
 

--- a/docs/pages/guides/product-demo-script.md
+++ b/docs/pages/guides/product-demo-script.md
@@ -1,7 +1,17 @@
 # Product Demo Script: PlanGate
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
+
+## 事前準備
+
+デモ実施前に以下を確認してください。
+
+- PlanGate が設定済みのリポジトリが手元にある（または [はじめる](./getting-started.md) で作成）
+- `docs/working/` 配下に TASK ディレクトリのサンプルが 1 件以上ある
+- Claude Code CLI が起動できる状態である
+
+サンプルがない場合は、デモ前に ultra-light モードで 1 タスクを実行しておくことを推奨します。
 
 ## 目的
 
@@ -187,3 +197,9 @@ AI が速く動く前に、何を作るか、なぜ作るか、どう検証す�
 - [ ] verification evidence を見せられる
 - [ ] C-4 / handoff を見せられる
 - [ ] PM / PO 向けの価値に戻して説明できる
+
+## 関連ページ
+
+- [はじめる（Getting Started）](./getting-started.md) — 初期セットアップ
+- [高品質な実行計画ができるまで](../explanation/product/plan-creation-process.md) — 計画プロセスの詳細説明
+- [Product FAQ](../reference/product-faq.md) — デモ後の質問対応

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -12,6 +12,7 @@ No approved plan, no code.
 
 | ドキュメント | 内容 |
 | --- | --- |
+| [はじめる（Getting Started）](./guides/getting-started.md) | 3 ステップで PlanGate の基本的な流れを体験する |
 | [Product Overview](./explanation/product/overview.md) | PlanGate の概要、対象ユーザー、価値、仕組み |
 | [PM / PO Elevator Pitch](./explanation/product/pm-po-elevator-pitch.md) | PM / PO 向けの短い説明、タグライン、月次見直し観点 |
 | [Before / After](./explanation/product/before-after.md) | PlanGate 導入前後で何が変わるか |
@@ -38,3 +39,10 @@ PlanGate は、AI が速くコードを書く時代に、PM / PO が守るべき
 AI は実装前に計画と受入条件を出し、人間が承認してからコードを書く。実装後は検証と handoff を残す。
 
 だから PlanGate は、AI 開発を単なる自動化ではなく、プロダクト価値に接続された開発プロセスに変える。
+
+## 使い始める
+
+PlanGate を初めて導入する場合は、以下のガイドから始めてください。
+
+- [はじめる（Getting Started）](./guides/getting-started.md) — 3 ステップで PlanGate の基本的な流れを体験する
+- [段階的導入ガイド（GitHub）](https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md) — Phase 0 〜 Phase 3 の成長パスと、各フェーズで使うコンポーネントの詳細

--- a/docs/pages/reference/product-faq.md
+++ b/docs/pages/reference/product-faq.md
@@ -1,6 +1,6 @@
 # Product FAQ: PlanGate
 
-> **Status**: v0
+> **Status**: Stable
 > **Review cadence**: Monthly
 
 ## 基本理解
@@ -10,6 +10,8 @@
 PlanGate は、AI コーディングエージェントをプロダクト開発に安全に組み込むためのゲート型ワークフローハーネスである。
 
 AI が本番コードを書く前に、PBI、計画、TODO、受入条件、人間承認を必須化する。
+
+> 詳細は [Product Overview](../explanation/product/overview.md) を参照。
 
 ### Q. 一言で言うと？
 
@@ -50,6 +52,8 @@ AI がコードを書く前に、計画と受入条件を通す仕組みであ�
 - critical
 
 低リスクでは軽く、高リスクでは厳しくする。
+
+> 詳細は [Before / After](../explanation/product/before-after.md) を参照。
 
 ### Q. AI に任せる意味が薄れませんか？
 
@@ -157,3 +161,38 @@ PlanGate では code だけでなく、plan、test-cases、handoff も対象に�
 | 何が違う？ | 承認境界、監査可能性、Scrum-friendly delivery を重視する |
 | 競合は？ | Cursor / Claude Code / Codex の代替ではなく補完 |
 | 一番の価値は？ | PM / PO が守るべき価値、スコープ、Done を AI 開発でも守ること |
+
+## 導入に関する質問
+
+### Q. どこから始めればいいですか？
+
+[はじめる（Getting Started）](../guides/getting-started.md) を参照してください。ultra-light モードで 1 タスクを完了する体験から始めるのが最短経路です。
+
+段階的に導入を広げたい場合は [段階的導入ガイド](https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md) を参照してください。
+
+### Q. 既存プロジェクトに追加できますか？
+
+できます。PlanGate は既存のリポジトリに `.claude/` ディレクトリと設定ファイルを追加する形で導入します。既存コードへの変更は不要です。
+
+Phase 0（ultra-light）から始めて、チームの習熟度に応じて段階的にモードを上げていくことを推奨します。
+
+### Q. 依存関係・前提条件は何ですか？
+
+- Claude Code（CLI）または Codex CLI
+- Git リポジトリ
+- GitHub アカウント（PR ベースの C-4 ゲートに必要）
+
+PlanGate 自体は特定のプログラミング言語に依存しません。
+
+### Q. チーム全員が PlanGate を理解する必要がありますか？
+
+必須ではありません。最初は 1 人が PlanGate を使ってタスクを進め、C-3 / C-4 ゲートで他のメンバーがレビューする形でも機能します。
+
+徐々に plan.md / test-cases.md の読み方をチームに共有していく運用が現実的です。
+
+## 関連ページ
+
+- [はじめる（Getting Started）](../guides/getting-started.md) — 実際に使い始める
+- [Product Overview](../explanation/product/overview.md) — PlanGate の概要
+- [高品質な実行計画ができるまで](../explanation/product/plan-creation-process.md) — 計画プロセスの詳細
+- [Positioning](../explanation/product/positioning.md) — 競合・代替手段との差別化

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,6 +6,7 @@ module.exports = {
       type: 'category',
       label: 'ガイド',
       items: [
+        'guides/getting-started',
         'guides/product-demo-script',
         {
           type: 'category',


### PR DESCRIPTION
## Summary

公開ドキュメント（`docs/pages/`）の品質を OSS 公開水準に引き上げる。監査エージェントが検出した 18 件の問題（major×4 / minor×14）をすべて解消。

## 変更内容

### 新規ページ（1件）
- **`docs/pages/guides/getting-started.md`**: Quickstart ガイド。`staged-adoption-guide.md` の Phase 0 を元に「3ステップで始める」を作成

### 全ページ共通
- **Status `v0` → `Stable`**: 製品は v8.9.0 リリース済みのため全ページ更新
- **「関連ページ」セクション追加**: 全10ページに相互リンクを追加（孤立ページゼロ化）

### ページ別修正
| ファイル | 主な変更 |
|---------|---------|
| `index.md` | 「はじめる」をトップ行に、「使い始める」セクション追加 |
| `product-faq.md` | 「導入に関する質問」4 Q&A 新規追加 |
| `product-demo-script.md` | 事前準備セクション追加 |
| `documentation-management.md` | §7 migration 完了明記、Quickstart リンク修正 |
| `plan-creation-process.md` | §6 に staged-adoption-guide リンク追加 |
| `positioning.md` | FAQ への注記追加 |
| `sidebars.js` | getting-started をガイド先頭に追加 |

## 検証
- markdownlint 0 error ✅
- 全リンク先ファイル実在確認済み ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)