### PR TITLE
feat(#463): 運用ガード 3 点の非HO 分を整備

### DIFF
--- a/.agents/skills/working-context/SKILL.md
+++ b/.agents/skills/working-context/SKILL.md
@@ -30,6 +30,7 @@ PlanGate の `docs/working/TASK-XXXX/` 配下を **L0〜L3 の Progressive Discl
 - INDEX.md が無ければフォールバックで status.md を直接読む（旧形式互換）
 - セッション開始は L0 → L1 の順で必要分だけ読む（不要 read を抑制）
 - 計画からの逸脱は status.md「計画からの変更点」セクションに記録
+- **status.md のフェーズ履歴は `YYYY-MM-DD HH:mm`（分まで）を必須**とする（#463）。日付のみ・時刻欠落は不可。セッション跨ぎ・同日複数フェーズ遷移の順序を一意に追跡するため。テンプレート: `docs/working/templates/status.md`
 - handoff.md は WF-05 完了時に 1 回発行（6 要素は `.claude/rules/working-context.md` および `docs/working/templates/handoff.md` を正本とする）
 
 ## CLI 呼び出し

--- a/.codex/agents/workflow_conductor.toml
+++ b/.codex/agents/workflow_conductor.toml
@@ -34,6 +34,15 @@ Ready → In Progress
   → Done
 
 詳細定義: .claude/agents/workflow-conductor.md を参照。
+
+【Codex runtime での conductor 相当運用（#463）】
+Codex CLI では Claude Code の Task ツールによる sub-agent 起動ができないため、
+workflow-conductor を「別エージェントとして起動」する形は取れない。代わりに、
+本 conductor 指示を Codex セッションの司令塔ロールとして読み込み、フェーズ遷移の
+調整・品質ゲート確認を **メインセッションが直接代行** する（status.md / todo.md
+への記録は維持）。実装・テスト・git 書き込みは委譲先（codex exec 等）が行い、
+conductor ロールはあくまで調整に徹する（Iron Law 不変）。
+正本の権威ある記述は .claude/agents/workflow-conductor.md（HO）側で更新される。
 ワークフロー詳細: docs/plangate.md を参照。
 プロジェクト指示は AGENTS.md → docs/ai/project-rules.md（正本）を参照。日本語でやり取りする。
 """

--- a/docs/ai/external-reviewer-interface.md
+++ b/docs/ai/external-reviewer-interface.md
@@ -259,3 +259,34 @@ reviewers:
         evidence: finding.body
         location: "finding.id"
 ```
+
+
+## 10. 外部レビュー実行不可時の記録規約（#463）
+
+C-2 / V-3 の外部 AI レビューが**実行不可**（CLI 未導入・API 不達・quota 超過・ネットワーク遮断等）の場合、`review-external.md` に以下を**必須記録**する。これにより「指摘なし（実行したが finding ゼロ）」と「実行不可（実行できなかった）」を区別し、監査連続性を保つ。
+
+### 必須記録項目（`unavailable` 時）
+
+| 項目 | 説明 |
+|------|------|
+| `実行状態` | `executed` / `unavailable` を明示 |
+| `実行不可の理由` | 具体的事由（例: `codex CLI 未導入` / `Gemini quota 超過`）|
+| `代替レビュー観点` | セルフレビュー（C-1）で補った観点、または後追いレビューの予定 |
+| `未充足リスク` | 外部レビュー欠如で残るリスク（severity 相当の見積り）|
+
+### 判定への影響
+
+- `unavailable` かつ上記 3 項目が記録されていれば、C-3 / 後続フェーズは**条件付きで進行可**（未充足リスクを承認境界の判断材料にする）。
+- `unavailable` なのに理由・代替観点・未充足リスクが空欄の場合、監査上**無効**として扱い、レビュー成果物を FAIL とする。
+
+### events 連携（#230 と additive）
+
+将来 events 化する場合の最小フィールド:
+
+```json
+{ "review_id": "R-NNN", "lane": "design|codebase|security",
+  "review_status": "executed|unavailable",
+  "unavailable_reason": "<string|null>", "residual_risk": "<string|null>" }
+```
+
+テンプレート: [`docs/working/templates/review-external.md`](../working/templates/review-external.md) の「外部レビュー実行可否（必須）」セクション。

--- a/docs/ai/external-reviewer-interface.md
+++ b/docs/ai/external-reviewer-interface.md
@@ -276,8 +276,8 @@ C-2 / V-3 の外部 AI レビューが**実行不可**（CLI 未導入・API 不
 
 ### 判定への影響
 
-- `unavailable` かつ上記 3 項目が記録されていれば、C-3 / 後続フェーズは**条件付きで進行可**（未充足リスクを承認境界の判断材料にする）。
-- `unavailable` なのに理由・代替観点・未充足リスクが空欄の場合、監査上**無効**として扱い、レビュー成果物を FAIL とする。
+- `unavailable` かつ上記 `unavailable` 時必須の 3 項目（実行不可の理由 / 代替レビュー観点 / 未充足リスク）が記録されていれば、C-3 / 後続フェーズは**条件付きで進行可**（未充足リスクを承認境界の判断材料にする）。この場合、`review-external.md` のフロントマター `verdict` は **`WARN`** とする。
+- `unavailable` なのに理由・代替観点・未充足リスクが空欄の場合、監査上**無効**として扱い、レビュー成果物を **FAIL** とする。この場合、フロントマター `verdict` は **`FAIL`** とする。
 
 ### events 連携（#230 と additive）
 
@@ -286,7 +286,9 @@ C-2 / V-3 の外部 AI レビューが**実行不可**（CLI 未導入・API 不
 ```json
 { "review_id": "R-NNN", "lane": "design|codebase|security",
   "review_status": "executed|unavailable",
-  "unavailable_reason": "<string|null>", "residual_risk": "<string|null>" }
+  "unavailable_reason": "<string|null>",
+  "alternative_perspective": "<string|null>",
+  "residual_risk": "<string|null>" }
 ```
 
 テンプレート: [`docs/working/templates/review-external.md`](../working/templates/review-external.md) の「外部レビュー実行可否（必須）」セクション。

--- a/docs/working/templates/review-external.md
+++ b/docs/working/templates/review-external.md
@@ -10,9 +10,24 @@ created_by: orchestrator
 
 # TASK-XXXX 外部AIレビュー結果（C-2）
 
-> レビュー日: YYYY-MM-DD
+> レビュー日時: YYYY-MM-DD HH:mm
 > レビューア: orchestrator → {backend-specialist, frontend-specialist, explorer}
 > 判定: **PASS** / **WARN** / **FAIL** — critical={0}, major={0}, minor={0}
+
+## 外部レビュー実行可否（必須）
+
+外部 AI レビューが**実行不可**だった場合は、このセクションを必ず記録する（空欄不可）。
+「指摘なし（実行したが finding ゼロ）」と「実行不可（そもそも実行できなかった）」を**区別する**こと。
+
+| 項目 | 内容 |
+|------|------|
+| **実行状態** | `executed`（実行済み） / `unavailable`（実行不可） |
+| **実行不可の理由** | （unavailable 時必須）例: codex CLI 未導入 / Gemini quota 超過 / API 不達 / ネットワーク遮断 |
+| **代替レビュー観点** | （unavailable 時必須）セルフレビューで補った観点、または後追いレビューの予定 |
+| **未充足リスク** | （unavailable 時必須）外部レビュー欠如により残るリスクの明示（critical/major/minor 相当の見積り）|
+
+> 実行状態が `executed` の場合は本セクションを「実行済み・finding は下記」と1行で済ませてよい。
+> `unavailable` の場合、理由・代替観点・未充足リスクの3点が空欄だと監査上 **無効**（FAIL 扱い）。
 
 ## サマリー
 

--- a/docs/working/templates/review-external.md
+++ b/docs/working/templates/review-external.md
@@ -27,7 +27,7 @@ created_by: orchestrator
 | **未充足リスク** | （unavailable 時必須）外部レビュー欠如により残るリスクの明示（critical/major/minor 相当の見積り）|
 
 > 実行状態が `executed` の場合は本セクションを「実行済み・finding は下記」と1行で済ませてよい。
-> `unavailable` の場合、理由・代替観点・未充足リスクの3点が空欄だと監査上 **無効**（FAIL 扱い）。
+> `unavailable` の場合、理由・代替観点・未充足リスクの3点が空欄だと監査上 **無効**（フロントマター `verdict` は `FAIL` 扱い）。すべて記録されていれば条件付き進行可（`verdict` は `WARN` 扱い）。
 
 ## サマリー
 

--- a/docs/working/templates/status.md
+++ b/docs/working/templates/status.md
@@ -1,0 +1,45 @@
+# TASK-XXXX 作業ステータス
+
+> 最終更新: YYYY-MM-DD HH:mm
+> 現在フェーズ: {plan / exec / review / verify / done}
+> モード: {ultra-light / light / standard / high-risk / critical}
+
+## フェーズ履歴
+
+> **日時は `YYYY-MM-DD HH:mm`（分まで）必須**（#463）。日付のみ・時刻欠落は不可。
+
+| 日時 (YYYY-MM-DD HH:mm) | フェーズ | 結果 / メモ |
+|------------------------|---------|------------|
+| YYYY-MM-DD HH:mm | A: PBI INPUT | 作成完了 |
+| YYYY-MM-DD HH:mm | B: plan 生成 | plan/todo/test-cases 生成 |
+| YYYY-MM-DD HH:mm | C-3 Gate | APPROVED / CONDITIONAL / REJECTED |
+| YYYY-MM-DD HH:mm | D: exec | 実装完了 |
+| YYYY-MM-DD HH:mm | V-1 | PASS / FAIL / WARN |
+
+## 全体構成（PR 一覧）
+
+| PR | ブランチ | 状態 |
+|----|---------|------|
+| #NNN | feat/task-xxxx | OPEN / MERGED |
+
+## 残タスク
+
+- [ ] {タスク}
+
+## 計画からの変更点
+
+- {リネーム・削除・設計変更などの差分}
+
+## V 系ステップ進捗
+
+| ステップ | 結果 |
+|---------|------|
+| L-0 | — |
+| V-1 | — |
+| V-2 | — |
+| V-3 | — |
+| V-4 | — |
+
+## 次の作業（Claude Code プロンプト）
+
+{コンテキスト・背景・具体的タスクを含む次回用プロンプト}


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
Issue #463（status 日時・外部レビュー不可時・runtime 差分の運用ガード）の **AI 完結分（非HO）** を整備。Codex 相談に基づき HO なしで価値を出せる順に実装。

### (2) 外部レビュー実行不可時の記録様式 — 非HO 完結
- **review-external.md テンプレート**: 「外部レビュー実行可否（必須）」セクション追加（実行状態 / 理由 / 代替観点 / 未充足リスク）。「指摘なし」と「実行不可」を区別
- **external-reviewer-interface.md**: §10「実行不可時の記録規約」追加（判定への影響・events 案含む）

### (1) status.md フェーズ履歴の日時必須 — 非HO 完結
- **working-context/SKILL.md**: `YYYY-MM-DD HH:mm`（分まで）必須を明記
- **docs/working/templates/status.md**: 新規作成（従来 status テンプレート不在を解消）

### (3) Codex runtime conductor 運用 — 非HO 補足
- **.codex/agents/workflow_conductor.toml**: Task ツール非対応の Codex ではメインセッションが conductor ロールを代行する旨を補足

## 検証
- CI globs 対象 markdown lint: **0 error**
- status テンプレートの MD060（15件）は既存テンプレート（handoff 52 / review-external 14）と同じ新ルール由来でリポジトリ全体の別軸課題（CI 対象外）

## Human TODO（HO パス）
- `.claude/rules/working-context.md`: status 日時必須の正本反映
- `.claude/agents/workflow-conductor.md`: runtime conductor 運用の権威ある記述
- `.claude/rules/review-principles.md`: 外部レビュー不可記録の正本反映（任意・IF 参照で代替可）

Refs #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)