### PR TITLE
feat: yaml 設定ファイルの schema 検証を追加（#521）

### DIFF
--- a/scripts/validate-yaml-schemas.py
+++ b/scripts/validate-yaml-schemas.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""validate-yaml-schemas.py — yaml 設定ファイルの JSON Schema 検証（issue #521）
+
+schema を持つ yaml 実体が CI を素通りする Shadow Spec（2026-06-10 棚卸し）の解消。
+bin/plangate validate-schemas は JSON 専用のため、yaml は本スクリプトが担う。
+tests/extras/ta-35 から呼ばれ「plangate CLI tests」CI ジョブで全 PR 検証される。
+
+usage: python3 scripts/validate-yaml-schemas.py [--file YAML --schema SCHEMA]
+  引数なし: 既知ペアを一括検証（存在しない optional yaml は SKIP）
+exit code: 0=全 PASS / 1=FAIL あり / 2=依存欠如
+"""
+import json
+import os
+import sys
+
+try:
+    import yaml
+    import jsonschema
+except ImportError as e:
+    print(f"SKIP: dependency missing ({e})")
+    sys.exit(2)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# (yaml, schema, required) — required=False は存在時のみ検証
+KNOWN_PAIRS = [
+    ("docs/ai/model-profiles.yaml", "schemas/model-profile.schema.json", True),
+    (".plangate-pollution-patterns.yaml", "schemas/plangate-pollution-patterns.schema.json", True),
+    (".plangate-reviewers.yaml", "schemas/plangate-reviewers.schema.json", False),
+]
+
+
+def validate_pair(yaml_path: str, schema_path: str) -> str | None:
+    """戻り値: None=PASS / エラーメッセージ=FAIL"""
+    with open(yaml_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    with open(schema_path, encoding="utf-8") as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(data, schema)
+        return None
+    except jsonschema.ValidationError as e:
+        return f"{e.json_path}: {e.message}"
+
+
+def main() -> int:
+    if len(sys.argv) == 5 and sys.argv[1] == "--file" and sys.argv[3] == "--schema":
+        pairs = [(sys.argv[2], sys.argv[4], True)]
+    else:
+        pairs = [(os.path.join(ROOT, y), os.path.join(ROOT, s), req)
+                 for y, s, req in KNOWN_PAIRS]
+
+    failed = False
+    for yaml_path, schema_path, required in pairs:
+        rel = os.path.relpath(yaml_path, ROOT) if yaml_path.startswith(ROOT) else yaml_path
+        if not os.path.exists(yaml_path):
+            if required:
+                print(f"FAIL {rel}: file not found")
+                failed = True
+            else:
+                print(f"SKIP {rel}: not present (optional)")
+            continue
+        err = validate_pair(yaml_path, schema_path)
+        if err is None:
+            print(f"PASS {rel}")
+        else:
+            print(f"FAIL {rel}: {err}")
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-yaml-schemas.py
+++ b/scripts/validate-yaml-schemas.py
@@ -31,11 +31,17 @@ KNOWN_PAIRS = [
 
 
 def validate_pair(yaml_path: str, schema_path: str) -> str | None:
-    """戻り値: None=PASS / エラーメッセージ=FAIL"""
-    with open(yaml_path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    with open(schema_path, encoding="utf-8") as f:
-        schema = json.load(f)
+    """戻り値: None=PASS / エラーメッセージ=FAIL（パース失敗・schema 不読も FAIL）"""
+    try:
+        with open(yaml_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as e:
+        return f"yaml load error: {e}"
+    try:
+        with open(schema_path, encoding="utf-8") as f:
+            schema = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return f"schema load error: {e}"
     try:
         jsonschema.validate(data, schema)
         return None
@@ -44,11 +50,15 @@ def validate_pair(yaml_path: str, schema_path: str) -> str | None:
 
 
 def main() -> int:
-    if len(sys.argv) == 5 and sys.argv[1] == "--file" and sys.argv[3] == "--schema":
-        pairs = [(sys.argv[2], sys.argv[4], True)]
-    else:
+    if len(sys.argv) == 1:
         pairs = [(os.path.join(ROOT, y), os.path.join(ROOT, s), req)
                  for y, s, req in KNOWN_PAIRS]
+    elif len(sys.argv) == 5 and sys.argv[1] == "--file" and sys.argv[3] == "--schema":
+        pairs = [(sys.argv[2], sys.argv[4], True)]
+    else:
+        # 不完全な引数で既知ペア検証へサイレントフォールバックしない
+        print(f"usage: {os.path.basename(sys.argv[0])} [--file YAML --schema SCHEMA]")
+        return 1
 
     failed = False
     for yaml_path, schema_path, required in pairs:

--- a/tests/extras/ta-35-yaml-schema.sh
+++ b/tests/extras/ta-35-yaml-schema.sh
@@ -1,0 +1,31 @@
+# tests/extras/ta-35-yaml-schema.sh
+# Sourced by tests/run-tests.sh
+# Issue #521: yaml 設定ファイルの schema 検証（Shadow Spec 解消）。
+# 依存（pyyaml / jsonschema）欠如時はスキップ（CI には導入済み）。
+
+printf '\n=== TA-35: yaml schema validation (#521) ===\n'
+
+_t35_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+if ! python3 -c 'import yaml, jsonschema' >/dev/null 2>&1; then
+  printf '[SKIP] TA-35 — pyyaml/jsonschema 未導入\n'
+else
+  # TC-01: 既知ペアの一括検証が PASS
+  _t35_out="$(python3 "$_t35_root/scripts/validate-yaml-schemas.py" 2>&1)" && _t35_rc=0 || _t35_rc=$?
+  if [ "$_t35_rc" -eq 0 ]; then
+    printf '[PASS] TA-35 TC-01: 既知 yaml が全て schema PASS\n'; pass=$((pass + 1))
+  else
+    printf '[FAIL] TA-35 TC-01: rc=%s out=%s\n' "$_t35_rc" "$_t35_out"; fail=$((fail + 1))
+  fi
+
+  # TC-02: 壊した yaml で FAIL する（ネガティブ検証 — 検証器が機能している証明）
+  _t35_tmp="$(mktemp -d "${TMPDIR:-/tmp}/ta35.XXXXXX")"
+  sed 's/family: gpt-5$/family: not-a-valid-family/' "$_t35_root/docs/ai/model-profiles.yaml" > "$_t35_tmp/broken.yaml"
+  if python3 "$_t35_root/scripts/validate-yaml-schemas.py" \
+       --file "$_t35_tmp/broken.yaml" --schema "$_t35_root/schemas/model-profile.schema.json" >/dev/null 2>&1; then
+    printf '[FAIL] TA-35 TC-02: 壊した yaml が PASS してしまう（検証が機能していない）\n'; fail=$((fail + 1))
+  else
+    printf '[PASS] TA-35 TC-02: 壊した yaml を FAIL として検出\n'; pass=$((pass + 1))
+  fi
+  rm -rf "$_t35_tmp"
+fi


### PR DESCRIPTION
## Summary

EPIC #527 の子 PBI 4 に相当。schema を持つ yaml が CI を素通りする Shadow Spec を解消。

- `scripts/validate-yaml-schemas.py`: 既知ペア（model-profiles / pollution-patterns / reviewers※optional）の一括検証 + 単体検証モード
- `ta-35`: 正常系 + **壊した yaml が FAIL することのネガティブ検証**（受入基準どおり）
- CI 配線: 既存「plangate CLI tests」ジョブが extras を実行するため **HO（.github/workflows）変更なしで全 PR に効く**
- 初回突合: 既存 yaml 2 件とも現行 schema に PASS（違反なし）。reviewers yaml は実体がリポジトリに無く ta-24 がテスト内生成するため optional 扱い

CLI **282 PASS**（+2）

closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)