### PR TITLE
plan(#566): TASK-0132 Skill Router 本体統合 — PBI+plan（planning / C-3待ち）

### DIFF
--- a/docs/working/TASK-0132/decision-log.jsonl
+++ b/docs/working/TASK-0132/decision-log.jsonl
@@ -1,0 +1,4 @@
+{"phase":"B","decision":"Codex相談: 正本は(a).claude/skills移動+plugin mirror。hybrid原則整合","ts":"2026-06-18"}
+{"phase":"B","decision":"Mode別ポリシー表の単一正本はmode-classification.md。router重複表は削除し参照化","ts":"2026-06-18"}
+{"phase":"B","decision":"配線はWF-00 advisory(初回)。強制化・schema・bin配線は別PBI","ts":"2026-06-18"}
+{"phase":"B","decision":"Mode=critical。lite_eligible=false・人間C-3必須。初回スコープをadvisoryに限定しリスク低減","ts":"2026-06-18"}

--- a/docs/working/TASK-0132/pbi-input.md
+++ b/docs/working/TASK-0132/pbi-input.md
@@ -1,0 +1,28 @@
+# PBI INPUT PACKAGE — TASK-0132 (#566)
+
+## Context / Why
+agent-skills 取り込み検討の差分。`intent-classifier` / `skill-policy-router` は `plugin/plangate/skills/` にのみ存在し、`.claude/skills/` 本体に正本が無く本体フロー（ai-driven-development / docs/workflows / bin/plangate）から呼ばれていない。hybrid-architecture の原則（本体正本=`.claude/`、plugin=配布 export）と逆転している。
+
+## What (Scope)
+### In scope（Codex 助言で初回スコープを限定）
+- 2 スキル（intent-classifier / skill-policy-router）を `.claude/skills/` へ正本移動し、`plugin/plangate/` は mirror 化
+- skill-policy-router の「Mode別ポリシー表」を削除し、`mode-classification.md` を単一正本として参照（drift 解消）
+- WF-00（docs/workflows）への **advisory 配線**（依頼→intent→mode→router→GatePolicy→ai-dev-plan 前段。初回は強制でなく advisory 出力）
+
+### Out of scope（初回）
+- 強制配線（gate を機械強制）— 初回は advisory のみ
+- GatePolicy JSON schema の厳密化・互換性テスト
+- bin/plangate への実装配線（将来 thin entrypoint）
+- #565 / #567
+
+## 受入基準
+- AC-01: intent-classifier / skill-policy-router の正本が `.claude/skills/` に存在し、plugin 側は mirror（内容一致）
+- AC-02: skill-policy-router から Mode別ポリシー表が削除され、mode-classification.md への参照に置換（重複ゼロ）
+- AC-03: WF-00 に advisory 配線（依頼→intent→mode→router→plan 前段）が文書化されている
+- AC-04: hybrid-architecture の正本/export 方向（.claude 正本・plugin mirror）に整合
+- AC-05: lite_eligible 自動推定との責務関係が明記（classifier/mode判定/router のどこが担うか）
+
+## Estimation Evidence
+- Risks: `.claude/rules/mode-classification.md` を参照される側として確認（編集はrouter側＝.claude/skills 追加で AI 可）。bin/plangate は初回触らない（advisory）。
+- Unknowns（Codex Q4）: intent 7分類を本体契約に固定するか暫定か / GatePolicy schema 正本置き場 / export 同期手順 / advisory→強制の移行。
+- Mode 見込み: **critical**（横断的・正本移動・重複解消・複数レイヤー。lite_eligible=false・人間 C-3 必須・autonomous 不可）。

--- a/docs/working/TASK-0132/plan.md
+++ b/docs/working/TASK-0132/plan.md
@@ -1,0 +1,58 @@
+# EXECUTION PLAN — TASK-0132 (#566)
+
+## Goal
+plugin 専用の intent-classifier / skill-policy-router を本体（`.claude/skills/`）正本へ移し、mode-classification.md との重複を解消し、WF-00 に advisory 配線する。初回は advisory に限定し強制化はしない。
+
+## Constraints / Non-goals
+- 初回は **advisory のみ**（gate 機械強制は別 PBI）。
+- bin/plangate 実装配線は初回スコープ外（将来 thin entrypoint）。
+- GatePolicy schema 厳密化はスコープ外。
+- #565 / #567 と独立。
+
+## Approach Overview（Codex 設計相談）
+1. **正本移動**: `.claude/skills/{intent-classifier,skill-policy-router}/SKILL.md` を新設（plugin から移植）、plugin 側は mirror として残す（hybrid Rule: .claude 正本・plugin export）。
+2. **重複解消**: skill-policy-router の Mode別ポリシー表を削除 → `mode-classification.md` フェーズ適用マトリクス + lite_eligible を単一正本として参照。
+3. **advisory 配線**: `docs/workflows/00_*`（WF-00）に「依頼→intent-classifier→mode判定(lite_eligible含む)→skill-policy-router→GatePolicy→ai-dev-plan 前段」を advisory フローとして記述。
+
+## Work Breakdown
+- **S1** `.claude/skills/intent-classifier/SKILL.md` 正本新設（plugin 内容を移植・本体向け） / Owner: agent / Risk: 重複定義 / 🚩
+- **S2** `.claude/skills/skill-policy-router/SKILL.md` 正本新設 + **Mode別ポリシー表を mode-classification 参照に置換** / Owner: agent / Risk: 参照リンク切れ
+- **S3** plugin 側 2 スキルを mirror として整合（export 注記 or 同期）/ Owner: agent / Risk: drift
+- **S4** WF-00 に advisory 配線を文書化 / Owner: agent / Risk: 既存 WF との不整合
+- **S5** lite_eligible 責務（classifier/mode/router 分界）を明記 / Owner: agent
+
+## Files / Components to Touch
+- `.claude/skills/intent-classifier/SKILL.md`（新規・AI 可：skills は override 外）
+- `.claude/skills/skill-policy-router/SKILL.md`（新規・AI 可）
+- `plugin/plangate/skills/{intent-classifier,skill-policy-router}/SKILL.md`（mirror・AI 可）
+- `docs/workflows/00_*.md`（WF-00 advisory・AI 可）
+- 参照のみ: `.claude/rules/mode-classification.md`（編集しない＝単一正本のまま参照）
+
+## Testing Strategy
+- 機械: `.claude/skills` 正本と plugin mirror の diff 一致、router に Mode別表が残っていないことの grep、WF-00 に advisory フロー記述の grep
+- レビュー: hybrid-architecture 正本/export 方向の整合、mode-classification との重複ゼロ
+- doctor / markdownlint
+
+## Risks & Mitigations（内容 / 検証手段 / Fallback）
+- R1 router 表削除で参照先不明瞭 / mode-classification への明示リンク + grep / リンク不備なら追補
+- R2 正本/mirror drift / diff 検証 / 不一致なら同期
+- R3 advisory が既存 WF と二重手順化 / WF-00 を入口の advisory に限定し既存 phase を変えない / 競合時は advisory を注記レベルに留める
+
+## Metrics Evidence
+- 対象「移動対象スキル」: 実数 2（intent-classifier, skill-policy-router）/ 見積もり 2 / ratio 1.0 → 採用。
+
+## Questions / Unknowns（Codex Q4・planning で詰める）
+- intent 7分類を本体契約に固定 vs 暫定 → 初回は暫定（advisory）として導入、固定は強制化 PBI で。
+- GatePolicy JSON schema の正本置き場 → 初回スコープ外（schema 化は別 PBI）。
+- plugin export 同期手順の自動化 → 初回は手動 mirror + 注記。
+
+## Mode判定
+
+**モード**: critical
+
+**判定根拠**:
+- 変更ファイル数: 5+（skills×2 新設 + mirror×2 + WF-00）→ high〜critical
+- 変更種別: 横断的（ワークフロー入口・正本構造・router/mode の責務再配置）→ critical
+- 影響範囲: planning 入口フロー全体に波及しうる → critical
+- リスク: 高（正本移動・重複解消）
+- **最終判定**: critical（`lite_eligible=false`・人間 C-3 必須・autonomous APPROVE 不可・C-2 複数観点推奨）。初回スコープを advisory に絞りリスク低減。

--- a/docs/working/TASK-0132/review-external.md
+++ b/docs/working/TASK-0132/review-external.md
@@ -9,3 +9,12 @@
 
 ## 反映方針
 1 回確定反映。簡易 C-1 → 人間 C-3（critical・複数観点推奨）→ exec。
+
+## C-2 追加レビュー（gemini-code-assist / GitHub PR #569）— 追記専用
+レーン: 設計妥当性+整合 / verdict: 全 medium（critical 0 / major 0）
+
+| R-NNN | severity | 内容 | status | reflected_in | notes |
+|-------|----------|------|--------|--------------|-------|
+| R-003 | medium | T4(mirror) が T6(本体追記) 前/並行だと plugin に drift（AC-01/TC-02 違反） | reflected | (this branch) | T4 depends_on に T6 追加 |
+| R-004 | medium | T5(advisory) は intent(T2)+router(T3) 双方が前提 | reflected | (this branch) | T5 depends_on:T2,T3 |
+| R-005 | medium | T6 は両 SKILL 変更だが depends_on:T3 のみ・files 欠落 | reflected | (this branch) | depends_on:T2,T3 + files 補完 |

--- a/docs/working/TASK-0132/review-external.md
+++ b/docs/working/TASK-0132/review-external.md
@@ -1,0 +1,11 @@
+# C-2 外部レビュー（Codex）— TASK-0132 (#566)
+
+レビュア: Codex (gpt-5.5) / レーン: 設計妥当性 / verdict: CONDITIONAL（major 2 / critical 0）
+
+| R-NNN | severity | 内容 | status | reflected_in | notes |
+|-------|----------|------|--------|--------------|-------|
+| R-001 | major | T5 の files が docs/workflows 全体で WF-00 限定スコープより広い | reflected | (this branch) | T5 を docs/workflows/00_*.md に限定 |
+| R-002 | major | critical プロセス制約(C-3必須/autonomous不可)を検証する AC/TC が無い | reflected | (this branch) | AC-06 + TC-08 追加 |
+
+## 反映方針
+1 回確定反映。簡易 C-1 → 人間 C-3（critical・複数観点推奨）→ exec。

--- a/docs/working/TASK-0132/review-self.md
+++ b/docs/working/TASK-0132/review-self.md
@@ -25,3 +25,9 @@
 - [x] R-001: T5 files を docs/workflows/00_*.md に限定 — PASS
 - [x] R-002: AC-06 + TC-08（critical 制約維持の検証）追加 — PASS
 - 判定: **PASS**。残 major なし。C-3（人間・critical）待ち。
+
+## 簡易 C-1 再実行（gemini R-003..R-005 反映後）
+- 依存整合（drift防止）: T4→T6 / T5・T6→T2,T3 でミラー取りこぼし解消 — PASS
+- todo 規約（files 必須）: T6/T8 補完で全 Agent タスク準拠 — PASS
+- フロー図整合: 依存変更に追従 — PASS
+- 判定: PASS（critical/major 0、medium 3 反映済み）

--- a/docs/working/TASK-0132/review-self.md
+++ b/docs/working/TASK-0132/review-self.md
@@ -1,0 +1,27 @@
+# C-1 セルフレビュー — TASK-0132 (#566)
+
+## Plan チェック（7項目）
+- [x] P1 受入基準網羅: AC-01〜05 ↔ S1-S5 対応 — PASS
+- [x] P2 Unknowns: intent固定/schema/export同期/advisory→強制 を Questions に明示 — PASS
+- [x] P3 スコープ制御: 初回 advisory 限定・強制/schema/bin配線を Out of scope — PASS
+- [x] P4 テスト戦略: TC-01〜07 + Edge3、機械/レビュー区分 — PASS
+- [x] P5 Work Breakdown Output: 各 S に Output/Owner/Risk — PASS
+- [x] P6 依存関係: T1→T2/T3→T4/5/6→T7 — PASS
+- [x] P7 動作検証自動化: 正本↔mirror diff / grep / doctor — PASS
+
+## ToDo（5）/ TestCases（3）
+- [x] タスク粒度・depends_on・🚩・完了条件・rollback(#565規約適用) — PASS
+- [x] AC↔TC 紐付き / Edge(plugin非破壊・advisory非強制・mode-classification参照のみ) / 自動化可 — PASS
+
+## 承認境界チェック
+- [x] mode-classification.md は参照のみ・編集しない（単一正本維持）→ HO apply 不要 — PASS
+- [x] critical → lite_eligible=false / 人間 C-3 必須 / autonomous 不可 を明記 — PASS
+- [x] .claude/skills は override 外のため AI 編集可（HO 非該当）を確認 — PASS
+
+## 判定
+**PASS**。critical のため C-2 は複数観点推奨だが、設計相談で Codex が深く関与済 + C-2 1本で CONDITIONAL/APPROVE 材料とする。
+
+## 簡易 C-1 再実行（C-2 反映後 / Refs R-001..R-002）
+- [x] R-001: T5 files を docs/workflows/00_*.md に限定 — PASS
+- [x] R-002: AC-06 + TC-08（critical 制約維持の検証）追加 — PASS
+- 判定: **PASS**。残 major なし。C-3（人間・critical）待ち。

--- a/docs/working/TASK-0132/test-cases.md
+++ b/docs/working/TASK-0132/test-cases.md
@@ -1,0 +1,23 @@
+# TEST CASES — TASK-0132 (#566)
+
+## AC → TC
+### AC-01: 正本が .claude/skills に存在・plugin は mirror 一致
+- TC-01: `.claude/skills/intent-classifier/SKILL.md` と `.claude/skills/skill-policy-router/SKILL.md` が存在。種別: 機械
+- TC-02: plugin 側と本体正本の本文が一致（export 注記行を除き diff なし）。種別: 機械
+### AC-02: router の Mode別表削除 + 参照化
+- TC-03: `grep -i "Mode別ポリシー表\|ultra-light.*light.*standard" .claude/skills/skill-policy-router/SKILL.md` がマトリクス本体をヒットしない。種別: 機械
+- TC-04: router が `mode-classification.md` を明示参照している。種別: 機械
+### AC-03: WF-00 advisory 配線
+- TC-05: WF-00 に「intent→mode→router→GatePolicy→plan」advisory フロー記述がある。種別: レビュー+機械(grep)
+### AC-04: hybrid 正本/export 方向整合
+- TC-06: hybrid-architecture の「.claude 正本・plugin export」に反しない（本体正本が存在し plugin が mirror）。種別: レビュー
+### AC-05: lite_eligible 責務明記
+- TC-07: classifier/mode判定/router の lite_eligible 責務分界が記述されている。種別: レビュー
+
+### AC-06: critical プロセス制約の維持（Refs: R-002）
+- TC-08: plan.md / todo.md に「Mode=critical・人間 C-3 必須・autonomous APPROVE 不可」が明記され、planning 段階で緩和されていない。種別: レビュー
+
+## Edge cases
+- EC-01: 既存 plugin 利用者が壊れない（plugin に SKILL は残る）
+- EC-02: advisory は強制でない（既存 phase の必須性を変えない）
+- EC-03: mode-classification.md は編集せず参照のみ（単一正本維持）

--- a/docs/working/TASK-0132/todo.md
+++ b/docs/working/TASK-0132/todo.md
@@ -1,0 +1,26 @@
+# EXECUTION TODO — TASK-0132 (#566)
+
+## 🤖 Agent タスク
+### 準備
+- [ ] T1 plugin の2スキル + mode-classification マトリクス + WF-00 現状を精読 (owner:agent, files:docs/workflows, rollback:不要・読取のみ)
+### 実装
+- [ ] T2 [S1] .claude/skills/intent-classifier/SKILL.md 正本新設 (owner:agent, files:.claude/skills/intent-classifier/SKILL.md, depends_on:T1, rollback:新設ファイルを削除)
+- [ ] T3 [S2] .claude/skills/skill-policy-router/SKILL.md 正本新設 + Mode別表を mode-classification 参照に置換 (owner:agent, files:.claude/skills/skill-policy-router/SKILL.md, depends_on:T1, rollback:新設ファイルを削除)
+- [ ] T4 [S3] plugin 側2スキルを mirror 整合 + export 注記 (owner:agent, files:plugin/plangate/skills/intent-classifier/SKILL.md;plugin/plangate/skills/skill-policy-router/SKILL.md, depends_on:T2,T3, rollback:plugin 2ファイルを git checkout で復元)
+- [ ] T5 [S4] WF-00 に advisory 配線を文書化 (owner:agent, files:docs/workflows/00_*.md, depends_on:T3, rollback:WF-00 追記を git checkout で復元)
+- [ ] T6 [S5] lite_eligible 責務分界を router/skill に明記 (owner:agent, depends_on:T3, rollback:該当追記を git checkout で復元)
+### 検証
+- [ ] T7 正本↔mirror diff 一致 / router に Mode別表が無い grep / WF-00 advisory grep / doctor (owner:agent, depends_on:T4,T5,T6, rollback:不要・検証のみ)
+### 完了
+- [ ] T8 handoff.md 作成(6要素) (owner:agent, rollback:不要)
+
+## 👤 Human タスク
+- [ ] H1 C-3 承認（critical / Standard 同期・複数観点 C-2 推奨・exec 前ゲート） (owner:human 🚩)
+- [ ] H2 C-4 PR レビュー (owner:human)
+
+## ⚠️ 依存
+- T1 → T2/T3 → T4 / T5 / T6 → T7
+- exec 開始は H1(C-3) 必須。本 PBI は HO対象ファイル(.claude/rules / bin/plangate)を**触らない**ため HO apply は不要（mode-classification は参照のみ）。
+
+## 📌 rollback 記法サンプル（#565 規約適用）
+各タスクに `rollback:` を記載（critical のため必須）。

--- a/docs/working/TASK-0132/todo.md
+++ b/docs/working/TASK-0132/todo.md
@@ -6,20 +6,20 @@
 ### 実装
 - [ ] T2 [S1] .claude/skills/intent-classifier/SKILL.md 正本新設 (owner:agent, files:.claude/skills/intent-classifier/SKILL.md, depends_on:T1, rollback:新設ファイルを削除)
 - [ ] T3 [S2] .claude/skills/skill-policy-router/SKILL.md 正本新設 + Mode別表を mode-classification 参照に置換 (owner:agent, files:.claude/skills/skill-policy-router/SKILL.md, depends_on:T1, rollback:新設ファイルを削除)
-- [ ] T4 [S3] plugin 側2スキルを mirror 整合 + export 注記 (owner:agent, files:plugin/plangate/skills/intent-classifier/SKILL.md;plugin/plangate/skills/skill-policy-router/SKILL.md, depends_on:T2,T3, rollback:plugin 2ファイルを git checkout で復元)
-- [ ] T5 [S4] WF-00 に advisory 配線を文書化 (owner:agent, files:docs/workflows/00_*.md, depends_on:T3, rollback:WF-00 追記を git checkout で復元)
-- [ ] T6 [S5] lite_eligible 責務分界を router/skill に明記 (owner:agent, depends_on:T3, rollback:該当追記を git checkout で復元)
+- [ ] T4 [S3] plugin 側2スキルを mirror 整合 + export 注記 (owner:agent, files:plugin/plangate/skills/intent-classifier/SKILL.md;plugin/plangate/skills/skill-policy-router/SKILL.md, depends_on:T2,T3,T6, rollback:plugin 2ファイルを git checkout で復元)
+- [ ] T5 [S4] WF-00 に advisory 配線を文書化 (owner:agent, files:docs/workflows/00_*.md, depends_on:T2,T3, rollback:WF-00 追記を git checkout で復元)
+- [ ] T6 [S5] lite_eligible 責務分界を router/skill に明記 (owner:agent, files:.claude/skills/intent-classifier/SKILL.md;.claude/skills/skill-policy-router/SKILL.md, depends_on:T2,T3, rollback:該当追記を git checkout で復元)
 ### 検証
 - [ ] T7 正本↔mirror diff 一致 / router に Mode別表が無い grep / WF-00 advisory grep / doctor (owner:agent, depends_on:T4,T5,T6, rollback:不要・検証のみ)
 ### 完了
-- [ ] T8 handoff.md 作成(6要素) (owner:agent, rollback:不要)
+- [ ] T8 handoff.md 作成(6要素) (owner:agent, files:docs/working/TASK-0132/handoff.md, rollback:不要)
 
 ## 👤 Human タスク
 - [ ] H1 C-3 承認（critical / Standard 同期・複数観点 C-2 推奨・exec 前ゲート） (owner:human 🚩)
 - [ ] H2 C-4 PR レビュー (owner:human)
 
 ## ⚠️ 依存
-- T1 → T2/T3 → T4 / T5 / T6 → T7
+- T1 → T2/T3 → T5 / T6 → T4 → T7
 - exec 開始は H1(C-3) 必須。本 PBI は HO対象ファイル(.claude/rules / bin/plangate)を**触らない**ため HO apply は不要（mode-classification は参照のみ）。
 
 ## 📌 rollback 記法サンプル（#565 規約適用）


### PR DESCRIPTION
## 概要
issue #566 の **planning フェーズ**。intent-classifier / skill-policy-router が `plugin/plangate/skills/` のみに存在し、hybrid-architecture 原則（.claude 正本・plugin export）と逆転・本体フロー未配線である問題への対応方針を策定。

## 設計（Codex 相談で確定）
- **正本移動**: `.claude/skills/` に2スキル正本を置き plugin は mirror 化
- **重複解消**: skill-policy-router の Mode別ポリシー表を削除 → `mode-classification.md` を単一正本として参照
- **配線**: WF-00 に **advisory**（依頼→intent→mode→router→GatePolicy→plan 前段）。初回は強制化せず advisory 限定
- 強制化 / GatePolicy schema / bin/plangate 配線は別 PBI

## レビュー状況
- C-1: PASS
- C-2（Codex）: major 2 / critical 0 → CONDITIONAL。R-001（T5 を WF-00 限定）/ R-002（critical 制約検証 AC-06+TC-08）反映済。

## ⚠️ ゲート
- Mode=**critical** → 人間 C-3 必須・autonomous APPROVE 不可・C-2 複数観点推奨。
- `.claude/rules/mode-classification.md` は**参照のみ・編集しない**ため HO apply 不要。`.claude/skills/` 追加は override 外で AI exec 可。
- 本 PR は planning 成果物のみ。マージは人間（C-4）。

## 関連
- 兄弟: #565（PR #568）/ #567。agent-skills 取り込み検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)