### PR TITLE
chore: apply-ho-followups.sh に Phase3 ci.yml glob 更新を統合（Human 実行用 1 ファイル）

### DIFF
--- a/scripts/apply-ho-followups.sh
+++ b/scripts/apply-ho-followups.sh
@@ -168,6 +168,19 @@ if anchor in s:
 sys.stdout.write(s)
 PY463C
 
+printf '=== Phase3: ci.yml の markdownlint glob を docs/pages/ 新パスへ更新（#488）===\n'
+printf '    前提: PR #488 マージ後に実行（philosophy/oss-governance が docs/pages/ へ移動済みであること）\n'
+edit_file .github/workflows/ci.yml <<'PYCI'
+import sys
+p = sys.argv[1]; s = open(p, encoding='utf-8').read()
+for old, new in [
+    ('            docs/philosophy.md\n', '            docs/pages/explanation/product/philosophy.md\n'),
+    ('            docs/oss-governance.md\n', '            docs/pages/guides/governance/oss-governance.md\n'),
+]:
+    s = s.replace(old, new)
+sys.stdout.write(s)
+PYCI
+
 printf '\n'
 if [ "$DRY" = "1" ]; then
   printf '=== --dry-run 完了。書き込みは行っていません。 ===\n'

--- a/scripts/apply-ho-followups.sh
+++ b/scripts/apply-ho-followups.sh
@@ -171,13 +171,21 @@ PY463C
 printf '=== Phase3: ci.yml の markdownlint glob を docs/pages/ 新パスへ更新（#488）===\n'
 printf '    前提: PR #488 マージ後に実行（philosophy/oss-governance が docs/pages/ へ移動済みであること）\n'
 edit_file .github/workflows/ci.yml <<'PYCI'
-import sys
+import sys, re
 p = sys.argv[1]; s = open(p, encoding='utf-8').read()
-for old, new in [
-    ('            docs/philosophy.md\n', '            docs/pages/explanation/product/philosophy.md\n'),
-    ('            docs/oss-governance.md\n', '            docs/pages/guides/governance/oss-governance.md\n'),
+# インデント幅・改行コードに依存しない行単位置換。glob 行が見つからない場合は
+# 黙ってスキップせず WARN を出す（ci.yml フォーマット変更時の適用漏れを検出）。
+for oldp, newp in [
+    ('docs/philosophy.md', 'docs/pages/explanation/product/philosophy.md'),
+    ('docs/oss-governance.md', 'docs/pages/guides/governance/oss-governance.md'),
 ]:
-    s = s.replace(old, new)
+    if newp in s:
+        continue  # 既適用（冪等）
+    pat = re.compile(r'^([ \t]*)' + re.escape(oldp) + r'[ \t]*$', re.M)
+    if not pat.search(s):
+        sys.stderr.write('WARN: %s の glob 行が見つかりません（既適用 or ci.yml フォーマット変更）\n' % oldp)
+        continue
+    s = pat.sub(lambda m: m.group(1) + newp, s)
 sys.stdout.write(s)
 PYCI
 


### PR DESCRIPTION
## 概要

ドキュメント整理 Phase 3（#488）の Human TODO「`ci.yml` の markdownlint glob を新パスへ更新」を、既存の HO 適用スクリプト `scripts/apply-ho-followups.sh` に集約。**Human が実行すべき HO 操作を 1 ファイルにまとめる**（責務 4 分類: AI が script 提供・Human が実行）。

## 変更内容

`scripts/apply-ho-followups.sh` に Phase3 セクションを追加:

```text
docs/philosophy.md      → docs/pages/explanation/product/philosophy.md
docs/oss-governance.md  → docs/pages/guides/governance/oss-governance.md
```

- `edit_file` による**冪等**適用（既に新パスなら skip）
- `--dry-run` 対応
- 前提注記: **PR #488 マージ後に実行**（philosophy/oss-governance が移動済みであること）

## 検証（実測 dry-run）

- 既存 4 セクション（#452/#451/#454/#463）は **`[skip]`**（main で適用済み・冪等）
- ci.yml セクションのみ正しい差分（glob を docs/pages/ 新パスへ）

## Human の使い方

```bash
# PR #488 マージ後:
sh scripts/apply-ho-followups.sh --dry-run   # ci.yml の差分確認（既存は skip）
sh scripts/apply-ho-followups.sh             # ci.yml glob を新パスへ更新
```

これで philosophy/oss-governance が CI markdownlint の対象に復帰する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)