### PR TITLE
docs: 第2ラウンド監査 — Unreleased 記録・sidebar 掲載・WF 定義整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+### Added
+
+- **status の BLOCKED 状態 + Deferred ゲート**（#498 / #510）— 外部依存で着手不能なタスクを未着手と区別して明示し、解除条件を一覧化
+- **V-1 テスト実行の単一プロセス既定化**（#497 / #509）— 並行 flaky な timeout を fix loop に流す前に単独再実行で切り分け
+- **doc-light モード適用スクリプト**（#496 / #503）— mode 分類に変更種別軸 + doc-light を追加する Human 適用スクリプト
+- **ブランチ base verify 規範の apply スクリプト**（#505 / #506）— `scripts/apply-responsibility-classes-branch-base.sh`（HO 適用は Human）
+
+### Changed
+
+- **Iron Law #8「NO CLAIM WITHOUT SOURCE CROSS-CHECK」追加**（#494 / #501）— core-contract に主張時の出典突合を義務化
+- **ワークフロー責務範囲の明文化**（#487 / #491・#492）— ワークフローは C-4 まで・リリース/公開は責務外。CI 縮退・C-4 自律承認を Specification として正本化
+- **WF-05 PR 変更ファイル検証 + HO 仕様+apply フロー正本化**（#505 / #507）、**retro 単発セッション捕捉の改善仕様**（#505 / #508）
+- **Wiring Integrity Enforcement 仕様の策定**（#500 / #504）
+- **L-0 カスタム静的解析の false-positive canary 必須化ガイド**（#499 / #502）
+- **ドキュメント整理 Phase 3**（#488〜#490）— philosophy / oss-governance を docs/pages/ へ移行、markdownlint glob・apply-ho-followups.sh を追随
+
+### Fixed
+
+- **全体監査 + テスト分離**（#511）— ドキュメント鮮度更新（v8.12.0 表記・テスト数実測・管理ディレクトリ文書化）、hooks テストのサンドボックス隔離、tracked 成果物汚染（TASK-9991 残骸・TASK-0059 eval-result・監査ログ fixture ノイズ 114 行）の根治
+
 ## v8.12.0 - 2026-06-07
 
 feat: 並列レビューア実行 + Plugin sync 品質ガード + 導入促進・運用ガード整備

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,26 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+### Added
+
+- **status の BLOCKED 状態 + Deferred ゲート**（#498 / #510）— 外部依存で着手不能なタスクを未着手と区別して明示し、解除条件を一覧化
+- **V-1 テスト実行の単一プロセス既定化**（#497 / #509）— 並行 flaky な timeout を fix loop に流す前に単独再実行で切り分け
+- **doc-light モード適用スクリプト**（#496 / #503）— mode 分類に変更種別軸 + doc-light を追加する Human 適用スクリプト
+- **ブランチ base verify 規範の apply スクリプト**（#505 / #506）— `scripts/apply-responsibility-classes-branch-base.sh`（HO 適用は Human）
+
+### Changed
+
+- **Iron Law #8「NO CLAIM WITHOUT SOURCE CROSS-CHECK」追加**（#494 / #501）— core-contract に主張時の出典突合を義務化
+- **ワークフロー責務範囲の明文化**（#487 / #491・#492）— ワークフローは C-4 まで・リリース/公開は責務外。CI 縮退・C-4 自律承認を Specification として正本化
+- **WF-05 PR 変更ファイル検証 + HO 仕様+apply フロー正本化**（#505 / #507）、**retro 単発セッション捕捉の改善仕様**（#505 / #508）
+- **Wiring Integrity Enforcement 仕様の策定**（#500 / #504）
+- **L-0 カスタム静的解析の false-positive canary 必須化ガイド**（#499 / #502）
+- **ドキュメント整理 Phase 3**（#488〜#490）— philosophy / oss-governance を docs/pages/ へ移行、markdownlint glob・apply-ho-followups.sh を追随
+
+### Fixed
+
+- **全体監査 + テスト分離**（#511）— ドキュメント鮮度更新（v8.12.0 表記・テスト数実測・管理ディレクトリ文書化）、hooks テストのサンドボックス隔離、tracked 成果物汚染（TASK-9991 残骸・TASK-0059 eval-result・監査ログ fixture ノイズ 114 行）の根治
+
 ## v8.12.0 - 2026-06-07
 
 feat: 並列レビューア実行 + Plugin sync 品質ガード + 導入促進・運用ガード整備

--- a/docs/workflows/02_requirement_expansion.md
+++ b/docs/workflows/02_requirement_expansion.md
@@ -25,6 +25,7 @@
 - `requirement-gap-scan`
 - `nonfunctional-check`
 - `edgecase-enumeration`
+- `risk-assessment`
 - `acceptance-criteria-build`
 
 ## 主担当 Agent

--- a/docs/workflows/execution-sequence.md
+++ b/docs/workflows/execution-sequence.md
@@ -68,6 +68,13 @@ sequenceDiagram
 
 詳細は `docs/workflows/README.md` 参照。
 
+## WF-06 Retro（opt-in・既定 OFF）
+
+標準シーケンスは WF-05 で終端する。WF-06 Retro は **opt-in 時のみ** C-4 後に
+`retrospective-analyst` が実行する終端フェーズで、`docs/working/improvement-seeds.md`
+へ追記専用で累積する（標準シーケンス図に含まれないのは既定 OFF のため）。
+詳細は [`06_retro.md`](./06_retro.md) / 正本仕様 `docs/ai/retro-phase.md` を参照。
+
 ## 既存 PlanGate Agent との並立
 
 本実行シーケンスは **責務ベース 5 体** で構成されるが、既存 PlanGate 特化版 Agent（`workflow-conductor`, `spec-writer`, `implementer`, `acceptance-tester` 等）は legacy として **並立**する。

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,17 +8,21 @@ module.exports = {
       items: [
         'guides/getting-started',
         'guides/product-demo-script',
+        'guides/codex-guarded-execution',
         {
           type: 'category',
           label: 'ガバナンス',
-          items: ['guides/governance/documentation-management'],
+          items: [
+            'guides/governance/documentation-management',
+            'guides/governance/oss-governance',
+          ],
         },
       ],
     },
     {
       type: 'category',
       label: 'リファレンス',
-      items: ['reference/product-faq'],
+      items: ['reference/product-faq', 'reference/glossary'],
     },
     {
       type: 'category',
@@ -29,6 +33,9 @@ module.exports = {
           label: 'プロダクト',
           items: [
             'explanation/product/overview',
+            'explanation/product/why-plangate',
+            'explanation/product/philosophy',
+            'explanation/product/when-not-to-use',
             'explanation/product/pm-po-elevator-pitch',
             'explanation/product/before-after',
             'explanation/product/positioning',


### PR DESCRIPTION
## Summary

全体監査の第2ラウンド。docs/ai 全 63 ファイル・周辺ドキュメント・テスト/スキル/エージェント/ワークフローの最適化検証を実施し、確定した 4 件を修正。

### 修正内容

| 対象 | 内容 |
|---|---|
| `CHANGELOG.md` / `docs/changelog.md` | 空だった **Unreleased** に v8.12.0 以降の機能 PR 15 件（#488〜#511）を記録・同期 |
| `sidebars.js` | 本文から参照されるが未掲載だった **6 ページ**を追加（why-plangate / philosophy / when-not-to-use / glossary / codex-guarded-execution / oss-governance） |
| `docs/workflows/execution-sequence.md` | README と不整合だった **WF-06 Retro（opt-in）** の終端フェーズ記載を追加 |
| `docs/workflows/02_requirement_expansion.md` | skill-mapping.md と乖離していた `risk-assessment` を呼び出す Skill に追記 |

### 監査で「健全」と確定した領域（修正不要）

- docs/ai/ 全 63 ファイル: 旧用語・リンク切れ・相互矛盾ゼロ、#497/#498/#505 反映済み
- エージェント 23 体: 重複に見えるペアはすべて意図的分担、model/tools 適正、未使用なし
- TROUBLESHOOTING / CONTRIBUTING / install.sh / plugin 群 / examples / RFC ステータス: 整合
- 誤検出として棄却: ta-12「cleanup なし」（実際は 4 箇所で削除済み）、gate-events fixture「死にコード」（gate-event-normalization.md:78 が配置を明記）

### 設計判断を要する検出事項 → 別 issue で起票

- ultra-light.yaml と mode マトリクスの乖離（ゲート明示 or 設計意図文書化）
- スキル SSoT 整理（plan-quality-check/reviewer の配置、plugin 限定 8 skill の status 明記、Use when 欠落 4 件）
- bin/plangate 未テスト 11 サブコマンドのカバレッジ拡充

### 検証

- `sh tests/run-tests.sh` — 271 passed / `sh tests/hooks/run-tests.sh` — 79 passed
- `node -e "require('./sidebars.js')"` 構文 OK、`scripts/sync-release-docs.sh` 同期済み
- テスト実行後の監査ログ汚染なし（#511 の隔離修正が有効に機能していることを実測確認）

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)