### PR TITLE
docs: Plugin 正式配布対応を README / CHANGELOG に反映

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+### Added
+
+- **Plugin 正式配布対応**（TASK-0124〜0126 後続）— Claude Code / Codex Plugin を正式配布可能な状態に整備。
+  - `install.sh`: ワンコマンドインストール（`--claude` / `--codex` / `--force` / `--uninstall` / `--version` / `--dry-run`）
+  - `.claude-plugin/marketplace.json`: `/plugin marketplace add s977043/PlanGate` / `codex plugin marketplace add s977043/PlanGate` 対応
+  - `scripts/check-codex-skill-spec.sh`: openai.yaml 仕様チェック（short_description 25-64 文字・default_prompt `$skill-name` 形式・brand_color）
+  - `scripts/install-plangate-skills-to-codex.sh`: `.agents/skills/` → `.codex/skills/` 変換スクリプト
+  - `plugin/plangate/scripts/install-plangate-skills.sh`: Plugin 自己完結 Codex インストールスクリプト
+  - `.codex/skills/`: 28 スキルを openai.yaml 付きで展開（公式仕様準拠）
+  - `plugin.json`: `skills` / `repository` / `license` / `keywords` フィールド追加（公式ベストプラクティス）
+  - CI: `sync-plugin-plangate.yml` に仕様チェックステップを追加
+
 ### Changed
 
 - **retrospective scoring 配点変更**（TASK-0121）— 振り返りメトリクスを Plan-primacy 思想に整合。計画精度 15→30・効率性 25→10・成果物品質 30 維持（計画で定めた品質の達成度 = 保全達成度として再定義）。計画精度の評価基準に C-1 語彙（受入基準網羅性・スコープ制御・テスト戦略妥当性）を追加。`docs/ai/reporting.md`（§2-bis 新設） / `docs/ai-driven-development.md` を更新、`scripts/check-retro-scoring-consistency.sh` を新規追加。

--- a/README.md
+++ b/README.md
@@ -120,24 +120,53 @@ OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推�
 
 ## インストール
 
-### Option A: clone + plugin 登録（推奨）
+### Option A: Marketplace から 1 コマンド（最推奨）
 
-```bash
-git clone https://github.com/s977043/plangate.git
-cd plangate
+**Claude Code（セッション内スラッシュコマンド）:**
+```
+/plugin marketplace add s977043/PlanGate
 ```
 
-その後、[Claude Code plugin 登録手順](plugin/plangate/README.md) に従うか、`.claude/` をプロジェクトにコピーしてください。
+その後、セッション内で:
+```
+/plugin install plangate
+```
 
-### Option B: `.claude/` を直接コピー
+**CLI から:**
+```bash
+# Claude Code
+claude plugin marketplace add s977043/PlanGate
+claude plugin install plangate
+
+# Codex
+codex plugin marketplace add s977043/PlanGate
+codex plugin install plangate
+```
+
+### Option B: clone + install スクリプト
 
 ```bash
-git clone https://github.com/s977043/plangate.git
-cp -r plangate/.claude/ your-project/.claude/
+git clone https://github.com/s977043/plangate.git ~/plangate
+cd /your-project
+sh ~/plangate/install.sh       # .claude/ と .codex/ を自動検出してインストール
+```
+
+オプション例:
+```bash
+sh ~/plangate/install.sh --claude    # Claude Code のみ
+sh ~/plangate/install.sh --codex     # Codex のみ
+sh ~/plangate/install.sh --dry-run   # 変更内容を確認（実行しない）
+```
+
+### Option C: `.claude/` を直接コピー
+
+```bash
+git clone https://github.com/s977043/plangate.git ~/plangate
+cp -r ~/plangate/.claude/ /your-project/.claude/
 ```
 
 > [!NOTE]
-> **新規利用者は Option A または B のどちらか一方を推奨します。**
+> **新規利用者は Option A（Marketplace）または Option B（install スクリプト）を推奨します。**
 > 既存利用者や段階的移行を行う場合、plugin と `.claude/` のデュアル運用は技術的に可能ですが、同名 Skill / コマンドの解決順に注意してください。
 > plugin 側を明示的に呼び出す場合は `plangate:<skill-or-agent>` prefix を使用します。詳細は [plugin 移行ガイド](docs/plangate-plugin-migration.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ codex plugin install plangate
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cd /your-project
+cd path/to/your-project
 sh ~/plangate/install.sh       # .claude/ と .codex/ を自動検出してインストール
 ```
 
@@ -162,7 +162,7 @@ sh ~/plangate/install.sh --dry-run   # 変更内容を確認（実行しない�
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cp -r ~/plangate/.claude/ /your-project/.claude/
+cp -r ~/plangate/.claude/ path/to/your-project/.claude/
 ```
 
 > [!NOTE]

--- a/README_en.md
+++ b/README_en.md
@@ -120,24 +120,53 @@ OS: macOS / Linux (POSIX shell required). Use WSL on Windows. Without Claude Cod
 
 ## Install
 
-### Option A: Clone and register plugin (recommended)
+### Option A: One command via Marketplace (recommended)
 
-```bash
-git clone https://github.com/s977043/plangate.git
-cd plangate
+**Claude Code (slash command in session):**
+```
+/plugin marketplace add s977043/PlanGate
 ```
 
-Then follow [Claude Code plugin registration instructions](plugin/plangate/README.md), or copy `.claude/` into your project.
+Then in session:
+```
+/plugin install plangate
+```
 
-### Option B: Copy `.claude/` directly
+**Via CLI:**
+```bash
+# Claude Code
+claude plugin marketplace add s977043/PlanGate
+claude plugin install plangate
+
+# Codex
+codex plugin marketplace add s977043/PlanGate
+codex plugin install plangate
+```
+
+### Option B: Clone and install script
 
 ```bash
-git clone https://github.com/s977043/plangate.git
-cp -r plangate/.claude/ your-project/.claude/
+git clone https://github.com/s977043/plangate.git ~/plangate
+cd /your-project
+sh ~/plangate/install.sh       # auto-detects .claude/ and .codex/
+```
+
+Options:
+```bash
+sh ~/plangate/install.sh --claude    # Claude Code only
+sh ~/plangate/install.sh --codex     # Codex only
+sh ~/plangate/install.sh --dry-run   # preview changes without applying
+```
+
+### Option C: Copy `.claude/` directly
+
+```bash
+git clone https://github.com/s977043/plangate.git ~/plangate
+cp -r ~/plangate/.claude/ /your-project/.claude/
 ```
 
 > [!NOTE]
-> **New users should pick either Option A or Option B.**
+> **New users should use Option A (Marketplace) or Option B (install script).**
 > For existing users or staged migrations, dual-running the plugin alongside `.claude/` is technically supported, but be aware that same-named Skills / commands may resolve in non-obvious order.
 > To explicitly invoke the plugin side, use the `plangate:<skill-or-agent>` prefix. See [plugin migration guide](docs/plangate-plugin-migration.md) for details.
 

--- a/README_en.md
+++ b/README_en.md
@@ -147,7 +147,7 @@ codex plugin install plangate
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cd /your-project
+cd path/to/your-project
 sh ~/plangate/install.sh       # auto-detects .claude/ and .codex/
 ```
 
@@ -162,7 +162,7 @@ sh ~/plangate/install.sh --dry-run   # preview changes without applying
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cp -r ~/plangate/.claude/ /your-project/.claude/
+cp -r ~/plangate/.claude/ path/to/your-project/.claude/
 ```
 
 > [!NOTE]

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推�
 | [Orchestrator Mode 仕様](./orchestrator-mode.md) | 親 PBI 分解 / 子 PBI 並行実行 / 統合ゲートの仕様（v1, Spec only） |
 | [Workflow 定義](./workflows/README.md) | WF-01〜WF-05 + Orchestrator Decomposition / Integration |
 | [Harness Improvement Roadmap](./ai/harness-improvement-roadmap.md) | モデル差分・実利用データ・評価結果を使って PlanGate ハーネスを継続改善するロードマップ |
-| [plugin 移行ガイド](./plangate-plugin-migration.md) | Claude Code plugin として使う場合の導入・移行 |
+| [plugin 移行ガイド](./plangate-plugin-migration.md) | Claude Code / Codex plugin として使う場合の導入・移行・インストール（Marketplace 対応） |
 | [OSS Governance](./oss-governance.md) | OSS 公開設定・運用判断 |
 | [Changelog](./changelog.md) | リリース履歴（リリース時に自動同期: scripts/sync-release-docs.sh） |
 

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -16,6 +16,39 @@ PlanGate は、AI コーディングエージェントをプロダクト開発�
 - Git リポジトリ
 - GitHub アカウント
 
+## インストール
+
+### Marketplace から（推奨）
+
+**Claude Code セッション内:**
+```
+/plugin marketplace add s977043/PlanGate
+/plugin install plangate
+```
+
+**CLI から:**
+```bash
+# Claude Code
+claude plugin marketplace add s977043/PlanGate
+claude plugin install plangate
+
+# Codex
+codex plugin marketplace add s977043/PlanGate
+codex plugin install plangate
+```
+
+### ワンコマンド（clone して install.sh）
+
+```bash
+git clone https://github.com/s977043/plangate.git ~/plangate
+cd /your-project
+sh ~/plangate/install.sh
+```
+
+詳細は [plugin/plangate/README.md](../../../plugin/plangate/README.md) を参照してください。
+
+---
+
 ## 3ステップで始める（Phase 0 体験）
 
 Phase 0 は「Day 1 で体験する」フェーズです。ultra-light モードで 1 タスクを最後まで完了し、PlanGate の基本的な流れを体感します。plan / C-1〜C-4 / V-1〜V-4 / エージェント / フック / metrics はすべて不要です。まず動かすことが目的です。

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -41,7 +41,7 @@ codex plugin install plangate
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cd /your-project
+cd path/to/your-project
 sh ~/plangate/install.sh
 ```
 

--- a/docs/plangate-plugin-migration.md
+++ b/docs/plangate-plugin-migration.md
@@ -1,7 +1,7 @@
 # PlanGate Claude Code Plugin 移行ガイド
 
-> 最終更新: 2026-04-27
-> 対象バージョン: plugin 0.5.0
+> 最終更新: 2026-06-04
+> 対象バージョン: plugin 8.10.0
 
 ## 背景・目的
 
@@ -24,9 +24,31 @@ PlanGate は当初、`.claude/` ディレクトリを含むリポジトリ配布
 
 このため、**既存利用者は急いで移行する必要はありません**。plugin の安定性を確認してから段階的に移行できます。
 
-## 同梱範囲（plugin 0.5.0）
+## インストール方法
 
-### Skills (14)
+### Marketplace から 1 コマンド（推奨）
+
+```bash
+# Claude Code セッション内
+/plugin marketplace add s977043/PlanGate
+/plugin install plangate
+
+# CLI から
+claude plugin marketplace add s977043/PlanGate && claude plugin install plangate
+codex plugin marketplace add s977043/PlanGate && codex plugin install plangate
+```
+
+### install.sh を使う
+
+```bash
+git clone https://github.com/s977043/plangate.git ~/plangate
+cd /your-project
+sh ~/plangate/install.sh   # .claude/ と .codex/ を自動検出
+```
+
+## 同梱範囲（plugin 8.10.0）
+
+### Skills (38)
 
 | Skill | 役割 |
 |-------|------|

--- a/docs/plangate-plugin-migration.md
+++ b/docs/plangate-plugin-migration.md
@@ -42,7 +42,7 @@ codex plugin marketplace add s977043/PlanGate && codex plugin install plangate
 
 ```bash
 git clone https://github.com/s977043/plangate.git ~/plangate
-cd /your-project
+cd path/to/your-project
 sh ~/plangate/install.sh   # .claude/ と .codex/ を自動検出
 ```
 


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
Plugin 正式配布完成に合わせてドキュメントを更新。

### README.md / README_en.md
インストール手順を 3 段階に整理:
- **Option A（最推奨）**: `/plugin marketplace add s977043/PlanGate`
- **Option B**: `sh install.sh` ワンコマンド
- **Option C**: 手動コピー（従来）

### CHANGELOG.md
Unreleased セクションに Plugin 配布対応の変更点を記録:
- `install.sh` / `marketplace.json` / `check-codex-skill-spec.sh` 等

🤖 Generated with [Claude Code](https://claude.com/claude-code)