### PR TITLE
test/fix: レビュー major 指摘対応 — テスト動的分岐 + sync semver ガード + codex 堅牢化

### DIFF
--- a/scripts/check-codex-plugin-status.sh
+++ b/scripts/check-codex-plugin-status.sh
@@ -7,6 +7,8 @@
 # cache path は Codex CLI 実装依存:
 #   $CODEX_HOME/.tmp/marketplaces/plangate/  （CODEX_HOME 既定: ~/.codex）
 # 実装変更で path が変わり得るため、未検出でも fatal にせず「未登録」案内に留める。
+# TODO: `codex plugin marketplace list` 等の公式 status API が提供されたら、
+#       cache 直接検査からそのコマンド出力ベースへ移行する（内部 layout 依存を解消）。
 #
 # Usage: sh scripts/check-codex-plugin-status.sh [--online]
 #   --online: GitHub 最新リリースとの version 比較（opt-in、ネットワーク使用）
@@ -18,7 +20,7 @@ REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 ONLINE=0
 [ "${1:-}" = "--online" ] && ONLINE=1
 
-CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CODEX_HOME="${CODEX_HOME:-${HOME:-}/.codex}"
 MP_CACHE="$CODEX_HOME/.tmp/marketplaces/plangate"
 REPO_PLUGIN_JSON="$REPO_ROOT/plugin/plangate/.claude-plugin/plugin.json"
 REPO_SKILLS_DIR="$REPO_ROOT/plugin/plangate/skills"

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -74,6 +74,14 @@ _ver=""
 if [ -f "$REPO_ROOT/CHANGELOG.md" ]; then
   _ver=$(grep '^## v[0-9]' "$REPO_ROOT/CHANGELOG.md" | head -1 | sed 's/## \(v[^ ]*\).*/\1/')
 fi
+# semver 形式を検証（CHANGELOG フォーマット変更時の誤 version 注入を防ぐ）。
+# 非 semver なら _ver を空にし、後続の version 書き込みを全てスキップする。
+if [ -n "$_ver" ]; then
+  case "${_ver#v}" in
+    [0-9]*.[0-9]*.[0-9]*) : ;;
+    *) _log "WARN: CHANGELOG の version '$_ver' が semver 形式でないため version 同期をスキップ"; _ver="" ;;
+  esac
+fi
 
 # README.md の Version 行を更新
 PLUGIN_README="$PLUGIN_DIR/README.md"

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -77,10 +77,12 @@ fi
 # semver 形式を検証（CHANGELOG フォーマット変更時の誤 version 注入を防ぐ）。
 # 非 semver なら _ver を空にし、後続の version 書き込みを全てスキップする。
 if [ -n "$_ver" ]; then
-  case "${_ver#v}" in
-    [0-9]*.[0-9]*.[0-9]*) : ;;
-    *) _log "WARN: CHANGELOG の version '$_ver' が semver 形式でないため version 同期をスキップ"; _ver="" ;;
-  esac
+  # X.Y.Z（任意で -prerelease）を厳格検証。case の glob は緩く 8.11.0.1 等を
+  # 通してしまうため grep -E の正規表現で判定する。
+  if ! printf '%s' "${_ver#v}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+    _log "WARN: CHANGELOG の version '$_ver' が semver 形式でないため version 同期をスキップ"
+    _ver=""
+  fi
 fi
 
 # README.md の Version 行を更新

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -72,3 +72,30 @@ if [ -n "${_t28_ver:-}" ] && [ "${_t28_ver:-}" = "${_t28_mpver:-}" ]; then
 else
   t28_fail "TC-07 version drift: plugin.json=${_t28_ver:-} / marketplace.json=${_t28_mpver:-}"
 fi
+
+# TC-08: marketplace.json mismatch で exit 1（negative / 本体の動的分岐検証 / レビュー major）
+# tag 不在環境（shallow clone 等）では検証不能のためスキップ。実ファイルは即復元。
+_t28_tag=$(git -C "$PG_T28_ROOT" describe --tags --abbrev=0 2>/dev/null || printf '')
+_t28_mp="$PG_T28_ROOT/.claude-plugin/marketplace.json"
+if [ -n "$_t28_tag" ] && [ -f "$_t28_mp" ]; then
+  _t28_bak=$(mktemp)
+  cp "$_t28_mp" "$_t28_bak"
+  python3 - "$_t28_mp" << 'PYBREAK' 2>/dev/null
+import json, sys
+d = json.load(open(sys.argv[1], encoding='utf-8'))
+for plug in d.get('plugins', []):
+    if plug.get('name') == 'plangate':
+        plug['version'] = '0.0.0-ta28test'
+json.dump(d, open(sys.argv[1], 'w', encoding='utf-8'), indent=2, ensure_ascii=False)
+open(sys.argv[1], 'a', encoding='utf-8').write('\n')
+PYBREAK
+  if sh "$PG_T28_SCRIPT" >/dev/null 2>&1; then _t28_neg=0; else _t28_neg=1; fi
+  cp "$_t28_bak" "$_t28_mp"; rm -f "$_t28_bak"
+  if [ "$_t28_neg" = "1" ]; then
+    t28_pass "TC-08 marketplace.json mismatch で exit 1（動的分岐）"
+  else
+    t28_fail "TC-08 mismatch なのに exit 0（検出漏れ）"
+  fi
+else
+  t28_pass "TC-08 SKIP（tag 不在 or marketplace.json なし）"
+fi

--- a/tests/extras/ta-31-codex-plugin-status.sh
+++ b/tests/extras/ta-31-codex-plugin-status.sh
@@ -49,3 +49,17 @@ else
   t31_fail "TC-05 未登録案内が無い"
 fi
 rm -rf "$_t31_tmp"
+
+# TC-06: cache 登録済み環境で registered:YES + cache version を出力（positive / レビュー major）
+_t31_home=$(mktemp -d) || { t31_fail "TC-06 mktemp 失敗"; return 0 2>/dev/null || true; }
+mkdir -p "$_t31_home/.tmp/marketplaces/plangate/.claude-plugin"
+printf '{"name":"plangate","plugins":[{"name":"plangate","version":"9.9.9"}]}\n' \
+  > "$_t31_home/.tmp/marketplaces/plangate/.claude-plugin/marketplace.json"
+_t31_out6=$(CODEX_HOME="$_t31_home" sh "$PG_T31_SCRIPT" 2>/dev/null || printf '')
+if printf '%s' "$_t31_out6" | grep -q 'registered: YES' && \
+   printf '%s' "$_t31_out6" | grep -q 'cache version: 9.9.9'; then
+  t31_pass "TC-06 cache 登録済みで registered:YES + cache version 出力"
+else
+  t31_fail "TC-06 registered:YES / cache version が出ない"
+fi
+rm -rf "$_t31_home"

--- a/tests/extras/ta-32-real-ssot-pollution.sh
+++ b/tests/extras/ta-32-real-ssot-pollution.sh
@@ -34,3 +34,15 @@ else
     t32_warn "TC-01 実 SSoT に汚染残存（warn-only、#452 の HO 除去待ち）。除去後 STRICT_AGENTS_CHECK=1 で block 化"
   fi
 fi
+
+# TC-02: STRICT 昇格の前提を検証 — 汚染ありなら guard が exit 1 を返す（レビュー major）
+# 実 SSoT が現在 clean だと TC-01 で STRICT 分岐に入らないため、汚染 fixture で
+# 「STRICT 時に FAIL 昇格させる根拠（guard の非0 exit）」を独立して固定する。
+_t32_dirty=$(mktemp)
+printf '<claude-mem-context>\nget_observations([1])\n</claude-mem-context>\n' > "$_t32_dirty"
+if POLLUTION_TARGET_FILES="$_t32_dirty" sh "$PG_T32_SCRIPT" >/dev/null 2>&1; then
+  t32_fail "TC-02 汚染 fixture を guard が見逃した（STRICT 昇格の前提が崩壊）"
+else
+  t32_pass "TC-02 汚染 fixture で guard exit 1 → STRICT 時 FAIL 昇格の前提を満たす"
+fi
+rm -f "$_t32_dirty"


### PR DESCRIPTION
## 概要

今セッションでマージした plugin sync 関連成果物（#456/#451/#452）への **3 視点レビュー**で検出された最優先 major 3 件に対応する。

### レビュー経緯
- **セルフレビュー（機械）**: 6 ファイル構文 OK / version 4 者一貫 / HO 未変更 / 全テスト PASS → 機能上の欠陥なし
- **別視点レビュー（保守・運用）**: major 7 / minor 9 / info 6。最優先 3 件を本 PR で対応
- **Codex レビュー**: usage limit のため保留（後日実施可能）

## 変更内容（最優先 major 3 件）

### 1. テストが本体の動的分岐を未検証（major × 3）
3 テストが静的検査（存在/syntax/フィールド有無）に偏り、本体の振る舞いを検証していなかった。

| テスト | 追加 TC | 検証内容 |
| --- | --- | --- |
| ta-28 | TC-08 | marketplace.json mismatch で **exit 1**（negative、tag 不在環境はスキップ、実ファイル即復元） |
| ta-31 | TC-06 | cache 登録済みで **registered:YES + cache version**（positive、mktemp、ネットワーク不要） |
| ta-32 | TC-02 | 汚染 fixture で guard exit 1 ＝ **STRICT 時 FAIL 昇格の前提**を検証 |

### 2. sync の CHANGELOG version 抽出が脆い（major）
`scripts/sync-plugin-plangate.sh`: `## v...` フォーマット変更で誤 version を全 manifest に書き込むリスク。**semver 検証ガード**を追加し、非 semver なら `_ver` を空にして version 書き込みを全スキップ。

### 3. check-codex の堅牢化（major + info）
- 公式 status API（`codex plugin marketplace list` 等）が出たら cache 直接検査から移行する **TODO をヘッダに明示**
- `HOME` 未設定でも `set -u` で落ちないよう `${HOME:-}` 化

## 検証（実測）

- 全テスト PASS: **ta-28:8 / ta-31:6 / ta-32:2（計 16 TC）**、`set -eu` 耐性維持
- semver ガード: `v8.BROKEN.x` で `WARN + 同期スキップ` 発火を確認
- HOME 未設定（`env -u HOME`）で exit 0
- marketplace.json / CHANGELOG に副作用差分なし

> minor 9 / info 6（shallow clone tag・重大度ラベル統一・--online テスト等）は機能影響が小さく、本 PR では見送り（必要なら follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)