### PR TITLE
docs: Hook enforcement の実装/物理配線を区別（12/12 実装・6/12 配線）

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこ�
 | 最新リリース | **v8.12.0**（Latest, 2026-06-07）— 並列レビューア実行 + Plugin sync 品質ガード + 導入促進（Why PlanGate）・運用ガード整備 |
 | リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 / **v8.11.0** Claude Code / Codex Plugin 正式配布対応 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
-| Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3、v8.5.0 で 10/10、v8.6.0 で EH-8、v8.7.0 で EH-9 を追加） |
+| Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3。物理配線は 6/12 — 残りは [#500](https://github.com/s977043/plangate/issues/500) で配線予定、詳細は [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)） |
 | Metrics v1 | `bin/plangate metrics` による workflow event 集計（v8.6.0 初出） |
 | Reporting v1 | events.ndjson から sprint retrospective を導出（v8.9.0） |
 | Baseline | v8.5.0 直後の baseline を `docs/ai/eval-baselines/` に固定（v8.6.0 初出） |

--- a/README_en.md
+++ b/README_en.md
@@ -84,7 +84,7 @@ v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "wher
 | Latest release | **v8.12.0** (Latest, 2026-06-07) — Parallel reviewer execution + plugin sync quality guards + adoption landing (Why PlanGate) / operations guards |
 | Shipped | **v8.7.0** OSS adoption foundations + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1, Dynamic Context Engine v1, Model Profile v2, Gate Event Normalization, Dogfooding Eval v1 |
 | Roadmap | **EPIC #193 complete (CLOSED / COMPLETED)** — Phases 0-6 + Governance + Lightweight Plan Quality Checks all Done, child PBIs 12/12 CLOSED |
-| Hook enforcement | **12/12 hooks implemented** (EH-1 to EH-9 + EHS-1 to EHS-3; v8.5.0=10/10, v8.6.0 added EH-8, v8.7.0 added EH-9) |
+| Hook enforcement | **12/12 hooks implemented** (EH-1 to EH-9 + EHS-1 to EHS-3; physical wiring is 6/12 — remainder planned in [#500](https://github.com/s977043/plangate/issues/500), see [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)) |
 | Metrics v1 | Workflow event collection and reporting via `bin/plangate metrics` (introduced in v8.6.0) |
 | Reporting v1 | Sprint retrospective derived from events.ndjson (v8.9.0) |
 | Baseline | v8.5.0 baseline fixed under `docs/ai/eval-baselines/` (introduced in v8.6.0) |

--- a/docs/ai/hook-enforcement.md
+++ b/docs/ai/hook-enforcement.md
@@ -7,6 +7,19 @@
 > 現状は **EH-1〜EH-9 + EHS-1〜EHS-3 = 12/12**。本書本文の表は v8.5.0 構成のまま
 > 維持し、追加分の詳細はそれぞれの実装 PR / CHANGELOG / `bin/plangate doctor` 出力を参照。
 
+> **実装と物理配線の区別（2026-06-10 棚卸し）**: 12/12 は「スクリプト実装 +
+> 単体テスト済み」を指す。**発火経路（settings.json / .codex/hooks.json / CI /
+> bin/plangate）への物理配線は 6/12**。配線の完全化は
+> [#500 Wiring Integrity Enforcement](https://github.com/s977043/plangate/issues/500)
+> （仕様策定済み）の実装範囲。
+>
+> | 配線状態 | Hook | 発火経路 |
+> |---------|------|---------|
+> | ✅ 配線済み（6） | EH-1 / EH-2 / EH-3 / EH-6 / EH-9 | Claude PreToolUse + Codex hooks.json |
+> | | EH-8 | CI（metrics-privacy.yml）+ doctor + codex-guarded |
+> | ⏳ 実装済み・未配線（6） | EH-4 / EH-5 / EH-7 | 発火経路なし（#500 で配線予定） |
+> | | EHS-1 / EHS-2 / EHS-3 | 発火条件の `validation_bias: strict` 自体が未配線（model-profiles.yaml は参照層） |
+
 > 関連: [`responsibility-boundary.md`](./responsibility-boundary.md) / [`tool-policy.md`](./tool-policy.md) / [`model-profiles.md`](./model-profiles.md)
 > 実装: [`scripts/hooks/check-plan-exists.sh`](../../scripts/hooks/check-plan-exists.sh) / [`check-c3-approval.sh`](../../scripts/hooks/check-c3-approval.sh) / [`check-plan-hash.sh`](../../scripts/hooks/check-plan-hash.sh) / [`check-test-cases.sh`](../../scripts/hooks/check-test-cases.sh) / [`check-verification-evidence.sh`](../../scripts/hooks/check-verification-evidence.sh) / [`check-forbidden-files.sh`](../../scripts/hooks/check-forbidden-files.sh) / [`check-merge-approvals.sh`](../../scripts/hooks/check-merge-approvals.sh) / [`check-v3-review.sh`](../../scripts/hooks/check-v3-review.sh) / [`check-handoff-elements.sh`](../../scripts/hooks/check-handoff-elements.sh) / [`check-fix-loop.sh`](../../scripts/hooks/check-fix-loop.sh)
 > 設定例: [`.claude/settings.example.json`](../../.claude/settings.example.json) / 単体テスト: [`tests/hooks/run-tests.sh`](../../tests/hooks/run-tests.sh)

--- a/scripts/apply-hook-wiring-note.sh
+++ b/scripts/apply-hook-wiring-note.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# apply-hook-wiring-note.sh — CLAUDE.md の Hook enforcement 表現を実態整合（Human 実行）
+#
+# 背景: 2026-06-10 の Shadow Spec 棚卸しで「12/12」公称に対し物理配線は 6/12 と判明。
+# 正本（docs/ai/hook-enforcement.md）には配線状態表を追加済み。CLAUDE.md は
+# Hardening Override 対象のため本スクリプトで Human が適用する。
+#
+# 使い方: sh scripts/apply-hook-wiring-note.sh [--dry-run|--apply]
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+F="$ROOT/CLAUDE.md"
+OLD='Hook enforcement は **12/12**'
+NEW='Hook enforcement は **12/12 実装**（物理配線 6/12、詳細は [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)）'
+
+if grep -qF "$NEW" "$F"; then echo "OK (already applied)"; exit 0; fi
+grep -qF "$OLD" "$F" || { echo "ERROR: アンカーが見つかりません: $OLD" >&2; exit 1; }
+if [ "$MODE" = "--dry-run" ]; then
+  echo "[dry-run] CLAUDE.md:"; echo "- $OLD"; echo "+ $NEW"
+elif [ "$MODE" = "--apply" ]; then
+  python3 - "$F" "$OLD" "$NEW" <<'PY'
+import sys
+f, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(f, encoding="utf-8") as fp: s = fp.read()
+assert s.count(old) == 1
+with open(f, "w", encoding="utf-8") as fp: fp.write(s.replace(old, new))
+PY
+  echo "APPLIED: CLAUDE.md"
+else
+  echo "usage: $0 [--dry-run|--apply]"; exit 1
+fi


### PR DESCRIPTION
## Summary

「設定されているが未実装」の Shadow Spec 棚卸しで判明した、Hook enforcement の公称（12/12）と物理配線（6/12）の乖離を実態整合。

- **hook-enforcement.md**: 配線状態表を正本化（配線済み 6: EH-1/2/3/6/9 + EH-8 / 未配線 6: EH-4/5/7 + EHS-1〜3。EHS 群は発火条件の `validation_bias: strict` 自体が未配線）
- **README / README_en**: Hook enforcement 行に配線状態と #500 への参照を追記
- **CLAUDE.md**（HO）: `scripts/apply-hook-wiring-note.sh` で Human 適用（dry-run 検証済み）

配線の完全化は #500（Wiring Integrity Enforcement、仕様策定済み）の実装範囲。

検証: CLI 271 PASS

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF