### PR TITLE
docs: Why PlanGate の Gemini 指摘対応（相対リンク・index 整合性）

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ PlanGate は **「計画の精度が実装品質を方向づける」** とい�
 
 ## 新規利用者: 最初に読む
 
-PlanGate を初めて知った方は、まず **[Why PlanGate](./pages/explanation/product/why-plangate.md)**（約 3 分）で「自分に必要か」を判断してください。その後、以下の順に **15-30 分** で読むことを推奨します。
+PlanGate を初めて知った方は、まず **[Why PlanGate][why-plangate]**（約 3 分）で「自分に必要か」を判断してください。その後、以下の順に **15-30 分** で読むことを推奨します。
 
 1. **[PlanGate ガイド](./plangate.md)** — 全体像・5 フェーズ・解決する問題（約 5 分）
 2. **[段階的導入ガイド (Phase 0 = 正本)](./staged-adoption-guide.md#phase-0-体験day-1)** — Level 1 (Day 1) から始める **30 分初回体験の正本**（約 10 分）

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ PlanGate は **「計画の精度が実装品質を方向づける」** とい�
 
 ![Harness Engineering と PlanGate の関係](assets/harness-plangate-readme-dark-v2.png)
 
-## 新規利用者: 最初に読む 3 ページ
+## 新規利用者: 最初に読む
 
-PlanGate を初めて知った方は、以下の順に **15-30 分** で読むことを推奨します。
+PlanGate を初めて知った方は、まず **[Why PlanGate](./pages/explanation/product/why-plangate.md)**（約 3 分）で「自分に必要か」を判断してください。その後、以下の順に **15-30 分** で読むことを推奨します。
 
 1. **[PlanGate ガイド](./plangate.md)** — 全体像・5 フェーズ・解決する問題（約 5 分）
 2. **[段階的導入ガイド (Phase 0 = 正本)](./staged-adoption-guide.md#phase-0-体験day-1)** — Level 1 (Day 1) から始める **30 分初回体験の正本**（約 10 分）

--- a/docs/pages/explanation/product/why-plangate.md
+++ b/docs/pages/explanation/product/why-plangate.md
@@ -139,4 +139,4 @@ ultra-light モードでは計画フェーズを省略し、**1 タスクを最�
 | [Product Overview](./overview.md) | 概要、対象ユーザー、価値、仕組み |
 | [Positioning](./positioning.md) | 競合・代替手段との差別化 |
 
-[staged-adoption]: https://github.com/s977043/PlanGate/blob/main/docs/staged-adoption-guide.md
+[staged-adoption]: ../../../staged-adoption-guide.md


### PR DESCRIPTION
<!-- skip-issue-link-check -->

## Summary
PR #468（Why PlanGate 新設）への Gemini レビュー 2 件を followup 対応。

| 指摘 | 対応 |
|------|------|
| `why-plangate.md` の staged-adoption が GitHub 絶対 URL | 相対パス `../../../staged-adoption-guide.md` に変更（オフライン/ブランチ間で機能） |
| `docs/index.md` で「最初に読む」と紹介しつつ上部の推奨読書セクションに未収録 | Why PlanGate を導入検討者の入口として**筆頭**に追加し整合 |

## 検証
- markdown lint: **0 error**（CI 対象の docs/index.md 含む）
- 相対リンク `docs/staged-adoption-guide.md` 実在確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)