### PR TITLE
feat: 鮮度ドリフト恒久対策 + release-prep 自動化 + PR 状態宣言規約

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこ�
 | Reporting v1 | events.ndjson から sprint retrospective を導出（v8.9.0） |
 | Baseline | v8.5.0 直後の baseline を `docs/ai/eval-baselines/` に固定（v8.6.0 初出） |
 | Governance | Issue / Label / Milestone Governance + Metrics Privacy Policy（v8.6.0 初出） |
-| CLI テスト | `sh tests/run-tests.sh` — **271 PASS** |
-| Hook テスト | `sh tests/hooks/run-tests.sh` — **79 PASS** |
+| CLI テスト | `sh tests/run-tests.sh`（全 PR を CI で検証。件数は実行結果が正） |
+| Hook テスト | `sh tests/hooks/run-tests.sh`（同上） |
 | Eval | `bin/plangate eval` による 8 観点評価と release blocker 検知 |
 | Schema | `validate-schemas` + CI による JSON artifact 検証 |
 
@@ -384,8 +384,8 @@ sh tests/hooks/run-tests.sh
 
 | スイート | 件数 | 主な検証対象 |
 | --- | ---: | --- |
-| `tests/run-tests.sh` | **271 PASS** | CLI、Workflow DSL、schema validate、eval、metrics v1、reporting、provider dispatch、fixture 検証 |
-| `tests/hooks/run-tests.sh` | **79 PASS** | EH-1〜EH-9 / EHS-1〜EHS-3、default / strict / bypass の 3 mode 挙動 |
+| `tests/run-tests.sh` | 全 PASS（CI 検証） | CLI、Workflow DSL、schema validate、eval、metrics v1、reporting、provider dispatch、fixture 検証 |
+| `tests/hooks/run-tests.sh` | 全 PASS（CI 検証） | EH-1〜EH-9 / EHS-1〜EHS-3、default / strict / bypass の 3 mode 挙動 |
 
 主な検証対象:
 

--- a/README_en.md
+++ b/README_en.md
@@ -89,8 +89,8 @@ v8.7.0 through v8.9.0 have all shipped, addressing the external OSS user's "wher
 | Reporting v1 | Sprint retrospective derived from events.ndjson (v8.9.0) |
 | Baseline | v8.5.0 baseline fixed under `docs/ai/eval-baselines/` (introduced in v8.6.0) |
 | Governance | Issue / Label / Milestone Governance + Metrics Privacy Policy (introduced in v8.6.0) |
-| CLI tests | `sh tests/run-tests.sh` — **271 PASS** |
-| Hook tests | `sh tests/hooks/run-tests.sh` — **79 PASS** |
+| CLI tests | `sh tests/run-tests.sh` (verified in CI on every PR; the run result is canonical) |
+| Hook tests | `sh tests/hooks/run-tests.sh` (same as above) |
 | Eval | 8-observation evaluation and release blocker detection via `bin/plangate eval` |
 | Schema | JSON artifact validation via `validate-schemas` + CI |
 
@@ -345,8 +345,8 @@ Test status (latest):
 
 | Suite | Count | Main coverage |
 | --- | ---: | --- |
-| `tests/run-tests.sh` | **271 PASS** | CLI, Workflow DSL, schema validate, eval, metrics v1, reporting, provider dispatch, fixture validation |
-| `tests/hooks/run-tests.sh` | **79 PASS** | EH-1 to EH-9 / EHS-1 to EHS-3, default / strict / bypass mode behavior |
+| `tests/run-tests.sh` | all PASS (CI-verified) | CLI, Workflow DSL, schema validate, eval, metrics v1, reporting, provider dispatch, fixture validation |
+| `tests/hooks/run-tests.sh` | all PASS (CI-verified) | EH-1 to EH-9 / EHS-1 to EHS-3, default / strict / bypass mode behavior |
 
 Main coverage:
 

--- a/docs/ai/project-rules.md
+++ b/docs/ai/project-rules.md
@@ -125,3 +125,14 @@ PlanGate — ゲート型AI駆動開発ワークフローのリポジトリ。
 | **`docs/ai/hook-enforcement.md`** | Hook で強制すべき項目（EHS-1〜EHS-3） |
 | `schemas/model-profile.schema.json` | Model Profile JSON Schema |
 | `schemas/{review-result,acceptance-result,mode-classification,handoff-summary}.schema.json` | Structured Outputs schema × 4 |
+
+## PR レビュー対応中の状態宣言（2026-06-11 / #533 競合の再発防止）
+
+AI が外部レビュー（Gemini 等）への対応・HO apply 待ちで PR に追加コミットを
+予定している間に C-4 マージが行われると、対応が main に乗らず follow-up PR が
+必要になる（PR #533 で実害、PR #537 でも apply 漏れが発生）。
+
+- AI は対応着手時に PR へ **「⏳ レビュー対応中 — マージは完了コメントまで待機してください」** とコメントし、
+  完了時に **「✅ 対応完了 — マージ可能です」** をコメントする
+- C-4 判断者は最新の状態コメントと未 resolve スレッドゼロを確認してからマージする
+- 状態コメントが無い PR は従来どおり（CI pass + スレッド resolve 済みでマージ可）

--- a/scripts/apply-agent-slimming.sh
+++ b/scripts/apply-agent-slimming.sh
@@ -16,9 +16,16 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 AGENTS="agile-coach scrum-master migration-agent prompt-engineer research-analyst claude-code-reviewer"
 
 if [ "$MODE" = "--dry-run" ]; then
-  echo "[dry-run] 削除予定:"
-  for a in $AGENTS; do echo "  .claude/agents/$a.md"; done
-  echo "[dry-run] 更新予定: .claude/agents/README.md（6 行削除 + 空セクション除去 + コア/支援 2 層注記）"
+  _pending=0
+  for a in $AGENTS; do
+    if [ -f "$ROOT/.claude/agents/$a.md" ]; then
+      echo "[dry-run] 削除予定: .claude/agents/$a.md"; _pending=1
+    fi
+  done
+  if grep -q "2 層構成" "$ROOT/.claude/agents/README.md" 2>/dev/null; then :; else
+    echo "[dry-run] 更新予定: .claude/agents/README.md"; _pending=1
+  fi
+  [ "$_pending" -eq 0 ] && echo "OK (already applied)"
   exit 0
 fi
 [ "$MODE" = "--apply" ] || { echo "usage: $0 [--dry-run|--apply]"; exit 1; }

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# release-prep.sh — リリース準備の機械化 + readiness 検査（v8.13.0 の準備漏れ実害から / 2026-06-11）
+#
+# v8.13.0 リリースで「CLAUDE.md apply 漏れ」「README 数値更新漏れ」が発生したため、
+# 機械化できる準備と検査を 1 コマンドに集約する。tag push / Release 作成は本スクリプトの
+# 範囲外（docs/release-process.md の Iron Law フローに従い、Human または明示承認済み AI）。
+#
+# 使い方:
+#   sh scripts/release-prep.sh --check     # readiness 検査のみ（変更なし）
+#   sh scripts/release-prep.sh vX.Y.Z      # 準備実行（CHANGELOG 確定 / version bump / 同期 + 検査）
+set -eu
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MODE="${1:-}"
+
+fail=0
+note() { printf '%s\n' "$1"; }
+ng() { printf 'NG: %s\n' "$1"; fail=1; }
+ok() { printf 'OK: %s\n' "$1"; }
+
+check_versions() {
+  v1=$(python3 -c "import json;print(json.load(open('$ROOT/plugin/plangate/.claude-plugin/plugin.json'))['version'])")
+  v2=$(python3 -c "
+import json
+d = json.load(open('$ROOT/.claude-plugin/marketplace.json'))
+vs = set()
+def walk(x):
+    if isinstance(x, dict):
+        if 'version' in x and isinstance(x['version'], str): vs.add(x['version'])
+        [walk(v) for v in x.values()]
+    elif isinstance(x, list):
+        [walk(v) for v in x]
+walk(d)
+print(vs.pop() if len(vs) == 1 else 'INCONSISTENT:' + ','.join(sorted(vs)))
+")
+  if [ "$v1" = "$v2" ]; then ok "plugin version 一致 ($v1)"; else ng "plugin version 不一致: plugin.json=$v1 marketplace=$v2"; fi
+}
+
+check_pending_applies() {
+  pending=""
+  for f in "$ROOT"/scripts/apply-*.sh; do
+    [ -f "$f" ] || continue
+    out="$(sh "$f" --dry-run 2>/dev/null || true)"
+    case "$out" in
+      *"[dry-run]"*) pending="$pending $(basename "$f")" ;;
+    esac
+  done
+  if [ -z "$pending" ]; then ok "適用待ち apply スクリプトなし"; else ng "適用待ち apply あり（Human 実行が必要）:$pending"; fi
+}
+
+check_changelog_sync() {
+  if sh "$ROOT/scripts/sync-release-docs.sh" | grep -q "no-op"; then
+    ok "docs/changelog.md 同期済み"
+  else
+    ng "docs/changelog.md が未同期だったため今同期した（コミットに含めること）"
+  fi
+}
+
+run_checks() {
+  note "=== release readiness 検査 ==="
+  check_versions
+  check_pending_applies
+  check_changelog_sync
+  note "=== 手動確認 TODO（機械化対象外） ==="
+  note "- README / README_en の最新リリース行（散文）が対象 version か"
+  note "- CLAUDE.md の最新リリース節（HO — apply スクリプトで Human 適用）"
+  note "- テスト実行: sh tests/run-tests.sh && sh tests/hooks/run-tests.sh"
+  if [ "$fail" -eq 0 ]; then note "READY"; else note "NOT READY"; fi
+  return "$fail"
+}
+
+case "$MODE" in
+  --check)
+    run_checks
+    ;;
+  v[0-9]*)
+    V="${MODE#v}"
+    DATE="$(date -u +%Y-%m-%d)"
+    note "=== v$V 準備実行 ($DATE) ==="
+    python3 - "$ROOT" "$V" "$DATE" <<'PY'
+import json, re, sys
+root, v, date = sys.argv[1], sys.argv[2], sys.argv[3]
+p = f"{root}/CHANGELOG.md"
+s = open(p, encoding="utf-8").read()
+m = re.search(r"## Unreleased\n(.+?)\n## v", s, re.S)
+assert m and m.group(1).strip(), "Unreleased が空（リリース対象なし）"
+s = s.replace("## Unreleased\n", f"## Unreleased\n\n## v{v} - {date}\n", 1)
+open(p, "w", encoding="utf-8").write(s)
+print(f"OK CHANGELOG: v{v} セクション化（サマリ文は手動で追記）")
+for f in [f"{root}/plugin/plangate/.claude-plugin/plugin.json",
+          f"{root}/.claude-plugin/marketplace.json"]:
+    s2 = open(f, encoding="utf-8").read()
+    s3 = re.sub(r'"version":\s*"[0-9.]+"', f'"version": "{v}"', s2)
+    open(f, "w", encoding="utf-8").write(s3)
+    print(f"OK version bump: {f.split('/')[-1]}")
+PY
+    sh "$ROOT/scripts/sync-release-docs.sh" >/dev/null || true
+    note "=== 続けて readiness 検査 ==="
+    run_checks || true
+    note "次: README 散文 / CLAUDE.md apply（Human）/ テスト → PR → merge → tag push → check-tag-main-parity.sh → gh release create"
+    ;;
+  *)
+    note "usage: $0 [--check | vX.Y.Z]"; exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

v8.13.0 リリースの self-review で検出した実害 3 系統への恒久対策（改善提案 1B / 2 / 4）。

### 1B. 手書きテスト数の撤廃（README 両言語）
同型の乖離（211→271→290）が 2 回発生。**CI とローカルでテスト件数が環境依存に異なる**（codex CLI 非搭載の CI では SKIP — 既知のテスト分離方針）ため恒等検査は構造的に不成立 → 数値の手書き自体を廃止し「実行結果が正」に変更。

### 2. scripts/release-prep.sh
リリース準備（CHANGELOG セクション化 / plugin version bump / docs 同期）+ **readiness 検査**を 1 コマンド化。検査は導入時点で既に有効:
- 既知の `apply-release-v8.13.0-note.sh`（CLAUDE.md 注記）に加え、**`apply-task-0123-patches.sh`（HMAC 署名検証等の HO パッチ、issue #420 系）が未適用のまま滞留していたことを発掘**
- 誤検出 1 件（agent-slimming の dry-run が適用済みを見ない）も同時修正

### 4. PR レビュー対応中の状態宣言（project-rules）
#533 の競合・#537 の apply 漏れの再発防止として「⏳ 対応中 / ✅ マージ可」コメント運用を規約化。

CLI 290 PASS / release-prep --check 実機検証済み。

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)