### PR TITLE
fix(codex): openai.yaml icon_large デフォルトを実在アセットに修正（#516 レビュー対応）

### DIFF
--- a/.codex/skills/acceptance-criteria-build/agents/openai.yaml
+++ b/.codex/skills/acceptance-criteria-build/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "acceptance-criteria-build"
-  short_description: "Build acceptance criteria from requirements"
+  short_description: "要件とエッジケースから受け入れ条件（AC）を明文化し、チェックリスト形式で整理する。Use when: WF-02 で A..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $acceptance-criteria-build to build acceptance criteria for this task."
+  default_prompt: "Use $acceptance-criteria-build to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/acceptance-review/agents/openai.yaml
+++ b/.codex/skills/acceptance-review/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "acceptance-review"
-  short_description: "Review and verify acceptance criteria are met"
+  short_description: "実装結果を受け入れ条件（AC）と照合し、適合 / 不足を明確化する。Use when: WF-05 Verify & Ha..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $acceptance-review to verify acceptance criteria are met."
+  default_prompt: "Use $acceptance-review to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/ai-dev-brainstorm/agents/openai.yaml
+++ b/.codex/skills/ai-dev-brainstorm/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "ai-dev-brainstorm"
-  short_description: "Brainstorm and structure AI dev ideas into plans"
+  short_description: "アイデアや曖昧な要件を PlanGate の PBI INPUT PACKAGE に対話的に整理する。Use when: ..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $ai-dev-brainstorm to brainstorm ideas for this development task."
+  default_prompt: "Use $ai-dev-brainstorm to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/ai-dev-exec/agents/openai.yaml
+++ b/.codex/skills/ai-dev-exec/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "ai-dev-exec"
-  short_description: "Execute AI dev tasks with TDD and agent control"
+  short_description: "PlanGate の exec フェーズを TDD で実行する。Use when: C-3 APPROVED 後にコード実..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $ai-dev-exec to execute this development task."
+  default_prompt: "Use $ai-dev-exec to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/ai-dev-plan/agents/openai.yaml
+++ b/.codex/skills/ai-dev-plan/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "ai-dev-plan"
-  short_description: "Plan AI dev tasks with structured work breakdown"
+  short_description: "PBI INPUT PACKAGE から PlanGate の plan.md / todo.md / test-case..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $ai-dev-plan to create a structured plan for this task."
+  default_prompt: "Use $ai-dev-plan to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/ai-dev-verify/agents/openai.yaml
+++ b/.codex/skills/ai-dev-verify/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "ai-dev-verify"
-  short_description: "Verify AI dev implementation against requirements"
+  short_description: "PlanGate の V-1〜V-4 受け入れ検査と handoff.md 発行を行う。Use when: exec 完了..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $ai-dev-verify to verify the implementation meets requirements."
+  default_prompt: "Use $ai-dev-verify to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/architecture-sketch/agents/openai.yaml
+++ b/.codex/skills/architecture-sketch/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "architecture-sketch"
-  short_description: "Sketch architecture and module boundaries"
+  short_description: "確定した仕様を、モジュール境界・データフロー・状態管理・失敗時挙動を持つ設計案に落とし込む。Use when: WF-03..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $architecture-sketch to sketch the architecture for this feature."
+  default_prompt: "Use $architecture-sketch to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/brainstorming/agents/openai.yaml
+++ b/.codex/skills/brainstorming/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "brainstorming"
-  short_description: "Brainstorm and structure ideas into PBI packages"
+  short_description: "アイデアや要件を対話的に設計書（PBI INPUT PACKAGE）へ昇華する。Use when: 「こういう機能を作りた..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $brainstorming to brainstorm and structure ideas for this project."
+  default_prompt: "Use $brainstorming to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/codex-multi-agent/agents/openai.yaml
+++ b/.codex/skills/codex-multi-agent/agents/openai.yaml
@@ -2,6 +2,6 @@ interface:
   display_name: "codex-multi-agent"
   short_description: "マルチエージェントでタスク分解・委譲・並列実行・結果統合を行うための共通運用スキル。Use when: 「マルチエージェン..."
   icon_small: "./assets/plangate-small.svg"
-  icon_large: "./assets/plangate.png"
+  icon_large: "./assets/plangate-small.svg"
   default_prompt: "Use $codex-multi-agent to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/codex-mvp-split/agents/openai.yaml
+++ b/.codex/skills/codex-mvp-split/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "codex-mvp-split"
-  short_description: "Split tasks into MVP and backlog items"
+  short_description: "規模 L 以上の機能の最小 MVP (Phase 1) を Codex に選定相談し Phase 分割表を作る。Use w..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $codex-mvp-split to split this task into MVP and backlog."
+  default_prompt: "Use $codex-mvp-split to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/context-load/agents/openai.yaml
+++ b/.codex/skills/context-load/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "context-load"
-  short_description: "Load and restore session context quickly"
+  short_description: "AGENTS.md と依頼文から案件の前提・制約・品質基準を抽出し、context artifact としてサマライズする..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $context-load to load context for the current session."
+  default_prompt: "Use $context-load to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/edgecase-enumeration/agents/openai.yaml
+++ b/.codex/skills/edgecase-enumeration/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "edgecase-enumeration"
-  short_description: "Enumerate edge cases and boundary conditions"
+  short_description: "境界条件・例外条件・異常系を体系的に列挙し、エッジケース一覧を作成する。Use when: WF-02 でエッジケース検討..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $edgecase-enumeration to enumerate edge cases for this feature."
+  default_prompt: "Use $edgecase-enumeration to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/feature-implement/agents/openai.yaml
+++ b/.codex/skills/feature-implement/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "feature-implement"
-  short_description: "Implement features with TDD and clean patterns"
+  short_description: "design artifact に従って、最小単位で実装・テスト・自己レビューを繰り返し、動作するコード差分を生成する。U..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $feature-implement to implement this feature."
+  default_prompt: "Use $feature-implement to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/known-issues-log/agents/openai.yaml
+++ b/.codex/skills/known-issues-log/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "known-issues-log"
-  short_description: "Log and track known issues and workarounds"
+  short_description: "妥協点・既知不具合・V2 候補を文書化し、次の担当者が再開可能な形に整備する。Use when: WF-05 Verify..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $known-issues-log to log known issues for this task."
+  default_prompt: "Use $known-issues-log to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/local-exec-handoff/agents/openai.yaml
+++ b/.codex/skills/local-exec-handoff/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "local-exec-handoff"
-  short_description: "Hand off local execution tasks to the agent"
+  short_description: "PlanGate のローカル実行（Codex CLI / Claude Code）で exec を再開・引き継ぐための短い..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $local-exec-handoff to hand off this task for local execution."
+  default_prompt: "Use $local-exec-handoff to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/manual-cloud-task/agents/openai.yaml
+++ b/.codex/skills/manual-cloud-task/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "manual-cloud-task"
-  short_description: "Manage manual cloud tasks and deployments"
+  short_description: "tracked handoff packet を使って Codex Cloud task を手動起動するための指示を組み立..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $manual-cloud-task to manage this cloud deployment task."
+  default_prompt: "Use $manual-cloud-task to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/nonfunctional-check/agents/openai.yaml
+++ b/.codex/skills/nonfunctional-check/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "nonfunctional-check"
-  short_description: "Check non-functional requirements like perf"
+  short_description: "性能・保守性・安全性・アクセシビリティなど非機能要件を体系的にチェックし、明示すべき非機能要件を一覧化する。Use whe..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $nonfunctional-check to check non-functional requirements."
+  default_prompt: "Use $nonfunctional-check to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/plan-review-gate/agents/openai.yaml
+++ b/.codex/skills/plan-review-gate/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "plan-review-gate"
-  short_description: "Gate plan review before implementation starts"
+  short_description: "PlanGate の C-1 / C-2 / C-3 ゲートを確認し、exec 開始可否を判定する。Use when: p..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $plan-review-gate to review and gate this plan before execution."
+  default_prompt: "Use $plan-review-gate to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/plangate-setup/agents/openai.yaml
+++ b/.codex/skills/plangate-setup/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "plangate-setup"
-  short_description: "Set up PlanGate in a new project"
+  short_description: "PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の ..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $plangate-setup to set up PlanGate for this project."
+  default_prompt: "Use $plangate-setup to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/requirement-gap-scan/agents/openai.yaml
+++ b/.codex/skills/requirement-gap-scan/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "requirement-gap-scan"
-  short_description: "Scan for gaps in requirements and acceptance"
+  short_description: "初期要求から抜け漏れ・曖昧さ・対象外を体系的に洗い出し、追加要件候補をリストアップする。Use when: WF-02 R..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $requirement-gap-scan to scan for requirement gaps."
+  default_prompt: "Use $requirement-gap-scan to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/risk-assessment/agents/openai.yaml
+++ b/.codex/skills/risk-assessment/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "risk-assessment"
-  short_description: "Assess risks and define mitigation strategies"
+  short_description: "制約・未確定要素・技術的リスクを洗い出し、severity と mitigation を付けて一覧化する。Use when..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $risk-assessment to assess risks for this task."
+  default_prompt: "Use $risk-assessment to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/self-review/agents/openai.yaml
+++ b/.codex/skills/self-review/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "self-review"
-  short_description: "Self-review plan and implementation quality"
+  short_description: "変更内容に対して詳細なセルフレビューを実施し、構造化されたレポートを出力する。Use when: コミット・PR前に自分の..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $self-review to review the current plan and implementation."
+  default_prompt: "Use $self-review to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/setup-team/agents/openai.yaml
+++ b/.codex/skills/setup-team/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "setup-team"
-  short_description: "Set up agent team roles and responsibilities"
+  short_description: "タスクに応じたマルチエージェントチームを設計・構成する。Use when: 「エージェントチームを組んで」「複数エージェン..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $setup-team to set up the agent team for this project."
+  default_prompt: "Use $setup-team to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/subagent-driven-development/agents/openai.yaml
+++ b/.codex/skills/subagent-driven-development/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "subagent-driven-development"
-  short_description: "Drive development with subagent delegation"
+  short_description: "実装計画のタスクをサブエージェントに委譲し、spec準拠+品質の2段階レビューで品質を担保する。Use when: 「この..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $subagent-driven-development to delegate this task to subagents."
+  default_prompt: "Use $subagent-driven-development to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/systematic-debugging/agents/openai.yaml
+++ b/.codex/skills/systematic-debugging/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "systematic-debugging"
-  short_description: "Debug issues systematically with root cause"
+  short_description: "バグや障害を体系的に調査し、エビデンスに基づいて根本原因を特定する。Use when: 「動かない」「エラーが出る」「なぜ..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
-  default_prompt: "Use $systematic-debugging to debug this issue systematically."
+  default_prompt: "Use $systematic-debugging to assist with this project."
   brand_color: "#1A56DB"

--- a/.codex/skills/working-context/agents/openai.yaml
+++ b/.codex/skills/working-context/agents/openai.yaml
@@ -2,6 +2,6 @@ interface:
   display_name: "working-context"
   short_description: "PlanGate の TASK-XXXX 作業コンテキストを Progressive Disclosure で読込・更新す..."
   icon_small: "./assets/plangate-small.svg"
-  icon_large: "./assets/plangate.png"
+  icon_large: "./assets/plangate-small.svg"
   default_prompt: "Use $working-context to assist with this project."
   brand_color: "#1A56DB"

--- a/scripts/apply-agent-slimming.sh
+++ b/scripts/apply-agent-slimming.sh
@@ -24,13 +24,13 @@ fi
 [ "$MODE" = "--apply" ] || { echo "usage: $0 [--dry-run|--apply]"; exit 1; }
 
 for a in $AGENTS; do
-  git -C "$ROOT" rm -q ".claude/agents/$a.md"
+  git -C "$ROOT" rm -q --ignore-unmatch ".claude/agents/$a.md"
 done
 
 python3 - "$ROOT/.claude/agents/README.md" <<'PYEOF2'
 import re, sys
 p = sys.argv[1]
-lines = open(p).read().splitlines()
+lines = open(p, encoding="utf-8").read().splitlines()
 drop = ("| claude-code-reviewer ", "| prompt-engineer ", "| migration-agent ",
         "| research-analyst ", "| scrum-master ", "| agile-coach ")
 out = [l for l in lines if not l.startswith(drop)]
@@ -54,7 +54,7 @@ note = anchor + """
 """
 assert s.count(anchor) == 1
 s = s.replace(anchor, note)
-open(p, "w").write(s)
+open(p, "w", encoding="utf-8").write(s)
 print("README.md updated")
 PYEOF2
 

--- a/scripts/apply-agent-slimming.sh
+++ b/scripts/apply-agent-slimming.sh
@@ -30,7 +30,8 @@ done
 python3 - "$ROOT/.claude/agents/README.md" <<'PYEOF2'
 import re, sys
 p = sys.argv[1]
-lines = open(p, encoding="utf-8").read().splitlines()
+with open(p, encoding="utf-8") as f:
+    lines = f.read().splitlines()
 drop = ("| claude-code-reviewer ", "| prompt-engineer ", "| migration-agent ",
         "| research-analyst ", "| scrum-master ", "| agile-coach ")
 out = [l for l in lines if not l.startswith(drop)]
@@ -54,7 +55,8 @@ note = anchor + """
 """
 assert s.count(anchor) == 1
 s = s.replace(anchor, note)
-open(p, "w", encoding="utf-8").write(s)
+with open(p, "w", encoding="utf-8") as f:
+    f.write(s)
 print("README.md updated")
 PYEOF2
 

--- a/scripts/install-plangate-skills-to-codex.sh
+++ b/scripts/install-plangate-skills-to-codex.sh
@@ -144,7 +144,7 @@ PYTRUNC
 )
   fi
   [ -z "$frontmatter_icon_small" ] && frontmatter_icon_small="./assets/plangate-small.svg"
-  [ -z "$frontmatter_icon_large" ] && frontmatter_icon_large="./assets/plangate.png"
+  [ -z "$frontmatter_icon_large" ] && frontmatter_icon_large="./assets/plangate-small.svg"
   if [ -z "$frontmatter_default_prompt" ]; then
     frontmatter_default_prompt="Use \$$skill_name to assist with this project."
   fi


### PR DESCRIPTION
## Summary

マージ済み PR #516 への Gemini レビュー指摘のフォローアップ。

- **実バグ修正**: `install-plangate-skills-to-codex.sh` の `icon_large` デフォルトが実在しない `./assets/plangate.png` を指していた（同梱実体は `plangate-small.svg` のみ）。デフォルトを修正し全 26 skill の openai.yaml を再生成（icon_large 26/26 統一）。再生成により `.agents/skills` 正本の description 更新に対する `.codex` 側の stale も解消
- **スクリプト堅牢化**: `apply-agent-slimming.sh` に `git rm --ignore-unmatch`（再実行安全）と `encoding="utf-8"` 明示を追加

## 検証

- `scripts/check-codex-skill-spec.sh` 全 PASS / CLI 271 PASS
- `grep icon_large .codex/skills/*/agents/openai.yaml` → 26/26 が `plangate-small.svg`

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)