### PR TITLE
fix: plugin.json description 短縮・sync 差分解消

### DIFF
--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plangate",
   "version": "8.10.0",
-  "description": "PlanGate — AI coding control OS for Claude Code. Intent/Mode classification, Skill Policy Router, Evidence Ledger, 4-Gate system (Design/TDD/Review/Completion), Context Packager, Subagent Dispatch, Worktree Policy, PR Decision, Setup Team. Commands: /pg-think /pg-hunt /pg-check /pg-verify /pg-tdd.",
+  "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"
   },

--- a/plugin/plangate/rules/hybrid-architecture.md
+++ b/plugin/plangate/rules/hybrid-architecture.md
@@ -92,9 +92,9 @@ Rule 4 を補完する **強制力の軸** での境界:
 
 | Rule | 機械検出方法 |
 |------|------------|
-| Rule 1 | `grep -El "実装方法|コード例|\`\`\`typescript|\`\`\`python" docs/workflows/0*.md` → 0 件 |
-| Rule 2 | `grep -El "プロジェクト固有|このプロジェクト|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
-| Rule 3 | `grep -El "Laravel|PostgreSQL|ECS|Cloudflare" .claude/agents/<new>.md` → 0 件 |
+| Rule 1 | `grep -El "実装方法\|コード例\|\`\`\`typescript\|\`\`\`python" docs/workflows/0*.md` → 0 件 |
+| Rule 2 | `grep -El "プロジェクト固有\|このプロジェクト\|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
+| Rule 3 | `grep -El "Laravel\|PostgreSQL\|ECS\|Cloudflare" .claude/agents/<new>.md` → 0 件 |
 | Rule 4 | Agent / Skill 内に特定プロジェクト名が無いことを確認 |
 | Rule 5 | 全 PBI で `docs/working/TASK-XXXX/handoff.md` 存在確認 |
 

--- a/plugin/plangate/rules/hybrid-architecture.md
+++ b/plugin/plangate/rules/hybrid-architecture.md
@@ -92,9 +92,9 @@ Rule 4 を補完する **強制力の軸** での境界:
 
 | Rule | 機械検出方法 |
 |------|------------|
-| Rule 1 | `grep -l "実装方法\|コード例\|\\\`\\\`\\\`typescript\|\\\`\\\`\\\`python" docs/workflows/0*.md` → 0 件 |
-| Rule 2 | `grep -l "プロジェクト固有\|このプロジェクト\|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
-| Rule 3 | `grep -l "Laravel\|PostgreSQL\|ECS\|Cloudflare" .claude/agents/<new>.md` → 0 件 |
+| Rule 1 | `grep -El "実装方法|コード例|\`\`\`typescript|\`\`\`python" docs/workflows/0*.md` → 0 件 |
+| Rule 2 | `grep -El "プロジェクト固有|このプロジェクト|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
+| Rule 3 | `grep -El "Laravel|PostgreSQL|ECS|Cloudflare" .claude/agents/<new>.md` → 0 件 |
 | Rule 4 | Agent / Skill 内に特定プロジェクト名が無いことを確認 |
 | Rule 5 | 全 PBI で `docs/working/TASK-XXXX/handoff.md` 存在確認 |
 


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
Codex 動作検証で発見した残課題を修正。

- `plugin/plangate/.claude-plugin/plugin.json`: description を 298字 → 185字に短縮（推奨 200字以内）
- `plugin/plangate/rules/hybrid-architecture.md`: sync スクリプトで同期済みに更新

## Human TODO（HO パスのため手動対応）

### CI に spec check を追加

`.github/workflows/sync-plugin-plangate.yml` の `Run sync script` ステップの**前**に以下を追加:

```yaml
      - name: Codex skill spec check
        run: sh scripts/check-codex-skill-spec.sh --warn-only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)