### PR TITLE
docs(why-plangate): 導入3ステップの前提明記でオンボーディング離脱を防止

### DIFF
--- a/docs/pages/explanation/product/why-plangate.md
+++ b/docs/pages/explanation/product/why-plangate.md
@@ -86,9 +86,18 @@ codex plugin marketplace add s977043/PlanGate
 sh install.sh --codex
 ```
 
+> **次のステップ 2・3 を実行するには、リポジトリの clone が必要です。** Marketplace 導入はスキル / コマンドを配布しますが、ゲートを機械強制する `bin/plangate` と hook 本体はリポジトリに含まれます。clone してそのルートで作業してください。
+>
+> ```bash
+> git clone https://github.com/s977043/PlanGate.git
+> cd PlanGate   # 以降のコマンドはこのルートで実行
+> ```
+>
+> **前提**: `python3`（hook / doctor が使用）。`python3 --version` で確認できます。
+
 ### 2. hook 強制を配線（必須）
 
-承認境界の保護（plan_hash / forbidden_files）は hook で機械強制されます。**これを配線しないと保護が無効** です。
+承認境界の保護（plan_hash / forbidden_files）は hook で機械強制されます。**これを配線しないと保護が無効** です。リポジトリのルートで実行します。
 
 ```bash
 bin/plangate doctor --fix
@@ -99,6 +108,8 @@ bin/plangate doctor --fix --yes
 ```
 
 ### 3. Phase 0 を体験 — ultra-light で 1 タスク完了
+
+同じくリポジトリのルートで実行します。
 
 ```bash
 bin/plangate init <TASK-番号>   # 例: bin/plangate init TASK-0001
@@ -126,6 +137,12 @@ ultra-light モードでは計画フェーズを省略し、**1 タスクを最�
 - **導入 1 ヶ月後**: C-3 / C-4 の 2 ゲートがチームの標準リズムになり、承認後の改ざん・scope 外編集が hook で自動検知される。AI 作業の成功・失敗を後から説明できる状態が定着する。
 
 > Phase の詳細・各コンポーネントの昇格手順は [段階的導入ガイド][staged-adoption] を参照してください。
+
+---
+
+## まず試す
+
+迷ったら **Phase 0 を 1 タスクだけ** 試してください。チーム全体の合意も、フル運用の決断もまだ要りません。clone → `bin/plangate doctor --fix` → `bin/plangate init TASK-0001` の 3 コマンドで、AI が承認前にコードを書かない体験を 5 分で確認できます。合わなければ捨てるだけ、コストはほぼゼロです。
 
 ---
 

--- a/docs/pages/explanation/product/why-plangate.md
+++ b/docs/pages/explanation/product/why-plangate.md
@@ -86,7 +86,7 @@ codex plugin marketplace add s977043/PlanGate
 sh install.sh --codex
 ```
 
-> **次のステップ 2・3 を実行するには、リポジトリの clone が必要です。** Marketplace 導入はスキル / コマンドを配布しますが、ゲートを機械強制する `bin/plangate` と hook 本体はリポジトリに含まれます。clone してそのルートで作業してください。
+> **次のステップ 2・3 を実行するには、PlanGate リポジトリの clone が必要です。** Marketplace 導入はスキル / コマンドを配布しますが、ゲートを機械強制する `bin/plangate` と hook 本体は PlanGate リポジトリに含まれます。clone してそのルートで作業してください。
 >
 > ```bash
 > git clone https://github.com/s977043/PlanGate.git
@@ -97,7 +97,7 @@ sh install.sh --codex
 
 ### 2. hook 強制を配線（必須）
 
-承認境界の保護（plan_hash / forbidden_files）は hook で機械強制されます。**これを配線しないと保護が無効** です。リポジトリのルートで実行します。
+承認境界の保護（plan_hash / forbidden_files）は hook で機械強制されます。**これを配線しないと保護が無効** です。PlanGate リポジトリのルートで実行します。
 
 ```bash
 bin/plangate doctor --fix
@@ -109,7 +109,7 @@ bin/plangate doctor --fix --yes
 
 ### 3. Phase 0 を体験 — ultra-light で 1 タスク完了
 
-同じくリポジトリのルートで実行します。
+同じく PlanGate リポジトリのルートで実行します。
 
 ```bash
 bin/plangate init <TASK-番号>   # 例: bin/plangate init TASK-0001
@@ -142,7 +142,7 @@ ultra-light モードでは計画フェーズを省略し、**1 タスクを最�
 
 ## まず試す
 
-迷ったら **Phase 0 を 1 タスクだけ** 試してください。チーム全体の合意も、フル運用の決断もまだ要りません。clone → `bin/plangate doctor --fix` → `bin/plangate init TASK-0001` の 3 コマンドで、AI が承認前にコードを書かない体験を 5 分で確認できます。合わなければ捨てるだけ、コストはほぼゼロです。
+迷ったら **Phase 0 を 1 タスクだけ** 試してください。チーム全体の合意も、フル運用の決断もまだ要りません。`git clone` → `bin/plangate doctor --fix` → `bin/plangate init TASK-0001` の 3 コマンドで、AI が承認前にコードを書かない体験を 5 分で確認できます。合わなければ捨てるだけ、コストはほぼゼロです。
 
 ---
 


### PR DESCRIPTION
## 概要

`why-plangate.md`（導入検討者向けランディング）に対するセルフレビュー + 利用者視点レビューで検出された **major 2 件** を反映する。

## レビュー経緯

- **セルフレビュー（PASS）**: marketplace add / install.sh --codex / doctor --fix のコマンド整合、不正な `codex plugin install` 不在、全相対リンク有効を確認
- **利用者・マーケ視点レビュー（general-purpose agent）**: 以下の major を検出
  - 3 ステップが Marketplace 導入だけではつまずく（Step 2/3 の `bin/plangate` が存在しない / root 実行・python3 前提が未記載）
  - CTA が弱い（参照表で終わり、試す動線がない）
- Codex レビューは usage limit のため今回未実施

> C-3/C-4 略語の指摘は価値表で既に「実装前の計画承認 / PR 最終レビュー」と注釈済みのため追加対応なし。

## 変更内容

- Step 1 直後に **「Step 2/3 にはリポジトリ clone が必要」** を明記（`git clone` + `cd PlanGate`）。Marketplace 導入はスキル/コマンド配布、`bin/plangate`・hook 本体はリポジトリ同梱、という構造を説明
- **前提 `python3`** を明記
- Step 2/3 に「リポジトリのルートで実行」を追記
- 末尾に **「まず試す」CTA**（Phase 0 を 1 タスク、5 分、コストほぼゼロ）を追加

## 検証

- `markdownlint-cli2 docs/pages/explanation/product/why-plangate.md` → 0 error
- 既存リンク・参照は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)