### PR TITLE
feat(#451): Codex Plugin 状態のローカル検査 helper を追加

### DIFF
--- a/scripts/check-codex-plugin-status.sh
+++ b/scripts/check-codex-plugin-status.sh
@@ -34,9 +34,12 @@ except Exception:
     print('')
 PYV
 )
+# skill 数は POSIX 準拠のシェルループでカウント（find -mindepth/-maxdepth は非 POSIX）
 _repo_skills=0
 if [ -d "$REPO_SKILLS_DIR" ]; then
-  _repo_skills=$(find "$REPO_SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+  for _sk in "$REPO_SKILLS_DIR"/*/; do
+    [ -d "$_sk" ] && _repo_skills=$((_repo_skills + 1))
+  done
 fi
 printf '[codex-plugin] repo manifest: version=%s skills=%s\n' "${_repo_ver:-?}" "$_repo_skills"
 

--- a/scripts/check-codex-plugin-status.sh
+++ b/scripts/check-codex-plugin-status.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# check-codex-plugin-status.sh — Codex Plugin の登録・version・skill 数をローカル検査（#451）
+#
+# ネットワーク不要のローカル状態確認。`codex plugin marketplace list` が存在しない
+# 現行 CLI でも動くよう、marketplace cache を直接検査する。
+#
+# cache path は Codex CLI 実装依存:
+#   $CODEX_HOME/.tmp/marketplaces/plangate/  （CODEX_HOME 既定: ~/.codex）
+# 実装変更で path が変わり得るため、未検出でも fatal にせず「未登録」案内に留める。
+#
+# Usage: sh scripts/check-codex-plugin-status.sh [--online]
+#   --online: GitHub 最新リリースとの version 比較（opt-in、ネットワーク使用）
+# Exit: 常に 0（doctor の非 fatal セクション想定。検査結果は stdout に出す）
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ONLINE=0
+[ "${1:-}" = "--online" ] && ONLINE=1
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+MP_CACHE="$CODEX_HOME/.tmp/marketplaces/plangate"
+REPO_PLUGIN_JSON="$REPO_ROOT/plugin/plangate/.claude-plugin/plugin.json"
+REPO_SKILLS_DIR="$REPO_ROOT/plugin/plangate/skills"
+
+command -v python3 >/dev/null 2>&1 || { printf '[codex-plugin] python3 required\n' >&2; exit 0; }
+
+# --- リポジトリ側 manifest（常にローカルにある正）---
+_repo_ver=$(python3 - "$REPO_PLUGIN_JSON" << 'PYV' 2>/dev/null || printf ''
+import json, sys
+try:
+    print(json.load(open(sys.argv[1], encoding='utf-8')).get('version', ''))
+except Exception:
+    print('')
+PYV
+)
+_repo_skills=0
+if [ -d "$REPO_SKILLS_DIR" ]; then
+  _repo_skills=$(find "$REPO_SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+fi
+printf '[codex-plugin] repo manifest: version=%s skills=%s\n' "${_repo_ver:-?}" "$_repo_skills"
+
+# --- Codex marketplace cache 検査（登録状態）---
+if [ -d "$MP_CACHE" ]; then
+  printf '[codex-plugin] registered: YES (cache: %s)\n' "$MP_CACHE"
+  _cache_mp="$MP_CACHE/.claude-plugin/marketplace.json"
+  if [ -f "$_cache_mp" ]; then
+    _cache_ver=$(python3 - "$_cache_mp" << 'PYC' 2>/dev/null || printf ''
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding='utf-8'))
+    for plug in d.get('plugins', []):
+        if plug.get('name') == 'plangate':
+            print(plug.get('version', '')); break
+except Exception:
+    print('')
+PYC
+)
+    printf '[codex-plugin] cache version: %s\n' "${_cache_ver:-?}"
+    if [ -n "${_cache_ver:-}" ] && [ -n "${_repo_ver:-}" ] && [ "$_cache_ver" != "$_repo_ver" ]; then
+      printf '[codex-plugin] NOTE: cache(%s) != repo(%s) — 更新: codex plugin marketplace upgrade plangate\n' "$_cache_ver" "$_repo_ver"
+    fi
+  fi
+else
+  printf '[codex-plugin] registered: NO\n'
+  printf '[codex-plugin] 導入: codex plugin marketplace add s977043/PlanGate && sh install.sh --codex\n'
+fi
+
+# --- online 比較（opt-in）---
+if [ "$ONLINE" = "1" ]; then
+  if command -v gh >/dev/null 2>&1; then
+    _latest=$(gh release view --repo s977043/plangate --json tagName --jq '.tagName' 2>/dev/null | sed 's/^v//' || printf '')
+    if [ -n "$_latest" ]; then
+      printf '[codex-plugin] latest release: v%s\n' "$_latest"
+      [ "$_latest" != "${_repo_ver:-}" ] && printf '[codex-plugin] NOTE: repo(%s) != latest(%s)\n' "${_repo_ver:-?}" "$_latest"
+    else
+      printf '[codex-plugin] online: 最新リリース取得失敗（スキップ）\n'
+    fi
+  else
+    printf '[codex-plugin] online: gh CLI 不在のためスキップ\n'
+  fi
+fi
+
+exit 0

--- a/tests/extras/ta-31-codex-plugin-status.sh
+++ b/tests/extras/ta-31-codex-plugin-status.sh
@@ -1,0 +1,51 @@
+# tests/extras/ta-31-codex-plugin-status.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# #451: Codex Plugin の登録・version・skill 数のローカル検査スクリプトを検証
+
+printf '\n=== TA-31: codex-plugin-status (#451) ===\n'
+
+PG_T31_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T31_SCRIPT="$PG_T31_ROOT/scripts/check-codex-plugin-status.sh"
+
+t31_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t31_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# TC-01: スクリプト存在・実行可能
+if [ -f "$PG_T31_SCRIPT" ] && [ -x "$PG_T31_SCRIPT" ]; then
+  t31_pass "TC-01 check-codex-plugin-status.sh 存在・実行可能"
+else
+  t31_fail "TC-01 不在 or 非実行可能"
+fi
+
+# TC-02: sh -n syntax
+if sh -n "$PG_T31_SCRIPT" 2>/dev/null; then
+  t31_pass "TC-02 sh -n syntax check"
+else
+  t31_fail "TC-02 syntax error"
+fi
+
+# TC-03: 常に exit 0（doctor 非 fatal セクション想定）
+if sh "$PG_T31_SCRIPT" >/dev/null 2>&1; then
+  t31_pass "TC-03 exit 0（非 fatal）"
+else
+  t31_fail "TC-03 exit 非 0"
+fi
+
+# TC-04: repo manifest の version/skills 行を出力する
+_t31_out=$(sh "$PG_T31_SCRIPT" 2>/dev/null || printf '')
+if printf '%s' "$_t31_out" | grep -q 'repo manifest: version='; then
+  t31_pass "TC-04 repo manifest version/skills を出力"
+else
+  t31_fail "TC-04 repo manifest 行が無い"
+fi
+
+# TC-05: 未登録環境（空 CODEX_HOME）で導入コマンドを案内する
+_t31_tmp=$(mktemp -d) || { t31_fail "TC-05 mktemp 失敗"; return 0 2>/dev/null || true; }
+_t31_out2=$(CODEX_HOME="$_t31_tmp" sh "$PG_T31_SCRIPT" 2>/dev/null || printf '')
+if printf '%s' "$_t31_out2" | grep -q 'registered: NO' && \
+   printf '%s' "$_t31_out2" | grep -q 'marketplace add s977043/PlanGate'; then
+  t31_pass "TC-05 未登録時に導入コマンドを案内"
+else
+  t31_fail "TC-05 未登録案内が無い"
+fi
+rm -rf "$_t31_tmp"


### PR DESCRIPTION
## 概要

issue #451（doctor で Codex Plugin の登録・version 状態確認）への対応。`bin/plangate doctor` 本体は HO のため、**非 HO の独立 helper + test** を提供する。Human は doctor に 1 行（`sh scripts/check-codex-plugin-status.sh`）追加するだけで配線できる。

## 設計

issue 設計メモに沿い、ネットワーク不要・`codex plugin marketplace list` 非依存:

- **登録検査**: `$CODEX_HOME/.tmp/marketplaces/plangate`（既定 `~/.codex`）cache を直接検査
- **version**: repo manifest（`plugin/plangate/.claude-plugin/plugin.json`）と cache の `marketplace.json` 双方を表示・乖離検知
- **skill 数**: `plugin/plangate/skills/` のディレクトリ数
- **未登録時**: 導入コマンド（`marketplace add` + `install.sh --codex`）を案内
- **--online**（opt-in）: `gh` 経由で最新リリースと比較
- **常に exit 0**: doctor の非 fatal セクション想定
- cache path が **CLI 実装依存**である旨をヘッダコメントに明記

## 受け入れ条件への対応

| issue 受け入れ条件 | 対応 |
| --- | --- |
| 登録有無と version を確認できる | ✅ cache 検査 + manifest version |
| 未登録時に導入コマンドを案内 | ✅ `registered: NO` + add/install 案内 |
| ネットワークなしでローカル確認 | ✅ 既定はローカル cache のみ |
| `codex plugin marketplace list` が無くても動く | ✅ cache ディレクトリ直接検査 |

## 検証（実測）

- TA-31: **全 5 TC PASS**（存在/syntax/exit0/manifest 出力/未登録案内）
- 実走: 登録済み環境（version 8.11.0 / skills 37）/ 空 CODEX_HOME で未登録案内 / `--online` で最新 v8.11.0 比較

## Human TODO（HO）

`bin/plangate doctor`（HO）の非 fatal セクションに `sh scripts/check-codex-plugin-status.sh` の呼び出しを 1 行追加すると、doctor から状態確認できる。helper 単体でも `sh scripts/check-codex-plugin-status.sh` で利用可能。

Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> **Note（Issue Link WARN について）**: 本 PR は非 HO helper の追加のみで、issue #451 の受け入れ条件「doctor で Codex Plugin 状態を確認できる」は **doctor 本体（HO）への配線（Human）完了で達成**されます。helper だけで自動クローズすると配線未完のまま issue が閉じるため、意図的に `Closes` ではなく `Refs #451` としています（CI の Issue Link は WARN ＝非 block）。