### PR TITLE
fix: Plugin スクリプト群のレビュー指摘横展開 + 実地バグ修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -219,10 +219,12 @@ _print_caveats() {
 install_codex() {
   CODEX_DIR="${TARGET_DIR:-$(pwd)/.codex/skills}"
   _log "Codex: skills → $CODEX_DIR (v$PLUGIN_VERSION)"
+  _codex_force=""
+  [ "$FORCE" = "1" ] && _codex_force="--force"
   if [ "$DRY_RUN" = "1" ]; then
-    _dry "WOULD RUN: sh $PLUGIN_DIR/scripts/install-plangate-skills.sh --target $CODEX_DIR"
+    _dry "WOULD RUN: sh $PLUGIN_DIR/scripts/install-plangate-skills.sh --target $CODEX_DIR $_codex_force"
   else
-    sh "$PLUGIN_DIR/scripts/install-plangate-skills.sh" --target "$CODEX_DIR"
+    sh "$PLUGIN_DIR/scripts/install-plangate-skills.sh" --target "$CODEX_DIR" $_codex_force
     _log "Codex インストール完了"
     printf '\n\033[1m確認\033[0m: Codex セッションで $plangate-setup を実行してください\n\n'
   fi

--- a/plugin/plangate/assets/plangate.png.placeholder
+++ b/plugin/plangate/assets/plangate.png.placeholder
@@ -1,1 +1,0 @@
-placeholder: replace with actual plangate.png (128x128 recommended)

--- a/plugin/plangate/rules/hybrid-architecture.md
+++ b/plugin/plangate/rules/hybrid-architecture.md
@@ -92,9 +92,9 @@ Rule 4 を補完する **強制力の軸** での境界:
 
 | Rule | 機械検出方法 |
 |------|------------|
-| Rule 1 | `grep -El "実装方法\|コード例\|\`\`\`typescript\|\`\`\`python" docs/workflows/0*.md` → 0 件 |
-| Rule 2 | `grep -El "プロジェクト固有\|このプロジェクト\|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
-| Rule 3 | `grep -El "Laravel\|PostgreSQL\|ECS\|Cloudflare" .claude/agents/<new>.md` → 0 件 |
+| Rule 1 | `grep -El "実装方法|コード例|\`\`\`typescript|\`\`\`python" docs/workflows/0*.md` → 0 件 |
+| Rule 2 | `grep -El "プロジェクト固有|このプロジェクト|TASK-" .claude/skills/<new>/SKILL.md` → 0 件 |
+| Rule 3 | `grep -El "Laravel|PostgreSQL|ECS|Cloudflare" .claude/agents/<new>.md` → 0 件 |
 | Rule 4 | Agent / Skill 内に特定プロジェクト名が無いことを確認 |
 | Rule 5 | 全 PBI で `docs/working/TASK-XXXX/handoff.md` 存在確認 |
 

--- a/plugin/plangate/scripts/install-plangate-skills.sh
+++ b/plugin/plangate/scripts/install-plangate-skills.sh
@@ -68,7 +68,12 @@ for skill_dir in "$SKILLS_SRC"/*/; do
     continue
   fi
 
-  # Copy SKILL.md
+  # Copy SKILL.md（symlink はセキュリティのためスキップ）
+  if [ -L "$skill_md" ]; then
+    _log "SKIP symlink: $name"
+    skipped=$((skipped+1))
+    continue
+  fi
   mkdir -p "$dst"
   if ! cp "$skill_md" "$dst_md"; then
     _log "ERROR copying SKILL.md for $name"
@@ -98,6 +103,16 @@ for skill_dir in "$SKILLS_SRC"/*/; do
     short_desc="Use the $name skill."
   fi
 
+  # short_description を 64 文字以内に安全に切り詰め（UTF-8 マルチバイト対応・UI 表示用）
+  if command -v python3 >/dev/null 2>&1; then
+    short_desc=$(python3 - "$short_desc" << 'PYTRUNC'
+import sys
+s = sys.argv[1]
+print(s[:61] + '...' if len(s) > 64 else s)
+PYTRUNC
+)
+  fi
+
   # Copy assets
   mkdir -p "$dst/assets"
   if [ -f "$ASSETS_SRC/plangate-small.svg" ]; then
@@ -114,7 +129,8 @@ interface:
   short_description: "$short_desc"
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $name to assist with this project."
+  default_prompt: "Use \$$name to assist with this project."
+  brand_color: "#1A56DB"
 YAML
 
   _log "INSTALL: $name"

--- a/scripts/install-plangate-skills-to-codex.sh
+++ b/scripts/install-plangate-skills-to-codex.sh
@@ -60,7 +60,7 @@ extract_frontmatter_value() {
         value = substr(value, 2, length(value) - 2)
       }
       # シングルクォート除去
-      else if (value ~ /'"'"'^'"'"'.*'"'"''"'"'$/) {
+      else if (value ~ /^'"'"'.*'"'"'$/) {
         value = substr(value, 2, length(value) - 2)
       }
       print value
@@ -134,10 +134,26 @@ for skill_file in "$SOURCE_DIR"/*/SKILL.md; do
   # フォールバック値
   [ -z "$frontmatter_name" ] && frontmatter_name="$skill_name"
   [ -z "$frontmatter_description" ] && frontmatter_description="PlanGate skill: $skill_name"
+  # short_description を 64 文字以内に安全に切り詰め（UTF-8 マルチバイト対応）
+  if command -v python3 >/dev/null 2>&1; then
+    frontmatter_description=$(python3 - "$frontmatter_description" << 'PYTRUNC'
+import sys
+s = sys.argv[1]
+print(s[:61] + '...' if len(s) > 64 else s)
+PYTRUNC
+)
+  fi
   [ -z "$frontmatter_icon_small" ] && frontmatter_icon_small="./assets/plangate-small.svg"
   [ -z "$frontmatter_icon_large" ] && frontmatter_icon_large="./assets/plangate.png"
   if [ -z "$frontmatter_default_prompt" ]; then
-    frontmatter_default_prompt="Use $skill_name to assist with this project."
+    frontmatter_default_prompt="Use \$$skill_name to assist with this project."
+  fi
+
+  # symlink はセキュリティのためスキップ
+  if [ -L "$skill_file" ]; then
+    skipped_count=$((skipped_count + 1))
+    printf 'skip(symlink): %s\n' "$skill_name"
+    continue
   fi
 
   mkdir -p "$target_agents_dir"
@@ -149,7 +165,10 @@ for skill_file in "$SOURCE_DIR"/*/SKILL.md; do
   if [ -d "$ASSETS_SRC" ]; then
     target_assets_dir="$target_dir/assets"
     mkdir -p "$target_assets_dir"
-    for _a in "$ASSETS_SRC"/*; do [ -f "$_a" ] && cp "$_a" "$target_assets_dir/" 2>/dev/null || true; done
+    for _a in "$ASSETS_SRC"/*; do
+      case "$_a" in *.placeholder) continue ;; esac
+      [ -f "$_a" ] && [ ! -L "$_a" ] && cp "$_a" "$target_assets_dir/" 2>/dev/null || true
+    done
   fi
 
   # openai.yaml を生成
@@ -166,6 +185,7 @@ for skill_file in "$SOURCE_DIR"/*/SKILL.md; do
     printf '  icon_small: "%s"\n' "$icon_small"
     printf '  icon_large: "%s"\n' "$icon_large"
     printf '  default_prompt: "%s"\n' "$default_prompt"
+    printf '  brand_color: "#1A56DB"\n'
   } > "$target_openai_yaml"
 
   installed_count=$((installed_count + 1))

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -93,21 +93,30 @@ fi
 # plugin.json の version フィールドを更新
 PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 if [ -n "$_ver" ] && [ -f "$PLUGIN_JSON" ] && command -v python3 >/dev/null 2>&1; then
-  _pcur=$(python3 -c "import json; d=json.load(open('$PLUGIN_JSON')); print(d.get('version',''))" 2>/dev/null || true)
-  if [ "$_pcur" != "$_ver" ]; then
-    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE plugin.json version: $_pcur -> $_ver"
+  _pcur=$(python3 - "$PLUGIN_JSON" << 'PYJSON' 2>/dev/null || true
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as f:
+        print(json.load(f).get('version', ''))
+except Exception:
+    print('')
+PYJSON
+)
+  _ver_noprefix="${_ver#v}"
+  if [ "$_pcur" != "$_ver_noprefix" ]; then
+    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE plugin.json version: $_pcur -> $_ver_noprefix"
     else
       python3 - "$PLUGIN_JSON" "$_ver" << 'PYEOF'
 import json, sys
 path, ver = sys.argv[1], sys.argv[2]
-with open(path) as f:
+with open(path, encoding='utf-8') as f:
     d = json.load(f)
 d['version'] = ver.lstrip('v')
-with open(path, 'w') as f:
+with open(path, 'w', encoding='utf-8') as f:
     json.dump(d, f, indent=2, ensure_ascii=False)
     f.write('\n')
 PYEOF
-      _log "UPDATE plugin.json version: $_pcur -> $_ver"
+      _log "UPDATE plugin.json version: $_pcur -> $_ver_noprefix"
     fi
     changed=1
   fi


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
Codex と Gemini の最終レビューで指摘された「前回 install.sh のみ修正した観点が他スクリプトに残存している」問題を横展開で解消。さらに**実行検証で発見した複数の本物のバグ**を修正。

## レビュー指摘対応

### Gemini Major: パス注入の残存
- `scripts/sync-plugin-plangate.sh`: `python3 -c "...open('$VAR')..."` を `sys.argv` 渡しに変更（install.sh で撤去した唯一の残存パターン）+ `encoding='utf-8'` 統一

### Codex Major: --force 転送漏れ
- `install.sh`: `install_codex` で `--force` を `install-plangate-skills.sh` へ転送

### Codex Major: openai.yaml 仕様非準拠
- 両 install スクリプト: `default_prompt` を `$skill-name` リテラル形式に / `brand_color` 追加 / `short_description` を 64 文字以内に安全切り詰め（UTF-8 対応）

### 両エージェント一致: symlink 無検査
- 両スクリプトの cp / assets コピーに symlink スキップを追加

## 実行検証で発見した本物のバグ
| バグ | 影響 | 修正 |
|------|------|------|
| `install-plangate-skills-to-codex.sh` の awk シングルクォート除去正規表現 `/'^'.*''$/` が破綻 | frontmatter 抽出が**全失敗**してスクリプトが実質機能していなかった | `/^'.'$/` に修正 |
| 同スクリプトが `plangate.png.placeholder` を配布先へ伝播 | 不要ファイルが各スキルに散乱 | `*.placeholder` 除外 + 不要 placeholder 削除 |
| sync の version 比較が `v8.10.0`(CHANGELOG) vs `8.10.0`(plugin.json) で毎回差分扱い | **CI が毎 push で無駄な同期 PR を作成** | v プレフィックス除去して比較 |

## 検証結果
- `install-plangate-skills.sh` 生成物: check-codex-skill-spec **37/37 PASS**
- `install-plangate-skills-to-codex.sh` 生成物: **28/28 PASS**
- リポジトリ同梱 `.codex/skills/` 回帰なし: **28/28 PASS**
- `sync --dry-run`: **clean（no changes）**

🤖 Generated with [Claude Code](https://claude.com/claude-code)