### PR TITLE
fix(#456): plugin.json ↔ marketplace.json の version 二重管理を同期+検証でガード

### DIFF
--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -38,12 +38,40 @@ if [ -z "$LATEST_TAG" ]; then
   exit 0
 fi
 
-if [ "$PLUGIN_VERSION" = "$LATEST_TAG" ]; then
-  printf '[plugin-version] OK: plugin.json (%s) = tag (v%s)\n' "$PLUGIN_VERSION" "$LATEST_TAG"
+# marketplace.json の plugins[name==plangate].version も検証（#456）
+MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+MARKETPLACE_VERSION=""
+if [ -f "$MARKETPLACE_JSON" ]; then
+  MARKETPLACE_VERSION=$(python3 - "$MARKETPLACE_JSON" << 'PYMP'
+import json, sys
+try:
+    with open(sys.argv[1], encoding='utf-8') as f:
+        d = json.load(f)
+    for plug in d.get('plugins', []):
+        if plug.get('name') == 'plangate':
+            print(plug.get('version', ''))
+            break
+except Exception:
+    print('')
+PYMP
+)
+fi
+
+_mismatch=0
+if [ "$PLUGIN_VERSION" != "$LATEST_TAG" ]; then
+  printf '[plugin-version] MISMATCH: plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
+  _mismatch=1
+fi
+if [ -n "$MARKETPLACE_VERSION" ] && [ "$MARKETPLACE_VERSION" != "$LATEST_TAG" ]; then
+  printf '[plugin-version] MISMATCH: marketplace.json=%s / latest tag=v%s\n' "$MARKETPLACE_VERSION" "$LATEST_TAG" >&2
+  _mismatch=1
+fi
+
+if [ "$_mismatch" = "0" ]; then
+  printf '[plugin-version] OK: plugin.json (%s) = marketplace.json (%s) = tag (v%s)\n' "$PLUGIN_VERSION" "$MARKETPLACE_VERSION" "$LATEST_TAG"
   exit 0
 fi
 
-printf '[plugin-version] MISMATCH: plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
-printf '  リリース時は plugin.json version を tag に合わせてください（sync-plugin-plangate.sh が CHANGELOG から自動更新）。\n' >&2
+printf '  リリース時は plugin.json / marketplace.json version を tag に合わせてください（sync-plugin-plangate.sh が CHANGELOG から自動更新）。\n' >&2
 [ "$WARN_ONLY" = "1" ] && { printf '[plugin-version] --warn-only: 継続\n'; exit 0; }
 exit 1

--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -39,22 +39,32 @@ if [ -z "$LATEST_TAG" ]; then
 fi
 
 # marketplace.json の plugins[name==plangate].version も検証（#456）
+# 存在する以上は version を厳格に取得（parse 失敗・plangate 未定義・version 空は
+# サイレントスキップせずエラー扱い）
 MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
 MARKETPLACE_VERSION=""
+MARKETPLACE_ERR=""
 if [ -f "$MARKETPLACE_JSON" ]; then
   MARKETPLACE_VERSION=$(python3 - "$MARKETPLACE_JSON" << 'PYMP'
 import json, sys
 try:
     with open(sys.argv[1], encoding='utf-8') as f:
         d = json.load(f)
-    for plug in d.get('plugins', []):
-        if plug.get('name') == 'plangate':
-            print(plug.get('version', ''))
-            break
-except Exception:
-    print('')
+except Exception as e:
+    sys.stderr.write('parse-error: %s\n' % e)
+    sys.exit(1)
+for plug in d.get('plugins', []):
+    if plug.get('name') == 'plangate':
+        v = plug.get('version', '')
+        if not v:
+            sys.stderr.write('plangate plugin version が空\n')
+            sys.exit(1)
+        print(v)
+        sys.exit(0)
+sys.stderr.write('plangate plugin 定義が見つかりません\n')
+sys.exit(1)
 PYMP
-)
+) || MARKETPLACE_ERR=1
 fi
 
 _mismatch=0
@@ -62,7 +72,10 @@ if [ "$PLUGIN_VERSION" != "$LATEST_TAG" ]; then
   printf '[plugin-version] MISMATCH: plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
   _mismatch=1
 fi
-if [ -n "$MARKETPLACE_VERSION" ] && [ "$MARKETPLACE_VERSION" != "$LATEST_TAG" ]; then
+if [ -n "$MARKETPLACE_ERR" ]; then
+  printf '[plugin-version] ERROR: marketplace.json から plangate version を取得できません（存在するのに parse 失敗 / plangate 未定義 / version 空）\n' >&2
+  _mismatch=1
+elif [ -n "$MARKETPLACE_VERSION" ] && [ "$MARKETPLACE_VERSION" != "$LATEST_TAG" ]; then
   printf '[plugin-version] MISMATCH: marketplace.json=%s / latest tag=v%s\n' "$MARKETPLACE_VERSION" "$LATEST_TAG" >&2
   _mismatch=1
 fi

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -126,14 +126,22 @@ fi
 MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
 if [ -n "$_ver" ] && [ -f "$MARKETPLACE_JSON" ] && command -v python3 >/dev/null 2>&1; then
   _ver_noprefix="${_ver#v}"
-  _mp_changed=$(python3 - "$MARKETPLACE_JSON" "$_ver_noprefix" "$DRY_RUN" << 'PYJSON' 2>/dev/null || true
+  _mp_changed=$(python3 - "$MARKETPLACE_JSON" "$_ver_noprefix" "$DRY_RUN" << 'PYJSON'
 import json, sys
 path, ver, dry = sys.argv[1], sys.argv[2], sys.argv[3]
-with open(path, encoding='utf-8') as f:
-    d = json.load(f)
+try:
+    with open(path, encoding='utf-8') as f:
+        d = json.load(f)
+except Exception as e:
+    sys.stderr.write('marketplace.json read/parse error: %s\n' % e)
+    sys.exit(1)
+target = [p for p in d.get('plugins', []) if p.get('name') == 'plangate']
+if not target:
+    sys.stderr.write('marketplace.json に plangate plugin 定義がありません\n')
+    sys.exit(1)
 changed = []
-for plug in d.get('plugins', []):
-    if plug.get('name') == 'plangate' and plug.get('version') != ver:
+for plug in target:
+    if plug.get('version') != ver:
         changed.append('%s -> %s' % (plug.get('version'), ver))
         if dry != '1':
             plug['version'] = ver
@@ -143,7 +151,7 @@ if changed and dry != '1':
         f.write('\n')
 print(';'.join(changed))
 PYJSON
-)
+) || { _log "ERROR: marketplace.json 同期に失敗（parse 失敗 / plangate 未定義）"; exit 1; }
   if [ -n "$_mp_changed" ]; then
     if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE marketplace.json version: $_mp_changed"
     else _log "UPDATE marketplace.json version: $_mp_changed"; fi

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -122,6 +122,35 @@ PYEOF
   fi
 fi
 
+# marketplace.json の plugins[].version を更新（plugin.json と同期 / #456）
+MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+if [ -n "$_ver" ] && [ -f "$MARKETPLACE_JSON" ] && command -v python3 >/dev/null 2>&1; then
+  _ver_noprefix="${_ver#v}"
+  _mp_changed=$(python3 - "$MARKETPLACE_JSON" "$_ver_noprefix" "$DRY_RUN" << 'PYJSON' 2>/dev/null || true
+import json, sys
+path, ver, dry = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, encoding='utf-8') as f:
+    d = json.load(f)
+changed = []
+for plug in d.get('plugins', []):
+    if plug.get('name') == 'plangate' and plug.get('version') != ver:
+        changed.append('%s -> %s' % (plug.get('version'), ver))
+        if dry != '1':
+            plug['version'] = ver
+if changed and dry != '1':
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(d, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+print(';'.join(changed))
+PYJSON
+)
+  if [ -n "$_mp_changed" ]; then
+    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD UPDATE marketplace.json version: $_mp_changed"
+    else _log "UPDATE marketplace.json version: $_mp_changed"; fi
+    changed=1
+  fi
+fi
+
 if [ "$changed" = "1" ]; then
   _log "Sync complete — changes detected"
 else

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -46,3 +46,29 @@ case "${_t28_ver:-}" in
   "") t28_fail "TC-05 plugin.json version 取得失敗" ;;
   *)  t28_pass "TC-05 plugin.json version は v プレフィックスなし（${_t28_ver:-}）" ;;
 esac
+
+# TC-06: marketplace.json に plangate plugin の version フィールドが存在（#456）
+PG_T28_MP="$PG_T28_ROOT/.claude-plugin/marketplace.json"
+_t28_mpver=$(python3 - "$PG_T28_MP" << 'PYMP' 2>/dev/null || printf ''
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding='utf-8'))
+    for plug in d.get('plugins', []):
+        if plug.get('name') == 'plangate':
+            print(plug.get('version', '')); break
+except Exception:
+    print('')
+PYMP
+)
+if [ -n "${_t28_mpver:-}" ]; then
+  t28_pass "TC-06 marketplace.json に plangate version あり（${_t28_mpver:-}）"
+else
+  t28_fail "TC-06 marketplace.json に plangate version なし"
+fi
+
+# TC-07: plugin.json version == marketplace.json version（二重管理 drift なし / #456）
+if [ -n "${_t28_ver:-}" ] && [ "${_t28_ver:-}" = "${_t28_mpver:-}" ]; then
+  t28_pass "TC-07 plugin.json (${_t28_ver:-}) = marketplace.json (${_t28_mpver:-}) — version drift なし"
+else
+  t28_fail "TC-07 version drift: plugin.json=${_t28_ver:-} / marketplace.json=${_t28_mpver:-}"
+fi


### PR DESCRIPTION
## 概要

issue #456（plugin.json 二重管理）への対応。**実装着手前の実体調査で issue 前提と現状の差異が判明**したため、スコープを補正した（[#456 コメント](https://github.com/s977043/plangate/issues/456#issuecomment-4636297856)）。

### 実体調査結果

- `.codex-plugin/plugin.json` は**リポジトリにも git 履歴にも存在しない** → issue 記載の二重管理は実在せず
- 実在する二重管理: `plugin/plangate/.claude-plugin/plugin.json` の `version` ↔ ルート `.claude-plugin/marketplace.json` の `plugins[].version`
- `sync-plugin-plangate.sh` は plugin.json のみ自動更新、`check-plugin-version.sh` も plugin.json のみ検証 → **marketplace.json の version 取り残しリスクが現存**

## 変更内容（本質: version 更新漏れ防止 を実在対象に補正）

| ファイル | 変更 |
| --- | --- |
| `scripts/sync-plugin-plangate.sh` | marketplace.json の plangate plugin version も CHANGELOG 由来 version へ同期（plugin.json と同時更新、dry-run 対応） |
| `scripts/check-plugin-version.sh` | marketplace.json の version も release tag と検証。plugin.json / marketplace.json いずれかの drift で MISMATCH（exit 1） |
| `tests/extras/ta-28-plugin-version.sh` | TC-06（marketplace.json に version あり）/ TC-07（plugin.json == marketplace.json drift なし）を追加 |

→ 更新漏れ（sync）と取り残し（check）の双方をガード。

## 検証（実測）

- TA-28: **全 7 TC PASS**
- `check-plugin-version.sh`: 一致時 OK(exit 0) / marketplace 不一致で MISMATCH(exit 1) / 復元後 OK
- `sync --dry-run`: marketplace.json 同期検知（`0.0.1 -> 8.11.0`）
- `sh -n` 構文チェック: 両スクリプト OK

両スクリプトは `scripts/` 直下（非 HO）のため AI 対応範囲。

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)