### PR TITLE
fix: explorer-agent の不正ツール名除去 + tools 機械検査 + CLAUDE.md v8.13.0 注記

### DIFF
--- a/.claude/agents/explorer-agent.md
+++ b/.claude/agents/explorer-agent.md
@@ -1,7 +1,7 @@
 ---
 name: explorer-agent
 description: コードベース探索、アーキテクチャ分析、調査エージェント。初期監査、リファクタリング計画、深い調査タスクに使用。
-tools: Read, Grep, Glob, Bash, ViewCodeItem, FindByName
+tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@
 - 共有スキル: `.agents/skills/`（Codex CLI と共用）
 - ワークフロー詳細: [`docs/ai-driven-development.md`](docs/ai-driven-development.md) / Orchestrator: [`docs/orchestrator-mode.md`](docs/orchestrator-mode.md)
 
-## v8.12.0 並列レビューア実行・Plugin sync 品質ガード（最新リリース機能）
+## v8.13.0 全体健全化・エージェント model tier（最新リリース機能）
 
-> 最新リリース: **v8.12.0**（2026-06-07）並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）/運用ガード整備。v8.11.0 で Claude Code / Codex Plugin 正式配布、v8.10.0 で Codex CLI parity 完成・Hook/Guard 拡充・Skill 整備。EPIC [#193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **CLOSED / COMPLETED**（Phase 0-6 + Governance + #213 全 Done、子 12/12 CLOSED）。リリース履歴の正本は [`CHANGELOG.md`](CHANGELOG.md)。
+> 最新リリース: **v8.13.0**（2026-06-11）全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）+ エージェント model tier（docs/ai/model-profiles.md §11）+ Hook enforcement 実態整合 + doc-light モード。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード、v8.11.0 で Plugin 正式配布、v8.10.0 で Codex CLI parity 完成。EPIC [#193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **CLOSED / COMPLETED**（Phase 0-6 + Governance + #213 全 Done、子 12/12 CLOSED）。リリース履歴の正本は [`CHANGELOG.md`](CHANGELOG.md)。
 
 - **Metrics v1**（v8.6.0 初出）: [`docs/ai/metrics.md`](docs/ai/metrics.md) — `bin/plangate metrics <TASK> --collect|--report|--validate`
 - **Reporting & Retrospective v1**（v8.9.0 / #200）: [`docs/ai/reporting.md`](docs/ai/reporting.md) — events.ndjson 由来で sprint retrospective を導出、retrospective テンプレート [`docs/working/templates/retrospective-template.md`](docs/working/templates/retrospective-template.md)

--- a/plugin/plangate/agents/explorer-agent.md
+++ b/plugin/plangate/agents/explorer-agent.md
@@ -1,7 +1,7 @@
 ---
 name: explorer-agent
 description: コードベース探索、アーキテクチャ分析、調査エージェント。初期監査、リファクタリング計画、深い調査タスクに使用。
-tools: Read, Grep, Glob, Bash, ViewCodeItem, FindByName
+tools: Read, Grep, Glob, Bash
 model: inherit
 ---
 

--- a/scripts/apply-explorer-agent-tools-fix.sh
+++ b/scripts/apply-explorer-agent-tools-fix.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# apply-explorer-agent-tools-fix.sh — explorer-agent の実在しないツール名を除去（Human 実行）
+#
+# 背景: tools: に Claude Code に存在しない ViewCodeItem / FindByName が残存
+# （v6 期の他ツール由来の名残。model tier レビューで指摘、2026-06-11 改善提案 3）。
+# .claude/agents/*.md は HO のため AI は本スクリプト作成と --dry-run まで。
+# 再発防止は tests/extras/ta-38-agent-tools.sh が CI で機械検査する。
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+F="$ROOT/.claude/agents/explorer-agent.md"
+OLD='tools: Read, Grep, Glob, Bash, ViewCodeItem, FindByName'
+NEW='tools: Read, Grep, Glob, Bash'
+
+if grep -qF -- "$NEW" "$F" && ! grep -qF -- "$OLD" "$F"; then echo "OK (already)"; exit 0; fi
+grep -qF -- "$OLD" "$F" || { echo "ERROR: アンカー不在" >&2; exit 1; }
+case "$MODE" in
+  --dry-run) echo "[dry-run] explorer-agent.md:"; echo "- $OLD"; echo "+ $NEW" ;;
+  --apply)
+    python3 - "$F" "$OLD" "$NEW" <<'PY'
+import sys
+f, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(f, encoding="utf-8").read()
+assert s.count(old) == 1
+open(f, "w", encoding="utf-8").write(s.replace(old, new))
+PY
+    echo "APPLIED: explorer-agent.md" ;;
+  *) echo "usage: $0 [--dry-run|--apply]"; exit 1 ;;
+esac

--- a/scripts/apply-explorer-agent-tools-fix.sh
+++ b/scripts/apply-explorer-agent-tools-fix.sh
@@ -20,9 +20,11 @@ case "$MODE" in
     python3 - "$F" "$OLD" "$NEW" <<'PY'
 import sys
 f, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
-s = open(f, encoding="utf-8").read()
+with open(f, encoding="utf-8") as fp:
+    s = fp.read()
 assert s.count(old) == 1
-open(f, "w", encoding="utf-8").write(s.replace(old, new))
+with open(f, "w", encoding="utf-8") as fp:
+    fp.write(s.replace(old, new))
 PY
     echo "APPLIED: explorer-agent.md" ;;
   *) echo "usage: $0 [--dry-run|--apply]"; exit 1 ;;

--- a/tests/extras/ta-38-agent-tools.sh
+++ b/tests/extras/ta-38-agent-tools.sh
@@ -10,10 +10,10 @@ _t38_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 _t38_allow=" Read Grep Glob Bash Edit Write Agent NotebookEdit WebFetch WebSearch AskUserQuestion Skill "
 
 _t38_bad=""
-for _t38_f in "$_t38_root"/.claude/agents/*.md; do
+for _t38_f in "$_t38_root"/.claude/agents/*.md "$_t38_root"/plugin/plangate/agents/*.md; do
   [ -f "$_t38_f" ] || continue
   case "$(basename "$_t38_f")" in README.md) continue ;; esac
-  _t38_tools="$(grep -m1 '^tools:' "$_t38_f" | sed 's/^tools: *//' | tr ',' ' ')"
+  _t38_tools="$(grep -m1 '^tools:' "$_t38_f" | sed 's/^tools: *//' | tr ',' ' ' | tr -d '\r')"
   for _t38_t in $_t38_tools; do
     case "$_t38_allow" in
       *" $_t38_t "*) ;;
@@ -22,7 +22,7 @@ for _t38_f in "$_t38_root"/.claude/agents/*.md; do
   done
 done
 if [ -z "$_t38_bad" ]; then
-  printf '[PASS] TA-38 TC-01: 全エージェントの tools が既知ツール名のみ\n'; pass=$((pass + 1))
+  printf '[PASS] TA-38 TC-01: 全エージェント（.claude + plugin 配布版）の tools が既知ツール名のみ\n'; pass=$((pass + 1))
 else
   printf '[FAIL] TA-38 TC-01: 実在しないツール名:%s\n' "$_t38_bad"; fail=$((fail + 1))
 fi

--- a/tests/extras/ta-38-agent-tools.sh
+++ b/tests/extras/ta-38-agent-tools.sh
@@ -1,0 +1,28 @@
+# tests/extras/ta-38-agent-tools.sh
+# Sourced by tests/run-tests.sh
+# 改善提案 3（2026-06-11）: エージェント定義の tools 欄が実在ツール名のみで構成されることを検証。
+# 背景: explorer-agent に ViewCodeItem / FindByName（実在しない）が v6 期から残存していた。
+
+printf '\n=== TA-38: agent tools validation ===\n'
+
+_t38_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+# Claude Code の既知ツール名（エージェント定義で使用を許容する集合）
+_t38_allow=" Read Grep Glob Bash Edit Write Agent NotebookEdit WebFetch WebSearch AskUserQuestion Skill "
+
+_t38_bad=""
+for _t38_f in "$_t38_root"/.claude/agents/*.md; do
+  [ -f "$_t38_f" ] || continue
+  case "$(basename "$_t38_f")" in README.md) continue ;; esac
+  _t38_tools="$(grep -m1 '^tools:' "$_t38_f" | sed 's/^tools: *//' | tr ',' ' ')"
+  for _t38_t in $_t38_tools; do
+    case "$_t38_allow" in
+      *" $_t38_t "*) ;;
+      *) _t38_bad="$_t38_bad $(basename "$_t38_f" .md):$_t38_t" ;;
+    esac
+  done
+done
+if [ -z "$_t38_bad" ]; then
+  printf '[PASS] TA-38 TC-01: 全エージェントの tools が既知ツール名のみ\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-38 TC-01: 実在しないツール名:%s\n' "$_t38_bad"; fail=$((fail + 1))
+fi


### PR DESCRIPTION
## Summary

改善提案 3 とリリース後フォローの Human apply 反映（HO 2 件、確立フロー準拠）。

- **explorer-agent**: `tools:` から実在しない `ViewCodeItem` / `FindByName`（v6 期の他ツール由来の名残）を除去
- **ta-38**: 全エージェントの tools 欄を既知ツール名 allowlist と突合する機械検査（適用前の状態を正しく FAIL 検出することを確認済み = 再発防止が機能）
- **CLAUDE.md**: 最新リリース節を v8.13.0 へ（PR #537 時の適用漏れ解消 — release-prep `--check` の検出項目が 1 つ解消）
- plugin 再同期 / CLI **291 PASS**（+1）

✅ 対応完了 — マージ可能です

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)