### PR TITLE
docs: リリース後フォロー — CLI テスト数 290 へ更新 + CLAUDE.md v8.13.0 注記（Human apply 同梱予定）

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこ�
 | Reporting v1 | events.ndjson から sprint retrospective を導出（v8.9.0） |
 | Baseline | v8.5.0 直後の baseline を `docs/ai/eval-baselines/` に固定（v8.6.0 初出） |
 | Governance | Issue / Label / Milestone Governance + Metrics Privacy Policy（v8.6.0 初出） |
-| CLI テスト | `sh tests/run-tests.sh` — **271 PASS** |
+| CLI テスト | `sh tests/run-tests.sh` — **290 PASS** |
 | Hook テスト | `sh tests/hooks/run-tests.sh` — **79 PASS** |
 | Eval | `bin/plangate eval` による 8 観点評価と release blocker 検知 |
 | Schema | `validate-schemas` + CI による JSON artifact 検証 |
@@ -384,7 +384,7 @@ sh tests/hooks/run-tests.sh
 
 | スイート | 件数 | 主な検証対象 |
 | --- | ---: | --- |
-| `tests/run-tests.sh` | **271 PASS** | CLI、Workflow DSL、schema validate、eval、metrics v1、reporting、provider dispatch、fixture 検証 |
+| `tests/run-tests.sh` | **290 PASS** | CLI、Workflow DSL、schema validate、eval、metrics v1、reporting、provider dispatch、fixture 検証 |
 | `tests/hooks/run-tests.sh` | **79 PASS** | EH-1〜EH-9 / EHS-1〜EHS-3、default / strict / bypass の 3 mode 挙動 |
 
 主な検証対象:

--- a/README_en.md
+++ b/README_en.md
@@ -89,7 +89,7 @@ v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "wher
 | Reporting v1 | Sprint retrospective derived from events.ndjson (v8.9.0) |
 | Baseline | v8.5.0 baseline fixed under `docs/ai/eval-baselines/` (introduced in v8.6.0) |
 | Governance | Issue / Label / Milestone Governance + Metrics Privacy Policy (introduced in v8.6.0) |
-| CLI tests | `sh tests/run-tests.sh` — **271 PASS** |
+| CLI tests | `sh tests/run-tests.sh` — **290 PASS** |
 | Hook tests | `sh tests/hooks/run-tests.sh` — **79 PASS** |
 | Eval | 8-observation evaluation and release blocker detection via `bin/plangate eval` |
 | Schema | JSON artifact validation via `validate-schemas` + CI |
@@ -345,7 +345,7 @@ Test status (latest):
 
 | Suite | Count | Main coverage |
 | --- | ---: | --- |
-| `tests/run-tests.sh` | **271 PASS** | CLI, Workflow DSL, schema validate, eval, metrics v1, reporting, provider dispatch, fixture validation |
+| `tests/run-tests.sh` | **290 PASS** | CLI, Workflow DSL, schema validate, eval, metrics v1, reporting, provider dispatch, fixture validation |
 | `tests/hooks/run-tests.sh` | **79 PASS** | EH-1 to EH-9 / EHS-1 to EHS-3, default / strict / bypass mode behavior |
 
 Main coverage:


### PR DESCRIPTION
## Summary

v8.13.0 リリース直後の self-review で検出した鮮度乖離 2 件のフォロー。

1. **README 両言語の CLI テスト数 271 → 実測 290**（v8.13.0 で ta-33〜37 の 19 TC を追加したのに表記未更新 — 本コミットで修正済み）
2. **CLAUDE.md の最新リリース注記が v8.12.0 のまま**（HO のため、本ブランチ上で `sh scripts/apply-release-v8.13.0-note.sh --apply` の Human 実行が必要 → 実行後に AI がコミット追加します）

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)