### PR TITLE
docs(settings-wiring): Wiring Integrity Enforcement 仕様を策定 (#500)

### DIFF
--- a/docs/ai/settings-wiring-contract.md
+++ b/docs/ai/settings-wiring-contract.md
@@ -100,3 +100,56 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 - `.claude/settings.json` / `bin/plangate` / `scripts/hooks/*.sh` 等の Hardening Override 領域を改変するのは依然として **AI 改変不可** (Human-owned)
 - 新規 hook 追加 (`.codex/hooks.json` / `.codex/hooks/*.sh`) は AI-owned (Override 対象外)
 - 既存 hook 改変は Human-owned
+
+## Wiring Integrity Enforcement（#500 / 配線整合性の強制・Specification）
+
+> Status: Specification（方針確定。実装は HO パス絡みのため受け入れ条件ごとに段階 PBI へ分解）
+> 出自: river 3 相レビュー（2026-06-08、Gemini + コードベース調査で代替実行 /
+> external-reviewer-interface §10 unavailable 準拠）で検出した「規範↔実装」乖離
+> （Shadow Config）への是正方針。
+
+### 強制モード方針（example=warning / 本番=strict）
+
+- `settings.example.json` は配布テンプレートのため **warning モード**（`PLANGATE_HOOK_STRICT`
+  未設定）を既定とし、導入直後の破壊を避ける。
+- **本番運用（承認境界を信頼する運用）では strict 必須**。`PLANGATE_HOOK_STRICT=1` を
+  設定し EH-2 / EH-3 / EH-6 等を block モードで動かす。
+- この warning↔strict の差は「設定の罠（Shadow Config）」になりうるため、後述の doctor
+  検証で乖離を物理ブロックする。
+
+### doctor によるモード別必須 strict 配線検証
+
+- `bin/plangate doctor --check-settings` は、コード整合性に加えて **現在のモードで必須
+  フックが strict 配線・有効化されているか** を検証する。
+- Governance Contract（モード → 必須 strict フック集合）を定義し、乖離があれば **exit 1
+  で物理ブロック**する。
+- これにより「スクリプトは存在するが settings に配線されておらず動かない幽霊ガバナンス」を
+  構造的に排除する。
+
+### EH-10: 承認トークン書込みガードの採番・配線
+
+- `scripts/check-approval-token-write.sh`（c3.json / maintenance.json 等の承認トークンへの
+  AI 書込みガード）を **EH-10** として正規採番し、`PreToolUse(Edit|Write)` に配線する。
+- #420（maintenance.json 発行元検証ギャップ / R-012）と直結。provenance 検証はそちらと協調。
+
+### 検証ロジックの対称化・テスト空白の解消（実装方針）
+
+| 受け入れ条件 | 実装方針 | 主パス（HO） |
+|------------|---------|-----------|
+| EH-2（c3_status）strict 化 | EH-3 と同じ python3 strict JSON 解析へ置換（permissive な grep/sed 抽出を廃止し EH-3 と対称化） | `scripts/hooks/check-c3-approval.sh` |
+| EH-1/EH-2 stdin fallback | env 未注入時に stdin `tool_input.file_path` から解決し SKIP(allow) を解消 | `scripts/hooks/*.sh` |
+| maintenance verdict テスト | VALID / CONSUMED / OUT_OF_SCOPE / HARDENING_OVERRIDE の fixture + assert を追加 | `tests/hooks/` |
+| ta-06 ログ握りつぶし解消 | `>/dev/null 2>&1` 圧縮をやめ、どの EH が落ちたかをログに残す | `tests/.../ta-06-hooks.sh` |
+
+### 段階 PBI 分解（HO 実適用は Human）
+
+本仕様の HO 実装は以下の順で段階 PBI に分解する（各々 plan → C-3 承認 👤 → exec、
+HO 適用は Human）:
+
+1. **EH-2 strict 化 + EH-1/EH-2 stdin fallback**（hooks 堅牢化・最小単位・回帰リスク低）
+2. **EH-10 採番・配線 + check-approval-token-write 統合**（#420 と協調）
+3. **doctor Wiring Integrity Enforcement**（Governance Contract 定義 + exit 1）
+4. **hooks 回帰テスト拡充**（maintenance verdict fixture + ta-06 ログ解消）
+
+各段階は承認境界（HO）の変更を含むため `mode-classification.md` により最低 high・
+Standard C-3 同期固定（autonomous APPROVE 無効）とする。

--- a/docs/ai/settings-wiring-contract.md
+++ b/docs/ai/settings-wiring-contract.md
@@ -121,8 +121,11 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 
 - `bin/plangate doctor --check-settings` は、コード整合性に加えて **現在のモードで必須
   フックが strict 配線・有効化されているか** を検証する。
-- Governance Contract（モード → 必須 strict フック集合）を定義し、乖離があれば **exit 1
-  で物理ブロック**する。
+- Governance Contract（モード → 必須 strict フック集合）を定義する。
+- **モード別 exit code**: **strict モード**では乖離があれば **exit 1 で物理ブロック**する。
+  一方 **warning モード（example 既定）** では「導入直後の破壊を避ける」方針（上節）と
+  整合させ、未配線・非 strict 配線に対して **warning を出力したうえで exit 0 で通過**させる
+  （block しない）。モードごとの exit code 挙動を doctor 実装時に明示する。
 - これにより「スクリプトは存在するが settings に配線されておらず動かない幽霊ガバナンス」を
   構造的に排除する。
 
@@ -131,6 +134,7 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 - `scripts/check-approval-token-write.sh`（c3.json / maintenance.json 等の承認トークンへの
   AI 書込みガード）を **EH-10** として正規採番し、`PreToolUse(Edit|Write)` に配線する。
 - #420（maintenance.json 発行元検証ギャップ / R-012）と直結。provenance 検証はそちらと協調。
+- **配線方式（重要）**: Claude Code のフック実行環境は env `PLANGATE_HOOK_FILE` を自動 export しないため、`.claude/settings.json` の配線で `${PLANGATE_HOOK_FILE:-}` を **引数として明示的に渡す**（EH-3 と同様）。`check-approval-token-write.sh` は引数 `$1` をターゲットファイルパスの fallback として受け取れるよう実装する（env のみ参照だと Claude Code 環境下でガードがスルーされる）。
 
 ### 検証ロジックの対称化・テスト空白の解消（実装方針）
 
@@ -147,7 +151,7 @@ V-1/handoff 完了の DoD（[`docs/workflows/05_verify_and_handoff.md`](../workf
 HO 適用は Human）:
 
 1. **EH-2 strict 化 + EH-1/EH-2 stdin fallback**（hooks 堅牢化・最小単位・回帰リスク低）
-2. **EH-10 採番・配線 + check-approval-token-write 統合**（#420 と協調）
+2. **EH-10 採番・配線 + check-approval-token-write 統合**（#420 と協調）。配線時は既存の契約検証スクリプト `scripts/check-settings-wiring.sh` の `checks` リストにも EH-10（`check-approval-token-write.sh`）を追加し、CI / ローカルの契約ドリフト検知（`--target example`）に組み込んで配線漏れを防ぐ
 3. **doctor Wiring Integrity Enforcement**（Governance Contract 定義 + exit 1）
 4. **hooks 回帰テスト拡充**（maintenance verdict fixture + ta-06 ログ解消）
 


### PR DESCRIPTION
## 概要

issue #500（承認境界の強制実態ギャップ是正 / river 3 相レビュー由来）対応の **第 1 歩: 仕様策定**。`docs/ai/settings-wiring-contract.md`（**非HO**）に Wiring Integrity Enforcement の方針を明文化する。

## 背景

river 3 相レビューで、承認境界に「**正本に書いてあるが配線・検証されていない**」Shadow Config が集中していることを検出（2 視点一致で最重要課題）。本 PR はその是正方針の正本化。

## 策定した仕様

| 項目 | 内容 |
| --- | --- |
| 強制モード方針 | `settings.example.json`=warning（導入直後の破壊回避）/ 本番=strict（`PLANGATE_HOOK_STRICT=1` 必須） |
| doctor 配線検証 | `--check-settings` がモード別必須 strict フック配線を検証し、乖離で **exit 1 物理ブロック** |
| EH-10 採番 | `check-approval-token-write.sh`（存在するが未配線）を EH-10 として正規採番・配線（#420 協調） |
| EH-2 strict 化 | permissive な grep/sed 抽出を python3 strict JSON 解析へ統一し EH-3 と対称化 |
| stdin fallback | EH-1/EH-2 に env 未注入時の stdin `tool_input.file_path` fallback を追加し SKIP(allow) 解消 |
| テスト空白解消 | maintenance verdict fixture + assert / ta-06 ログ握りつぶし解消 |

## 段階 PBI 分解（HO 実装は Human 適用）

受け入れ条件 5 つは HO パス（hooks/bin/plangate/tests）絡みが多いため、issue 備考どおり 4 段階 PBI に分解（各々 plan→C-3→exec、HO 適用は Human）：

1. EH-2 strict 化 + EH-1/EH-2 stdin fallback
2. EH-10 採番・配線 + check-approval-token-write 統合
3. doctor Wiring Integrity Enforcement
4. hooks 回帰テスト拡充

## スコープ

本 PR は **仕様策定（非HO docs）のみ**。HO 実装は含まない。Issue は段階 PBI 完了後にクローズ想定（本 PR は `Refs #500`）。

## 検証

- markdownlint: 追記範囲（line 104-156）に新規エラーなし（既存 error 38/66/69 は CI glob 対象外で本 PR 範囲外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)