### PR TITLE
chore: セッション後片付け 2026-06-03b

### DIFF
--- a/docs/working/TASK-0059/eval-result.json
+++ b/docs/working/TASK-0059/eval-result.json
@@ -1,6 +1,6 @@
 {
   "task_id": "TASK-0059",
-  "evaluated_at": "2026-06-03T00:39:22Z",
+  "evaluated_at": "2026-06-03T06:47:45Z",
   "evaluator_version": "1.2.0",
   "schema_compliance": {
     "json_files_validated": 0,

--- a/docs/working/TASK-0059/eval-result.md
+++ b/docs/working/TASK-0059/eval-result.md
@@ -1,6 +1,6 @@
 # Eval Result: TASK-0059
 
-> Evaluated at: 2026-06-03T00:39:22Z
+> Evaluated at: 2026-06-03T06:47:45Z
 > Runner version: 1.2.0
 
 ## サマリ

--- a/docs/working/TASK-9991/review-external.md
+++ b/docs/working/TASK-9991/review-external.md
@@ -2,15 +2,14 @@
 
 > Phase: c2
 > Reviewer: codex
-> Generated: 2026-06-03T00:40:08Z
+> Generated: 2026-06-03T06:49:08Z
 
 **Findings**
 
-- High: The plan is effectively empty. `**モード**: light` only declares an execution mode; it does not describe the target, scope, steps, files, validation, rollback, or completion criteria.
-- High: There is no requirement mapping. A reviewer cannot verify whether the plan satisfies the requested task because no objective or acceptance criteria are stated.
-- Medium: No safety or risk handling is included. Even in `light` mode, the plan should say what will be inspected or changed and what will be avoided.
-- Medium: No verification path is defined. There are no commands, checks, or review points to confirm completion.
+- Major: [plan.md](/private/var/folders/_h/ffwb9tkx52vgq63h7vgtdgq80000gp/T/tmp.xBxdIvvNvj/docs/working/TASK-9991/plan.md:1) does not define what `tc-05` is supposed to test. The only goal is “Test plan for tc-05”, so the plan has no target behavior, inputs, expected outputs, affected files, or acceptance criteria. It is not reviewable or executable as a plan.
 
-**Recommendation**
+- Major: [plan.md](/private/var/folders/_h/ffwb9tkx52vgq63h7vgtdgq80000gp/T/tmp.xBxdIvvNvj/docs/working/TASK-9991/plan.md:4) sets mode to `light`, but [.plangate-reviewers.yaml](/private/var/folders/_h/ffwb9tkx52vgq63h7vgtdgq80000gp/T/tmp.xBxdIvvNvj/.plangate-reviewers.yaml:6) configures the available reviewer with `mode_threshold: high-risk`. If `tc-05` is meant to exercise that reviewer, this plan likely will not trigger it.
 
-Reject as incomplete. A minimal PlanGate plan should include at least: objective, affected scope, concrete steps, validation method, and completion criteria.
+- Minor: There is no validation step. The plan should state how success will be checked, especially since the reviewer command is configured as `printf 'SHOULD_NOT_APPEAR'` in [.plangate-reviewers.yaml](/private/var/folders/_h/ffwb9tkx52vgq63h7vgtdgq80000gp/T/tmp.xBxdIvvNvj/.plangate-reviewers.yaml:7), which looks like a negative assertion.
+
+No files were modified.

--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -82,3 +82,5 @@
 {"ts":"2026-06-02T09:54:34Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T09:58:21Z"}
 {"ts":"2026-06-03T00:39:09Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-06-03T00:39:09Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-06-03T06:47:30Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-06-03T06:47:31Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
- `TASK-0059/eval-result.*`: タイムスタンプ更新
- `TASK-9991/review-external.md`: Codex レビュー再実行結果に更新
- `_audit/skip-decision-log.jsonl`: 新規 EH-3_SKIP エントリ追加

## Human TODO（このPRとは別に手動実施）

### 1. sync-plugin-plangate CI workflow のコミット（HO パス）

```bash
git checkout main && git pull origin main
git checkout -b chore/add-sync-plugin-workflow
git add .github/workflows/sync-plugin-plangate.yml
git commit -m "chore(TASK-0124): sync-plugin-plangate.yml を追加（HO 適用）"
git push origin chore/add-sync-plugin-workflow
gh pr create --base main \
  --title "chore(TASK-0124): sync-plugin-plangate CI workflow 追加" \
  --body "apply-task-0124-patches.sh 適用結果。main push で plugin/plangate/ が自動同期される。"
```

### 2. skip-decision-log.jsonl の acknowledged_by 追記

`_audit/skip-decision-log.jsonl` の `acknowledged_by: null` エントリを確認し、手動で追記してください。

### 3. hybrid-architecture.md の grep -E 化（HO パス）

`.claude/rules/hybrid-architecture.md` の L95-97 にある `grep -l "...\|..."` を `grep -El "...|..."` に変更（BRE → ERE）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)