### PR TITLE
docs(#505): PR 変更ファイル検証(WF-05) + HO 仕様+apply フロー正本化（ギャップ2,3）

### DIFF
--- a/docs/ai/ho-change-workflow.md
+++ b/docs/ai/ho-change-workflow.md
@@ -1,0 +1,53 @@
+# HO パス変更の標準フロー（仕様 + apply 分割）
+
+> 非HO 正本。責務4分類（[`responsibility-classes.md`](../../.claude/rules/responsibility-classes.md)
+> 「HO 実適用は Human」）の **how** を定義する。出自: #505 ギャップ3
+> （PR #501-504 セッションの振り返りで確立した実務パターンの手順化）。
+
+## 背景
+
+AI は Hardening Override (HO) パスを**直接編集できない**（HO 常時 block）。対象は
+`.claude/rules/` / `.claude/agents/` / `.claude/commands/` / `CLAUDE.md` / `AGENTS.md` /
+`bin/plangate` / `scripts/hooks/` / `schemas/*.schema.json` / `.github/workflows/`。
+
+一方、これらの変更も**設計・検証・PR 準備は AI が担える**（責務4分類: AI-owned =
+実装・検証・PR 準備 / Human-owned = HO 実適用）。本書はその分割フローを定める。
+
+> 注: `.claude/skills/` と `scripts/_*.py` は HO 対象**外**（AI 直接編集可）。
+> `docs/` 配下も原則 HO 対象外。
+
+## 標準フロー
+
+HO パスの変更を伴う PBI は以下に分割する:
+
+1. **AI: 非HO の仕様 docs** に変更の意図・仕様を正本化（必要な場合）
+2. **AI: apply スクリプト**（`scripts/apply-*.sh`、非HO）を作成
+   - **冪等**: 既適用ならスキップ
+   - **`--dry-run`**: unified diff プレビュー（書き込みなし）
+   - **引数 strict 検証**: `--dry-run` 以外の引数は exit 1（誤適用防止）
+   - **アンカー検証**: 挿入位置が見つからなければ exit 1
+3. **AI: PR 作成**（apply スクリプト + 仕様 docs のみ。HO 実ファイルは含めない）
+4. **Human: C-3 判断 → `--dry-run` で差分確認 → apply 実行**（HO 適用）
+
+## 適用例
+
+| PBI | 非HO 成果物 | HO 適用先 |
+|-----|-----------|----------|
+| #496 doc-light | `apply-mode-classification-doc-light.sh` | `.claude/rules/mode-classification.md` |
+| #505 gap1 | `apply-responsibility-classes-branch-base.sh` | `.claude/rules/responsibility-classes.md` |
+| #500 wiring | `settings-wiring-contract.md` 仕様 + 4 段階 PBI | `scripts/hooks/` / `bin/plangate` 等 |
+
+## 禁止事項
+
+- AI が apply スクリプトを **`--dry-run` なしで実行してはならない**。self-mod guard
+  違反となり HO を誤変更する（実害例: `apply-ho-followups.sh` を AI が誤実行し
+  `ci.yml` を破損。`git checkout` で revert）。apply スクリプトの実行は **Human、
+  または計画段階で明示的に y 承認された AI 実行**に限る。
+- 仕様 docs と apply スクリプトを**同一 PR**に置き、HO 実ファイルは PR に含めない
+  （PR 段階では HO は未変更のまま＝混入・誤適用を構造的に防ぐ）。
+
+## 関連
+
+- 責務4分類正本: [`responsibility-classes.md`](../../.claude/rules/responsibility-classes.md)
+- HO パターン定義: `check-plan-hash.sh` L124-134（9 カテゴリ正本）
+- WF-04 Build & Refine / WF-05 Verify & Handoff

--- a/docs/workflows/05_verify_and_handoff.md
+++ b/docs/workflows/05_verify_and_handoff.md
@@ -19,6 +19,7 @@
 - V2 候補（今回の scope 外と確認された項目）が一覧化されている
 - 妥協点（選ばなかった選択肢と理由）が明文化されている
 - 引き継ぎ文書が handoff パッケージとして統合されている
+- **PR の変更ファイルが想定スコープどおりである**（`gh pr view --json files` または `git diff main --stat` で確認し、他ブランチ・他 PBI の混入がないこと。#505 ギャップ2）
 - **`bin/plangate doctor --check-settings` が PASS している**（TASK-0080
   S1c タスクロック: settings wiring 契約未準拠＝Shadow Configuration の
   状態では V-1/handoff を完了扱いにできない。未適用なら


### PR DESCRIPTION
## 概要

issue #505 のギャップ2・3 対応（いずれも**非HO**）。

## ギャップ2: PR 作成後の変更ファイル検証（WF-05）

`docs/workflows/05_verify_and_handoff.md` の完了条件に **「PR の変更ファイルが想定スコープどおりである（混入なし）」** を追加。#502 のような他 PBI 混入を PR 段階で検知できるようにする。Rule 1（Workflow は順序と完了条件のみ）に準拠し、コマンドは例示にとどめ完了条件として記述。

## ギャップ3: HO 仕様+apply フローの正本化

新規 `docs/ai/ho-change-workflow.md`（非HO 正本）に、本セッションで確立した **「HO パス変更は 非HO 仕様 docs + dry-run 付き apply スクリプト + Human 適用」** の標準フローを明文化：

- apply スクリプト要件（冪等 / `--dry-run` / 引数 strict / アンカー検証）
- 適用例（#496 / #505gap1 / #500）
- 禁止事項（AI の dry-run なし実行禁止 = self-mod guard 違反 / HO 実ファイルは PR に含めない）

責務4分類「HO 実適用は Human」の **how** を補完する。

## dogfooding

本 PR は #505 ギャップ1 で追加する規範どおり、**main から分岐し `git diff --cached --stat` で変更ファイル検証**（2 ファイルのみ＝混入なし）して作成した。

## 検証
- markdownlint: 0 error

`Refs #505`

🤖 Generated with [Claude Code](https://claude.com/claude-code)