### PR TITLE
ci: markdownlint glob を philosophy/oss-governance の docs/pages/ 新パスへ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
             CONTRIBUTING.md
             SECURITY.md
             docs/index.md
-            docs/philosophy.md
-            docs/oss-governance.md
+            docs/pages/explanation/product/philosophy.md
+            docs/pages/guides/governance/oss-governance.md
             docs/workflows/**/*.md


### PR DESCRIPTION
## 概要

Human が `sh scripts/apply-ho-followups.sh` を実行した結果の HO 変更。ドキュメント整理 Phase 3（#488）で `docs/pages/` へ移行した `philosophy.md` / `oss-governance.md` を CI markdownlint の lint 対象に復帰させる。

## 変更

```diff
-            docs/philosophy.md
-            docs/oss-governance.md
+            docs/pages/explanation/product/philosophy.md
+            docs/pages/guides/governance/oss-governance.md
```

## 経緯（責務4分類）

`.github/workflows/ci.yml` は **HO パス**で AI 編集不可。AI が冪等な適用スクリプト（`scripts/apply-ho-followups.sh`、#489）を提供し、**Human が実行**、AI が結果を **PR 化**（C-4 レビュー用）。実行時に既適用の #452/#451/#454/#463 は skip され、ci.yml の glob のみ更新された。

これで Phase 2/3 で移行した公開説明文書（when-not-to-use / glossary / philosophy / oss-governance）がすべて CI lint 対象として整合する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)