### PR TITLE
docs: skill SSoT 残項目の整理（Use when / 使い分け matrix / plugin 限定 status / 配置宣言）

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -16,6 +16,15 @@
 | `local-exec-handoff` | ローカル exec 再開・ツール間引き継ぎ用の短い指示パケット（Cloud 不使用時）|
 | `plangate-setup` | PlanGate 初期セットアップを対話的に進めるためのチェックリスト・5 要素対応観点（TASK-0107 / Claude Code + Codex CLI 共用）|
 
+## 似た責務スキルの使い分け（#514）
+
+| 迷ったら | 選ぶスキル | 理由 |
+|---------|-----------|------|
+| plan の品質を**軽くスコアリング**したい | `plan-quality-check`（.claude 専用） | `bin/plangate plan-check` に配線された軽量ゲート。C-1 の代替ではない |
+| C-1/C-2/C-3 の**正式ゲート判定**を回したい | `plan-review-gate` | ゲート列の判定と exec 可否確認の正本フロー |
+| plan を**外部レビュアー視点で講評**してほしい | `plan-quality-reviewer`（.claude 専用） | スコアでなく講評を返す。正式ゲートの代替ではない |
+| 新しいスキルを**作りたい** | `skill-creator` | 要件→SKILL.md 一式の生成。既存スキルの改善は対象外 |
+
 Codex CLI の標準入口は `./scripts/ai-dev-workflow TASK-XXXX brainstorm|plan|gate|exec|prepare-cloud|sync-cloud`。verify 系は `bin/plangate validate|review|eval|metrics TASK-XXXX` を併用する。
 本 skill (`plangate-setup`) は Codex 用 agent `.codex/agents/setup_coordinator.toml` から参照される。
 

--- a/.agents/skills/plangate-setup/SKILL.md
+++ b/.agents/skills/plangate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plangate-setup
-description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。
+description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。Use when: 「PlanGate をセットアップして」「導入したい」「初期設定」「doctor が FAIL する」と依頼された時、または導入直後の環境検証時。
 ---
 
 # PlanGate Setup — チェックリスト & 観点

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Design a new Codex skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
+description: Design a new repo-owned skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -39,3 +39,10 @@ v7（`docs/plangate-v7-hybrid.md`）で追加された **再利用可能 Skill**
 - フォルダー名はkebab-case
 - 詳細ドキュメントは `references/` に分離する
 - テンプレート等は `assets/` に配置する
+
+## 配置の宣言（#514）
+
+`plan-quality-check` / `plan-quality-reviewer` は **Claude Code 専用スキル**として
+本ディレクトリのみに置く（共有 SSoT `.agents/skills/` へは置かない）。理由:
+`bin/plangate plan-check` の Claude 向け配線・講評形式が Claude Code の利用文脈に
+依存するため。Codex 側の同等機能は `plan-review-gate` + `bin/plangate validate` が担う。

--- a/.claude/skills/plangate-setup/SKILL.md
+++ b/.claude/skills/plangate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plangate-setup
-description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。
+description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。Use when: 「PlanGate をセットアップして」「導入したい」「初期設定」「doctor が FAIL する」と依頼された時、または導入直後の環境検証時。
 ---
 
 # PlanGate Setup — チェックリスト & 観点

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Design a new Claude Code skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
+description: Design a new repo-owned skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 

--- a/.codex/skills/plangate-setup/SKILL.md
+++ b/.codex/skills/plangate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plangate-setup
-description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。
+description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。Use when: 「PlanGate をセットアップして」「導入したい」「初期設定」「doctor が FAIL する」と依頼された時、または導入直後の環境検証時。
 ---
 
 # PlanGate Setup — チェックリスト & 観点

--- a/plugin/plangate/skills/README.md
+++ b/plugin/plangate/skills/README.md
@@ -52,3 +52,22 @@ WF-01〜WF-05 の各 phase で呼び出す再利用可能スキル。
 |--------|------|
 | `skill-creator` | 新しいスキルを対話的に設計・生成 |
 | `setup-team` | タスク規模・モードに応じた最適チーム設計とエージェント委譲準備 |
+
+## plugin 限定スキルの status（#514）
+
+以下 8 スキルは `.agents/skills/`（共有 SSoT）に存在せず **plugin 配布専用**。
+v7 統制層（TASK-0029 / TASK-0033）で plugin に直接追加され、導入先リポジトリで
+Intent/Mode 分類・4 Gate・エージェント統制を動かすための製品面コンポーネント:
+
+| スキル | 役割 | status |
+|--------|------|--------|
+| `intent-classifier` | 依頼の意図分類（mode 判定の前段） | plugin 専用・現役 |
+| `skill-policy-router` | mode に応じた skill 選択ルーティング | plugin 専用・現役 |
+| `design-gate` / `review-gate` | 設計/レビューゲートの実行枠 | plugin 専用・現役 |
+| `context-packager` | サブエージェントへの文脈パッケージング | plugin 専用・現役 |
+| `subagent-dispatch` | サブエージェント委譲の定型化 | plugin 専用・現役 |
+| `evidence-ledger` | レビュー根拠の台帳化 | plugin 専用・現役 |
+| `pr-decision` | PR 作成可否の判定 | plugin 専用・現役 |
+
+本リポジトリ自身の運用では同等機能を rules / workflow / bin/plangate が担うため
+`.agents/skills` には置かない（共有 SSoT へ昇格する場合は #514 の後続判断）。

--- a/plugin/plangate/skills/plangate-setup/SKILL.md
+++ b/plugin/plangate/skills/plangate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plangate-setup
-description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。
+description: PlanGate 初期セットアップを対話的に進めるためのチェックリスト、5 要素対応観点、Human-owned 操作の script 提示テンプレ。doctor を単一検証源とする。Use when: 「PlanGate をセットアップして」「導入したい」「初期設定」「doctor が FAIL する」と依頼された時、または導入直後の環境検証時。
 ---
 
 # PlanGate Setup — チェックリスト & 観点

--- a/plugin/plangate/skills/skill-creator/SKILL.md
+++ b/plugin/plangate/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Design a new Codex skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
+description: Design a new repo-owned skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 


### PR DESCRIPTION
## Summary

issue #514 の残項目をすべて対応（skill-ops-planner / skill-optimizer 分は PR #516 の削除で対象外化済み）。

- **Use when 追記**: plangate-setup（唯一の欠落残）
- **provider 中立化**: skill-creator の説明文（レビュー指摘 P1-C）
- **使い分け matrix**: .agents/skills/README に plan-quality-check / plan-review-gate / plan-quality-reviewer / skill-creator の選択基準表
- **plugin 限定 8 skill の status 明記**: v7 統制層由来・plugin 専用・現役であることと、本リポジトリでは rules/workflow が同等機能を担うため共有 SSoT に置かない理由を README に正本化
- **配置宣言**: plan-quality-check / plan-quality-reviewer は Claude Code 専用（bin/plangate plan-check 配線依存）として .claude/skills/README に宣言

closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)