### PR TITLE
fix: plugin.json version をリリースタグと同期（0.5.0 → v8.10.0）

### DIFF
--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "0.5.0",
+  "version": "v8.10.0",
   "description": "PlanGate — AI coding control OS for Claude Code. Intent/Mode classification, Skill Policy Router, Evidence Ledger, 4-Gate system (Design/TDD/Review/Completion), Context Packager, Subagent Dispatch, Worktree Policy, PR Decision, Setup Team. Commands: /pg-think /pg-hunt /pg-check /pg-verify /pg-tdd.",
   "author": {
     "name": "PlanGate contributors"

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -51,21 +51,47 @@ for _dir in agents rules commands; do
 done
 sync_dir "$SKILLS_DIR" "$PLUGIN_DIR/skills" "skills"
 
-# バージョン行を最新 CHANGELOG に合わせて更新
-PLUGIN_README="$PLUGIN_DIR/README.md"
-if [ -f "$REPO_ROOT/CHANGELOG.md" ] && [ -f "$PLUGIN_README" ]; then
+# バージョン番号を CHANGELOG から取得（README.md / plugin.json 共用）
+_ver=""
+if [ -f "$REPO_ROOT/CHANGELOG.md" ]; then
   _ver=$(grep '^## v[0-9]' "$REPO_ROOT/CHANGELOG.md" | head -1 | sed 's/## \(v[^ ]*\).*/\1/')
-  if [ -n "$_ver" ]; then
-    _cur=$(grep '^\- \*\*Version\*\*:' "$PLUGIN_README" | sed 's/.*: //' || true)
-    if [ "$_cur" != "$_ver" ]; then
-      if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE version: $_cur -> $_ver"
-      else
-        _tmp=$(mktemp)
-        sed "s/^\(- \*\*Version\*\*:\).*/\1 $_ver/" "$PLUGIN_README" > "$_tmp" && mv "$_tmp" "$PLUGIN_README"
-        _log "UPDATE version: $_cur -> $_ver"
-      fi
-      changed=1
+fi
+
+# README.md の Version 行を更新
+PLUGIN_README="$PLUGIN_DIR/README.md"
+if [ -n "$_ver" ] && [ -f "$PLUGIN_README" ]; then
+  _cur=$(grep '^\- \*\*Version\*\*:' "$PLUGIN_README" | sed 's/.*: //' || true)
+  if [ "$_cur" != "$_ver" ]; then
+    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE README version: $_cur -> $_ver"
+    else
+      _tmp=$(mktemp)
+      sed "s/^\(- \*\*Version\*\*:\).*/\1 $_ver/" "$PLUGIN_README" > "$_tmp" && mv "$_tmp" "$PLUGIN_README"
+      _log "UPDATE README version: $_cur -> $_ver"
     fi
+    changed=1
+  fi
+fi
+
+# plugin.json の version フィールドを更新
+PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
+if [ -n "$_ver" ] && [ -f "$PLUGIN_JSON" ] && command -v python3 >/dev/null 2>&1; then
+  _pcur=$(python3 -c "import json; d=json.load(open('$PLUGIN_JSON')); print(d.get('version',''))" 2>/dev/null || true)
+  if [ "$_pcur" != "$_ver" ]; then
+    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE plugin.json version: $_pcur -> $_ver"
+    else
+      python3 - "$PLUGIN_JSON" "$_ver" << 'PYEOF'
+import json, sys
+path, ver = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+d['version'] = ver
+with open(path, 'w') as f:
+    json.dump(d, f, indent=2, ensure_ascii=False)
+    f.write('\n')
+PYEOF
+      _log "UPDATE plugin.json version: $_pcur -> $_ver"
+    fi
+    changed=1
   fi
 fi
 


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
- `plugin/plangate/.claude-plugin/plugin.json`: `version` を `0.5.0` → `v8.10.0` に修正
- `scripts/sync-plugin-plangate.sh`: `plugin.json` の `version` フィールドを `README.md` と同様に CHANGELOG 最新タグへ自動同期する処理を追加

## 変更後の動作
`sh scripts/sync-plugin-plangate.sh` 実行時に以下を自動更新:
1. `plugin/plangate/README.md` の `- **Version**: ...` 行（既存）
2. `plugin/plangate/.claude-plugin/plugin.json` の `"version": "..."` フィールド（今回追加）

両方とも `CHANGELOG.md` の先頭 `## vX.Y.Z` からバージョンを取得して同期する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)