### PR TITLE
chore: HO 適用 — #565 rollback 規約 / #571 並列レビュー --progress

### DIFF
--- a/.claude/rules/working-context.md
+++ b/.claude/rules/working-context.md
@@ -199,6 +199,7 @@ confirmed_by）。人間 confirm 済のみ追記。#200 期間集計の入力源
 - ⚠️ 依存関係（Agent ↔ Human）
 - 各タスクに Owner（agent / human）と 🚩チェックポイントを明記
 - L-0〜V-4, PR作成はworkflow-conductorが自動制御するため含めない
+- 各タスクに `rollback:` を記載（戻し手順）。**必須=high-risk / critical の実装タスク**。standard 以下は任意、検証/読取のみは `rollback:不要` と明記可
 
 ### test-cases.md（テストケース定義）
 

--- a/bin/plangate
+++ b/bin/plangate
@@ -1535,6 +1535,7 @@ cmd_review() {
   plangate_require_task_dir "$task_id"
 
   phase="c2"
+  _review_progress=0
   while [ $# -gt 0 ]; do
     case "$1" in
       --phase)
@@ -1544,6 +1545,9 @@ cmd_review() {
       --file)
         shift
         ;;  # --file is accepted but unused in this version; kept for future use
+      --progress)
+        _review_progress=1
+        ;;
     esac
     shift
   done
@@ -1647,6 +1651,7 @@ _review_parallel() {
   _rp_work_dir=$3
   _rp_output_file=$4
   _rp_reviewers_yaml=$5
+  _rp_progress="${_review_progress:-0}"
 
   # タスクの mode を current-state.md または plan.md から取得
   _rp_task_mode=""
@@ -1798,10 +1803,35 @@ PYEOF
       _rp_status_file="$_rp_tmpdir/status_$(printf '%03d' "$_rp_idx")"
       printf 'Starting reviewer: %s (lane=%s)\n' "$provider" "$lane"
       # shellcheck disable=SC2086
-      (eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file") &
+      (eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file"; : > "$_rp_tmpdir/done_$(printf '%03d' "$_rp_idx")") &
     fi
     _rp_idx=$((_rp_idx + 1))
   done
+
+  if [ "$_rp_progress" = "1" ]; then
+    _rp_seen_count=0
+    _rp_printed_count=0
+    while [ "$_rp_seen_count" -lt "$_rp_count" ]; do
+      _rp_seen_count=0
+      _rp_pi=0
+      while [ "$_rp_pi" -lt "$_rp_count" ]; do
+        if [ -f "$_rp_tmpdir/done_$(printf '%03d' "$_rp_pi")" ]; then
+          _rp_seen_count=$((_rp_seen_count + 1))
+          if [ ! -f "$_rp_tmpdir/seen_$(printf '%03d' "$_rp_pi")" ]; then
+            : > "$_rp_tmpdir/seen_$(printf '%03d' "$_rp_pi")"
+            _rp_printed_count=$((_rp_printed_count + 1))
+            _rp_pstat=$(cat "$_rp_tmpdir/status_$(printf '%03d' "$_rp_pi")" 2>/dev/null || echo 1)
+            _rp_pprov=""
+            [ -f "$_rp_tmpdir/spec_$(printf '%03d' "$_rp_pi")" ] && _rp_pprov=$(sed -n 's/^provider=//p' "$_rp_tmpdir/spec_$(printf '%03d' "$_rp_pi")")
+            if [ "$_rp_pstat" = "0" ]; then _rp_pres="ok"; else _rp_pres="failed"; fi
+            printf '[done %s/%s] %s %s\n' "$_rp_printed_count" "$_rp_count" "$_rp_pprov" "$_rp_pres"
+          fi
+        fi
+        _rp_pi=$((_rp_pi + 1))
+      done
+      [ "$_rp_seen_count" -lt "$_rp_count" ] && sleep 1
+    done
+  fi
 
   wait
 


### PR DESCRIPTION
## 概要
exec PR #575（#565）/ #576（#571）でマージ済みの apply-script を**人間が実行**した HO 反映結果。bin/plangate / .claude/rules/working-context.md は HO 対象のため apply-script 経由で適用。

## 変更（HO）
- **`.claude/rules/working-context.md`**: todo.md 規約に rollback 行追加（#565）
- **`bin/plangate`**: cmd_review `--progress` + _review_parallel ライブ進捗（#571）。`_rp_printed_count` 採用版（順不同完了でも連番）。

## 検証
- bash syntax OK / `plangate help` OK
- grep: `_review_progress=0` / `--progress)` / `_rp_progress`×2 / `_rp_printed_count`×3 / done sentinel×2 反映確認

## 経緯
apply-script は #575/#576 でマージ済。本 PR はその apply 結果（HO 本体反映）を main へ。適用トリガー・判断は人間（Human-owned）。

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)