### PR TITLE
feat: fix_loop_incremented イベントの生成側を実装（#522）

### DIFF
--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -186,6 +186,7 @@ def derive_events(task_dir: Path, task_id: str) -> list[dict]:
 
     # 8. hook_violation — derived from docs/working/_audit/hook-events.log (v8.6.0 PR3 / A-1)
     events.extend(derive_hook_events(task_id))
+    events.extend(derive_fix_loop_events(task_id))
 
     # 9. pr_created — derived from git log on handoff.md (v8.6.0 PR3 / A-2)
     if (task_dir / "handoff.md").is_file():
@@ -226,6 +227,48 @@ def derive_hook_events(task_id: str, audit_log: Path = HOOK_AUDIT_LOG) -> list[d
         out.append(
             base_event(task_id, "hook_violation", ts)
             | {"hook_id": hook_id, "hook_result": result}
+        )
+    return out
+
+
+def derive_fix_loop_events(task_id: str, audit_log: Path = HOOK_AUDIT_LOG) -> list[dict]:
+    """Read hook audit log and emit fix_loop_incremented events (#522).
+
+    check-fix-loop.sh logs INCREMENT lines as: ts \t INCREMENT \t hook \t task \t count=N
+    従来は VIOLATION 系のみ変換され INCREMENT が捨てられていたため、fix loop は
+    上限超過まで metrics 上不可視だった（Shadow Spec 棚卸し 2026-06-10）。
+    Privacy: message 列からは fix_loop_count（schema 許可スカラー）のみ抽出する。
+    """
+    out: list[dict] = []
+    if not audit_log.is_file():
+        return out
+    try:
+        lines = audit_log.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        parts = line.split("\t")
+        if len(parts) < 5:
+            continue
+        ts, level, hook_name, log_task, message = parts[0], parts[1], parts[2], parts[3], parts[4]
+        if log_task != task_id or level != "INCREMENT":
+            continue
+        if "check-fix-loop" not in hook_name:
+            continue
+        count = None
+        for token in message.split(","):
+            token = token.strip()
+            if token.startswith("count="):
+                try:
+                    count = int(token[len("count="):])
+                except ValueError:
+                    count = None
+                break
+        if count is None:
+            continue
+        out.append(
+            base_event(task_id, "fix_loop_incremented", ts)
+            | {"fix_loop_count": count}
         )
     return out
 

--- a/scripts/metrics_collector.py
+++ b/scripts/metrics_collector.py
@@ -253,7 +253,7 @@ def derive_fix_loop_events(task_id: str, audit_log: Path = HOOK_AUDIT_LOG) -> li
         ts, level, hook_name, log_task, message = parts[0], parts[1], parts[2], parts[3], parts[4]
         if log_task != task_id or level != "INCREMENT":
             continue
-        if "check-fix-loop" not in hook_name:
+        if hook_name != "check-fix-loop":
             continue
         count = None
         for token in message.split(","):
@@ -264,7 +264,7 @@ def derive_fix_loop_events(task_id: str, audit_log: Path = HOOK_AUDIT_LOG) -> li
                 except ValueError:
                     count = None
                 break
-        if count is None:
+        if count is None or count < 0:
             continue
         out.append(
             base_event(task_id, "fix_loop_incremented", ts)

--- a/tests/extras/ta-36-fixloop-event.sh
+++ b/tests/extras/ta-36-fixloop-event.sh
@@ -1,0 +1,50 @@
+# tests/extras/ta-36-fixloop-event.sh
+# Sourced by tests/run-tests.sh
+# Issue #522: fix_loop_incremented イベント生成（collector の INCREMENT 変換）。
+# 一時 audit log fixture を使い実リポジトリを汚染しない。
+
+printf '\n=== TA-36: fix_loop_incremented event generation (#522) ===\n'
+
+_t36_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+if ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+  printf '[SKIP] TA-36 — jsonschema 未導入\n'
+else
+  _t36_out="$(python3 - "$_t36_root" <<'PY'
+import json, sys, tempfile, os
+from pathlib import Path
+root = sys.argv[1]
+sys.path.insert(0, os.path.join(root, "scripts"))
+import importlib
+mc = importlib.import_module("metrics_collector")
+import jsonschema
+
+# fixture audit log: INCREMENT 2 件（対象 task）+ 他 task + PASS 行
+with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+    f.write("2026-06-11T00:00:01Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-9936\tcount=1\n")
+    f.write("2026-06-11T00:00:02Z\tPASS\tcheck-fix-loop.sh\tTASK-9936\tcount=1, max=5\n")
+    f.write("2026-06-11T00:00:03Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-OTHER\tcount=1\n")
+    f.write("2026-06-11T00:00:04Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-9936\tcount=2\n")
+    log = f.name
+try:
+    events = mc.derive_fix_loop_events("TASK-9936", Path(log))
+    assert len(events) == 2, f"expected 2 events, got {len(events)}"
+    assert [e["fix_loop_count"] for e in events] == [1, 2], events
+    assert all(e["event"] == "fix_loop_incremented" for e in events)
+    # schema 適合（fix_loop_incremented は fix_loop_count 必須）
+    schema = json.load(open(os.path.join(root, "schemas", "plangate-event.schema.json")))
+    for e in events:
+        jsonschema.validate(e, schema)
+    print("OK")
+finally:
+    os.unlink(log)
+PY
+)" && _t36_rc=0 || _t36_rc=$?
+  if [ "$_t36_rc" -eq 0 ] && [ "$_t36_out" = "OK" ]; then
+    printf '[PASS] TA-36 TC-01: INCREMENT 行から schema 適合の fix_loop_incremented を生成（他 task/PASS 行は除外）\n'
+    pass=$((pass + 1))
+  else
+    printf '[FAIL] TA-36 TC-01: rc=%s out=%s\n' "$_t36_rc" "$_t36_out"
+    fail=$((fail + 1))
+  fi
+fi

--- a/tests/extras/ta-36-fixloop-event.sh
+++ b/tests/extras/ta-36-fixloop-event.sh
@@ -21,10 +21,10 @@ import jsonschema
 
 # fixture audit log: INCREMENT 2 件（対象 task）+ 他 task + PASS 行
 with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
-    f.write("2026-06-11T00:00:01Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-9936\tcount=1\n")
-    f.write("2026-06-11T00:00:02Z\tPASS\tcheck-fix-loop.sh\tTASK-9936\tcount=1, max=5\n")
-    f.write("2026-06-11T00:00:03Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-OTHER\tcount=1\n")
-    f.write("2026-06-11T00:00:04Z\tINCREMENT\tcheck-fix-loop.sh\tTASK-9936\tcount=2\n")
+    f.write("2026-06-11T00:00:01Z\tINCREMENT\tcheck-fix-loop\tTASK-9936\tcount=1\n")
+    f.write("2026-06-11T00:00:02Z\tPASS\tcheck-fix-loop\tTASK-9936\tcount=1, max=5\n")
+    f.write("2026-06-11T00:00:03Z\tINCREMENT\tcheck-fix-loop\tTASK-OTHER\tcount=1\n")
+    f.write("2026-06-11T00:00:04Z\tINCREMENT\tcheck-fix-loop\tTASK-9936\tcount=2\n")
     log = f.name
 try:
     events = mc.derive_fix_loop_events("TASK-9936", Path(log))


### PR DESCRIPTION
## Summary

EPIC #527 の子 PBI 5 に相当。reporter に消費側だけ存在し生成側が無かった `fix_loop_incremented` の生成を実装。

- `derive_fix_loop_events`: audit log の INCREMENT 行（check-fix-loop.sh）→ schema 適合イベントへ変換し `--collect` 経路に配線
- **schema 変更なし = 非 HO で完結**（イベント種別・fix_loop_count は定義済み）。agent/model 帰属の追加は schema 変更（HO）を要するため別スコープ（issue 記載どおり）
- Privacy: message からは schema 許可スカラー（fix_loop_count）のみ抽出
- ta-36: fixture audit log によるユニット検証（他 task / PASS 行の除外・jsonschema 適合まで確認）

CLI **281 PASS**（+1）

closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)