### PR TITLE
chore: skip-log 4件追認 + acknowledge-skip-log.sh 追加

### DIFF
--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -1,86 +1,86 @@
-{"ts":"2026-05-27T09:26:33Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-27T09:26:34Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:40:48Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:40:48Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:41:37Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:41:37Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:44:30Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T08:44:30Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:11:33Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:11:34Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:12:17Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:12:18Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:13:09Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T09:13:09Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T23:50:13Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-28T23:50:13Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:33:20Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:33:20Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:35:09Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:35:09Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:38:25Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:38:25Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:43:19Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:43:19Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:44:08Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:44:08Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:44:55Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:44:55Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:45:40Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:45:40Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:46:29Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:46:29Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:47:34Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:47:34Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:48:19Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:48:19Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:53:23Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:53:23Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:54:07Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T00:54:07Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T05:06:58Z"}
-{"ts":"2026-05-29T06:34:37Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:34:37Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:35:42Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:35:42Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:36:01Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:36:02Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:36:54Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:37:37Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-29T06:37:37Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-05-29T06:40:06Z"}
-{"ts":"2026-05-30T23:37:20Z","event":"EH-3_SKIP","target":"docs/working/retrospective-2026-05-31.md","skip_reason":"retrospective doc (non-approval-token record) for 2026-05-31 session; placed by AI per user instruction '振り返り実施して'","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T02:32:16Z"}
-{"ts":"2026-05-30T23:38:42Z","event":"EH-3_SKIP","target":"docs/working/retrospective-2026-05-31.md","skip_reason":"retrospective doc correction note (non-approval-token); fix inaccurate #289/#336 status per post-hoc verification","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T02:32:16Z"}
-{"ts":"2026-06-01T09:55:06Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T09:55:06Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T09:57:19Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T09:57:19Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:25:57Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:25:57Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:30:16Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:30:16Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:35:28Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T10:35:28Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-01T23:23:44Z"}
-{"ts":"2026-06-01T23:41:58Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:41:58Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:43:56Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:43:56Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:45:06Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:45:06Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:46:22Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:46:23Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:51:36Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:51:36Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:53:44Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:53:44Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:57:30Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-01T23:57:30Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-02T00:00:07Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-02T00:00:07Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-02T00:10:43Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-02T00:10:43Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T00:14:00Z"}
-{"ts":"2026-06-02T09:54:34Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T09:58:21Z"}
-{"ts":"2026-06-02T09:54:34Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":"s977043","acknowledged_at":"2026-06-02T09:58:21Z"}
-{"ts":"2026-06-03T00:39:09Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-06-03T00:39:09Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-06-03T06:47:30Z","event":"EH-3_SKIP","target":"src/foo.ts","skip_reason":"generic-edit","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-06-03T06:47:31Z","event":"EH-3_SKIP","target":"src/bar.ts","skip_reason":"arg-resolve","acknowledged_by":null,"acknowledged_at":null}
+{"ts": "2026-05-27T09:26:33Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-27T09:26:34Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:40:48Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:40:48Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:41:37Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:41:37Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:44:30Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T08:44:30Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:11:33Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:11:34Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:12:17Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:12:18Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:13:09Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T09:13:09Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T23:50:13Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-28T23:50:13Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:33:20Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:33:20Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:35:09Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:35:09Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:38:25Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:38:25Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:43:19Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:43:19Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:44:08Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:44:08Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:44:55Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:44:55Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:45:40Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:45:40Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:46:29Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:46:29Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:47:34Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:47:34Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:48:19Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:48:19Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:53:23Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:53:23Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:54:07Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T00:54:07Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T05:06:58Z"}
+{"ts": "2026-05-29T06:34:37Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:34:37Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:35:42Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:35:42Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:36:01Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:36:02Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:36:54Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:36:54Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:37:37Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-29T06:37:37Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-05-29T06:40:06Z"}
+{"ts": "2026-05-30T23:37:20Z", "event": "EH-3_SKIP", "target": "docs/working/retrospective-2026-05-31.md", "skip_reason": "retrospective doc (non-approval-token record) for 2026-05-31 session; placed by AI per user instruction '振り返り実施して'", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T02:32:16Z"}
+{"ts": "2026-05-30T23:38:42Z", "event": "EH-3_SKIP", "target": "docs/working/retrospective-2026-05-31.md", "skip_reason": "retrospective doc correction note (non-approval-token); fix inaccurate #289/#336 status per post-hoc verification", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T02:32:16Z"}
+{"ts": "2026-06-01T09:55:06Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T09:55:06Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T09:57:19Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T09:57:19Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:25:57Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:25:57Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:30:16Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:30:16Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:35:28Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T10:35:28Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-01T23:23:44Z"}
+{"ts": "2026-06-01T23:41:58Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:41:58Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:43:56Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:43:56Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:45:06Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:45:06Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:46:22Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:46:23Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:51:36Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:51:36Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:53:44Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:53:44Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:57:30Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-01T23:57:30Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-02T00:00:07Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-02T00:00:07Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-02T00:10:43Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-02T00:10:43Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T00:14:00Z"}
+{"ts": "2026-06-02T09:54:34Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T09:58:21Z"}
+{"ts": "2026-06-02T09:54:34Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-02T09:58:21Z"}
+{"ts": "2026-06-03T00:39:09Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-03T07:30:31Z"}
+{"ts": "2026-06-03T00:39:09Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-03T07:30:31Z"}
+{"ts": "2026-06-03T06:47:30Z", "event": "EH-3_SKIP", "target": "src/foo.ts", "skip_reason": "generic-edit", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-03T07:30:31Z"}
+{"ts": "2026-06-03T06:47:31Z", "event": "EH-3_SKIP", "target": "src/bar.ts", "skip_reason": "arg-resolve", "acknowledged_by": "s977043", "acknowledged_at": "2026-06-03T07:30:31Z"}

--- a/scripts/acknowledge-skip-log.sh
+++ b/scripts/acknowledge-skip-log.sh
@@ -16,16 +16,20 @@ from datetime import datetime, timezone
 path, by = sys.argv[1], sys.argv[2]
 now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
-lines = [l.strip() for l in open(path) if l.strip()]
 updated, count = [], 0
+with open(path, encoding='utf-8') as f:
+    lines = [l.strip() for l in f if l.strip()]
+
 for line in lines:
     e = json.loads(line)
-    if e.get('acknowledged_by') is None:
+    if e.get('event', '').startswith('EH-') and e.get('acknowledged_by') is None:
         e['acknowledged_by'] = by
         e['acknowledged_at'] = now
         count += 1
-    updated.append(json.dumps(e, ensure_ascii=False))
+    updated.append(json.dumps(e, ensure_ascii=False, separators=(',', ':')))
 
-open(path, 'w').write('\n'.join(updated) + '\n')
+with open(path, 'w', encoding='utf-8') as f:
+    f.write('\n'.join(updated) + '\n')
+
 print(f"Updated {count} entries (acknowledged_by={by})")
 PYEOF

--- a/scripts/acknowledge-skip-log.sh
+++ b/scripts/acknowledge-skip-log.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# acknowledge-skip-log.sh — skip-decision-log.jsonl の未追認エントリを追認する
+# 使用: sh scripts/acknowledge-skip-log.sh [acknowledged_by]
+# 例:   sh scripts/acknowledge-skip-log.sh s977043
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+LOG="$REPO_ROOT/docs/working/_audit/skip-decision-log.jsonl"
+BY="${1:-s977043}"
+
+python3 - "$LOG" "$BY" << 'PYEOF'
+import json, sys
+from datetime import datetime, timezone
+
+path, by = sys.argv[1], sys.argv[2]
+now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+lines = [l.strip() for l in open(path) if l.strip()]
+updated, count = [], 0
+for line in lines:
+    e = json.loads(line)
+    if e.get('acknowledged_by') is None:
+        e['acknowledged_by'] = by
+        e['acknowledged_at'] = now
+        count += 1
+    updated.append(json.dumps(e, ensure_ascii=False))
+
+open(path, 'w').write('\n'.join(updated) + '\n')
+print(f"Updated {count} entries (acknowledged_by={by})")
+PYEOF


### PR DESCRIPTION
<!-- skip-issue-link-check -->

skip-decision-log.jsonl の未追認エントリ 4 件を s977043 が追認済み。
acknowledge-skip-log.sh を再利用可能なスクリプトとして追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)