### PR TITLE
feat: river-review の計画作成 skill を ai-dev-plan へ統合受け入れ

### DIFF
--- a/.agents/skills/ai-dev-plan/SKILL.md
+++ b/.agents/skills/ai-dev-plan/SKILL.md
@@ -71,6 +71,24 @@ find . -name <pattern> -not -path './.git/*' -not -path './node_modules/*' | wc 
 - decision-log.jsonl に B-1/B-2/B-3 の主要判断を append-only で記録
 - mode が `critical` で `lite_eligible=true` の場合は人間の C-3 明示承認記録が前提（`mode-classification.md` AC-11）
 
+## 計画の構造化観点（river-review rr-upstream-create-plan-001 由来 / #517 受け入れ）
+
+plan.md 生成時、以下の観点を Work Breakdown / Risks に反映する:
+
+1. **仮説と確定事項の分離** — 判断に必要な事実が欠けていれば Questions / Unknowns に
+   質問として先出しし、仮説（未確認の前提）と確定事項を混ぜない。情報不足のまま
+   推測で進めない
+2. **リスクの 3 点セット** — Risks には `内容 / 検証手段 / Fallback` を揃える。
+   不確実性（互換性・性能・移行・セキュリティ）ごとに検証方法が無いリスクを残さない
+3. **人間ゲートの明示** — 設計確認・仕様確認など人間レビューが必要なブレーキ
+   ポイントを Work Breakdown の 🚩 チェックポイントとして明示する（自己設置 Gate は
+   勝手に解除しない — responsibility-classes.md 準拠）
+4. **速く学べる順** — ステップは検証が早く回る順に並べ、クリティカルパスを明示。
+   並列可能な作業はまとめて示す
+
+> 出典: river-review `rr-upstream-create-plan-001`（skill インベントリ監査で
+> 「plan を作る側 = PlanGate の責務」と整理され移管。s977043/river-review#1105）
+
 ## CLI 呼び出し
 
 - 実コマンド: `./scripts/ai-dev-workflow TASK-XXXX plan`

--- a/.codex/skills/ai-dev-plan/SKILL.md
+++ b/.codex/skills/ai-dev-plan/SKILL.md
@@ -71,6 +71,24 @@ find . -name <pattern> -not -path './.git/*' -not -path './node_modules/*' | wc 
 - decision-log.jsonl に B-1/B-2/B-3 の主要判断を append-only で記録
 - mode が `critical` で `lite_eligible=true` の場合は人間の C-3 明示承認記録が前提（`mode-classification.md` AC-11）
 
+## 計画の構造化観点（river-review rr-upstream-create-plan-001 由来 / #517 受け入れ）
+
+plan.md 生成時、以下の観点を Work Breakdown / Risks に反映する:
+
+1. **仮説と確定事項の分離** — 判断に必要な事実が欠けていれば Questions / Unknowns に
+   質問として先出しし、仮説（未確認の前提）と確定事項を混ぜない。情報不足のまま
+   推測で進めない
+2. **リスクの 3 点セット** — Risks には `内容 / 検証手段 / Fallback` を揃える。
+   不確実性（互換性・性能・移行・セキュリティ）ごとに検証方法が無いリスクを残さない
+3. **人間ゲートの明示** — 設計確認・仕様確認など人間レビューが必要なブレーキ
+   ポイントを Work Breakdown の 🚩 チェックポイントとして明示する（自己設置 Gate は
+   勝手に解除しない — responsibility-classes.md 準拠）
+4. **速く学べる順** — ステップは検証が早く回る順に並べ、クリティカルパスを明示。
+   並列可能な作業はまとめて示す
+
+> 出典: river-review `rr-upstream-create-plan-001`（skill インベントリ監査で
+> 「plan を作る側 = PlanGate の責務」と整理され移管。s977043/river-review#1105）
+
 ## CLI 呼び出し
 
 - 実コマンド: `./scripts/ai-dev-workflow TASK-XXXX plan`

--- a/plugin/plangate/skills/ai-dev-plan/SKILL.md
+++ b/plugin/plangate/skills/ai-dev-plan/SKILL.md
@@ -71,6 +71,24 @@ find . -name <pattern> -not -path './.git/*' -not -path './node_modules/*' | wc 
 - decision-log.jsonl に B-1/B-2/B-3 の主要判断を append-only で記録
 - mode が `critical` で `lite_eligible=true` の場合は人間の C-3 明示承認記録が前提（`mode-classification.md` AC-11）
 
+## 計画の構造化観点（river-review rr-upstream-create-plan-001 由来 / #517 受け入れ）
+
+plan.md 生成時、以下の観点を Work Breakdown / Risks に反映する:
+
+1. **仮説と確定事項の分離** — 判断に必要な事実が欠けていれば Questions / Unknowns に
+   質問として先出しし、仮説（未確認の前提）と確定事項を混ぜない。情報不足のまま
+   推測で進めない
+2. **リスクの 3 点セット** — Risks には `内容 / 検証手段 / Fallback` を揃える。
+   不確実性（互換性・性能・移行・セキュリティ）ごとに検証方法が無いリスクを残さない
+3. **人間ゲートの明示** — 設計確認・仕様確認など人間レビューが必要なブレーキ
+   ポイントを Work Breakdown の 🚩 チェックポイントとして明示する（自己設置 Gate は
+   勝手に解除しない — responsibility-classes.md 準拠）
+4. **速く学べる順** — ステップは検証が早く回る順に並べ、クリティカルパスを明示。
+   並列可能な作業はまとめて示す
+
+> 出典: river-review `rr-upstream-create-plan-001`（skill インベントリ監査で
+> 「plan を作る側 = PlanGate の責務」と整理され移管。s977043/river-review#1105）
+
 ## CLI 呼び出し
 
 - 実コマンド: `./scripts/ai-dev-workflow TASK-XXXX plan`


### PR DESCRIPTION
## Summary

issue #517 の受け入れ判断と実装。

- **受け入れ判断**: 受け入れる（plan を作る側 = PlanGate の責務、との整理に同意）
- **受け入れ形式**: **既存 ai-dev-plan へのエッセンス統合**。理由: PlanGate には plan 生成系（ai-dev-plan / brainstorming / plan-quality-check）が既にあり、river-review 固有形式（NO_REVIEW ゲート・`(summary):1:` 出力・rr- ID）のままの移植は不適合。重複新規スキルの追加は直近のスリム化（PR #516）と逆行
- 統合した観点: ①仮説と確定事項の分離（情報不足は質問に）②リスクの 3 点セット（内容/検証手段/Fallback）③人間ゲートの明示（自己設置 Gate 非解除と整合）④速く学べる順のステップ配置
- 出典を SKILL.md 内に記録、全系統（.agents → plugin / .codex）へ同期済み

マージ後、river-review 側へ受け入れ完了を通知します（削除 follow-up は river-review 側で実施とのこと）。

closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)