### PR TITLE
chore(release): v8.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "PlanGate — AI coding governance OS for Claude Code and Codex. 4-Gate approval system, Intent/Mode classification, Skill Policy Router, and agent control layer.",
-    "version": "8.11.0"
+    "version": "8.12.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "plangate",
       "description": "AI coding governance OS. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer for Claude Code.",
-      "version": "8.11.0",
+      "version": "8.12.0",
       "author": {
         "name": "PlanGate contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.12.0 - 2026-06-07
+
+feat: 並列レビューア実行 + Plugin sync 品質ガード + 導入促進・運用ガード整備
+
+`bin/plangate review` の並列レビューア実行（TASK-0122）を追加。Plugin マニフェストの version 二重管理ガード・Codex Plugin 状態検査 helper・実 SSoT 汚染の CI 可視化など plugin sync 周辺の品質を強化。導入検討者向けランディング（Why PlanGate）と HO 待ち運用ガード（status 日時必須・外部レビュー実行不可記録・runtime conductor 運用・AGENTS.md 汚染除去）を整備。3 視点レビュー（セルフ + 別視点 + Gemini）で検出した多数の指摘を反映。
+
+### Added
+
+- **並列レビューア実行**（TASK-0122）— `bin/plangate review` に複数外部レビューアの並列実行を追加。spec ファイルのコマンドに `shlex.quote` を適用。
+- **Why PlanGate ランディングページ**（#468-470）— 導入検討者が 3 分で必要性を判断し 5 分で導入を始められる訴求ページ `docs/pages/explanation/product/why-plangate.md`。3 つの価値・段階的導入・成功イメージ・CTA を整理。
+- **Codex Plugin 状態検査 helper**（#451 / #472）— `scripts/check-codex-plugin-status.sh`。Codex Plugin の登録 / version / skill 数をネットワーク非依存でローカル検査。`bin/plangate doctor` に non-fatal セクションとして配線。
+- **HO 適用スクリプト**（#479）— `scripts/apply-ho-followups.sh`。HO パス変更を Human が冪等・`--dry-run` 付きで 1 コマンド適用。
+
+### Changed
+
+- **Plugin sync 品質改善**（#476 / #478）— 重大度ラベル統一（`MISMATCH` → `ERROR`）、リポジトリ slug 表記ゆれ統一、shallow clone での tag 空テスト追加。
+- **運用ガード整備**（#463 → #480）— `status.md` フェーズ履歴の日時 `YYYY-MM-DD HH:mm` 必須、外部レビュー実行不可時の記録規約（§7-ter）、Codex runtime での conductor 相当運用を正本に反映。
+- **/plangate-setup 前提条件明示**（#454 → #480）— `bin/plangate` 前提と clone 必要性を `plangate-setup.md` / `setup-coordinator.md` に追記。
+
+### Fixed
+
+- **Plugin version 二重管理ガード**（#456 / #471）— `plugin.json` ↔ `marketplace.json` の version を sync で同期・check で検証。parse 失敗 / 未定義 / 空を ERROR 化。
+- **AGENTS.md 汚染除去 + CI 可視化**（#452 → #473 / #480）— `<claude-mem-context>` 汚染ブロックを除去。実 SSoT 汚染を run-tests で可視化（warn-only / `STRICT_AGENTS_CHECK` 切替）。
+- **テスト堅牢化**（#474 / #475 / #477 / #478）— sourced テストの `trap` 親シェル汚染をサブシェル隔離で解消、semver 検証の `grep -E` 厳格化、`mktemp` リーク防止、`--online` カバレッジ補完。
+
+### Meta
+
+- 本リリースは issue #451 / #452 / #454 / #456 / #463 / #476 を close。
+
 ## v8.11.0 - 2026-06-04
 
 feat: Claude Code / Codex Plugin 正式配布対応 + retrospective scoring 配点変更

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -3,7 +3,7 @@
 PlanGate — a governance OS for AI-assisted coding.
 Provides Intent/Mode classification, a 4-Gate approval system, and an agent control layer as a Claude Code plugin.
 
-- **Version**: v8.11.0
+- **Version**: v8.12.0
 - **Source**: <https://github.com/s977043/plangate>
 
 ## Install

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -155,6 +155,12 @@ for plug in target:
         changed.append('%s -> %s' % (plug.get('version'), ver))
         if dry != '1':
             plug['version'] = ver
+# marketplace 自体の metadata.version も同期（plugins[].version との二重管理防止）
+md = d.get('metadata')
+if isinstance(md, dict) and md.get('version') not in (None, ver):
+    changed.append('metadata %s -> %s' % (md.get('version'), ver))
+    if dry != '1':
+        md['version'] = ver
 if changed and dry != '1':
     with open(path, 'w', encoding='utf-8') as f:
         json.dump(d, f, indent=2, ensure_ascii=False)

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -130,3 +130,19 @@ elif [ "$_t28_res" = "FAIL" ]; then
 else
   t28_fail "TC-09 一時 repo 作成失敗（mktemp）"
 fi
+
+# TC-10: marketplace.json の metadata.version == plugins[].version（二重管理 drift / #481）
+_t28_md=$(python3 - "$PG_T28_MP" << 'PYMD' 2>/dev/null || printf ''
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding='utf-8'))
+    print(d.get('metadata', {}).get('version', ''))
+except Exception:
+    print('')
+PYMD
+)
+if [ -n "${_t28_md:-}" ] && [ "${_t28_md:-}" = "${_t28_mpver:-}" ]; then
+  t28_pass "TC-10 metadata.version (${_t28_md}) == plugins[].version (${_t28_mpver:-}) — drift なし"
+else
+  t28_fail "TC-10 marketplace 内 version drift: metadata=${_t28_md:-} / plugins=${_t28_mpver:-}"
+fi


### PR DESCRIPTION
## 概要

v8.12.0 リリース準備 PR。CHANGELOG v8.12.0 エントリ追記 + version bump（plugin.json / marketplace.json / README → 8.12.0）。

## リリース内容（v8.11.0 以降）

### Added
- 並列レビューア実行（TASK-0122）
- Why PlanGate ランディングページ（#468-470）
- Codex Plugin 状態検査 helper（#451/#472）
- HO 適用スクリプト（#479）

### Changed
- Plugin sync 品質改善（#476/#478）
- 運用ガード整備（#463→#480）
- /plangate-setup 前提条件明示（#454→#480）

### Fixed
- Plugin version 二重管理ガード（#456/#471）
- AGENTS.md 汚染除去 + CI 可視化（#452→#473/#480）
- テスト堅牢化（#474/#475/#477/#478）

## version 整合
- plugin.json: 8.12.0 / marketplace.json: 8.12.0 / README: v8.12.0
- markdownlint CHANGELOG: 0 error

## リリースフロー（本 PR マージ後）

1. **Human**: 本 PR を main へマージ
2. **AI（承認済み）**: tag `v8.12.0` push（tag-main parity 検証）+ GitHub Release 作成

> NO RELEASE WITHOUT TAG-MAIN PARITY を厳守し、tag push 後に `origin/main` との一致を検証してから Release を作成する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)