### PR TITLE
refactor(#476): plugin sync 品質改善 — shallow clone テスト / ラベル統一 / slug 統一

### DIFF
--- a/scripts/check-codex-plugin-status.sh
+++ b/scripts/check-codex-plugin-status.sh
@@ -21,6 +21,7 @@ ONLINE=0
 [ "${1:-}" = "--online" ] && ONLINE=1
 
 CODEX_HOME="${CODEX_HOME:-${HOME:-}/.codex}"
+REPO_SLUG="s977043/plangate"  # GitHub リポジトリ slug（表記ゆれ防止のため 1 箇所に集約）
 MP_CACHE="$CODEX_HOME/.tmp/marketplaces/plangate"
 REPO_PLUGIN_JSON="$REPO_ROOT/plugin/plangate/.claude-plugin/plugin.json"
 REPO_SKILLS_DIR="$REPO_ROOT/plugin/plangate/skills"
@@ -68,13 +69,13 @@ PYC
   fi
 else
   printf '[codex-plugin] registered: NO\n'
-  printf '[codex-plugin] 導入: codex plugin marketplace add s977043/PlanGate && sh install.sh --codex\n'
+  printf '[codex-plugin] 導入: codex plugin marketplace add %s && sh install.sh --codex\n' "$REPO_SLUG"
 fi
 
 # --- online 比較（opt-in）---
 if [ "$ONLINE" = "1" ]; then
   if command -v gh >/dev/null 2>&1; then
-    _latest=$(gh release view --repo s977043/plangate --json tagName --jq '.tagName' 2>/dev/null | sed 's/^v//' || printf '')
+    _latest=$(gh release view --repo "$REPO_SLUG" --json tagName --jq '.tagName' 2>/dev/null | sed 's/^v//' || printf '')
     if [ -n "$_latest" ]; then
       printf '[codex-plugin] latest release: v%s\n' "$_latest"
       [ "$_latest" != "${_repo_ver:-}" ] && printf '[codex-plugin] NOTE: repo(%s) != latest(%s)\n' "${_repo_ver:-?}" "$_latest"

--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -9,7 +9,9 @@
 
 set -eu
 
-REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# REPO_ROOT は通常スクリプト位置から決まるが、テスト用に PLANGATE_REPO_ROOT で
+# 上書き可能（shallow clone で tag が無い等のケース検証のため。後方互換）。
+REPO_ROOT="${PLANGATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)}"
 WARN_ONLY=0
 [ "${1:-}" = "--warn-only" ] && WARN_ONLY=1
 
@@ -69,14 +71,14 @@ fi
 
 _mismatch=0
 if [ "$PLUGIN_VERSION" != "$LATEST_TAG" ]; then
-  printf '[plugin-version] MISMATCH: plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
+  printf '[plugin-version] ERROR: plugin.json version mismatch — plugin.json=%s / latest tag=v%s\n' "$PLUGIN_VERSION" "$LATEST_TAG" >&2
   _mismatch=1
 fi
 if [ -n "$MARKETPLACE_ERR" ]; then
   printf '[plugin-version] ERROR: marketplace.json から plangate version を取得できません（存在するのに parse 失敗 / plangate 未定義 / version 空）\n' >&2
   _mismatch=1
 elif [ -n "$MARKETPLACE_VERSION" ] && [ "$MARKETPLACE_VERSION" != "$LATEST_TAG" ]; then
-  printf '[plugin-version] MISMATCH: marketplace.json=%s / latest tag=v%s\n' "$MARKETPLACE_VERSION" "$LATEST_TAG" >&2
+  printf '[plugin-version] ERROR: marketplace.json version mismatch — marketplace.json=%s / latest tag=v%s\n' "$MARKETPLACE_VERSION" "$LATEST_TAG" >&2
   _mismatch=1
 fi
 

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -104,3 +104,18 @@ PYBREAK
 else
   t28_pass "TC-08 SKIP（tag 不在 or marketplace.json なし）"
 fi
+
+# TC-09: tag 不在（shallow clone 相当）で WARN + exit 0（#476 / 運用の穴を固定）
+# PLANGATE_REPO_ROOT を tag の無い一時 git repo に向け、LATEST_TAG 空時の挙動を検証。
+_t28_sh=$(mktemp -d) || { t28_fail "TC-09 mktemp 失敗"; return 0 2>/dev/null || true; }
+mkdir -p "$_t28_sh/plugin/plangate/.claude-plugin" "$_t28_sh/.claude-plugin"
+printf '{"version":"8.11.0"}\n' > "$_t28_sh/plugin/plangate/.claude-plugin/plugin.json"
+printf '{"plugins":[{"name":"plangate","version":"8.11.0"}]}\n' > "$_t28_sh/.claude-plugin/marketplace.json"
+( cd "$_t28_sh" && git init -q 2>/dev/null )  # tag を作らない → describe 失敗
+if PLANGATE_REPO_ROOT="$_t28_sh" sh "$PG_T28_SCRIPT" 2>&1 | grep -q 'tag が見つかりません' \
+   && PLANGATE_REPO_ROOT="$_t28_sh" sh "$PG_T28_SCRIPT" >/dev/null 2>&1; then
+  t28_pass "TC-09 tag 不在で WARN + exit 0（shallow clone 相当）"
+else
+  t28_fail "TC-09 tag 不在時の WARN/exit 0 が成立しない"
+fi
+rm -rf "$_t28_sh"

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -107,15 +107,26 @@ fi
 
 # TC-09: tag 不在（shallow clone 相当）で WARN + exit 0（#476 / 運用の穴を固定）
 # PLANGATE_REPO_ROOT を tag の無い一時 git repo に向け、LATEST_TAG 空時の挙動を検証。
-_t28_sh=$(mktemp -d) || { t28_fail "TC-09 mktemp 失敗"; return 0 2>/dev/null || true; }
-mkdir -p "$_t28_sh/plugin/plangate/.claude-plugin" "$_t28_sh/.claude-plugin"
-printf '{"version":"8.11.0"}\n' > "$_t28_sh/plugin/plangate/.claude-plugin/plugin.json"
-printf '{"plugins":[{"name":"plangate","version":"8.11.0"}]}\n' > "$_t28_sh/.claude-plugin/marketplace.json"
-( cd "$_t28_sh" && git init -q 2>/dev/null )  # tag を作らない → describe 失敗
-if PLANGATE_REPO_ROOT="$_t28_sh" sh "$PG_T28_SCRIPT" 2>&1 | grep -q 'tag が見つかりません' \
-   && PLANGATE_REPO_ROOT="$_t28_sh" sh "$PG_T28_SCRIPT" >/dev/null 2>&1; then
+# TC-08 同様、trap をサブシェルに閉じ込めて親シェル（run-tests.sh）を汚染せず、
+# 中断時も一時ディレクトリを確実に掃除する。判定は stdout で返す。
+_t28_res=$(
+  _sh=$(mktemp -d) || exit 9
+  trap 'rm -rf "$_sh"' EXIT INT TERM
+  mkdir -p "$_sh/plugin/plangate/.claude-plugin" "$_sh/.claude-plugin"
+  printf '{"version":"8.11.0"}\n' > "$_sh/plugin/plangate/.claude-plugin/plugin.json"
+  printf '{"plugins":[{"name":"plangate","version":"8.11.0"}]}\n' > "$_sh/.claude-plugin/marketplace.json"
+  ( cd "$_sh" && git init -q 2>/dev/null )  # tag を作らない → describe 失敗
+  if PLANGATE_REPO_ROOT="$_sh" sh "$PG_T28_SCRIPT" 2>&1 | grep -q 'tag が見つかりません' \
+     && PLANGATE_REPO_ROOT="$_sh" sh "$PG_T28_SCRIPT" >/dev/null 2>&1; then
+    printf PASS
+  else
+    printf FAIL
+  fi
+)
+if [ "$_t28_res" = "PASS" ]; then
   t28_pass "TC-09 tag 不在で WARN + exit 0（shallow clone 相当）"
-else
+elif [ "$_t28_res" = "FAIL" ]; then
   t28_fail "TC-09 tag 不在時の WARN/exit 0 が成立しない"
+else
+  t28_fail "TC-09 一時 repo 作成失敗（mktemp）"
 fi
-rm -rf "$_t28_sh"

--- a/tests/extras/ta-31-codex-plugin-status.sh
+++ b/tests/extras/ta-31-codex-plugin-status.sh
@@ -43,7 +43,7 @@ fi
 _t31_tmp=$(mktemp -d) || { t31_fail "TC-05 mktemp 失敗"; return 0 2>/dev/null || true; }
 _t31_out2=$(CODEX_HOME="$_t31_tmp" sh "$PG_T31_SCRIPT" 2>/dev/null || printf '')
 if printf '%s' "$_t31_out2" | grep -q 'registered: NO' && \
-   printf '%s' "$_t31_out2" | grep -q 'marketplace add s977043/PlanGate'; then
+   printf '%s' "$_t31_out2" | grep -q 'marketplace add s977043/plangate'; then
   t31_pass "TC-05 未登録時に導入コマンドを案内"
 else
   t31_fail "TC-05 未登録案内が無い"


### PR DESCRIPTION
## 概要

issue #476（plugin sync minor/info 集約）の残項目②③④を一括対応し close する。同じ `scripts/` を触るためコンフリクト回避で 1 PR に統合。

## 変更内容

### ④ shallow clone tag 空テスト（運用の穴を固定）
- `check-plugin-version.sh` に `PLANGATE_REPO_ROOT` env 注入（後方互換・テスト用）
- `ta-28` TC-09: tag 不在の一時 git repo で **WARN + exit 0** を検証。CI の `actions/checkout` 既定 `fetch-depth:1` で tag が fetch されず mismatch を素通りする運用の穴をテストで固定

### ② 重大度ラベル統一
- `check-plugin-version.sh` の `MISMATCH:` → `ERROR:` に統一。**本文に "version mismatch" を保持**し情報を失わない。ラベル語彙が `ERROR`/`WARN`/`OK` に揃い grep 横断集計が容易に

### ③ slug 表記ゆれ統一（過剰定数化は回避）
- `check-codex-plugin-status.sh` の `s977043/PlanGate` と `s977043/plangate` の**表記ゆれを `REPO_SLUG` 変数に集約・統一**
- plugin name / cache path の `"plangate"` は固定値のため定数化せず（過剰回避）
- `ta-31` TC-05 を新 slug に追従

## 検証（実測）

- 全テスト PASS: **ta-28:9 / ta-31:7 / ta-32:2**、`set -eu` 下で完走
- `check-plugin-version` / `check-codex-plugin-status` 正常動作
- slug 統一確認（大文字 `PlanGate` 残存なし）

## #476 完了状況

| 項目 | 状態 |
| --- | --- |
| ① ta-31 --online 未テスト | ✅ #477 で完了 |
| ② ラベル統一 | ✅ 本 PR |
| ③ slug 統一（定数化は最小限） | ✅ 本 PR |
| ④ shallow clone テスト | ✅ 本 PR |

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)