### PR TITLE
feat(#453): plugin.json version と release tag の整合検証

### DIFF
--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# check-plugin-version.sh — plugin.json の version が最新 release tag と一致するか検証
+#
+# v8.11.0 で plugin.json version が release tag と乖離する事象（#453）の再発防止。
+# リリース後の整合検証に使う（開発中の version 先行を許容する場合は --warn-only）。
+#
+# Usage: sh scripts/check-plugin-version.sh [--warn-only]
+# Exit: 0=一致 or tag無し, 1=不一致（--warn-only 時は常に 0）
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+WARN_ONLY=0
+[ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
+
+PLUGIN_JSON="$REPO_ROOT/plugin/plangate/.claude-plugin/plugin.json"
+
+if [ ! -f "$PLUGIN_JSON" ]; then
+  printf '[plugin-version] ERROR: %s が存在しません\n' "$PLUGIN_JSON" >&2
+  exit 1
+fi
+command -v python3 >/dev/null 2>&1 || { printf '[plugin-version] ERROR: python3 required\n' >&2; exit 1; }
+
+PLUGIN_VERSION=$(python3 - "$PLUGIN_JSON" << 'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as f:
+        print(json.load(f).get('version', ''))
+except Exception:
+    print('')
+PYEOF
+)
+
+LATEST_TAG=$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)
+
+if [ -z "$LATEST_TAG" ]; then
+  printf '[plugin-version] WARN: release tag が見つかりません（検証スキップ）\n'
+  exit 0
+fi
+
+if [ "$PLUGIN_VERSION" = "$LATEST_TAG" ]; then
+  printf '[plugin-version] OK: plugin.json (%s) = tag (v%s)\n' "$PLUGIN_VERSION" "$LATEST_TAG"
+  exit 0
+fi
+
+printf '[plugin-version] MISMATCH: plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
+printf '  リリース時は plugin.json version を tag に合わせてください（sync-plugin-plangate.sh が CHANGELOG から自動更新）。\n' >&2
+[ "$WARN_ONLY" = "1" ] && { printf '[plugin-version] --warn-only: 継続\n'; exit 0; }
+exit 1

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -1,0 +1,48 @@
+# tests/extras/ta-28-plugin-version.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# #453: plugin.json version が最新 release tag と一致することを検証
+
+printf '\n=== TA-28: plugin-version (#453) ===\n'
+
+PG_T28_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T28_SCRIPT="$PG_T28_ROOT/scripts/check-plugin-version.sh"
+PG_T28_JSON="$PG_T28_ROOT/plugin/plangate/.claude-plugin/plugin.json"
+
+t28_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t28_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# TC-01: スクリプト存在・実行可能
+if [ -f "$PG_T28_SCRIPT" ] && [ -x "$PG_T28_SCRIPT" ]; then
+  t28_pass "TC-01 check-plugin-version.sh 存在・実行可能"
+else
+  t28_fail "TC-01 不在 or 非実行可能"
+fi
+
+# TC-02: sh -n syntax
+if sh -n "$PG_T28_SCRIPT" 2>/dev/null; then
+  t28_pass "TC-02 sh -n syntax check"
+else
+  t28_fail "TC-02 syntax error"
+fi
+
+# TC-03: plugin.json に version フィールドが存在
+if grep -q '"version"' "$PG_T28_JSON" 2>/dev/null; then
+  t28_pass "TC-03 plugin.json に version あり"
+else
+  t28_fail "TC-03 plugin.json に version なし"
+fi
+
+# TC-04: --warn-only は不一致でも exit 0
+if sh "$PG_T28_SCRIPT" --warn-only >/dev/null 2>&1; then
+  t28_pass "TC-04 --warn-only は exit 0"
+else
+  t28_fail "TC-04 --warn-only が exit 非0"
+fi
+
+# TC-05: version が v プレフィックスを持たない（8.11.0 形式）
+_t28_ver=$(python3 -c "import json; print(json.load(open('$PG_T28_JSON'))['version'])" 2>/dev/null || printf '')
+case "${_t28_ver:-}" in
+  v*) t28_fail "TC-05 plugin.json version に v プレフィックス（${_t28_ver:-}）" ;;
+  "") t28_fail "TC-05 plugin.json version 取得失敗" ;;
+  *)  t28_pass "TC-05 plugin.json version は v プレフィックスなし（${_t28_ver:-}）" ;;
+esac


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
v8.11.0 で plugin.json version が release tag と乖離した事象（#453）の再発防止。

- **scripts/check-plugin-version.sh**: `plugin/plangate/.claude-plugin/plugin.json` の version が最新 release tag（v 除去）と一致するか検証。tag 無し時はスキップ、`--warn-only` で開発中の version 先行を許容。
- **tests/extras/ta-28-plugin-version.sh**: TC-01〜05

## 検証
- ta-28: 5 passed, 0 failed
- 現状: plugin.json=8.11.0 = tag v8.11.0（一致）

## 補足
- repo 本体には `.codex-plugin/plugin.json` は存在せず `.claude-plugin/plugin.json` のみのため、それを対象としています（#456 の二重管理は repo 本体では非該当）。
- `sync-plugin-plangate.sh` が CHANGELOG から plugin.json version を自動更新する仕組みは既存。本スクリプトはその結果を CI/リリースで検証する補完です。

## Human TODO（HO パス）
CI 配線は `.github/workflows/`（HO パス）のため Human 適用が必要です。リリース後検証なら `--warn-only` 無し、常時 CI なら `--warn-only` を推奨:
```yaml
      - name: Check plugin.json version
        run: sh scripts/check-plugin-version.sh --warn-only
```

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)