### PR TITLE
docs: v8.11.0 リリース後のドキュメント最新化（Codex/Gemini レビュー反映）

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.10.0**（Latest）で、Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.11.0**（Latest）で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 
 | 項目 | 状態 |
 | --- | --- |
-| 最新リリース | **v8.10.0**（Latest, 2026-05-29）— Codex CLI parity 完成 / Hook・Guard 拡充 / Skill 整備 |
+| 最新リリース | **v8.11.0**（Latest, 2026-06-04）— Claude Code / Codex Plugin 正式配布対応（install.sh / marketplace.json / Codex スキル配布） |
 | リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3、v8.5.0 で 10/10、v8.6.0 で EH-8、v8.7.0 で EH-9 を追加） |
@@ -141,12 +141,11 @@ OS: macOS / Linux（POSIX shell が動作する環境）。Windows は WSL 推�
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex（marketplace 追加 + スキル展開）
+# Codex（marketplace 登録）
 codex plugin marketplace add s977043/PlanGate
-sh ~/plangate/install.sh --codex
 ```
 
-> Codex には `plugin install` サブコマンドはありません。`marketplace add` で marketplace を登録し、スキルは `install.sh --codex` で `.codex/skills/` に展開します。
+> Codex には `plugin install` サブコマンドはありません。`marketplace add` で marketplace を登録します。スキルを `.codex/skills/` に直接展開する場合は **Option B**（clone + `install.sh --codex`）を使用してください。
 
 ### Option B: clone + install スクリプト
 

--- a/README_en.md
+++ b/README_en.md
@@ -75,13 +75,13 @@ flowchart LR
 
 ## Current Status
 
-As of **v8.10.0** (Latest), PlanGate combines Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
+As of **v8.11.0** (Latest), PlanGate adds official Claude Code / Codex Plugin distribution and combines Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
 
 v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "where do I start, where do I stop" problem via OSS adoption foundations (staged adoption guide, plugin maturity, versioning stability policy) and the self-evaluation, context separation, model-profile, and reporting bases delivered in sequence.
 
 | Item | Status |
 | --- | --- |
-| Latest release | **v8.10.0** (Latest, 2026-05-29) — Codex CLI parity complete / Hook & Guard expansion / Skill overhaul |
+| Latest release | **v8.11.0** (Latest, 2026-06-04) — Official Claude Code / Codex Plugin distribution (install.sh / marketplace.json / Codex skill packaging) |
 | Shipped | **v8.7.0** OSS adoption foundations + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1, Dynamic Context Engine v1, Model Profile v2, Gate Event Normalization, Dogfooding Eval v1 |
 | Roadmap | **EPIC #193 complete (CLOSED / COMPLETED)** — Phases 0-6 + Governance + Lightweight Plan Quality Checks all Done, child PBIs 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks implemented** (EH-1 to EH-9 + EHS-1 to EHS-3; v8.5.0=10/10, v8.6.0 added EH-8, v8.7.0 added EH-9) |
@@ -141,12 +141,11 @@ Then in session:
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex (add marketplace + install skills)
+# Codex (register marketplace)
 codex plugin marketplace add s977043/PlanGate
-sh ~/plangate/install.sh --codex
 ```
 
-> Codex has no `plugin install` subcommand. Register the marketplace with `marketplace add`, then expand skills into `.codex/skills/` via `install.sh --codex`.
+> Codex has no `plugin install` subcommand. Register the marketplace with `marketplace add`. To expand skills directly into `.codex/skills/`, use **Option B** (clone + `install.sh --codex`).
 
 ### Option B: Clone and install script
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,37 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.11.0 - 2026-06-04
+
+feat: Claude Code / Codex Plugin 正式配布対応 + retrospective scoring 配点変更
+
+Plugin を Claude Code / Codex 双方で `marketplace add` / `install.sh` から導入できる正式配布状態に整備。Codex/Gemini レビューと ultracode 検証 Workflow（5観点並列）で発見した配布ブロッカー（実在しない `codex plugin install` の誤記、install.sh のパス注入・symlink・dry-run 副作用、openai.yaml 仕様非準拠など）を解消。
+
+### Added
+
+- **Plugin 正式配布対応**（TASK-0124〜0126 後続）— Claude Code / Codex Plugin を正式配布可能な状態に整備。
+  - `install.sh`: ワンコマンドインストール（`--claude` / `--codex` / `--force` / `--uninstall` / `--version` / `--dry-run`）
+  - `.claude-plugin/marketplace.json`: `/plugin marketplace add s977043/PlanGate` / `codex plugin marketplace add s977043/PlanGate` 対応
+  - `scripts/check-codex-skill-spec.sh`: openai.yaml 仕様チェック（short_description 25-64 文字・default_prompt `$skill-name` 形式・brand_color）
+  - `scripts/install-plangate-skills-to-codex.sh`: `.agents/skills/` → `.codex/skills/` 変換スクリプト
+  - `plugin/plangate/scripts/install-plangate-skills.sh`: Plugin 自己完結 Codex インストールスクリプト
+  - `.codex/skills/`: 28 スキルを openai.yaml 付きで展開（公式仕様準拠）
+  - `plugin.json`: `skills` / `repository` / `license` / `keywords` フィールド追加（公式ベストプラクティス）
+  - CI: `sync-plugin-plangate.yml` に仕様チェックステップを追加
+
+### Changed
+
+- **retrospective scoring 配点変更**（TASK-0121）— 振り返りメトリクスを Plan-primacy 思想に整合。計画精度 15→30・効率性 25→10・成果物品質 30 維持（計画で定めた品質の達成度 = 保全達成度として再定義）。計画精度の評価基準に C-1 語彙（受入基準網羅性・スコープ制御・テスト戦略妥当性）を追加。`docs/ai/reporting.md`（§2-bis 新設） / `docs/ai-driven-development.md` を更新、`scripts/check-retro-scoring-consistency.sh` を新規追加。
+
+### Fixed
+
+- **Plugin 配布の堅牢化**（PR #447 / #448 — Codex/Gemini レビュー + ultracode 検証 Workflow）:
+  - **Critical**: 4 ドキュメントの `codex plugin install plangate` を削除（`codex plugin` に install サブコマンドは無く配布の入口でエラー）→ `marketplace add` + `install.sh --codex` に修正
+  - install.sh: Python コードへのパス直接展開を `sys.argv` 渡しに変更（パス注入防止）、`cp` のシンボリックリンクスキップ、`--dry-run` の mkdir 副作用解消、uninstall の空ディレクトリ除去、python3 ガード
+  - openai.yaml 生成: `default_prompt` を `$skill-name` 形式に・`brand_color` 追加・`short_description` を 64 文字以内に UTF-8 安全切り詰め
+  - install-plangate-skills-to-codex.sh: awk シングルクォート除去の正規表現破綻を修正（frontmatter 抽出が機能していなかった）
+  - sync-plugin-plangate.sh: plugin.json version 比較の v プレフィックス不一致で CI が毎回無駄 PR を作る問題を解消
+
 ## v8.10.0 - 2026-05-29
 
 feat: Codex CLI parity 完成 + Hook/Guard 拡充 + Skill 整備 + ドキュメント品質向上

--- a/docs/pages/guides/getting-started.md
+++ b/docs/pages/guides/getting-started.md
@@ -34,10 +34,11 @@ PlanGate は、AI コーディングエージェントをプロダクト開発�
 claude plugin marketplace add s977043/PlanGate
 claude plugin install plangate
 
-# Codex（marketplace 追加 + スキル展開）
+# Codex（marketplace 登録）
 codex plugin marketplace add s977043/PlanGate
-sh ~/plangate/install.sh --codex
 ```
+
+> Codex でスキルを `.codex/skills/` に直接展開する場合は、下記「ワンコマンド（clone して install.sh）」で `sh ~/plangate/install.sh --codex` を実行してください。
 
 ### ワンコマンド（clone して install.sh）
 

--- a/docs/plangate-plugin-migration.md
+++ b/docs/plangate-plugin-migration.md
@@ -1,7 +1,7 @@
 # PlanGate Claude Code Plugin 移行ガイド
 
 > 最終更新: 2026-06-04
-> 対象バージョン: plugin 8.10.0
+> 対象バージョン: plugin 8.11.0
 > 対象ツール: Claude Code / Codex（両対応）
 
 ## 背景・目的
@@ -36,7 +36,7 @@ PlanGate は当初、`.claude/` ディレクトリを含むリポジトリ配布
 
 # CLI から
 claude plugin marketplace add s977043/PlanGate && claude plugin install plangate
-codex plugin marketplace add s977043/PlanGate   # その後 sh install.sh --codex でスキル展開
+codex plugin marketplace add s977043/PlanGate   # スキル展開は clone 後に sh install.sh --codex
 ```
 
 ### install.sh を使う
@@ -47,9 +47,9 @@ cd path/to/your-project
 sh ~/plangate/install.sh   # .claude/ と .codex/ を自動検出
 ```
 
-## 同梱範囲（plugin 8.10.0）
+## 同梱範囲（plugin 8.11.0）
 
-### Skills (38)  <!-- 実数: ls plugin/plangate/skills/ -->
+### Skills (37)  <!-- 実数: ls plugin/plangate/skills/ -->
 
 | Skill | 役割 |
 |-------|------|

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -143,7 +143,7 @@ sh plugin/plangate/scripts/install-plangate-skills.sh --force
 ```text
 plugin/plangate/
 ├── .claude-plugin/
-│   └── plugin.json         # manifest (v8.10.0)
+│   └── plugin.json         # manifest (v8.11.0)
 ├── agents/                 # 23 agents
 ├── assets/                 # アイコン等のアセット
 │   └── plangate-small.svg  # icon_small / icon_large 兼用 (SVG)


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
v8.11.0 リリース直後の Codex・Gemini レビュー + セルフレビューで検出したドキュメント最新性の問題を修正。

## Critical（Gemini）
Marketplace 経由の Codex インストール手順が clone 無しに `sh ~/plangate/install.sh --codex` を実行させ、install.sh 不在でコピペ失敗していた（README.md / README_en.md / getting-started.md）。
→ Codex は `marketplace add` のみとし、スキル展開は Option B（clone + install.sh）へ誘導。

## Major（セルフ + Gemini）: version 最新性
- README.md / README_en.md: 最新リリース v8.10.0 → v8.11.0
- docs/changelog.md: sync-release-docs.sh で v8.11.0 同期
- plugin README / migration: version 8.10.0 → 8.11.0

## Minor
- migration: Skills (38) → (37)

## Human TODO（HO パス）
- CLAUDE.md L13 の「## v8.10.0 …（最新リリース機能）」見出しは HO パスのため Human が v8.11.0 へ更新してください。

## 検証
- CI globs 対象 21 ファイル: markdown lint 0 error
- Critical: Marketplace セクションから install.sh 行を削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)