### PR TITLE
chore(#452): コミット済み memory 汚染検査 + HOOKTEST 後片付け

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docs/working/_metrics/events.ndjson
 docs/working/_audit/hook-events.log.bak.*
 docs/working/_audit/skip-decision-log.jsonl.bak
 .tmp-metrics-events.ndjson
+
+# hook テストの一時産物（#452 後片付け）
+docs/working/TASK-HOOKTEST*/

--- a/scripts/check-committed-memory-pollution.sh
+++ b/scripts/check-committed-memory-pollution.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# check-committed-memory-pollution.sh — コミット済み SSoT に AI memory 汚染がないか検査
+#
+# pre-commit hook (scripts/hooks/check-ai-memory-pollution.sh) は staged 変更のみを
+# 検査するため、既にコミット済みの汚染（例: AGENTS.md に過去混入した
+# <claude-mem-context> ブロック）は検知できない。本スクリプトは CI 用に
+# 対象ファイル全体をスキャンし、コミット済み汚染の残存を検出する（#452）。
+#
+# Usage: sh scripts/check-committed-memory-pollution.sh [--warn-only]
+# Exit: 0=クリーン, 1=汚染検出（--warn-only 時は常に 0）
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+WARN_ONLY=0
+[ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
+
+# 検査対象 SSoT
+TARGETS="AGENTS.md CLAUDE.md"
+# AI memory ツール（claude-mem 等）が自動挿入する汚染パターン
+PATTERN='<claude-mem-context>|</claude-mem-context>|get_observations|mem-search skill'
+
+found=0
+for f in $TARGETS; do
+  [ -f "$REPO_ROOT/$f" ] || continue
+  if grep -nE "$PATTERN" "$REPO_ROOT/$f" >/dev/null 2>&1; then
+    printf '[mem-pollution] %s に AI memory 汚染パターンを検出:\n' "$f"
+    grep -nE "$PATTERN" "$REPO_ROOT/$f" | sed 's/^/  /'
+    found=1
+  fi
+done
+
+if [ "$found" = "0" ]; then
+  printf '[mem-pollution] OK: コミット済み SSoT に汚染なし\n'
+  exit 0
+fi
+
+printf '\n除去方法: 該当 SSoT から <claude-mem-context>...</claude-mem-context> ブロックを削除してください。\n'
+[ "$WARN_ONLY" = "1" ] && { printf '[mem-pollution] --warn-only: 継続\n'; exit 0; }
+exit 1

--- a/scripts/check-committed-memory-pollution.sh
+++ b/scripts/check-committed-memory-pollution.sh
@@ -15,17 +15,21 @@ REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 WARN_ONLY=0
 [ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
 
-# 検査対象 SSoT
-TARGETS="AGENTS.md CLAUDE.md"
+# 検査対象 SSoT（POLLUTION_TARGET_FILES で上書き可、絶対/相対パス両対応）
+TARGETS="${POLLUTION_TARGET_FILES:-AGENTS.md CLAUDE.md}"
 # AI memory ツール（claude-mem 等）が自動挿入する汚染パターン
 PATTERN='<claude-mem-context>|</claude-mem-context>|get_observations|mem-search skill'
 
 found=0
 for f in $TARGETS; do
-  [ -f "$REPO_ROOT/$f" ] || continue
-  if grep -nE "$PATTERN" "$REPO_ROOT/$f" >/dev/null 2>&1; then
+  case "$f" in
+    /*) fpath="$f" ;;
+    *)  fpath="$REPO_ROOT/$f" ;;
+  esac
+  [ -f "$fpath" ] || continue
+  if grep -nE "$PATTERN" "$fpath" >/dev/null 2>&1; then
     printf '[mem-pollution] %s に AI memory 汚染パターンを検出:\n' "$f"
-    grep -nE "$PATTERN" "$REPO_ROOT/$f" | sed 's/^/  /'
+    grep -nE "$PATTERN" "$fpath" | sed 's/^/  /'
     found=1
   fi
 done

--- a/tests/extras/ta-29-committed-pollution.sh
+++ b/tests/extras/ta-29-committed-pollution.sh
@@ -31,22 +31,22 @@ else
   t29_fail "TC-03 --warn-only が exit 非0"
 fi
 
-# TC-04: 検出力 — 汚染を仕込んだ一時ファイルで grep 検出
+# TC-04: 検出力 — 実スクリプトを汚染フィクスチャに対して実行（exit 1 期待）
 _t29_tmp=$(mktemp)
 printf '# T\n<claude-mem-context>\nget_observations([1])\n</claude-mem-context>\n' > "$_t29_tmp"
-if grep -qE '<claude-mem-context>|get_observations' "$_t29_tmp" 2>/dev/null; then
-  t29_pass "TC-04 汚染パターンを検出できる（grep ロジック）"
+if POLLUTION_TARGET_FILES="$_t29_tmp" sh "$PG_T29_SCRIPT" >/dev/null 2>&1; then
+  t29_fail "TC-04 汚染を検出できず exit 0 になった"
 else
-  t29_fail "TC-04 汚染パターンを検出できない"
+  t29_pass "TC-04 汚染フィクスチャを実スクリプトが検出（exit 1）"
 fi
 rm -f "$_t29_tmp"
 
-# TC-05: クリーンなファイルは誤検出しない
+# TC-05: クリーンなファイルは実スクリプトで誤検出しない（exit 0 期待）
 _t29_clean=$(mktemp)
 printf '# AGENTS\nThis is a clean repo instruction file.\nMemory: persistent.\n' > "$_t29_clean"
-if grep -qE '<claude-mem-context>|</claude-mem-context>|get_observations|mem-search skill' "$_t29_clean" 2>/dev/null; then
-  t29_fail "TC-05 クリーンなファイルを誤検出した"
+if POLLUTION_TARGET_FILES="$_t29_clean" sh "$PG_T29_SCRIPT" >/dev/null 2>&1; then
+  t29_pass "TC-05 クリーンフィクスチャは実スクリプトで誤検出しない（exit 0）"
 else
-  t29_pass "TC-05 クリーンなファイルは誤検出しない"
+  t29_fail "TC-05 クリーンなファイルを誤検出した（exit 1）"
 fi
 rm -f "$_t29_clean"

--- a/tests/extras/ta-29-committed-pollution.sh
+++ b/tests/extras/ta-29-committed-pollution.sh
@@ -1,0 +1,52 @@
+# tests/extras/ta-29-committed-pollution.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# #452: コミット済み SSoT の AI memory 汚染検査スクリプトの検証
+
+printf '\n=== TA-29: committed-pollution (#452) ===\n'
+
+PG_T29_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T29_SCRIPT="$PG_T29_ROOT/scripts/check-committed-memory-pollution.sh"
+
+t29_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t29_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# TC-01: スクリプト存在・実行可能
+if [ -f "$PG_T29_SCRIPT" ] && [ -x "$PG_T29_SCRIPT" ]; then
+  t29_pass "TC-01 check-committed-memory-pollution.sh 存在・実行可能"
+else
+  t29_fail "TC-01 不在 or 非実行可能"
+fi
+
+# TC-02: sh -n syntax
+if sh -n "$PG_T29_SCRIPT" 2>/dev/null; then
+  t29_pass "TC-02 sh -n syntax check"
+else
+  t29_fail "TC-02 syntax error"
+fi
+
+# TC-03: --warn-only は汚染があっても exit 0
+if sh "$PG_T29_SCRIPT" --warn-only >/dev/null 2>&1; then
+  t29_pass "TC-03 --warn-only は exit 0"
+else
+  t29_fail "TC-03 --warn-only が exit 非0"
+fi
+
+# TC-04: 検出力 — 汚染を仕込んだ一時ファイルで grep 検出
+_t29_tmp=$(mktemp)
+printf '# T\n<claude-mem-context>\nget_observations([1])\n</claude-mem-context>\n' > "$_t29_tmp"
+if grep -qE '<claude-mem-context>|get_observations' "$_t29_tmp" 2>/dev/null; then
+  t29_pass "TC-04 汚染パターンを検出できる（grep ロジック）"
+else
+  t29_fail "TC-04 汚染パターンを検出できない"
+fi
+rm -f "$_t29_tmp"
+
+# TC-05: クリーンなファイルは誤検出しない
+_t29_clean=$(mktemp)
+printf '# AGENTS\nThis is a clean repo instruction file.\nMemory: persistent.\n' > "$_t29_clean"
+if grep -qE '<claude-mem-context>|</claude-mem-context>|get_observations|mem-search skill' "$_t29_clean" 2>/dev/null; then
+  t29_fail "TC-05 クリーンなファイルを誤検出した"
+else
+  t29_pass "TC-05 クリーンなファイルは誤検出しない"
+fi
+rm -f "$_t29_clean"


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
#452（AGENTS.md の claude-mem 汚染）の **AI 分担**（CI 検知スクリプト）+ リポジトリ後片付け。

### #452 AI 分担: コミット済み汚染の検知
既存 `scripts/hooks/check-ai-memory-pollution.sh` は **pre-commit（staged のみ）** のため、既にコミット済みの汚染（AGENTS.md L51-81）を検知できません。これを補完する CI 用全スキャンを追加:
- **scripts/check-committed-memory-pollution.sh**: AGENTS.md / CLAUDE.md を全体スキャン。`--warn-only` 対応
- **tests/extras/ta-29**: TC-01〜05
- 実行確認: 現状 AGENTS.md の汚染を正しく検出

### 後片付け
- `.gitignore`: hook テスト残骸 `docs/working/TASK-HOOKTEST*/` を除外

## Human TODO（HO パス・AI 編集不可）
1. **AGENTS.md（HO）から `<claude-mem-context>...</claude-mem-context>`（L51-81）を除去**
2. 除去後、`.github/workflows`（HO）に検査ステップを配線:
   ```yaml
   - name: Check committed memory pollution
     run: sh scripts/check-committed-memory-pollution.sh
   ```
   （除去前は `--warn-only` 推奨）

## 検証
- ta-29: 5 passed, 0 failed
- 検出力: AGENTS.md 汚染を検出 / クリーンファイルは誤検出なし

Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)