### PR TITLE
docs: workflows yaml と mode マトリクスの役割分担を正本化（#513 案B）

### DIFF
--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -114,3 +114,16 @@ Orchestrator Mode は親 PBI 配下の複数子 PBI を統制する仕様（[`do
 - Orchestrator Mode: `docs/orchestrator-mode.md` / `.claude/rules/orchestrator-mode.md`
 - モード分類: `.claude/rules/mode-classification.md`
 - レビュー原則: `.claude/rules/review-principles.md`
+
+## workflows/*.yaml（mode DSL）とフェーズ適用マトリクスの役割分担（#513）
+
+| 層 | 正本 | 機械消費 |
+|----|------|---------|
+| **artifact 検証** | `workflows/<mode>.yaml` の `gate_enforcement.c3.required_artifacts` | `bin/plangate validate/exec` が正規表現で消費（c3 のみ。c4 / plan_hash_check / phases[].artifact_schema は参照層） |
+| **ゲート列の適用範囲**（どの mode で L-0/V-1〜V-4/C-4 を実行するか） | [`mode-classification.md`](../../.claude/rules/mode-classification.md) のフェーズ適用マトリクス | workflow-conductor（runtime）+ Hook / CI |
+
+mode yaml がゲート列の一部しか含まない（例: `ultra-light.yaml` は WF-04 のみ・
+`gate_enforcement: {}`）のは**設計どおり**であり、ゲートの無効化を意味しない。
+yaml はあくまで「c3 ゲートで機械検証する成果物の一覧」を mode 別に定義する層。
+将来 c4 / plan_hash_check 等を機械配線する場合は #500（Wiring Integrity）系の
+実装 PBI として扱う。

--- a/workflows/ultra-light.yaml
+++ b/workflows/ultra-light.yaml
@@ -1,6 +1,14 @@
 workflow: ultra-light
 description: "Ultra-light mode — typo, config, comment fixes (1 file, 0-1 ACs)"
 
+# 設計意図（#513）: 本 yaml は bin/plangate validate/exec が消費する
+# 「artifact 検証層」であり、ゲート列の全体は表現しない。
+# mode-classification.md のフェーズ適用マトリクスが ultra-light に課す
+# L-0（○）/ V-1（△ 簡易確認）/ PR 作成（○）/ C-4（○）は
+# workflow-conductor（runtime）と Hook / CI が制御する。
+# gate_enforcement: {} は「c3 の required_artifacts 検証なし
+# （ultra-light は plan 不要のため）」を意味し、全ゲート無効ではない。
+
 phases:
   - id: wf04_build_and_refine
     requires: []


### PR DESCRIPTION
## Summary

issue #513 の乖離を**案 B（設計意図の文書化）**で解消。

- 乖離の正体: ultra-light.yaml の `gate_enforcement: {}` は「c3 の required_artifacts 検証なし（plan 不要 mode のため）」であり、L-0/V-1/PR/C-4 の無効化ではない
- yaml はあくまで「c3 ゲートで bin/plangate が機械検証する成果物一覧」の層（bin/plangate:91-100 の消費実態と一致）。ゲート列の適用範囲は mode-classification.md マトリクス + conductor/Hook/CI が正本
- ultra-light.yaml にコメント、docs/workflows/README に役割分担表を追加
- 案 A（yaml にゲート列を明示実装）は c4/plan_hash_check の機械配線を伴うため #500 系の実装 PBI へ委譲

closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)