### PR TITLE
fix: ta-37 に終了コード・json 非生成の検証を追加（#533 レビュー反映の follow-up）

### DIFF
--- a/tests/extras/ta-37-cli-coverage-batch2.sh
+++ b/tests/extras/ta-37-cli-coverage-batch2.sh
@@ -34,7 +34,8 @@ case "$_t37_out" in
 esac
 
 # TC-03: keep-rate --no-write — 正常終了 + レポート出力 + ファイル非生成（md/json とも）
-_t37_out="$(sh "$PLANGATE_BIN" keep-rate "$_t37_task" --no-write 2>&1)" && _t37_rc=0 || _t37_rc=$?
+_t37_rc=0
+_t37_out="$(sh "$PLANGATE_BIN" keep-rate "$_t37_task" --no-write 2>&1)" || _t37_rc=$?
 if [ "$_t37_rc" -eq 0 ] \
    && printf '%s' "$_t37_out" | grep -q "Keep Rate v1: $_t37_task" \
    && [ ! -f "$_t37_dir/keep-rate-result.md" ] && [ ! -f "$_t37_dir/keep-rate-result.json" ]; then
@@ -51,7 +52,8 @@ case "$_t37_out" in
 esac
 
 # TC-05: context --no-write — 正常終了 + manifest を stdout のみに出力（md/json とも非生成）
-_t37_out="$(sh "$PLANGATE_BIN" context "$_t37_task" --phase plan --no-write 2>&1)" && _t37_rc=0 || _t37_rc=$?
+_t37_rc=0
+_t37_out="$(sh "$PLANGATE_BIN" context "$_t37_task" --phase plan --no-write 2>&1)" || _t37_rc=$?
 if [ "$_t37_rc" -eq 0 ] \
    && printf '%s' "$_t37_out" | grep -q "Context Manifest: $_t37_task" \
    && [ ! -f "$_t37_dir/context-manifest.md" ] && [ ! -f "$_t37_dir/context-manifest.json" ]; then
@@ -62,7 +64,8 @@ fi
 
 # TC-06: exec — C-3 未承認でゲート拒否 + 非ゼロ終了（承認境界の機械検証。
 # exit 0 で素通りすると CI/CD で検知できないため終了コードまで検証する）
-_t37_out="$(sh "$PLANGATE_BIN" exec "$_t37_task" 2>&1)" && _t37_rc=0 || _t37_rc=$?
+_t37_rc=0
+_t37_out="$(sh "$PLANGATE_BIN" exec "$_t37_task" 2>&1)" || _t37_rc=$?
 if [ "$_t37_rc" -ne 0 ] && printf '%s' "$_t37_out" | grep -q "C-3 gate not cleared"; then
   printf '[PASS] TA-37 TC-06: exec が C-3 未承認をブロックし非ゼロ終了（rc=%s）\n' "$_t37_rc"; pass=$((pass + 1))
 else

--- a/tests/extras/ta-37-cli-coverage-batch2.sh
+++ b/tests/extras/ta-37-cli-coverage-batch2.sh
@@ -33,10 +33,11 @@ case "$_t37_out" in
   *) printf '[FAIL] TA-37 TC-02: %s\n' "$_t37_out"; fail=$((fail + 1)) ;;
 esac
 
-# TC-03: keep-rate --no-write — レポート出力 + ファイル非生成
-_t37_out="$(sh "$PLANGATE_BIN" keep-rate "$_t37_task" --no-write 2>&1)" || true
-if printf '%s' "$_t37_out" | grep -q "Keep Rate v1: $_t37_task" \
-   && [ ! -f "$_t37_dir/keep-rate-result.md" ]; then
+# TC-03: keep-rate --no-write — 正常終了 + レポート出力 + ファイル非生成（md/json とも）
+_t37_out="$(sh "$PLANGATE_BIN" keep-rate "$_t37_task" --no-write 2>&1)" && _t37_rc=0 || _t37_rc=$?
+if [ "$_t37_rc" -eq 0 ] \
+   && printf '%s' "$_t37_out" | grep -q "Keep Rate v1: $_t37_task" \
+   && [ ! -f "$_t37_dir/keep-rate-result.md" ] && [ ! -f "$_t37_dir/keep-rate-result.json" ]; then
   printf '[PASS] TA-37 TC-03: keep-rate --no-write がレポートを stdout のみに出力\n'; pass=$((pass + 1))
 else
   printf '[FAIL] TA-37 TC-03: %s\n' "$_t37_out"; fail=$((fail + 1))
@@ -49,21 +50,24 @@ case "$_t37_out" in
   *) printf '[FAIL] TA-37 TC-04: %s\n' "$_t37_out"; fail=$((fail + 1)) ;;
 esac
 
-# TC-05: context --no-write — manifest を stdout のみに出力
-_t37_out="$(sh "$PLANGATE_BIN" context "$_t37_task" --phase plan --no-write 2>&1)" || true
-if printf '%s' "$_t37_out" | grep -q "Context Manifest: $_t37_task" \
-   && [ ! -f "$_t37_dir/context-manifest.md" ]; then
+# TC-05: context --no-write — 正常終了 + manifest を stdout のみに出力（md/json とも非生成）
+_t37_out="$(sh "$PLANGATE_BIN" context "$_t37_task" --phase plan --no-write 2>&1)" && _t37_rc=0 || _t37_rc=$?
+if [ "$_t37_rc" -eq 0 ] \
+   && printf '%s' "$_t37_out" | grep -q "Context Manifest: $_t37_task" \
+   && [ ! -f "$_t37_dir/context-manifest.md" ] && [ ! -f "$_t37_dir/context-manifest.json" ]; then
   printf '[PASS] TA-37 TC-05: context --no-write が manifest を stdout のみに出力\n'; pass=$((pass + 1))
 else
   printf '[FAIL] TA-37 TC-05: %s\n' "$_t37_out"; fail=$((fail + 1))
 fi
 
-# TC-06: exec — C-3 未承認でゲート拒否（承認境界の機械検証）
-_t37_out="$(sh "$PLANGATE_BIN" exec "$_t37_task" 2>&1)" || true
-case "$_t37_out" in
-  *"C-3 gate not cleared"*) printf '[PASS] TA-37 TC-06: exec が C-3 未承認をブロック\n'; pass=$((pass + 1)) ;;
-  *) printf '[FAIL] TA-37 TC-06: ゲートが効いていない: %s\n' "$_t37_out"; fail=$((fail + 1)) ;;
-esac
+# TC-06: exec — C-3 未承認でゲート拒否 + 非ゼロ終了（承認境界の機械検証。
+# exit 0 で素通りすると CI/CD で検知できないため終了コードまで検証する）
+_t37_out="$(sh "$PLANGATE_BIN" exec "$_t37_task" 2>&1)" && _t37_rc=0 || _t37_rc=$?
+if [ "$_t37_rc" -ne 0 ] && printf '%s' "$_t37_out" | grep -q "C-3 gate not cleared"; then
+  printf '[PASS] TA-37 TC-06: exec が C-3 未承認をブロックし非ゼロ終了（rc=%s）\n' "$_t37_rc"; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-37 TC-06: rc=%s out=%s\n' "$_t37_rc" "$_t37_out"; fail=$((fail + 1))
+fi
 
 # 後始末（trap に頼らず明示実行）
 rm -rf "$_t37_dir"


### PR DESCRIPTION
## Summary

PR #533 への Gemini レビュー反映（high 1 + medium 2）がマージ前に取り込まれなかったため、follow-up として提出。

- **TC-06**: exec の C-3 ブロックが**非ゼロ終了（rc=1）**することを検証（exit 0 素通りは CI/CD で検知不能のため。実測で rc=1 確認済み = 製品側は健全）
- TC-03/05: `--no-write` の正常終了（rc=0）+ **json 側ファイル非生成**も検証
- set -e 下の非ゼロ rc 捕捉を `&& rc=0 || rc=$?` パターンに統一（途中終了バグの修正）

CLI 290 PASS。#533 のレビュースレッドには返信・resolve 済み。

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)