### PR TITLE
test(#452): 実 SSoT 汚染の回帰チェックを run-tests に追加（warn-only / strict 切替）

### DIFF
--- a/tests/extras/ta-32-real-ssot-pollution.sh
+++ b/tests/extras/ta-32-real-ssot-pollution.sh
@@ -24,9 +24,7 @@ t32_warn() { pass=$((pass + 1)); printf '  [WARN] %s\n' "$1"; }
 # TC-01: 実 SSoT（既定の AGENTS.md / CLAUDE.md）が AI memory 汚染を含まない
 # 汚染検出時は guard の詳細出力（どのファイルのどの行か）を CI ログに残す
 # ＝本テストの目的「現状の汚染を可視化」を達成する
-_t32_out=$(sh "$PG_T32_SCRIPT" 2>&1)
-_t32_rc=$?
-if [ "$_t32_rc" = "0" ]; then
+if _t32_out=$(sh "$PG_T32_SCRIPT" 2>&1); then
   t32_pass "TC-01 実 SSoT に AI memory 汚染なし"
 else
   printf '%s\n' "$_t32_out" | sed 's/^/      /'

--- a/tests/extras/ta-32-real-ssot-pollution.sh
+++ b/tests/extras/ta-32-real-ssot-pollution.sh
@@ -22,10 +22,17 @@ t32_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
 t32_warn() { pass=$((pass + 1)); printf '  [WARN] %s\n' "$1"; }
 
 # TC-01: 実 SSoT（既定の AGENTS.md / CLAUDE.md）が AI memory 汚染を含まない
-if sh "$PG_T32_SCRIPT" >/dev/null 2>&1; then
+# 汚染検出時は guard の詳細出力（どのファイルのどの行か）を CI ログに残す
+# ＝本テストの目的「現状の汚染を可視化」を達成する
+_t32_out=$(sh "$PG_T32_SCRIPT" 2>&1)
+_t32_rc=$?
+if [ "$_t32_rc" = "0" ]; then
   t32_pass "TC-01 実 SSoT に AI memory 汚染なし"
-elif [ "$PG_T32_STRICT" = "1" ]; then
-  t32_fail "TC-01 実 SSoT に汚染検出（STRICT）— AGENTS.md 等から <claude-mem-context> ブロックを除去してください（#452）"
 else
-  t32_warn "TC-01 実 SSoT に汚染残存（warn-only、#452 の HO 除去待ち）。除去後 STRICT_AGENTS_CHECK=1 で block 化"
+  printf '%s\n' "$_t32_out" | sed 's/^/      /'
+  if [ "$PG_T32_STRICT" = "1" ]; then
+    t32_fail "TC-01 実 SSoT に汚染検出（STRICT）— AGENTS.md 等から <claude-mem-context> ブロックを除去してください（#452）"
+  else
+    t32_warn "TC-01 実 SSoT に汚染残存（warn-only、#452 の HO 除去待ち）。除去後 STRICT_AGENTS_CHECK=1 で block 化"
+  fi
 fi

--- a/tests/extras/ta-32-real-ssot-pollution.sh
+++ b/tests/extras/ta-32-real-ssot-pollution.sh
@@ -1,0 +1,31 @@
+# tests/extras/ta-32-real-ssot-pollution.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# #452: 実 SSoT（AGENTS.md / CLAUDE.md）の AI memory 汚染を回帰チェックする。
+#
+# ta-29 は guard スクリプトの検出力を fixture で検証する。本テストは
+# 「実ファイルが今汚染されていないか」を CI で可視化する回帰チェック。
+#
+# モード:
+#   - 既定（warn-only）: 汚染を検出しても WARN 表示のみでテストスイートを壊さない。
+#     #452 の AGENTS.md 汚染除去（HO・Human）完了までの暫定。
+#   - STRICT_AGENTS_CHECK=1: 汚染検出を FAIL に昇格。AGENTS.md 除去完了後、
+#     CI でこの環境変数を設定すれば再混入を block できる。
+
+printf '\n=== TA-32: real-ssot-pollution (#452) ===\n'
+
+PG_T32_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T32_SCRIPT="$PG_T32_ROOT/scripts/check-committed-memory-pollution.sh"
+PG_T32_STRICT="${STRICT_AGENTS_CHECK:-0}"
+
+t32_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t32_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+t32_warn() { pass=$((pass + 1)); printf '  [WARN] %s\n' "$1"; }
+
+# TC-01: 実 SSoT（既定の AGENTS.md / CLAUDE.md）が AI memory 汚染を含まない
+if sh "$PG_T32_SCRIPT" >/dev/null 2>&1; then
+  t32_pass "TC-01 実 SSoT に AI memory 汚染なし"
+elif [ "$PG_T32_STRICT" = "1" ]; then
+  t32_fail "TC-01 実 SSoT に汚染検出（STRICT）— AGENTS.md 等から <claude-mem-context> ブロックを除去してください（#452）"
+else
+  t32_warn "TC-01 実 SSoT に汚染残存（warn-only、#452 の HO 除去待ち）。除去後 STRICT_AGENTS_CHECK=1 で block 化"
+fi


### PR DESCRIPTION
## 概要

issue #452 の構造ギャップ「**実 AGENTS.md / CLAUDE.md を誰もチェックしていない**」を埋める非HO追加策。Codex 相談（usage limit のため直接回答）で、4 issue のうち #452 のみ非HO追加価値があると判断した結果。

### 背景（前回調査で判明した構造ギャップ）

- guard `scripts/check-committed-memory-pollution.sh` は完成・機能（実 AGENTS.md 汚染を検出 exit 1）
- だが test `ta-29` は **fixture のみ**検査し実ファイルを見ない
- guard は **CI 未配線**（`.github/workflows` は HO）
- → これが AGENTS.md 汚染が残り続けた構造原因

## 変更内容

`tests/extras/ta-32-real-ssot-pollution.sh` を追加（`run-tests.sh` が自動 source → CI で発火）:

| モード | 挙動 | 用途 |
| --- | --- | --- |
| 既定（warn-only） | 汚染検出でも **WARN 表示のみ**でスイートを壊さない | AGENTS.md 汚染除去（HO・Human）完了までの暫定。現状の汚染を CI ログで可視化 |
| `STRICT_AGENTS_CHECK=1` | 汚染検出を **FAIL** に昇格 | 除去完了後 CI で設定すれば再混入を block（`.github/workflows`（HO）配線の非HO代替） |

## 検証（実測）

| シナリオ | 結果 |
| --- | --- |
| 現状（AGENTS.md 汚染あり・非 strict） | **WARN**・`pass=1 fail=0`（非 block） |
| `STRICT_AGENTS_CHECK=1`（汚染あり） | **FAIL**・`fail=1`（回帰 block） |
| clean ファイル | **PASS** |

`sh -n` 構文チェック OK。

## Human TODO（HO・本 issue の本丸は残存）

1. **`AGENTS.md` の L49-81（`<claude-mem-context>` ブロック）を除去**（HO）
2. 除去後、CI（`.github/workflows`）で `STRICT_AGENTS_CHECK=1` を設定 → 再混入を block 化

本 PR は除去を待たず安全に「実 SSoT 汚染を CI で可視化 + 除去後の回帰 block 準備」を先行導入する。

> **Note**: 本 PR は構造ギャップ補完であり AGENTS.md 本体除去（HO）は含まないため、意図的に `Closes` ではなく `Refs #452` としている。

Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)