### PR TITLE
docs(#550,#543): approve strict enforcement / Plan Review Gate 設計ノート

### DIFF
--- a/docs/working/discussions/2026-06-15-543-plan-review-gate-design.md
+++ b/docs/working/discussions/2026-06-15-543-plan-review-gate-design.md
@@ -1,0 +1,68 @@
+# #543 Plan Review Gate 判定連携 — 設計ノート（#544 Phase2）
+
+> **Status**: 設計ノート（2026-06-15）。実装は #551（Loop 戦略 rev.3）merge 後。
+> **位置づけ**: #544 Loop 安全制御の **Phase2（Gate 化・強制実装）**。#544/#551 が「明文化」、#543 が「強制」。
+> **関連**: #527（Enforcement Integrity）/ #487（Risk Budget）/ #493（計画修正）
+
+---
+
+## 1. 役割（rev.3 と一貫）
+
+- **#544/#551**: plan に Loop Scope / Stop / Resume / Replan Triggers（機械値）/ Revert / Loop Attempts を**記述**（ソフト強制）
+- **#543（本設計）**: その**充足と外部レビュー結果**を入力に、**進行可否を判定し止める・通す**（hard 強制）
+
+PlanGate の責務はレビューそのものでなく「レビュー結果で進行可否を判定」（#543 原文）。
+
+## 2. 入力（外部レビュー結果スキーマ・#543 原文）
+
+```text
+Decision: go | revise_plan | human_approval_required | no_go
+Risk: low | medium | high
+Blocking Issues / Non-Blocking Suggestions / Do Not Touch /
+Required Plan Changes / Verification Required / Stop-Work Conditions /
+Final Implementation Instruction
+```
+
+## 3. 判定マッピング（plan→approve→exec への接続）
+
+| 外部 Decision | PlanGate C-3 判定 | 挙動 |
+|--------------|-------------------|------|
+| `go` | APPROVED 候補（他条件次第） | exec 可 |
+| `revise_plan` | CONDITIONAL | Required Plan Changes を反映→再判定（既存 R-NNN 集約フローに乗せる） |
+| `human_approval_required` | 人間 C-3 強制（autonomous APPROVE 無効化） | mode-classification の HO 同様の格上げ |
+| `no_go` | REJECTED | plan 再生成 |
+
+- **Risk=high** → 最低 high mode・autonomous APPROVE 不可（mode-classification と整合）。
+- **Stop-Work Conditions** → #544/#551 の **機械トリガー**（変更ファイル2倍/+5・連続失敗3回・反復3回・plan外波及・AC変更）に**マッピング**し、exec 中に実行層（codex-guarded.sh / doctor）が監視。発火で Replan/停止。
+- **Verification Required** → plan の Verification Automation に必須注入。
+- **Do Not Touch** → 既存 `forbidden_files`（EH-6 / check-forbidden-files.sh）に接続。
+
+## 4. 充足チェックの強制化（#544 Phase1 → Phase2）
+
+- Phase1（#544）: C-1 拡張で「Replan Triggers に機械トリガー1つ以上」「Stop/Resume 記入」を**検出**（未記入で WARN）
+- Phase2（#543）: 上記未充足で **C-3 承認不可（strict Gate）**。`bin/plangate exec` が拒否。
+
+## 5. 既存資産への接続
+
+| 接続先 | 役割 |
+|--------|------|
+| `external-reviewer-interface.md` / `.plangate-reviewers.yaml` | 外部レビュー結果の取り込み規約（#227） |
+| `c3-approval.schema.json` | Decision→c3_status マッピングの schema 拡張（gate_checks 拡張 or 新フィールド） |
+| EH-3 / check-plan-hash | 確定 plan の hash 固定（既存） |
+| EH-6 / forbidden_files | Do Not Touch の強制 |
+| codex-guarded.sh / doctor | Stop-Work Conditions（機械トリガー）の実行層監視（#550/#527 と共有） |
+
+## 6. 段階
+1. #551 merge（rev.3 正本化）
+2. 外部レビュー結果スキーマ → c3.json/judgment への mapping 設計確定（本ノート）
+3. schema 拡張 + 充足チェック strict 化（HO: working-context/schema）
+4. Stop-Work=機械トリガーの実行層実装（#550/#527 と共通基盤）
+
+## 7. 未決
+- [ ] Decision→c3_status の schema 表現（新フィールド vs gate_checks 拡張）
+- [ ] 機械トリガー実行層（codex-guarded.sh / doctor）の #550 との共通化範囲
+- [ ] human_approval_required の autonomous 無効化を mode-classification 正本に追記するか
+- [ ] 外部レビュー未取得時の安全側（unavailable → strict 側に倒す）
+
+## 8. 一行サマリ
+> #543 = 外部レビュー結果（Decision/Risk/Stop-Work）を C-3 判定に接続し #544 の充足を強制する Phase2 Gate。Stop-Work は #544/#551 の機械トリガーへ、実行層監視は #550/#527 と共通化。

--- a/docs/working/discussions/2026-06-15-543-plan-review-gate-design.md
+++ b/docs/working/discussions/2026-06-15-543-plan-review-gate-design.md
@@ -6,6 +6,9 @@
 
 ---
 
+> **用語**: 本ノートの「HO」は **Hardening Override**（自己改変ガード対象パス）を指す。
+> 人間の責務分界は「Human-owned」と表記し区別する（混同回避 / #553 review）。
+
 ## 1. 役割（rev.3 と一貫）
 
 - **#544/#551**: plan に Loop Scope / Stop / Resume / Replan Triggers（機械値）/ Revert / Loop Attempts を**記述**（ソフト強制）
@@ -33,7 +36,7 @@ Final Implementation Instruction
 | `no_go` | REJECTED | plan 再生成 |
 
 - **Risk=high** → 最低 high mode・autonomous APPROVE 不可（mode-classification と整合）。
-- **Stop-Work Conditions** → #544/#551 の **機械トリガー**（変更ファイル2倍/+5・連続失敗3回・反復3回・plan外波及・AC変更）に**マッピング**し、exec 中に実行層（codex-guarded.sh / doctor）が監視。発火で Replan/停止。
+- **Stop-Work Conditions** → #544/#551 の **機械トリガー**（変更ファイル2倍/+5・連続失敗3回・反復3回・plan外波及・AC変更）に**マッピング**。検知方式は **post-flight（ツール実行後の事後検知）** を基本とする（`codex-guarded.sh` は非対話セッション中のリアルタイムフックを持たず post-flight 検証が中心のため）。発火で次サイクルの Replan/停止を要求。真のリアルタイム中断が要る場合は PreToolUse hook 層（別途）で扱う。
 - **Verification Required** → plan の Verification Automation に必須注入。
 - **Do Not Touch** → 既存 `forbidden_files`（EH-6 / check-forbidden-files.sh）に接続。
 

--- a/docs/working/discussions/2026-06-15-550-approve-strict-enforcement-design.md
+++ b/docs/working/discussions/2026-06-15-550-approve-strict-enforcement-design.md
@@ -1,0 +1,49 @@
+# #550 approve 承認境界の strict enforcement — 設計ノート
+
+> **Status**: 設計ノート（2026-06-15）。実装は HO のため別途（人間適用）。
+> **位置づけ**: EPIC #527（Enforcement Integrity）子 / #500（仕様↔強制実態ギャップ）の具体実例。
+> **発端**: #546 の `plangate approve`（L1-L4 Human-presence）が Codex レビューで **best-effort**（疑似 TTY バイパス可・`PLANGATE_FAKE_PPID_COMM` 本番残存）と判明。
+
+---
+
+## 1. 問題
+
+現状 L1-L4（isatty / env / ppid / nonce）は「非対話 stdin・既知 agent env・AI 親プロセス」を拒否するが、**承認の証跡が "agent が観測・応答できる" 経路（画面表示 nonce）にある**ため、疑似 TTY を持つ自動化は理論上突破できる。承認境界を「best-effort」から「**検証可能な boundary**」へ引き上げる。
+
+核心原則（今セッションの学び）: **承認は agent が観測・応答できない out-of-band な人間アクションに紐付ける**。
+
+## 2. 選択肢比較
+
+| 案 | 仕組み | provenance 強度 | コスト | AI 突破耐性 |
+|----|--------|----------------|--------|------------|
+| **A: HMAC 署名トークン** | 人間だけが持つ secret で `HMAC(task_id‖plan_hash‖ts)` を生成。EH-3/validate が検証 | secret の置き場次第 | 中 | secret が AI 不可達なら強。env/file 置きは無効 |
+| **B: GitHub Approve 連携** | C-3 を GitHub PR review で承認（C-4 と同方式）→ CI が c3.json 生成 | 高（GitHub 認証=out-of-band） | 高（exec 前 PR 必須） | 強（AI は GitHub 認証を持たない） |
+| **C: OS keychain / Touch ID** | approve が macOS Keychain から secret 取得（Touch ID/login 必須） | 高（生体/OS 認証） | 中 | 強（AI プロセスは keychain 不可達） | 
+| D（現状）: L1-L4 nonce | 画面表示 nonce を人間が打鍵 | 低〜中（best-effort） | 低 | 弱（疑似 TTY で突破可） |
+
+### 評価
+- **B が最も provenance が強く、既存 C-4（GitHub Approve）と一貫**。ただし「plan 段階で PR を要する」コストが PlanGate の plan→exec フローに摩擦。
+- **A（HMAC）は #420（EH-3 provenance hardening: HMAC + プロセス系譜）と統合可能**。secret を OS keychain（C）に置けば A+C で「AI 不可達な署名鍵」が成立。
+- **推奨: A（HMAC）+ C（keychain で鍵保護）を #420 と統合**。B は「重い承認」が許容される文脈（critical/リリース）でオプション化。
+
+## 3. 段階導入
+
+| Phase | 内容 | 層 |
+|-------|------|----|
+| **P0（最小ハードニング・即）** | (a) `PLANGATE_FAKE_PPID_COMM` を本番無効化（テスト専用フラグ化） (b) 対話 `read` → `read -r` (c) 既存 c3.json 上書きを既定拒否（`--force` 必須） | bin/plangate(HO)+apply-script |
+| **P1（署名基盤）** | approve が HMAC 署名を c3.json に付与。鍵は OS keychain（無ければ環境変数フォールバックを明示警告）。EH-3/validate が署名検証 | #420 統合・HO |
+| **P2（強制化）** | 署名不一致/未署名の c3.json で exec を hard block（warning でなく default block） | #527 EH strict 化と連動 |
+| **P3（重い承認）** | critical/リリースは GitHub Approve（案B）必須に格上げ | #487 Phase R と連動 |
+
+## 4. 「best-effort」表現の是正（横断）
+
+実装が P2 に到達するまでは、docs・PR・plan で **「best-effort 多層防御（絶対 boundary ではない）」** と表現する（#546 で docs 訂正済。plan.md など hash 凍結分は追補で対応）。
+
+## 5. 未決
+- [ ] secret の標準置き場（keychain 必須 vs env フォールバック許容範囲）
+- [ ] #420 の HMAC 設計との具体統合点
+- [ ] P0 の最小ハードニングを単独 PR にするか P1 と束ねるか
+- [ ] B（GitHub Approve）を C-3 にも適用する場合の plan 段階 PR コスト許容
+
+## 6. 一行サマリ
+> #550 = approve を best-effort から「AI 不可達な署名（HMAC+keychain / #420 統合）で検証可能な boundary」へ。P0 最小ハードニング即実施、強制化は #527 と連動。

--- a/docs/working/discussions/2026-06-15-550-approve-strict-enforcement-design.md
+++ b/docs/working/discussions/2026-06-15-550-approve-strict-enforcement-design.md
@@ -6,6 +6,8 @@
 
 ---
 
+> **用語**: 本ノートの「HO」は **Hardening Override**（自己改変ガード対象パス）。人間責務は「Human-owned」と表記し区別（#553 review）。
+
 ## 1. 問題
 
 現状 L1-L4（isatty / env / ppid / nonce）は「非対話 stdin・既知 agent env・AI 親プロセス」を拒否するが、**承認の証跡が "agent が観測・応答できる" 経路（画面表示 nonce）にある**ため、疑似 TTY を持つ自動化は理論上突破できる。承認境界を「best-effort」から「**検証可能な boundary**」へ引き上げる。
@@ -16,7 +18,7 @@
 
 | 案 | 仕組み | provenance 強度 | コスト | AI 突破耐性 |
 |----|--------|----------------|--------|------------|
-| **A: HMAC 署名トークン** | 人間だけが持つ secret で `HMAC(task_id‖plan_hash‖ts)` を生成。EH-3/validate が検証 | secret の置き場次第 | 中 | secret が AI 不可達なら強。env/file 置きは無効 |
+| **A: HMAC 署名トークン** | 人間だけが持つ secret で `HMAC(task_id‖plan_hash‖ts)` を生成。EH-3/validate が検証。**`ts` は `c3.json.approved_at` と同一値（ISO8601 UTC・秒精度）に固定**し、文字列表現のブレで検証不一致を起こさない | secret の置き場次第 | 中 | secret が AI 不可達なら強。env/file 置きは無効 |
 | **B: GitHub Approve 連携** | C-3 を GitHub PR review で承認（C-4 と同方式）→ CI が c3.json 生成 | 高（GitHub 認証=out-of-band） | 高（exec 前 PR 必須） | 強（AI は GitHub 認証を持たない） |
 | **C: OS keychain / Touch ID** | approve が macOS Keychain から secret 取得（Touch ID/login 必須） | 高（生体/OS 認証） | 中 | 強（AI プロセスは keychain 不可達） | 
 | D（現状）: L1-L4 nonce | 画面表示 nonce を人間が打鍵 | 低〜中（best-effort） | 低 | 弱（疑似 TTY で突破可） |
@@ -30,7 +32,7 @@
 
 | Phase | 内容 | 層 |
 |-------|------|----|
-| **P0（最小ハードニング・即）** | (a) `PLANGATE_FAKE_PPID_COMM` を本番無効化（テスト専用フラグ化） (b) 対話 `read` → `read -r` (c) 既存 c3.json 上書きを既定拒否（`--force` 必須） | bin/plangate(HO)+apply-script |
+| **P0（最小ハードニング・即）** | (a) `PLANGATE_FAKE_PPID_COMM` を本番無効化（テスト専用フラグ化） (b) 対話 `read` → `read -r` (c) 既存 c3.json 上書きを既定拒否（`--force` 必須）。**ただし plan_hash が変化した場合（＝正当な Replan→再承認）は摩擦回避のため自動許可**し、同一 plan_hash の再書込のみ拒否（無意味な再承認の抑止） | bin/plangate(HO)+apply-script |
 | **P1（署名基盤）** | approve が HMAC 署名を c3.json に付与。鍵は OS keychain（無ければ環境変数フォールバックを明示警告）。EH-3/validate が署名検証 | #420 統合・HO |
 | **P2（強制化）** | 署名不一致/未署名の c3.json で exec を hard block（warning でなく default block） | #527 EH strict 化と連動 |
 | **P3（重い承認）** | critical/リリースは GitHub Approve（案B）必須に格上げ | #487 Phase R と連動 |


### PR DESCRIPTION
Relates #550 #543 #527 #544

enforcement integrity 優先方針（Codex 相談で確定）に基づく設計ノート2件。実装はHO/#551 merge後、本PRは設計のみ。

## #550 approve strict enforcement
best-effort(L1-L4 nonce)→検証可能 boundary へ。out-of-band案比較(A: HMAC署名+keychain / B: GitHub Approve / C: keychain)、推奨=A+C を #420 統合。P0最小ハードニング(FAKE_PPID本番無効化/read -r/c3上書き既定拒否)→P1署名→P2強制化(#527連動)。

## #543 Plan Review Gate (#544 Phase2)
外部レビュー結果(Decision/Risk/Stop-Work)をC-3判定に接続。Decision→c3_status、Stop-Work→#544/#551機械トリガー、Do Not Touch→forbidden_files(EH-6)、実行層監視は#550/#527と共通化。

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)