### PR TITLE
plan(#565): TASK-0131 todo.md rollback 規約 — PBI+plan（planning / C-3待ち）

### DIFF
--- a/docs/working/TASK-0131/decision-log.jsonl
+++ b/docs/working/TASK-0131/decision-log.jsonl
@@ -1,0 +1,4 @@
+{"phase":"B","decision":"Codex設計相談で追加先を(d)組合せに確定: working-context正本(HO)+ai-dev-plan SKILL+ミラー(生成規約)+C-1(欠落検出)","ts":"2026-06-18"}
+{"phase":"B","decision":"rollback表現は1行インラインキー rollback: 採用、長手順のみ補助ブロック許可","ts":"2026-06-18"}
+{"phase":"C-2","decision":"Codex C-2: major3/critical0 → CONDITIONAL。R-001..003を1回確定反映(Refs)","ts":"2026-06-18"}
+{"phase":"C-2","decision":"Mode=high-risk(承認境界周辺/HO) → autonomous APPROVE不可・人間C-3同期固定","ts":"2026-06-18"}

--- a/docs/working/TASK-0131/pbi-input.md
+++ b/docs/working/TASK-0131/pbi-input.md
@@ -1,0 +1,43 @@
+# PBI INPUT PACKAGE — TASK-0131 (#565)
+
+## Context / Why
+
+外部提案（agent-skills → PlanGate 取り込み検討）のギャップ調査で、提案6要素中5要素は既存充足を確認した。唯一の実質ギャップが「**タスク粒度のロールバック手順の明示**」。現状、戻し手順は `plan.md` の Risks & Mitigations / Approach に散在し、`todo.md` の各タスク（owner / depends_on / files / 🚩）には Rollback 欄がない。
+
+high-risk / critical mode では「各タスクが失敗したらどう戻すか」を task 単位で持つ価値が高い（mode-classification.md 定性基準に「ロールバック: 計画的に必要 / 段階的ロールバック必須」が既にある）。
+
+## 重要な前提（調査で判明）
+
+- `docs/working/templates/` に **todo.md の独立テンプレ正本は存在しない**。
+- todo.md の構造定義は次に分散:
+  - `.claude/rules/working-context.md`（todo.md の役割・記載内容の正本）
+  - `.agents/skills/ai-dev-plan/SKILL.md` の「todo.md 規約」（`.codex/` `plugin/plangate/` `.claude/worktrees/` にミラー）
+- したがって「Rollback フィールドをどこに追加するか」は**設計判断**（Codex 相談対象）。
+
+## What (Scope)
+
+### In scope
+- todo.md 各タスクに Rollback 手順を表現する規約の追加（追加先は設計で確定）
+- mode 別の必須/任意ルール（high-risk / critical で必須、それ以下は任意・「不要」明記可）
+- 記入サンプル（既存 TASK の todo.md いずれか、またはテンプレ例）
+
+### Out of scope
+- `plan.md` の Risks 構造の改変（責務分界＝plan は全体リスク / todo はタスク戻し手順、に留める）
+- #566（Skill Router 統合）・#567（不採用理由の構造化）
+
+## 受入基準
+- AC-01: todo.md の各タスクに Rollback 手順を記す規約が、正本（working-context.md または ai-dev-plan skill）に明文化されている
+- AC-02: mode 別の必須/任意ルールが mode-classification.md / working-context.md と矛盾なく記載されている
+- AC-03: 記入サンプルが 1 件存在する
+- AC-04: ai-dev-plan skill の正本＋ミラー間で記述が整合している（drift を作らない）
+- AC-05: C-1（plan-quality-check / review-self）が high-risk/critical の rollback 欠落を FAIL 検出する（Refs: R-001）
+
+## Notes from Refinement
+- 「テンプレ」という提案語に引きずられず、実態（規約分散）に合わせた追加先を選ぶ。
+- 二重管理（plan.md Risks と todo.md Rollback）を避ける責務分界を明記する。
+
+## Estimation Evidence
+- Risks: 追加先が HO 対象（working-context.md = `.claude/rules/*.md`）の場合、AI 編集不可 → apply-script + 人間適用が必須。ai-dev-plan skill 正本（`.agents/skills/`）は override パターン外だが、ミラー同期の整合が必要。
+- Unknowns: 追加先（working-context.md / skill / 新規テンプレ）の最適解 → Codex 相談で決定。
+- Assumptions: mode-classification.md の既存ロールバック定性基準は変更しない（参照のみ）。
+- Mode 見込み: **high-risk**（承認境界周辺の `.claude/rules/*.md` に触れる可能性 → 最低 high-risk・人間 C-3 同期固定 / autonomous APPROVE 不可）。

--- a/docs/working/TASK-0131/pbi-input.md
+++ b/docs/working/TASK-0131/pbi-input.md
@@ -26,7 +26,7 @@ high-risk / critical mode では「各タスクが失敗したらどう戻すか
 - #566（Skill Router 統合）・#567（不採用理由の構造化）
 
 ## 受入基準
-- AC-01: todo.md の各タスクに Rollback 手順を記す規約が、正本（working-context.md または ai-dev-plan skill）に明文化されている
+- AC-01: todo.md の各タスクに Rollback 手順を記す規約が、正本（working-context.md および ai-dev-plan skill）の双方に明文化されている
 - AC-02: mode 別の必須/任意ルールが mode-classification.md / working-context.md と矛盾なく記載されている
 - AC-03: 記入サンプルが 1 件存在する
 - AC-04: ai-dev-plan skill の正本＋ミラー間で記述が整合している（drift を作らない）

--- a/docs/working/TASK-0131/plan.md
+++ b/docs/working/TASK-0131/plan.md
@@ -32,7 +32,7 @@ todo.md の各実装タスクに「タスク粒度のロールバック手順」
 - `docs/working/templates/review-self.md`（C-1 テンプレ・AI 編集可）
 
 ## Testing Strategy
-- Unit/機械: `grep` で 3 ミラー間の `rollback:` 規約一致を検証、markdownlint、`bin/plangate doctor`
+- Unit/機械: `grep` で 正本と2ミラー間の `rollback:` 規約一致を検証、markdownlint、`bin/plangate doctor`
 - Integration: 本 TASK todo.md に rollback 記入 → `bin/plangate validate TASK-0131` 整合
 - Verification: C-1 セルフレビューで rollback 欠落検出ロジックが high-risk で発火することを手動確認
 
@@ -42,7 +42,7 @@ todo.md の各実装タスクに「タスク粒度のロールバック手順」
 - R3 C-1 への項目追加で既存チェックと重複・誤検出 / 既存17項目を読み差分のみ追加 / 過検出時は条件を high-risk/critical に限定
 
 ## Metrics Evidence
-- 対象「ai-dev-plan SKILL ミラー全件」: 実数 4（`find` 実測）/ 見積もり 3 / ratio 1.33 → 採用、Risks R2 に記録。うち `.claude/worktrees/agent-ae384a6baedaaef08/` 1 件は worktree 残骸で同期対象外、正規ミラーは 3。
+- 対象「ai-dev-plan SKILL ミラー全件」: 実数 4（`find` 実測）/ 見積もり 3 / ratio 1.33 → 採用、Risks R2 に記録。うち `.claude/worktrees/agent-ae384a6baedaaef08/` 1 件は worktree 残骸で同期対象外、正本と正規ミラーの合計は 3。
 
 ## Questions / Unknowns
 - working-context.md の rollback 規約を「役割表」に足すか新規節にするか → apply-script 生成時に最小差分で決定。

--- a/docs/working/TASK-0131/plan.md
+++ b/docs/working/TASK-0131/plan.md
@@ -1,0 +1,59 @@
+# EXECUTION PLAN — TASK-0131 (#565)
+
+## Goal
+todo.md の各実装タスクに「タスク粒度のロールバック手順」を表現する規約を追加し、high-risk / critical mode で必須化する。戻し手順が plan.md Risks に散在する現状を、タスク単位で参照可能にする。
+
+## Constraints / Non-goals
+- 新規 `docs/working/templates/todo.md` は作らない（working-context / skill との三重正本化を避ける / Codex 助言 A-3）。
+- `mode-classification.md` の既存ロールバック定性基準は変更しない（参照のみ）。
+- `plan.md` Risks 構造は改変しない（責務分界で整理）。
+- #566 / #567 は対象外。
+
+## Approach Overview（Codex 設計相談 d: 組合せ を採用）
+1. **正本の責務宣言** → `.claude/rules/working-context.md`（HO 対象 → AI 編集せず apply-script を生成し人間が適用）
+2. **生成規約** → `ai-dev-plan` SKILL の「todo.md 規約」に `rollback:` インラインキーと mode 別必須を追記（正本 `.agents/` + 正規ミラー `.codex/` `plugin/plangate/`。override 外のため AI 編集可）
+3. **欠落検出** → C-1 セルフレビュー（`plan-quality-check` skill / `review-self.md` テンプレ）に「high-risk/critical で rollback 欠落 → FAIL」を追加（override 外）
+4. **表現** → 既存1行形式を維持し `rollback:` を追加。長手順のみ直下補助ブロック許可。
+
+## Work Breakdown
+- **S1** working-context.md に rollback 規約（責務分界 D + mode 別必須 C）を追記する apply-script + patch を**生成**（AI は適用しない）
+  - Output: `scripts/apply-task-0131-rollback.sh`（または patch） / Owner: agent / Risk: HO 適用漏れ / 🚩HO（人間適用）
+- **S2** ai-dev-plan SKILL「todo.md 規約」に `rollback:` キー + mode 別必須 + 補助ブロック許可を追記（`.agents/` 正本 → `.codex/` `plugin/plangate/` 同期）
+  - Output: 3 ファイル差分 / Owner: agent / Risk: ミラー drift / 🚩 正本→ミラー同期検証
+- **S3** `plan-quality-check` skill（および `review-self.md` テンプレ）に rollback 欠落検出項目を追加
+  - Output: skill/テンプレ差分 / Owner: agent / Risk: 既存17項目との重複
+- **S4** 記入サンプル追加（本 TASK の todo.md 自体をドッグフーディング例にする）
+  - Output: todo.md の rollback 記入例 / Owner: agent / Risk: なし
+
+## Files / Components to Touch
+- `.claude/rules/working-context.md`（**HO → apply-script 経由・人間適用**）
+- `.agents/skills/ai-dev-plan/SKILL.md` + `.codex/skills/ai-dev-plan/SKILL.md` + `plugin/plangate/skills/ai-dev-plan/SKILL.md`（AI 編集可）
+- `.claude/skills/plan-quality-check/SKILL.md`（AI 編集可）
+- `docs/working/templates/review-self.md`（C-1 テンプレ・AI 編集可）
+
+## Testing Strategy
+- Unit/機械: `grep` で 3 ミラー間の `rollback:` 規約一致を検証、markdownlint、`bin/plangate doctor`
+- Integration: 本 TASK todo.md に rollback 記入 → `bin/plangate validate TASK-0131` 整合
+- Verification: C-1 セルフレビューで rollback 欠落検出ロジックが high-risk で発火することを手動確認
+
+## Risks & Mitigations（内容 / 検証手段 / Fallback）
+- R1 HO 適用漏れで working-context 正本だけ未反映 / doctor + grep 突合 / apply-script 未適用なら V-1 を PASS にしない（settings タスクロックと同型）
+- R2 ai-dev-plan 正本とミラーの drift / grep 3 ファイル一致検証 / 不一致なら同期し直す
+- R3 C-1 への項目追加で既存チェックと重複・誤検出 / 既存17項目を読み差分のみ追加 / 過検出時は条件を high-risk/critical に限定
+
+## Metrics Evidence
+- 対象「ai-dev-plan SKILL ミラー全件」: 実数 4（`find` 実測）/ 見積もり 3 / ratio 1.33 → 採用、Risks R2 に記録。うち `.claude/worktrees/agent-ae384a6baedaaef08/` 1 件は worktree 残骸で同期対象外、正規ミラーは 3。
+
+## Questions / Unknowns
+- working-context.md の rollback 規約を「役割表」に足すか新規節にするか → apply-script 生成時に最小差分で決定。
+
+## Mode判定
+
+**モード**: high-risk
+
+**判定根拠**:
+- 変更ファイル数: 6（working-context + skill×3 + plan-quality-check + review-self）→ high
+- 受入基準数: 4 → standard
+- 変更種別: 承認境界周辺（`.claude/rules/*.md` = HO 対象）→ **最低 high-risk 強制**（mode-classification 例外ルール）
+- リスク: 中〜高（正本/ミラー整合・HO 適用）
+- **最終判定**: high-risk（`lite_eligible=false`・Standard 同期 C-3 固定・autonomous APPROVE 不可・人間 C-3 必須）

--- a/docs/working/TASK-0131/review-external.md
+++ b/docs/working/TASK-0131/review-external.md
@@ -1,0 +1,13 @@
+# C-2 外部レビュー（Codex）— TASK-0131 (#565)
+
+レビュア: Codex (gpt-5.5) / レーン: 設計妥当性 / verdict: CONDITIONAL（major 3 / critical 0）
+
+## 指摘一覧（追記専用）
+| R-NNN | severity | 内容 | status | reflected_in | notes |
+|-------|----------|------|--------|--------------|-------|
+| R-001 | major | C-1 の rollback 欠落検出が受入基準に無く、未実装でも AC PASS 可能 | reflected | (this branch) | AC-05 + TC-07 追加 |
+| R-002 | major | TC-03 が「working-context **または** skill」で双方反映を保証しない | reflected | (this branch) | TC-03 を「双方に」修正 |
+| R-003 | major | T6 が実装タスクなのに rollback:不要、high-risk 必須設計と矛盾 | reflected | (this branch) | T6 rollback 具体化 |
+
+## 反映方針
+1 回確定反映（本コミット）。簡易 C-1 再実行 → 人間 C-3（APPROVED）→ exec。

--- a/docs/working/TASK-0131/review-external.md
+++ b/docs/working/TASK-0131/review-external.md
@@ -11,3 +11,17 @@
 
 ## 反映方針
 1 回確定反映（本コミット）。簡易 C-1 再実行 → 人間 C-3（APPROVED）→ exec。
+
+## C-2 追加レビュー（gemini-code-assist / GitHub PR #568）— 追記専用
+レーン: 設計妥当性+整合 / verdict: 全 medium（critical 0 / major 0）
+
+| R-NNN | severity | 内容 | status | reflected_in | notes |
+|-------|----------|------|--------|--------------|-------|
+| R-004 | medium | AC-01 が「OR」で TC-03（双方）と不整合 | reflected | (this branch) | AC-01 を「および/双方」に修正 |
+| R-005 | medium | plan Testing「3 ミラー間」用語不正確（正本はミラーでない） | reflected | (this branch) | 「正本と2ミラー間」へ |
+| R-006 | medium | plan Metrics「正規ミラーは 3」用語不正確 | reflected | (this branch) | 「正本と正規ミラーの合計は 3」へ |
+| R-007 | medium | TC-05 grep が全行カウントで Agent タスク漏れを偽陽性化 | reflected | (this branch) | Agent タスク限定 grep へ |
+| R-008 | medium | T6 に files 欠落（ai-dev-plan SKILL 規約違反） | reflected | (this branch) | files 追記 |
+| R-009 | medium | T8 に depends_on/files 欠落 | reflected | (this branch) | depends_on:T7 + files 追記 |
+
+注: R-005/R-006 の用語修正は「正本=ミラーではない」を反映。gemini の指摘は妥当。

--- a/docs/working/TASK-0131/review-self.md
+++ b/docs/working/TASK-0131/review-self.md
@@ -36,3 +36,10 @@ C-2（Codex 外部レビュー）→ C-3（人間 APPROVED 必須・autonomous �
 - [x] R-002 反映: TC-03 を「working-context と SKILL の双方」に修正 — PASS
 - [x] R-003 反映: T6 の rollback を具体化（git checkout 復元）— PASS
 - 判定: **PASS**。残 major なし。C-3（人間 APPROVED）待ち。
+
+## 簡易 C-1 再実行（gemini R-004..R-009 反映後）
+- AC ↔ TC 整合: AC-01 を「双方」に統一し TC-03 と一致 — PASS
+- todo 規約（depends_on/files 必須）: T6/T8 補完で全 Agent タスク準拠 — PASS
+- TC-05 機械検証の妥当性: Agent タスク限定 grep に修正、偽陽性解消 — PASS
+- 用語整合（正本/ミラー）: plan 2 箇所修正 — PASS
+- 判定: PASS（critical/major 0、medium 6 反映済み）

--- a/docs/working/TASK-0131/review-self.md
+++ b/docs/working/TASK-0131/review-self.md
@@ -1,0 +1,38 @@
+# C-1 セルフレビュー — TASK-0131 (#565)
+
+## Plan チェック（7項目）
+- [x] P1 受入基準網羅性: AC-01〜04 が Work Breakdown S1-S4 と対応 — PASS
+- [x] P2 Unknowns 処理: working-context 追記形式を Questions に明示、apply-script 生成時決定 — PASS
+- [x] P3 スコープ制御: 新規テンプレ非作成・plan.md Risks 不改変・#566/#567 除外を Non-goals に明記 — PASS
+- [x] P4 テスト戦略: TC-01〜06 + Edge 3 件、機械/レビュー区分あり — PASS
+- [x] P5 Work Breakdown Output: 各 S に Output/Owner/Risk/🚩 — PASS
+- [x] P6 依存関係: todo.md ⚠️依存に T1→T2→T3/T5→T7、H2 後検証を明示 — PASS
+- [x] P7 動作検証自動化: grep 3 ミラー一致 / doctor / validate — PASS
+
+## ToDo チェック（5項目）
+- [x] D1 タスク粒度: T1-T8 が小単位 — PASS
+- [x] D2 depends_on 設定: あり — PASS
+- [x] D3 チェックポイント: 🚩HO（T4）/ H1/H2 — PASS
+- [x] D4 Iron Law 遵守: HO は apply-script 生成のみ・AI 適用しない（T4）— PASS
+- [x] D5 完了条件: handoff(T8) — PASS
+
+## TestCases チェック（3項目）
+- [x] T1 受入基準との紐付き: AC↔TC 明示 — PASS
+- [x] T2 Edge case 網羅: EC-01〜03（rollback不要許容 / 補助ブロック / worktree除外）— PASS
+- [x] T3 自動化可否: TC-01,02,05,06 機械化可 — PASS
+
+## 承認境界チェック（自己設置）
+- [x] HO 対象（working-context.md）は AI 編集せず apply-script 経由・人間適用（H2）を明示 — PASS
+- [x] high-risk → lite_eligible=false / Standard 同期 C-3 / autonomous APPROVE 不可を Mode 判定に明記 — PASS
+
+## 判定
+**PASS**（FAIL なし）。軽微 WARN: working-context 追記の具体文言は apply-script 生成時に確定（Unknowns 記載済み）。
+
+## 次フェーズ
+C-2（Codex 外部レビュー）→ C-3（人間 APPROVED 必須・autonomous 不可）。
+
+## 簡易 C-1 再実行（C-2 反映後 / Refs R-001..R-003）
+- [x] R-001 反映: AC-05 + TC-07 追加、pbi-input に AC-05 — PASS
+- [x] R-002 反映: TC-03 を「working-context と SKILL の双方」に修正 — PASS
+- [x] R-003 反映: T6 の rollback を具体化（git checkout 復元）— PASS
+- 判定: **PASS**。残 major なし。C-3（人間 APPROVED）待ち。

--- a/docs/working/TASK-0131/test-cases.md
+++ b/docs/working/TASK-0131/test-cases.md
@@ -11,7 +11,7 @@
 - **TC-04**: standard 以下で `rollback:不要` 明記が許容される旨が記載。種別: レビュー
 
 ### AC-03: 記入サンプルが1件存在
-- **TC-05**: `docs/working/TASK-0131/todo.md` の各タスクに `rollback:` が存在する。種別: 機械（`grep -c "rollback:" todo.md` ≥ 全タスク数）
+- **TC-05**: `docs/working/TASK-0131/todo.md` の各 Agent タスクに `rollback:` が存在する。種別: 機械（`grep '^- \[ \] T' docs/working/TASK-0131/todo.md | grep -vc 'rollback:'` が 0）
 
 ### AC-04: 正本+ミラー整合
 - **TC-06**: `.agents/` `.codex/` `plugin/plangate/` の ai-dev-plan SKILL の rollback 規約文が一致（diff 差分なし）。種別: 機械

--- a/docs/working/TASK-0131/test-cases.md
+++ b/docs/working/TASK-0131/test-cases.md
@@ -1,0 +1,25 @@
+# TEST CASES — TASK-0131 (#565)
+
+## AC → テストケース マッピング
+
+### AC-01: todo.md 各タスクに rollback を記す規約が正本に明文化
+- **TC-01**: `grep -n "rollback" .claude/rules/working-context.md` で rollback 規約節がヒットする（H2 適用後）。前提: working-context 更新適用済み。期待: 規約文がある。種別: 機械
+- **TC-02**: `grep -n "rollback" .agents/skills/ai-dev-plan/SKILL.md` で `rollback:` キー規約がヒットする。種別: 機械
+
+### AC-02: mode 別の必須/任意ルールが矛盾なく記載（Refs: R-002）
+- **TC-03**: working-context **と** ai-dev-plan SKILL の**双方**に「high-risk/critical で rollback 必須・standard 以下任意」が記載され、mode-classification.md の定性基準と矛盾せず、正本(責務宣言)と生成規約の責務差分が整合する。種別: レビュー
+- **TC-04**: standard 以下で `rollback:不要` 明記が許容される旨が記載。種別: レビュー
+
+### AC-03: 記入サンプルが1件存在
+- **TC-05**: `docs/working/TASK-0131/todo.md` の各タスクに `rollback:` が存在する。種別: 機械（`grep -c "rollback:" todo.md` ≥ 全タスク数）
+
+### AC-04: 正本+ミラー整合
+- **TC-06**: `.agents/` `.codex/` `plugin/plangate/` の ai-dev-plan SKILL の rollback 規約文が一致（diff 差分なし）。種別: 機械
+
+### AC-05: C-1 が rollback 欠落を検出（Refs: R-001）
+- **TC-07**: `plan-quality-check` SKILL と `docs/working/templates/review-self.md` に「high-risk/critical の実装タスクで rollback 欠落 → FAIL」検出項目が存在する。high-risk plan で rollback 欠落タスクを与えると C-1 が FAIL 判定する。種別: レビュー + 機械（grep で検出項目の存在確認）
+
+## Edge cases
+- EC-01: 検証/読取のみタスク → `rollback:不要` を許容（誤って必須化しない）
+- EC-02: 長手順 rollback → 直下補助ブロック記法が壊れずレンダリングされる
+- EC-03: worktree 残骸ミラー（`.claude/worktrees/...`）は同期対象外として TC-06 から除外

--- a/docs/working/TASK-0131/todo.md
+++ b/docs/working/TASK-0131/todo.md
@@ -10,13 +10,13 @@
 - [ ] T3 [S2] 上記を .codex/ と plugin/plangate/ のミラーへ同期 (owner:agent, files:.codex/skills/ai-dev-plan/SKILL.md;plugin/plangate/skills/ai-dev-plan/SKILL.md, depends_on:T2, rollback:2ミラーを git checkout で復元)
 - [ ] T4 [S1] working-context.md 追記の apply-script + patch を生成（AI編集しない） (owner:agent, files:scripts/apply-task-0131-rollback.sh, depends_on:T1, rollback:生成スクリプトを削除, 🚩HO)
 - [ ] T5 [S3] plan-quality-check SKILL + review-self.md に rollback 欠落検出を追加 (owner:agent, files:.claude/skills/plan-quality-check/SKILL.md;docs/working/templates/review-self.md, depends_on:T2, rollback:両ファイルを git checkout で復元)
-- [ ] T6 [S4] 本 todo.md を rollback 記入サンプルとして整える (owner:agent, depends_on:T2, rollback:todo.md のサンプル追記差分を git checkout で復元)
+- [ ] T6 [S4] 本 todo.md を rollback 記入サンプルとして整える (owner:agent, files:docs/working/TASK-0131/todo.md, depends_on:T2, rollback:todo.md のサンプル追記差分を git checkout で復元)
 
 ### 検証
 - [ ] T7 grep で3ミラー rollback 規約一致 + AC-05 検出項目確認 + markdownlint + doctor (owner:agent, depends_on:T3,T5, rollback:不要・検証のみ)
 
 ### 完了
-- [ ] T8 handoff.md 作成(6要素) (owner:agent, rollback:不要)
+- [ ] T8 handoff.md 作成(6要素) (owner:agent, files:docs/working/TASK-0131/handoff.md, depends_on:T7, rollback:不要)
 
 ## 👤 Human タスク
 - [ ] H1 C-3 承認（high-risk / Standard 同期・exec 前ゲート） (owner:human 🚩)

--- a/docs/working/TASK-0131/todo.md
+++ b/docs/working/TASK-0131/todo.md
@@ -1,0 +1,32 @@
+# EXECUTION TODO — TASK-0131 (#565)
+
+## 🤖 Agent タスク
+
+### 準備
+- [ ] T1 working-context.md / ai-dev-plan SKILL の todo.md 規約 現状箇所を特定 (owner:agent, files:.claude/rules/working-context.md, rollback:不要・読取のみ)
+
+### 実装
+- [ ] T2 [S2] ai-dev-plan SKILL「todo.md 規約」に rollback: キー + mode別必須 + 補助ブロック許可を追記 (owner:agent, files:.agents/skills/ai-dev-plan/SKILL.md, depends_on:T1, rollback:git checkout で該当SKILL.mdを元に戻す)
+- [ ] T3 [S2] 上記を .codex/ と plugin/plangate/ のミラーへ同期 (owner:agent, files:.codex/skills/ai-dev-plan/SKILL.md;plugin/plangate/skills/ai-dev-plan/SKILL.md, depends_on:T2, rollback:2ミラーを git checkout で復元)
+- [ ] T4 [S1] working-context.md 追記の apply-script + patch を生成（AI編集しない） (owner:agent, files:scripts/apply-task-0131-rollback.sh, depends_on:T1, rollback:生成スクリプトを削除, 🚩HO)
+- [ ] T5 [S3] plan-quality-check SKILL + review-self.md に rollback 欠落検出を追加 (owner:agent, files:.claude/skills/plan-quality-check/SKILL.md;docs/working/templates/review-self.md, depends_on:T2, rollback:両ファイルを git checkout で復元)
+- [ ] T6 [S4] 本 todo.md を rollback 記入サンプルとして整える (owner:agent, depends_on:T2, rollback:todo.md のサンプル追記差分を git checkout で復元)
+
+### 検証
+- [ ] T7 grep で3ミラー rollback 規約一致 + AC-05 検出項目確認 + markdownlint + doctor (owner:agent, depends_on:T3,T5, rollback:不要・検証のみ)
+
+### 完了
+- [ ] T8 handoff.md 作成(6要素) (owner:agent, rollback:不要)
+
+## 👤 Human タスク
+- [ ] H1 C-3 承認（high-risk / Standard 同期・exec 前ゲート） (owner:human 🚩)
+- [ ] H2 working-context.md の apply-script 実行（HO 適用） (owner:human 🚩)
+- [ ] H3 C-4 PR レビュー (owner:human)
+
+## ⚠️ 依存
+- T1 → T2 → T3 / T5 → T7
+- exec 開始は H1(C-3) 必須 / S1 反映は H2(HO 適用) 必須
+- AC-01 のうち working-context 正本反映の検証は H2(人間 apply) 後に実施
+
+## 📌 rollback 記法サンプル（#565 ドッグフーディング）
+各タスクの `rollback:` が本ファイルの記入例。検証/読取のみのタスクは `rollback:不要` と明記する（mode-classification の「不要明記可」に対応）。


### PR DESCRIPTION
## 概要
issue #565（agent-skills 取り込み検討の実質ギャップ = タスク粒度 rollback）の **planning フェーズ**。実装（exec）は含まず、PBI+plan+todo+test-cases+C-1+C-2 反映まで。

## 設計（Codex 相談で確定）
- 追加先 **(d) 組合せ**: `working-context.md`（正本責務宣言・HO）+ `ai-dev-plan` SKILL+正規ミラー（生成規約）+ C-1（欠落検出）。新規 `templates/todo.md` は三重正本化回避のため作らない。
- 表現: 1行形式維持で `rollback:` インラインキー、長手順のみ補助ブロック。
- 強制の層分離: working-context=必須宣言 / skill=生成時要求 / C-1=high-risk・critical で欠落 FAIL。
- 責務分界: plan.md Risks=全体リスク・Fallback / todo.md rollback=タスク単位の戻し手順（重複禁止）。

## レビュー状況
- C-1: PASS
- C-2（Codex）: major 3 / critical 0 → CONDITIONAL。R-001（AC-05 追加）/ R-002（TC-03 双方）/ R-003（T6 rollback 具体化）を確定反映済（`review-external.md`）。

## ⚠️ ゲート
- Mode=**high-risk**（承認境界周辺 / HO）→ **autonomous APPROVE 不可・人間 C-3 同期固定**。
- exec で `.claude/rules/working-context.md` を変更する S1 は **AI 編集不可** → apply-script 生成 + 人間適用（H2）。
- 本 PR は planning 成果物（`docs/working/TASK-0131/`）のみ。マージは人間（C-4）。

## 関連
- 親検討: #565 / 兄弟: #566 #567（同じく agent-skills 取り込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)