### PR TITLE
release: v8.14.0 — C-3 レビュー HTML 出力 + 人間ワンアクション C-3 承認

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "PlanGate — AI coding governance OS for Claude Code and Codex. 4-Gate approval system, Intent/Mode classification, Skill Policy Router, and agent control layer.",
-    "version": "8.13.0"
+    "version": "8.14.0"
   },
   "plugins": [
     {
       "name": "plangate",
       "description": "AI coding governance OS. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer for Claude Code.",
-      "version": "8.13.0",
+      "version": "8.14.0",
       "author": {
         "name": "PlanGate contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.14.0 - 2026-06-15
+
+feat: C-3 レビュー HTML 出力（plangate render）+ 人間ワンアクション C-3 承認（plangate approve）
+
+利用者の声「MD は確認しづらい / ファイルが多い / ブラウザで見たい」に応え、C-3 レビュー成果物をブラウザで横断把握できる HTML 出力を導入。あわせて「人間は承認の判断のみ、JSON/CLI 作業は負わない」という PlanGate コンセプトを実機化する承認 CLI を追加。
+
+### Added
+
+- **`plangate render`（C-3 レビュー HTML 出力 / TASK-0127・#546・#552）** — C-3 対象 7 種 MD（pbi-input / plan / todo / test-cases / review-self / review-external / handoff）を **1 枚の自己完結 HTML** に集約。目次アンカー / GFM 表 / チェックボックス / コードブロック / インラインをレンダリングし、HTML エスケープで XSS を防止。外部 CDN / script / 画像参照ゼロ（オフライン・ブラウザ直開き可）。実装 `scripts/render_review.py` は **Python 標準ライブラリのみ**（新規依存なし）。
+- **`plangate approve`（人間ワンアクション C-3 承認 / TASK-0128・#546）** — 対話 TTY で承認意思を示すだけで、plan_hash 自動算出・approved_by を git config 解決・`schemas/c3-approval.schema.json` 準拠の c3.json を自動生成（JSON 手書き不要）。`maintenance` 由来の L1-L4 Human-presence 検証（**best-effort**）で非対話実行からの自己承認を抑止。`check-approval-token-write.sh` を Edit\|Write + Bash matcher で配線し承認トークンへの直接書込を block。
+- **Loop 安全制御 討議メモ**（#544 / #545）— Loop Engineering の安全制御要素（Verification / Stop Condition / Replan Rule）の PlanGate 取り込み方針。
+
+### Notes
+
+- `plangate approve` の L1-L4 は **best-effort 多層防御**（疑似 TTY バイパスが理論上残る）。out-of-band 化（HMAC 署名 + OS keychain）による strict enforcement は #550 / #527 で継続。
+- `plangate render` の SVG 図解（html-diagram）・構造化 html-plan ナビは #548 / #549 で継続。
+
 ## v8.13.0 - 2026-06-11
 
 feat: 全体健全化リリース — 監査駆動の鮮度・整合・隔離改善 + エージェント model tier

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.13.0**（Latest）で全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）、エージェント model tier、Hook enforcement の実態整合を実施しました。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.14.0**（Latest）で C-3 レビュー HTML 出力（`plangate render`）と人間ワンアクション C-3 承認（`plangate approve`）を導入しました。v8.13.0 で全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）、エージェント model tier、Hook enforcement の実態整合を実施しました。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "8.13.0",
+  "version": "8.14.0",
   "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"


### PR DESCRIPTION
Relates #546 #547 #544

## v8.14.0 リリース準備（version bump + CHANGELOG）

利用者要望「C-3 レビューを HTML で確認したい」に応える **`plangate render`** を headline に、**`plangate approve`** を同梱。

### 含む変更（v8.13.0 以降）
- `plangate render`（C-3 HTML 出力 / #546 + #552）
- `plangate approve`（人間ワンアクション C-3 承認・best-effort L1-L4 / #546）
- Loop 安全制御 討議メモ（#544 / #545）

### マージ順序（重要）
本 release PR の **前に #552（render CLI 本体）を main へ merge** すること（main に `cmd_render` が無いと `plangate render` が動かないため）。

### リリース手順（merge 後・Human-owned / docs/release-process.md）
```sh
# 1) #552 → main, 本PR → main を merge 後
git fetch origin main && git checkout main && git pull
# 2) annotated tag
git tag -a v8.14.0 origin/main -m "release v8.14.0"
git push origin v8.14.0
# 3) Iron Law: TAG-MAIN PARITY 検証
sh scripts/check-tag-main-parity.sh v8.14.0
# 4) OK なら GitHub Release 作成
gh release create v8.14.0 --title "v8.14.0 — C-3 レビュー HTML 出力 + 人間ワンアクション C-3 承認" --notes-file <release-note>
```

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)