### PR TITLE
fix: _review_parallel を set -e 安全化（#580 critical 是正のマージ漏れ補填）

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -1803,7 +1803,7 @@ PYEOF
       _rp_status_file="$_rp_tmpdir/status_$(printf '%03d' "$_rp_idx")"
       printf 'Starting reviewer: %s (lane=%s)\n' "$provider" "$lane"
       # shellcheck disable=SC2086
-      (eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file"; : > "$_rp_tmpdir/done_$(printf '%03d' "$_rp_idx")") &
+      (_rp_ec=0; eval "$command" > "$_rp_out_file" 2>&1 || _rp_ec=$?; echo "$_rp_ec" > "$_rp_status_file"; : > "$_rp_tmpdir/done_$(printf '%03d' "$_rp_idx")") &
     fi
     _rp_idx=$((_rp_idx + 1))
   done

--- a/scripts/apply-task-0134-progress.sh
+++ b/scripts/apply-task-0134-progress.sh
@@ -58,7 +58,7 @@ reps = [
    '  _rp_reviewers_yaml=$5\n  _rp_progress="${_review_progress:-0}"\n'),
   # R4: 子プロセス完了 sentinel（done_NNN）— R-001 未完了/完了後欠落の区別
   ('      (eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file") &',
-   '      (eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file"; : > "$_rp_tmpdir/done_$(printf \'%03d\' "$_rp_idx")") &'),
+   '      (_rp_ec=0; eval "$command" > "$_rp_out_file" 2>&1 || _rp_ec=$?; echo "$_rp_ec" > "$_rp_status_file"; : > "$_rp_tmpdir/done_$(printf \'%03d\' "$_rp_idx")") &'),
   # R5: wait 前にライブ進捗ポーリング
   ('    _rp_idx=$((_rp_idx + 1))\n  done\n\n  wait\n',
    '    _rp_idx=$((_rp_idx + 1))\n  done\n\n' + PROG + '  wait\n'),


### PR DESCRIPTION
## 概要
#580 で gemini が指摘した **critical（set -e 下サブシェル hang）** の是正コミット（cc8aa4a）が、#580 マージのタイミングで**マージ漏れ**し main に未反映でした。本 PR で補填します。

## 問題
`origin/main` の `bin/plangate` L1806 は旧バグ版:
```sh
(eval "$command" > "$_rp_out_file" 2>&1; echo $? > "$_rp_status_file"; : > done) &
```
`set -eu` 下で reviewer command が失敗するとサブシェルが eval 時点で終了し、status/done が作られず **`--progress` の進捗監視が無限 hang** する移植性リスク。

## 是正
```sh
(_rp_ec=0; eval "$command" > "$_rp_out_file" 2>&1 || _rp_ec=$?; echo "$_rp_ec" > "$_rp_status_file"; : > done) &
```
- `|| _rp_ec=$?` で eval 失敗を捕捉（set -e 発動を回避）→ status/done を確実生成
- 変数名は zsh 予約 `status` を避け `_rp_ec`（既存命名規約）
- bin/plangate 本体 + apply-script(R4) 両方を是正

## 検証
- POSIX sh: eval 失敗→`status=1`/done あり、成功→`0`/done あり（hang なし）
- bash syntax OK

<!-- skip-issue-link-check -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)