### PR TITLE
test(#476): ta-31 に --online の gh 不在パス検証を追加

### DIFF
--- a/tests/extras/ta-31-codex-plugin-status.sh
+++ b/tests/extras/ta-31-codex-plugin-status.sh
@@ -65,3 +65,19 @@ else
   t31_fail "TC-06 registered:YES / cache version が出ない"
 fi
 rm -rf "$_t31_home"
+
+# TC-07: --online で gh 不在時に「gh CLI 不在のためスキップ」（#476 / coverage 補完）
+# gh だけを除外した PATH（python3/dirname のみリンク）で実行し、ネットワーク非依存で
+# online 分岐の gh 不在パスを検証する。
+_t31_bin=$(mktemp -d) || { t31_fail "TC-07 mktemp 失敗"; return 0 2>/dev/null || true; }
+_t31_home7=$(mktemp -d)
+for _c in sh python3 dirname; do
+  _src=$(command -v "$_c" 2>/dev/null) && ln -s "$_src" "$_t31_bin/$_c" 2>/dev/null
+done
+_t31_out7=$(CODEX_HOME="$_t31_home7" PATH="$_t31_bin" sh "$PG_T31_SCRIPT" --online 2>/dev/null || printf '')
+if printf '%s' "$_t31_out7" | grep -q 'gh CLI 不在のためスキップ'; then
+  t31_pass "TC-07 --online で gh 不在時にスキップ案内"
+else
+  t31_fail "TC-07 --online gh 不在スキップが出ない（出力: $(printf '%s' "$_t31_out7" | tr '\n' '|'))"
+fi
+rm -rf "$_t31_bin" "$_t31_home7"

--- a/tests/extras/ta-31-codex-plugin-status.sh
+++ b/tests/extras/ta-31-codex-plugin-status.sh
@@ -70,7 +70,7 @@ rm -rf "$_t31_home"
 # gh だけを除外した PATH（python3/dirname のみリンク）で実行し、ネットワーク非依存で
 # online 分岐の gh 不在パスを検証する。
 _t31_bin=$(mktemp -d) || { t31_fail "TC-07 mktemp 失敗"; return 0 2>/dev/null || true; }
-_t31_home7=$(mktemp -d)
+_t31_home7=$(mktemp -d) || { rm -rf "$_t31_bin"; t31_fail "TC-07 mktemp 失敗"; return 0 2>/dev/null || true; }
 for _c in sh python3 dirname; do
   _src=$(command -v "$_c" 2>/dev/null) && ln -s "$_src" "$_t31_bin/$_c" 2>/dev/null
 done


### PR DESCRIPTION
## 概要

issue #476（plugin sync 品質改善・minor/info 集約）の最優先項目「ta-31 `--online` パス未テスト」を補完。Codex 相談で推奨された coverage 補完の第 1 弾。

## 変更内容

`tests/extras/ta-31-codex-plugin-status.sh` に **TC-07** を追加:
- gh だけを除外した一時 PATH（`sh`/`python3`/`dirname` のみシンボリックリンク）で `--online` を実行
- **ネットワーク非依存**で `check-codex-plugin-status.sh` の online 分岐（gh 不在パス）を検証
- 「gh CLI 不在のためスキップ」案内が出ることを確認

## 検証（実測）

- ta-31: **全 7 TC PASS**（TC-07 追加）
- `set -eu` 下で完走
- 親シェル trap 非汚染（trap 不使用）、`/tmp` 残留なし
- `sh -n` 構文チェック OK

## #476 の残項目（follow-up）

- 重大度ラベル不統一（MISMATCH/ERROR/WARN/NOTE の統一）
- ハードコード散在（"plangate"/cache path/repo slug の定数化）
- shallow clone で tag 空→WARN 素通りの fixture テスト

これらは別 PR で順次対応予定。

Refs #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)