### PR TITLE
chore(v8.10.0): リリース準備 — CHANGELOG / README / skip-decision-log 更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ v8.9.0（EPIC #193 完遂）以降に蓄積した TASK-0107〜0120 / Issue #353 
 - `.claude/rules/responsibility-classes.md`: Bash 連結コマンド error guard (INC P-3 / TASK-0115) + 自己設置 Gate 非緩和原則を明文化。
 - `docs/pages/` を `pages/` から移設 (TASK-0111 / #295)。
 - `.mailmap`: kominem-unilabo を s977043 へ非破壊再マッピング (#406 / #407)。
+- 既存 5 skill を PlanGate 固有要素に整合、Shadow Prompting 解消 (#325 / #327 / #330)。
+- `AGENTS.md`: `.codex/agents/` からの bridge 方針を明記 (#341)。
 
 ### Security
 
@@ -77,41 +79,6 @@ v8.9.0（EPIC #193 完遂）以降に蓄積した TASK-0107〜0120 / Issue #353 
 - **Codex CLI parity 完成**: EPIC #338 100% 達成。EH-1/2/3/6/9 の物理強制が Codex session にも適用。
 - **INC-2026-05-26-001 対応完遂**: empty commit 直接 push 事故に対し規範層 + 技術層 + repo-wide の三段防御を実装。
 - **承認境界 Hardening**: 設定ファイル・hook スクリプト等 9 カテゴリへの変更は自動的に high 以上モード + 同期 C-3 が強制。
-
-- `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。OpenAI Codex CLI の公式 hook API ([docs](https://developers.openai.com/codex/hooks)) を活用し、Claude Code の `PreToolUse:Write/Edit/Bash` hook と等価な物理 pre-Write block を Codex session 中にも実現。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex 経由でも発火する。
-- `scripts/codex-guarded.sh`: Codex CLI 用 guarded entrypoint (#336 / #343)。session 前後で validate / doctor --check-settings / plan_hash drift 検知を実行。
-- `tests/extras/ta-14-codex-guarded.sh` / `ta-15-codex-hook-bridge.sh`: 上記 wrapper / hook bridge の 8 + 7 観点回帰テスト (#345 / #347)。
-- `docs/rfc/ai-self-set-gate-hook-enforcement.md`: RFC EH-10 Draft (Self-set Gate Enforcement) を追加 (#339)。
-- `docs/ai/settings-wiring-contract.md`: Codex CLI parity 達成に伴う wording 整備と EH-1〜EH-9 強制マトリクスを明文化 (#348)。
-- `docs/ai/project-rules.md` / `docs/ai/core-contract.md`: Codex CLI での運用を想定した doc 整合性の向上 (#331)。
-- `scripts/ai-dev-common.sh`: `set -e` 互換性を高めるための hotfix とテスト extras への適用 (#346)。
-- `AGENTS.md`: `.codex/agents/` から Claude Code 側の agent 定義を参照する際の bridge 方針を明記 (#341)。
-- `docs/ai/contracts/`: 共有 skill と実行契約 (contract) の接続を強化 (#344)。
-
-### Added (skill 整備)
-
-- `.agents/skills/` 配下に Codex CLI / Claude Code 共用の PlanGate ワークフロー skill 3 本を新設（#325 7601efb）
-  - `ai-dev-exec`: C-3 APPROVED 後の TDD exec phase（plan_hash 整合 + c3.json APPROVED 前提）
-  - `ai-dev-verify`: V-1〜V-4 受け入れ検査と handoff.md 発行（Rule 5 / 6 要素必須）
-  - `local-exec-handoff`: ローカル exec 再開・ツール間引き継ぎ用の短い指示パケット
-- `scripts/ai-dev-plan.sh` に環境変数追加（#330 efd86d0）
-  - `PLANGATE_PLAN_LEGACY=1`: 旧挙動（C-2 同パス作成 + Cloud handoff draft 強制）を保持（後方互換）
-  - `PLANGATE_CLOUD_HANDOFF=1`: 新挙動でも Cloud handoff draft を生成（Codex Cloud 利用時のみ）
-
-### Changed
-
-- 既存 5 skill (`ai-dev-brainstorm` / `ai-dev-plan` / `plan-review-gate` / `working-context` / `manual-cloud-task`) を PlanGate 固有要素 (mode 5 段階 + lite_eligible / C-1 17 項目 / R-NNN / handoff 6 要素 / EH-3 順序 / settings タスクロック) に整合（#325 7601efb）
-- `scripts/ai-dev-plan.sh` の Shadow Prompting を解消し、`.agents/skills/ai-dev-plan/SKILL.md` の B-1 → B-2 → B-3 フローと整合（#330 efd86d0）
-  - C-2 (review-external.md) 作成を本 phase から除外し `plan-review-gate` skill / `bin/plangate review --phase c2` に委譲
-  - Mode 5 段階判定 + `lite_eligible` を plan.md 必須セクションに追加
-- skill ↔ 実 CLI 整合（#327 6e31845）
-  - 架空 CLI コマンド (brainstorm/plan/gate/verify/handoff/handoff-local) を実在コマンドに置換
-  - settings タスクロックの参照位置を `ai-dev-exec` 開始条件 → `ai-dev-verify` 完了条件に修正（正本整合）
-  - Rule 2 ドリフト圧縮: skill 本体の固有仕様を `.claude/rules` 参照に置き換え（-57 行）
-
-### Security
-
-- `plan-review-gate` skill に `bin/plangate review` 誤起動警告を追加（実は外部 AI モデル呼び出しのため、C-1 セルフレビュー目的で起動するとコスト発生・機密送信のリスク）（#327 6e31845）
 
 ## v8.9.0 - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,77 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.10.0 - 2026-05-29
+
+feat: Codex CLI parity 完成 + Hook/Guard 拡充 + Skill 整備 + ドキュメント品質向上
+
+v8.9.0（EPIC #193 完遂）以降に蓄積した TASK-0107〜0120 / Issue #353 の実装群。Codex CLI parity の完成、セキュリティ hardening（INC P-1/P-3 対応）、pre-commit/pre-push guard 拡充、skill 整備、C-3 Autonomous APPROVE ルール明文化を含む。
+
+タグ対象 SHA: `1bde312`（#415 main HEAD）
+
 ### Added
+
+#### Codex CLI parity（EPIC #338 / 100% 達成）
+
+- `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex session 中にも物理発火する。
+- `scripts/codex-guarded.sh`: Codex CLI 用 guarded entrypoint (#336 / #343)。session 前後で validate / doctor --check-settings / plan_hash drift 検知を実行。
+- `docs/rfc/provider-codex.md`: Codex provider 完全対応ドキュメント (TASK-0109 / #315)。
+- `tests/extras/ta-14-codex-guarded.sh` / `ta-15-codex-hook-bridge.sh`: 8 + 7 観点回帰テスト (#345 / #347)。
+- `docs/rfc/ai-self-set-gate-hook-enforcement.md`: RFC EH-10 Draft (#339)。
+- `docs/ai/settings-wiring-contract.md`: EH-1〜EH-9 強制マトリクス明文化 (#348)。
+
+#### Skill 整備（#325 / #327 / #330 / TASK-0118）
+
+- `.agents/skills/ai-dev-exec` / `ai-dev-verify` / `local-exec-handoff`: Codex CLI / Claude Code 共用 skill 3 本を新設。
+- `.claude/commands/codex-mvp-split.md` + skill: MVP 分割判断 command/skill 実装 (TASK-0118 / #352)。
+- 既存 5 skill を PlanGate 固有要素（mode 5 段階 / lite_eligible / C-1 17 項目）に整合 (#325 / #327 / #330)。
+
+#### セキュリティ・Guard 拡充
+
+- `scripts/hooks/check-pre-push.sh`: main 直接 push を技術層でブロック (TASK-0114 / #360 / INC P-1)。
+- `scripts/check-git-add-scope.sh`: pre-commit で scope 外ファイル混入を機械検知 (TASK-0119)。
+- `scripts/hooks/check-ai-memory-pollution.sh`: claude-mem 自動挿入を pre-commit で検知 (TASK-0113 / #355)。
+- `scripts/check-tag-main-parity.sh`: NO RELEASE WITHOUT TAG-MAIN PARITY Iron Law (TASK-0116 / #354)。
+- `scripts/batch-acknowledge-skip-decisions.py`: skip-decision-log.jsonl 一括追認 CLI (TASK-0110 / #301)。
+- `tests/extras/ta-16〜ta-23`: 上記 guard/helper 群の回帰テスト追加。
+
+#### ヘルパー・UX
+
+- `scripts/gh-s977043.sh`: gh account pinning helper (TASK-0120)。
+- `/plangate-setup` Command + setup-coordinator Agent + plangate-setup Skill (TASK-0107 / #312)。
+- Cursor provider サポート（RFC / quickstart / hook adapters）(#292)。
+
+#### ドキュメント・公開ページ
+
+- `docs/pages/guides/getting-started.md`: 新規ユーザー向け Quickstart を追加。
+- `docs/pages/explanation/product/plan-creation-process.md`: 実行計画プロセス解説ガイド。
+- `docs/pages/` 全体の相互リンク・品質向上 (#414)。
+- `docs/working/incidents/2026-05-26-empty-commit-direct-push.md`: INC-2026-05-26-001 インシデント記録。
+
+#### C-3 運用改善
+
+- C-3 Autonomous APPROVE 基準を明文化 (#353 / #413)。
+- plan 事前メトリクス検証 mandatory gate 実装 (TASK-0117 / #351)。
+
+### Changed
+
+- `.claude/rules/mode-classification.md`: 承認境界周辺 9 カテゴリを `lite_eligible=false` 強制 + Standard C-3 同期固定に拡張 (TASK-0112)。
+- `.claude/rules/responsibility-classes.md`: Bash 連結コマンド error guard (INC P-3 / TASK-0115) + 自己設置 Gate 非緩和原則を明文化。
+- `docs/pages/` を `pages/` から移設 (TASK-0111 / #295)。
+- `.mailmap`: kominem-unilabo を s977043 へ非破壊再マッピング (#406 / #407)。
+
+### Security
+
+- pre-push hook による main 直接 push の技術層ブロック (TASK-0114)。
+- claude-mem 自動挿入の pre-commit 検知 (TASK-0113)。
+- git add scope guard による scope 外ファイル混入防止 (TASK-0119)。
+- `plan-review-gate` skill に `bin/plangate review` 誤起動警告を追加 (#327)。
+
+### Process Notes
+
+- **Codex CLI parity 完成**: EPIC #338 100% 達成。EH-1/2/3/6/9 の物理強制が Codex session にも適用。
+- **INC-2026-05-26-001 対応完遂**: empty commit 直接 push 事故に対し規範層 + 技術層 + repo-wide の三段防御を実装。
+- **承認境界 Hardening**: 設定ファイル・hook スクリプト等 9 カテゴリへの変更は自動的に high 以上モード + 同期 C-3 が強制。
 
 - `.codex/hooks.json` + `.codex/hooks/eh-bridge.sh`: Codex CLI 用 PreToolUse hook bridge を新設 (#336 / #347)。OpenAI Codex CLI の公式 hook API ([docs](https://developers.openai.com/codex/hooks)) を活用し、Claude Code の `PreToolUse:Write/Edit/Bash` hook と等価な物理 pre-Write block を Codex session 中にも実現。EH-1/EH-2/EH-3/EH-6/EH-9 が Codex 経由でも発火する。
 - `scripts/codex-guarded.sh`: Codex CLI 用 guarded entrypoint (#336 / #343)。session 前後で validate / doctor --check-settings / plan_hash drift 検知を実行。

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.9.0**（Latest）で、Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.10.0**（Latest）で、Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.9.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 
 | 項目 | 状態 |
 | --- | --- |
-| 最新リリース | **v8.9.0**（Latest, 2026-05-19）— Reporting & Retrospective v1 / EPIC #193 完遂 |
+| 最新リリース | **v8.10.0**（Latest, 2026-05-29）— Codex CLI parity 完成 / Hook・Guard 拡充 / Skill 整備 |
 | リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3、v8.5.0 で 10/10、v8.6.0 で EH-8、v8.7.0 で EH-9 を追加） |
@@ -88,8 +88,8 @@ v8.7.0〜v8.9.0 はリリース済みで、外部 OSS 利用者の **「どこ�
 | Reporting v1 | events.ndjson から sprint retrospective を導出（v8.9.0） |
 | Baseline | v8.5.0 直後の baseline を `docs/ai/eval-baselines/` に固定（v8.6.0 初出） |
 | Governance | Issue / Label / Milestone Governance + Metrics Privacy Policy（v8.6.0 初出） |
-| CLI テスト | `sh tests/run-tests.sh` — **68 PASS** |
-| Hook テスト | `sh tests/hooks/run-tests.sh` — **78 PASS** |
+| CLI テスト | `sh tests/run-tests.sh` — **211 PASS** |
+| Hook テスト | `sh tests/hooks/run-tests.sh` — **79 PASS** |
 | Eval | `bin/plangate eval` による 8 観点評価と release blocker 検知 |
 | Schema | `validate-schemas` + CI による JSON artifact 検証 |
 

--- a/README_en.md
+++ b/README_en.md
@@ -74,13 +74,13 @@ flowchart LR
 
 ## Current Status
 
-As of **v8.9.0** (Latest), PlanGate combines Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
+As of **v8.10.0** (Latest), PlanGate combines Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
 
 v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "where do I start, where do I stop" problem via OSS adoption foundations (staged adoption guide, plugin maturity, versioning stability policy) and the self-evaluation, context separation, model-profile, and reporting bases delivered in sequence.
 
 | Item | Status |
 | --- | --- |
-| Latest release | **v8.9.0** (Latest, 2026-05-19) — Reporting & Retrospective v1 / EPIC #193 complete |
+| Latest release | **v8.10.0** (Latest, 2026-05-29) — Codex CLI parity complete / Hook & Guard expansion / Skill overhaul |
 | Shipped | **v8.7.0** OSS adoption foundations + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1, Dynamic Context Engine v1, Model Profile v2, Gate Event Normalization, Dogfooding Eval v1 |
 | Roadmap | **EPIC #193 complete (CLOSED / COMPLETED)** — Phases 0-6 + Governance + Lightweight Plan Quality Checks all Done, child PBIs 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks implemented** (EH-1 to EH-9 + EHS-1 to EHS-3; v8.5.0=10/10, v8.6.0 added EH-8, v8.7.0 added EH-9) |

--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -50,3 +50,15 @@
 {"ts":"2026-05-29T00:53:23Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
 {"ts":"2026-05-29T00:54:07Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
 {"ts":"2026-05-29T00:54:07Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
+{"ts":"2026-05-29T06:34:37Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:34:37Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:35:42Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:35:42Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:01Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:02Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:37:37Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
+{"ts":"2026-05-29T06:37:37Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}


### PR DESCRIPTION
## Summary
v8.10.0 リリース前の最終準備 PR。

## 変更内容
- `CHANGELOG.md`: `## Unreleased` → `## v8.10.0 - 2026-05-29` に昇格。TASK-0107〜0120 + Issue #353 の全変更を Added/Changed/Security/Process Notes に整理。
- `README.md` / `README_en.md`: バージョン記載を v8.9.0 → v8.10.0 に更新、テスト数も最新（211/79）に更新。
- `docs/working/_audit/skip-decision-log.jsonl`: 検証ワークフロー実行中に発生した 12 件の新規 EH-3_SKIP エントリを追認。

## 残 Human-owned 対応（この PR マージ後）
- `CLAUDE.md` の v8.9.0 → v8.10.0 更新（HO ブロックのため手動必須）
  - L13: `## v8.9.0 Reporting & Governance（最新リリース機能）` → `## v8.10.0 Codex CLI parity・Hook/Guard 拡充（最新リリース機能）`
  - L14: `> 最新リリース: **v8.9.0**（2026-05-19）` → `> 最新リリース: **v8.10.0**（2026-05-29）`
- `git tag -a v8.10.0 -m "v8.10.0: ..." && git push origin v8.10.0`
- `gh release create v8.10.0 ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)