### PR TITLE
release: v8.11.0 — Plugin 正式配布対応（Critical codex install 修正含む）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "PlanGate — AI coding governance OS for Claude Code and Codex. 4-Gate approval system, Intent/Mode classification, Skill Policy Router, and agent control layer.",
-    "version": "8.10.0"
+    "version": "8.11.0"
   },
   "plugins": [
     {
       "name": "plangate",
       "description": "AI coding governance OS. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer for Claude Code.",
-      "version": "8.10.0",
+      "version": "8.11.0",
       "author": {
         "name": "PlanGate contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.11.0 - 2026-06-04
+
+feat: Claude Code / Codex Plugin 正式配布対応 + retrospective scoring 配点変更
+
+Plugin を Claude Code / Codex 双方で `marketplace add` / `install.sh` から導入できる正式配布状態に整備。Codex/Gemini レビューと ultracode 検証 Workflow（5観点並列）で発見した配布ブロッカー（実在しない `codex plugin install` の誤記、install.sh のパス注入・symlink・dry-run 副作用、openai.yaml 仕様非準拠など）を解消。
+
 ### Added
 
 - **Plugin 正式配布対応**（TASK-0124〜0126 後続）— Claude Code / Codex Plugin を正式配布可能な状態に整備。
@@ -21,6 +27,15 @@ PlanGate の主要リリース履歴。
 ### Changed
 
 - **retrospective scoring 配点変更**（TASK-0121）— 振り返りメトリクスを Plan-primacy 思想に整合。計画精度 15→30・効率性 25→10・成果物品質 30 維持（計画で定めた品質の達成度 = 保全達成度として再定義）。計画精度の評価基準に C-1 語彙（受入基準網羅性・スコープ制御・テスト戦略妥当性）を追加。`docs/ai/reporting.md`（§2-bis 新設） / `docs/ai-driven-development.md` を更新、`scripts/check-retro-scoring-consistency.sh` を新規追加。
+
+### Fixed
+
+- **Plugin 配布の堅牢化**（PR #447 / #448 — Codex/Gemini レビュー + ultracode 検証 Workflow）:
+  - **Critical**: 4 ドキュメントの `codex plugin install plangate` を削除（`codex plugin` に install サブコマンドは無く配布の入口でエラー）→ `marketplace add` + `install.sh --codex` に修正
+  - install.sh: Python コードへのパス直接展開を `sys.argv` 渡しに変更（パス注入防止）、`cp` のシンボリックリンクスキップ、`--dry-run` の mkdir 副作用解消、uninstall の空ディレクトリ除去、python3 ガード
+  - openai.yaml 生成: `default_prompt` を `$skill-name` 形式に・`brand_color` 追加・`short_description` を 64 文字以内に UTF-8 安全切り詰め
+  - install-plangate-skills-to-codex.sh: awk シングルクォート除去の正規表現破綻を修正（frontmatter 抽出が機能していなかった）
+  - sync-plugin-plangate.sh: plugin.json version 比較の v プレフィックス不一致で CI が毎回無駄 PR を作る問題を解消
 
 ## v8.10.0 - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -123,16 +123,19 @@ OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推�
 ### Option A: Marketplace から 1 コマンド（最推奨）
 
 **Claude Code（セッション内スラッシュコマンド）:**
-```
+
+```text
 /plugin marketplace add s977043/PlanGate
 ```
 
 その後、セッション内で:
-```
+
+```text
 /plugin install plangate
 ```
 
 **CLI から:**
+
 ```bash
 # Claude Code
 claude plugin marketplace add s977043/PlanGate
@@ -152,6 +155,7 @@ sh ~/plangate/install.sh       # .claude/ と .codex/ を自動検出してイ�
 ```
 
 オプション例:
+
 ```bash
 sh ~/plangate/install.sh --claude    # Claude Code のみ
 sh ~/plangate/install.sh --codex     # Codex のみ

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ sh ~/plangate/install.sh --dry-run   # 変更内容を確認（実行しない�
 ```
 
 > **導入後**: hook 強制を有効化するには `~/plangate/bin/plangate doctor --fix` を実行してください。
+>
+> **前提**: `install.sh` の manifest 生成・アンインストールには `python3` が必要です（未導入時は明示エラーで停止します）。
 
 ### Option C: `.claude/` を直接コピー
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推�
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex
+# Codex（marketplace 追加 + スキル展開）
 codex plugin marketplace add s977043/PlanGate
-codex plugin install plangate
+sh ~/plangate/install.sh --codex
 ```
+
+> Codex には `plugin install` サブコマンドはありません。`marketplace add` で marketplace を登録し、スキルは `install.sh --codex` で `.codex/skills/` に展開します。
 
 ### Option B: clone + install スクリプト
 

--- a/README_en.md
+++ b/README_en.md
@@ -123,16 +123,19 @@ OS: macOS / Linux (POSIX shell required). Use WSL on Windows. Without Claude Cod
 ### Option A: One command via Marketplace (recommended)
 
 **Claude Code (slash command in session):**
-```
+
+```text
 /plugin marketplace add s977043/PlanGate
 ```
 
 Then in session:
-```
+
+```text
 /plugin install plangate
 ```
 
 **Via CLI:**
+
 ```bash
 # Claude Code
 claude plugin marketplace add s977043/PlanGate
@@ -152,6 +155,7 @@ sh ~/plangate/install.sh       # auto-detects .claude/ and .codex/
 ```
 
 Options:
+
 ```bash
 sh ~/plangate/install.sh --claude    # Claude Code only
 sh ~/plangate/install.sh --codex     # Codex only

--- a/README_en.md
+++ b/README_en.md
@@ -141,10 +141,12 @@ Then in session:
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex
+# Codex (add marketplace + install skills)
 codex plugin marketplace add s977043/PlanGate
-codex plugin install plangate
+sh ~/plangate/install.sh --codex
 ```
+
+> Codex has no `plugin install` subcommand. Register the marketplace with `marketplace add`, then expand skills into `.codex/skills/` via `install.sh --codex`.
 
 ### Option B: Clone and install script
 

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -21,20 +21,22 @@ PlanGate は、AI コーディングエージェントをプロダクト開発�
 ### Marketplace から（推奨）
 
 **Claude Code セッション内:**
-```
+
+```text
 /plugin marketplace add s977043/PlanGate
 /plugin install plangate
 ```
 
 **CLI から:**
+
 ```bash
 # Claude Code
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex
+# Codex（marketplace 追加 + スキル展開）
 codex plugin marketplace add s977043/PlanGate
-codex plugin install plangate
+sh ~/plangate/install.sh --codex
 ```
 
 ### ワンコマンド（clone して install.sh）

--- a/docs/plangate-plugin-migration.md
+++ b/docs/plangate-plugin-migration.md
@@ -36,7 +36,7 @@ PlanGate は当初、`.claude/` ディレクトリを含むリポジトリ配布
 
 # CLI から
 claude plugin marketplace add s977043/PlanGate && claude plugin install plangate
-codex plugin marketplace add s977043/PlanGate && codex plugin install plangate
+codex plugin marketplace add s977043/PlanGate   # その後 sh install.sh --codex でスキル展開
 ```
 
 ### install.sh を使う

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ install_claude() {
     src="$PLUGIN_DIR/$dir"
     dst="$DEST/$dir"
     [ -d "$src" ] || continue
-    mkdir -p "$dst"
+    [ "$DRY_RUN" = "1" ] || mkdir -p "$dst"
     for f in "$src"/*; do
       [ -e "$f" ] || continue
       base="$(basename "$f")"
@@ -166,6 +166,17 @@ for f in d.get('files', []):
 if not dry:
     os.remove(manifest_path)
     print(f'[plangate] removed manifest: {manifest_path}')
+    # 空になった agents/skills/commands/rules ディレクトリを best-effort で除去
+    import os.path as _p
+    base = _p.dirname(manifest_path)
+    for _sub in ('agents', 'skills', 'commands', 'rules'):
+        _d = _p.join(base, _sub)
+        if os.path.isdir(_d) and not os.listdir(_d):
+            try:
+                os.rmdir(_d)
+                print(f'[plangate] removed empty dir: {_d}')
+            except OSError:
+                pass
 PYEOF
 }
 

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -3,7 +3,7 @@
 PlanGate — a governance OS for AI-assisted coding.
 Provides Intent/Mode classification, a 4-Gate approval system, and an agent control layer as a Claude Code plugin.
 
-- **Version**: v8.10.0
+- **Version**: v8.11.0
 - **Source**: https://github.com/s977043/plangate
 
 ## Install

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -147,7 +147,7 @@ plugin/plangate/
 ├── agents/                 # 23 agents
 ├── assets/                 # アイコン等のアセット
 │   └── plangate-small.svg  # icon_small / icon_large 兼用 (SVG)
-├── skills/                 # 38 skills（.agents/skills/ と完全同期）
+├── skills/                 # 37 skills（.agents/skills/ から同期 + plugin 専用スキルを含む上位集合）
 │   ├── acceptance-criteria-build/
 │   ├── acceptance-review/
 │   ├── ai-dev-brainstorm/
@@ -267,15 +267,15 @@ EH-1/2/3/6/9 などの Hook を使用するには、別途手動設定が必要�
 
 ## 配布チェックリスト
 
-- [ ] **ファイル整合性**: `plugin/plangate/skills/` のスキル数が `.agents/skills/` と一致していること（CI: `scripts/sync-plugin-plangate.sh` で自動同期）
-- [ ] **README 正確性**: Contents 欄のエージェント数・スキル数が実態と一致していること（agents: 23、skills: 38）
-- [ ] **openai.yaml 完全性**: 全スキルの `agents/openai.yaml` に 5 フィールド（display_name / short_description / icon_small / icon_large / default_prompt）が揃っていること
+- [ ] **ファイル整合性**: `plugin/plangate/skills/` が `.agents/skills/` を包含する上位集合であること（`scripts/sync-plugin-plangate.sh` で同期。`context-packager` 等の plugin 専用スキルを含む）
+- [ ] **README 正確性**: Contents 欄のエージェント数・スキル数が実態と一致していること（agents: 23、skills: 37）
+- [ ] **openai.yaml 完全性**: 全スキルの `agents/openai.yaml` に 6 フィールド（display_name / short_description / icon_small / icon_large / default_prompt / brand_color）が揃い、`scripts/check-codex-skill-spec.sh` を PASS すること
 - [ ] **アセット存在確認**: `plugin/plangate/assets/` に `plangate-small.svg` が実在すること（PNG は不要）
 - [ ] **インストールスクリプト動作確認**: `install-plangate-skills.sh` をクリーン環境で実行し、全スキルが `.codex/skills/` に展開されること
 - [ ] **Claude Code インストール確認**: `plugin/plangate/` をプラグインパスとして指定し、Claude Code セッション内でスキル・コマンド・エージェントが認識されること（`/setup-team` で確認）
 - [ ] **hooks 配線状況の明示**: `plugin/plangate/hooks/` が reserved である旨を明記済み
 - [ ] **バージョン整合性**: `plugin/plangate/.claude-plugin/plugin.json` の version と `CHANGELOG.md` の最新リリースバージョンが一致していること
-- [ ] **CI 同期チェック**: `.agents/skills/` と `plugin/plangate/skills/` の差分を検出する CI ジョブが存在すること
+- [ ] **CI 同期チェック**: `.agents/skills/` → `plugin/plangate/skills/` の同期差分を検出する CI ジョブ（`sync-plugin-plangate.yml`）が存在すること
 
 ---
 


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Release v8.11.0 — Claude Code / Codex Plugin 正式配布対応

このPRをマージすると v8.11.0 のリリース準備が完了します（マージ後に AI が tag-main parity 検証 → annotated tag push → GitHub Release を実行：計画承認済み）。

## 含まれる変更

### Critical（配布ブロッカー修正）
- `codex plugin install plangate`（実在しないコマンド）を 4 ドキュメントから削除 → `marketplace add` + `install.sh --codex` に修正

### Plugin 配布の堅牢化（ultracode 検証 Workflow + Codex/Gemini レビュー）
- install.sh: パス注入防止（sys.argv 渡し）/ symlink スキップ / `--dry-run` mkdir 副作用解消 / uninstall 空ディレクトリ除去 / python3 ガード
- openai.yaml: `$skill-name` 形式 / `brand_color` / `short_description` 64文字切り詰め
- install-plangate-skills-to-codex.sh: awk 正規表現破綻の修正（frontmatter 抽出が機能していなかった）
- sync-plugin-plangate.sh: version 比較の v プレフィックス不一致（CI 無駄 PR）解消

### リリース準備
- CHANGELOG: `Unreleased → v8.11.0` 確定
- plugin.json / marketplace.json / plugin README: version 8.11.0 に統一

## 検証
- CI: 全チェック green（前 commit で確認済み）
- markdown lint / marketplace validate / check-codex-skill-spec: PASS
- install.sh ラウンドトリップ実地検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)