### PR TITLE
feat(#455): README/docs の実在しない codex コマンドを CI 検査

### DIFF
--- a/scripts/check-codex-commands.sh
+++ b/scripts/check-codex-commands.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# check-codex-commands.sh — README/docs に実在しない codex サブコマンドが
+# 「コマンド例」として含まれていないか検査する。
+#
+# v8.11.0 の Critical Fix（実在しない `codex plugin install` の誤記）の再発防止。
+# 注記文（「〜はありません」等の説明）は許容し、コマンド例（行頭が codex の行）のみ検査する。
+#
+# Usage: sh scripts/check-codex-commands.sh [--warn-only]
+# Exit: 0=OK, 1=invalid command example found（--warn-only 時は常に 0）
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+WARN_ONLY=0
+[ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
+
+cd "$REPO_ROOT"
+
+# 検査対象（docs/working/ は作業ログなので除外）
+TARGETS="README.md README_en.md docs plugin"
+
+# 実在しない / 未実装の codex サブコマンド（コマンド例として書いてはいけない）
+#   codex plugin install            — install サブコマンド自体が存在しない
+#   codex plugin marketplace list   — 現行 Codex CLI で未実装
+INVALID_CMDS="codex plugin install|codex plugin marketplace list"
+
+violations=0
+
+# 行頭（インデント可）が無効コマンドで始まる行 = コマンド例。
+# 説明文中の言及（行頭が記号や文字）は除外される。
+matches=$(grep -rnE "^[[:space:]]*(${INVALID_CMDS})([[:space:]]|\$)" $TARGETS 2>/dev/null \
+  | grep -v "docs/working/" || true)
+
+if [ -n "$matches" ]; then
+  printf '[check-codex] 実在しない codex コマンドがコマンド例として含まれています:\n'
+  printf '%s\n' "$matches"
+  printf '\n有効な codex plugin サブコマンド: marketplace / help\n'
+  printf '有効な marketplace サブコマンド: add / upgrade / remove / help\n'
+  violations=1
+fi
+
+if [ "$violations" = "0" ]; then
+  printf '[check-codex] OK: 無効な codex コマンド例なし\n'
+  exit 0
+fi
+
+if [ "$WARN_ONLY" = "1" ]; then
+  printf '[check-codex] --warn-only: 違反を検出しましたが継続します\n'
+  exit 0
+fi
+exit 1

--- a/tests/extras/ta-27-codex-commands.sh
+++ b/tests/extras/ta-27-codex-commands.sh
@@ -1,0 +1,56 @@
+# tests/extras/ta-27-codex-commands.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# #455: README/docs に実在しない codex コマンド例が無いことを検証
+
+printf '\n=== TA-27: codex-commands (#455) ===\n'
+
+PG_T27_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T27_SCRIPT="$PG_T27_ROOT/scripts/check-codex-commands.sh"
+
+t27_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t27_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# TC-01: スクリプト存在・実行可能
+if [ -f "$PG_T27_SCRIPT" ] && [ -x "$PG_T27_SCRIPT" ]; then
+  t27_pass "TC-01 check-codex-commands.sh 存在・実行可能"
+else
+  t27_fail "TC-01 check-codex-commands.sh 不在 or 非実行可能"
+fi
+
+# TC-02: sh -n syntax
+if sh -n "$PG_T27_SCRIPT" 2>/dev/null; then
+  t27_pass "TC-02 sh -n syntax check"
+else
+  t27_fail "TC-02 syntax error"
+fi
+
+# TC-03: 現状の repo はクリーン（exit 0）
+if sh "$PG_T27_SCRIPT" >/dev/null 2>&1; then
+  t27_pass "TC-03 現状 repo に無効 codex コマンド例なし（exit 0）"
+else
+  t27_fail "TC-03 無効 codex コマンド例を検出（exit 1）"
+fi
+
+# TC-04: 検出力 — 無効コマンド例を仕込んだ一時ディレクトリで exit 1
+_t27_tmp=$(mktemp -d)
+(
+  cd "$_t27_tmp" || exit 1
+  printf '# T\n```bash\ncodex plugin install plangate\n```\n' > README.md
+  mkdir -p docs plugin
+  grep -rnE "^[[:space:]]*(codex plugin install|codex plugin marketplace list)([[:space:]]|\$)" README.md >/dev/null 2>&1
+)
+_t27_detect=$?
+rm -rf "$_t27_tmp"
+if [ "$_t27_detect" = "0" ]; then
+  t27_pass "TC-04 無効コマンド例を検出できる（grep ロジック）"
+else
+  t27_fail "TC-04 無効コマンド例を検出できない"
+fi
+
+# TC-05: 注記文（行頭が codex でない）は誤検出しない
+_t27_note='> 注記: `codex plugin install` は存在しません'
+if printf '%s\n' "$_t27_note" | grep -qE "^[[:space:]]*(codex plugin install)([[:space:]]|\$)"; then
+  t27_fail "TC-05 注記文を誤検出した（false positive）"
+else
+  t27_pass "TC-05 注記文は誤検出しない"
+fi


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
v8.11.0 の Critical Fix（実在しない `codex plugin install` の誤記）の**根本原因対策**。docs に無効な codex コマンド例が混入しないか検査するスクリプトを追加。

- **scripts/check-codex-commands.sh**: `codex plugin install` / `codex plugin marketplace list`（未実装）がコマンド例として docs に含まれないか検査
  - 注記文（説明中の言及）は行頭判定で許容、コマンド例（行頭が codex の行）のみ検出
  - `--warn-only` 対応
- **tests/extras/ta-27-codex-commands.sh**: TC-01〜05（存在/syntax/現状クリーン/検出力/注記の誤検出なし）

## 検証
- `sh tests/run-tests.sh`: **240 passed, 0 failed**
- 自己テスト: 現状 repo はクリーン（exit 0）
- 検出力: 無効コマンド例を検出（exit 1）、注記文は誤検出しない

## Human TODO（HO パス）
CI への配線は `.github/workflows/`（HO パス）のため Human 適用が必要です。`ci.yml` または `sync-plugin-plangate.yml` に以下を追加してください:
```yaml
      - name: Check codex commands in docs
        run: sh scripts/check-codex-commands.sh
```

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)