### PR TITLE
release: v8.13.0 準備 — CHANGELOG 確定・version bump・README 更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "PlanGate — AI coding governance OS for Claude Code and Codex. 4-Gate approval system, Intent/Mode classification, Skill Policy Router, and agent control layer.",
-    "version": "8.12.0"
+    "version": "8.13.0"
   },
   "plugins": [
     {
       "name": "plangate",
       "description": "AI coding governance OS. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer for Claude Code.",
-      "version": "8.12.0",
+      "version": "8.13.0",
       "author": {
         "name": "PlanGate contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.13.0 - 2026-06-11
+
+feat: 全体健全化リリース — 監査駆動の鮮度・整合・隔離改善 + エージェント model tier
+
+リポジトリ全体監査（2 ラウンド + Shadow Spec 棚卸し）を起点に、ドキュメント鮮度の回復、テストの実 docs/working 汚染の根治、未使用エージェント/スキルのスリム化、エージェント model tier（Claude: sonnet/inherit、Codex: low/medium effort）の導入、Hook enforcement の実装/配線の実態整合、yaml schema 検証、CLI テストカバレッジ完了（290 PASS）までを収録。
+
 ### Added
 
 - **エージェント model tier**（#519）— エージェントを「定型・構造化 / 判断系」の 2 tier に分類し、Claude Code は frontmatter `model:`（sonnet / inherit）、Codex は `model_reasoning_effort`（low / medium、GPT-5.5 の high はトークン消費の運用判断で不採用）で表現。正本 [`docs/ai/model-profiles.md`](docs/ai/model-profiles.md) §11。plugin 配布版は `sync-plugin-plangate.sh` が `model: inherit` へ自動正規化し、利用者環境にモデル固定を持ち込まない。tier の崩れは `tests/extras/ta-33` が CI で機械検査

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.12.0**（Latest）で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.13.0**（Latest）で全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）、エージェント model tier、Hook enforcement の実態整合を実施しました。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 
 | 項目 | 状態 |
 | --- | --- |
-| 最新リリース | **v8.12.0**（Latest, 2026-06-07）— 並列レビューア実行 + Plugin sync 品質ガード + 導入促進（Why PlanGate）・運用ガード整備 |
+| 最新リリース | **v8.13.0**（Latest, 2026-06-11）— 全体健全化（監査駆動の鮮度・整合・隔離改善）+ エージェント model tier + enforcement 実態整合 |
 | リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 / **v8.11.0** Claude Code / Codex Plugin 正式配布対応 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3。物理配線は 6/12 — 残りは [#500](https://github.com/s977043/plangate/issues/500) で配線予定、詳細は [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)） |

--- a/README_en.md
+++ b/README_en.md
@@ -75,13 +75,13 @@ flowchart LR
 
 ## Current Status
 
-As of **v8.12.0** (Latest), PlanGate adds parallel reviewer execution, plugin sync quality guards, an adoption landing page (Why PlanGate), and operations guards. v8.11.0 added official Claude Code / Codex Plugin distribution, and through v8.10.0 PlanGate combined Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
+As of **v8.13.0** (Latest), PlanGate ships a repository-wide health release: audit-driven documentation freshness, test isolation (no more tracked-file pollution), agent/skill slimming, agent model tiers (Claude: sonnet/inherit, Codex: low/medium effort), and Hook enforcement reality alignment. v8.12.0 added parallel reviewer execution, plugin sync quality guards, an adoption landing page (Why PlanGate), and operations guards. v8.11.0 added official Claude Code / Codex Plugin distribution, and through v8.10.0 PlanGate combined Hook enforcement, Metrics v1, and Harness Improvement Governance with **Reporting & Retrospective v1**, deriving sprint retrospectives deterministically from events.ndjson. With this, the [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) is **complete (CLOSED / COMPLETED)**.
 
 v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "where do I start, where do I stop" problem via OSS adoption foundations (staged adoption guide, plugin maturity, versioning stability policy) and the self-evaluation, context separation, model-profile, and reporting bases delivered in sequence.
 
 | Item | Status |
 | --- | --- |
-| Latest release | **v8.12.0** (Latest, 2026-06-07) — Parallel reviewer execution + plugin sync quality guards + adoption landing (Why PlanGate) / operations guards |
+| Latest release | **v8.13.0** (Latest, 2026-06-11) — Repository-wide health release (audit-driven freshness / test isolation / slimming) + agent model tiers + enforcement reality alignment |
 | Shipped | **v8.7.0** OSS adoption foundations + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1, Dynamic Context Engine v1, Model Profile v2, Gate Event Normalization, Dogfooding Eval v1 |
 | Roadmap | **EPIC #193 complete (CLOSED / COMPLETED)** — Phases 0-6 + Governance + Lightweight Plan Quality Checks all Done, child PBIs 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks implemented** (EH-1 to EH-9 + EHS-1 to EHS-3; physical wiring is 6/12 — remainder planned in [#500](https://github.com/s977043/plangate/issues/500), see [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)) |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,12 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.13.0 - 2026-06-11
+
+feat: 全体健全化リリース — 監査駆動の鮮度・整合・隔離改善 + エージェント model tier
+
+リポジトリ全体監査（2 ラウンド + Shadow Spec 棚卸し）を起点に、ドキュメント鮮度の回復、テストの実 docs/working 汚染の根治、未使用エージェント/スキルのスリム化、エージェント model tier（Claude: sonnet/inherit、Codex: low/medium effort）の導入、Hook enforcement の実装/配線の実態整合、yaml schema 検証、CLI テストカバレッジ完了（290 PASS）までを収録。
+
 ### Added
 
 - **エージェント model tier**（#519）— エージェントを「定型・構造化 / 判断系」の 2 tier に分類し、Claude Code は frontmatter `model:`（sonnet / inherit）、Codex は `model_reasoning_effort`（low / medium、GPT-5.5 の high はトークン消費の運用判断で不採用）で表現。正本 [`docs/ai/model-profiles.md`](docs/ai/model-profiles.md) §11。plugin 配布版は `sync-plugin-plangate.sh` が `model: inherit` へ自動正規化し、利用者環境にモデル固定を持ち込まない。tier の崩れは `tests/extras/ta-33` が CI で機械検査

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "8.12.0",
+  "version": "8.13.0",
   "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -3,7 +3,7 @@
 PlanGate — a governance OS for AI-assisted coding.
 Provides Intent/Mode classification, a 4-Gate approval system, and an agent control layer as a Claude Code plugin.
 
-- **Version**: v8.12.0
+- **Version**: v8.13.0
 - **Source**: <https://github.com/s977043/plangate>
 
 ## Install

--- a/scripts/apply-release-v8.13.0-note.sh
+++ b/scripts/apply-release-v8.13.0-note.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# apply-release-v8.13.0-note.sh — CLAUDE.md の最新リリース節を v8.13.0 へ（Human 実行）
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+F="$ROOT/CLAUDE.md"
+OLD_H='## v8.12.0 並列レビューア実行・Plugin sync 品質ガード（最新リリース機能）'
+NEW_H='## v8.13.0 全体健全化・エージェント model tier（最新リリース機能）'
+OLD_N='> 最新リリース: **v8.12.0**（2026-06-07）並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）/運用ガード整備。v8.11.0 で Claude Code / Codex Plugin 正式配布、v8.10.0 で Codex CLI parity 完成・Hook/Guard 拡充・Skill 整備。'
+NEW_N='> 最新リリース: **v8.13.0**（2026-06-11）全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）+ エージェント model tier（docs/ai/model-profiles.md §11）+ Hook enforcement 実態整合 + doc-light モード。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード、v8.11.0 で Plugin 正式配布、v8.10.0 で Codex CLI parity 完成。'
+
+if grep -qF -- "$NEW_H" "$F"; then echo "OK (already)"; exit 0; fi
+grep -qF -- "$OLD_H" "$F" || { echo "ERROR: アンカー不在（見出し）" >&2; exit 1; }
+grep -qF -- "$OLD_N" "$F" || { echo "ERROR: アンカー不在（注記）" >&2; exit 1; }
+if [ "$MODE" = "--dry-run" ]; then
+  echo "[dry-run] CLAUDE.md: 見出しと最新リリース注記を v8.13.0 に更新"
+elif [ "$MODE" = "--apply" ]; then
+  python3 - "$F" "$OLD_H" "$NEW_H" "$OLD_N" "$NEW_N" <<'PY'
+import sys
+f = sys.argv[1]
+with open(f, encoding="utf-8") as fp: s = fp.read()
+for old, new in [(sys.argv[2], sys.argv[3]), (sys.argv[4], sys.argv[5])]:
+    assert s.count(old) == 1
+    s = s.replace(old, new)
+with open(f, "w", encoding="utf-8") as fp: fp.write(s)
+PY
+  echo "APPLIED: CLAUDE.md"
+else
+  echo "usage: $0 [--dry-run|--apply]"; exit 1
+fi


### PR DESCRIPTION
## Summary

v8.13.0 リリース準備（ユーザー指示 2026-06-11）。

- **CHANGELOG**: Unreleased 12 項目を `v8.13.0 - 2026-06-11` として確定。テーマ: **全体健全化リリース** — 監査駆動の鮮度回復 / テスト隔離（tracked 汚染根治）/ エージェント・スキルのスリム化 / **エージェント model tier**（Claude: sonnet/inherit、Codex: low/medium）/ Hook enforcement 実態整合 / yaml schema 検証 / doc-light モード / CLI カバレッジ完了（290 PASS）
- plugin version 8.12.0 → 8.13.0（version 二重管理ガード対応含む）
- README 両言語の最新リリース表記更新、docs/changelog.md 同期
- CLAUDE.md（HO）は `scripts/apply-release-v8.13.0-note.sh` で Human 適用（dry-run 検証済み）

## マージ後の手順（宣言）

マージ後、**本指示（「v8.13.0 リリースして」）を明示承認として AI が以下を実行**します:
1. マージ commit へ annotated tag `v8.13.0` を作成・push
2. `scripts/check-tag-main-parity.sh v8.13.0` で Iron Law 検証（NO RELEASE WITHOUT TAG-MAIN PARITY）
3. `gh release create v8.13.0`（release note = CHANGELOG v8.13.0 セクション）

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)