### PR TITLE
fix(post-release): README Latest 表記 v8.12.0 + metadata 検証・drift 検知

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.11.0**（Latest）で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.12.0**（Latest）で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 
 | 項目 | 状態 |
 | --- | --- |
-| 最新リリース | **v8.11.0**（Latest, 2026-06-04）— Claude Code / Codex Plugin 正式配布対応（install.sh / marketplace.json / Codex スキル配布） |
-| リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 |
+| 最新リリース | **v8.12.0**（Latest, 2026-06-07）— 並列レビューア実行 + Plugin sync 品質ガード + 導入促進（Why PlanGate）・運用ガード整備 |
+| リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 / **v8.11.0** Claude Code / Codex Plugin 正式配布対応 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3、v8.5.0 で 10/10、v8.6.0 で EH-8、v8.7.0 で EH-9 を追加） |
 | Metrics v1 | `bin/plangate metrics` による workflow event 集計（v8.6.0 初出） |

--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -55,6 +55,9 @@ try:
 except Exception as e:
     sys.stderr.write('parse-error: %s\n' % e)
     sys.exit(1)
+if not isinstance(d, dict):
+    sys.stderr.write('parse-error: root element is not a dictionary\n')
+    sys.exit(1)
 pv = None
 for plug in d.get('plugins', []):
     if plug.get('name') == 'plangate':

--- a/scripts/check-plugin-version.sh
+++ b/scripts/check-plugin-version.sh
@@ -55,16 +55,22 @@ try:
 except Exception as e:
     sys.stderr.write('parse-error: %s\n' % e)
     sys.exit(1)
+pv = None
 for plug in d.get('plugins', []):
     if plug.get('name') == 'plangate':
-        v = plug.get('version', '')
-        if not v:
-            sys.stderr.write('plangate plugin version が空\n')
-            sys.exit(1)
-        print(v)
-        sys.exit(0)
-sys.stderr.write('plangate plugin 定義が見つかりません\n')
-sys.exit(1)
+        pv = plug.get('version', '')
+        break
+if not pv:
+    sys.stderr.write('plangate plugin version が空 or 未定義\n')
+    sys.exit(1)
+# metadata.version も検証（plugins[].version との二重管理 drift 防止 / #481）
+md = d.get('metadata', {})
+mdv = md.get('version') if isinstance(md, dict) else None
+if mdv is not None and mdv != pv:
+    sys.stderr.write('metadata.version (%s) != plugins[].version (%s)\n' % (mdv, pv))
+    sys.exit(1)
+print(pv)
+sys.exit(0)
 PYMP
 ) || MARKETPLACE_ERR=1
 fi

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -146,3 +146,11 @@ if [ -n "${_t28_md:-}" ] && [ "${_t28_md:-}" = "${_t28_mpver:-}" ]; then
 else
   t28_fail "TC-10 marketplace 内 version drift: metadata=${_t28_md:-} / plugins=${_t28_mpver:-}"
 fi
+
+# TC-11: ルート README の Latest 表記 == plugin.json version（#481 後レビュー / 再発防止）
+_t28_readme=$(grep -oE '\*\*v[0-9.]+\*\*（Latest' "$PG_T28_ROOT/README.md" 2>/dev/null | head -1 | grep -oE '[0-9][0-9.]*' || printf '')
+if [ -n "${_t28_readme:-}" ] && [ "${_t28_readme:-}" = "${_t28_ver:-}" ]; then
+  t28_pass "TC-11 README Latest (v${_t28_readme}) == plugin.json (${_t28_ver:-})"
+else
+  t28_fail "TC-11 README Latest drift: README=${_t28_readme:-} / plugin.json=${_t28_ver:-}"
+fi

--- a/tests/extras/ta-28-plugin-version.sh
+++ b/tests/extras/ta-28-plugin-version.sh
@@ -148,7 +148,7 @@ else
 fi
 
 # TC-11: ルート README の Latest 表記 == plugin.json version（#481 後レビュー / 再発防止）
-_t28_readme=$(grep -oE '\*\*v[0-9.]+\*\*（Latest' "$PG_T28_ROOT/README.md" 2>/dev/null | head -1 | grep -oE '[0-9][0-9.]*' || printf '')
+_t28_readme=$(grep 'Latest' "$PG_T28_ROOT/README.md" 2>/dev/null | grep -oE 'v[0-9][0-9.]*' | head -1 | grep -oE '[0-9][0-9.]*' || printf '')
 if [ -n "${_t28_readme:-}" ] && [ "${_t28_readme:-}" = "${_t28_ver:-}" ]; then
   t28_pass "TC-11 README Latest (v${_t28_readme}) == plugin.json (${_t28_ver:-})"
 else


### PR DESCRIPTION
## 概要

v8.12.0 リリース後の **2 視点レビュー**（セルフ + 別視点）で検出した major 1 + minor1 + 再発防止。リリース実体（tag-main parity / Release publish / 6 issue close / version bump）は健全だが、README 更新漏れと runtime ガードの穴を補修する。

## 変更内容

### major: README Latest 表記の取り残し
`README.md` の L78（散文）/ L84（表「最新リリース」）が **v8.11.0（Latest）のまま**で利用者が最新版を誤認していた。sync スクリプトが Version 行のみ更新し散文の Latest 表記を見落とす穴。
→ v8.12.0 に修正。L85「リリース済」に v8.11.0 を追加。

### minor1: check-plugin-version の metadata 未検証
`check-plugin-version.sh` は `plugins[].version` のみ検証し `metadata.version` を見ていなかった（doctor/CI 常時ガードの穴）。#481 で sync・テスト層は対応したが runtime check は未反映だった。
→ metadata.version と plugins[].version の drift を **runtime check でも exit 1** 化。

### 再発防止: README drift を CI 検知
`ta-28` TC-11 を追加。ルート README の Latest 表記 == plugin.json version を検証し、**次回 version bump で README 更新漏れを CI で fail** させる。

## 検証（実測）

- README Latest の v8.11.0 残存なし・markdownlint 0 error
- check-plugin-version: metadata 不一致で **exit 1**、一致で exit 0
- ta-28: **全 11 TC PASS**（TC-10 metadata drift / TC-11 README drift）

## 関連

- v8.12.0 リリース: https://github.com/s977043/PlanGate/releases/tag/v8.12.0
- リリース実体は健全。本 PR は表記・ガードの後追い補修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)