### PR TITLE
chore: markdownlint MD060(table-column-style) を無効化

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,9 @@
 {
   "config": {
     "MD013": false,
-    "MD024": { "siblings_only": true }
+    "MD024": {
+      "siblings_only": true
+    },
+    "MD060": false
   }
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,9 +1,10 @@
 {
   "config": {
     "MD013": false,
-    "MD024": {
-      "siblings_only": true
-    },
+    "MD024": { "siblings_only": true },
+    // MD060: table-column-style (markdownlint v0.40.0 新ルール) は
+    // テンプレート等で 324 件発火しローカル lint を汚染するため無効化。
+    // CI globs 対象では元々 0 件のため検査内容は実質不変。
     "MD060": false
   }
 }


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
markdownlint v0.40.0 の新ルール **MD060（table-column-style）** を `.markdownlint-cli2.jsonc` で無効化。

## 背景
MD060 が CI 対象外の `docs/templates` だけで **324 件**発火し、ローカル lint を大量エラーで汚染していた（migration doc / plugin README / status テンプレート等の作業で繰り返し遭遇）。

## 安全性
- **CI globs 対象**（README.md / docs/index.md / docs/philosophy.md / docs/oss-governance.md / CHANGELOG.md / docs/workflows/** / 各 OSS ファイル）の MD060 は**元々 0 件** → 無効化しても CI の実質検査内容は不変
- compact テーブルスタイルの強制は不要。無効化でローカルと CI の lint 結果が一致しノイズが消える

## 検証
- CI globs 対象: **0 error 維持**
- `docs/templates`: MD060 が **324→0 件**

Codex 相談で最優先（ultra-light・HO 外・即効・安全）と評価された対応です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)