### PR TITLE
Plan品質ゲートにSuperpowers由来のTask Sizing / No Placeholdersを追加

### DIFF
--- a/docs/working/templates/README.md
+++ b/docs/working/templates/README.md
@@ -6,6 +6,7 @@ PlanGate ワークフローで使うテンプレート群。
 
 | テンプレート | 用途 | フェーズ |
 | --- | --- | --- |
+| [`plan.md`](./plan.md) | 実装前の実行可能な作業指示書（Task Sizing / No Placeholders / 検証計画） | WF-03 / C-1 |
 | [`handoff.md`](./handoff.md) | 完了時の引き継ぎパッケージ（必須6要素・全PBI必須） | WF-05 |
 
 ## 親 PBI（Orchestrator Mode）

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -1,0 +1,176 @@
+---
+task_id: TASK-XXXX
+artifact_type: plan
+schema_version: 1
+status: draft
+mode: standard
+related_issue: <issue URL>
+created_by: orchestrator
+---
+
+# TASK-XXXX Implementation Plan
+
+> このテンプレートは、AI実装者が安全に実行できる **実行可能な作業指示書** として `plan.md` を書くためのもの。
+> Superpowers の `writing-plans` から、PlanGateに合う要素だけを翻訳している。
+
+## Goal
+
+{このPBIで何を達成するかを1文で書く}
+
+## Context
+
+- 背景: {なぜ必要か}
+- 関連Issue: {URL}
+- 関連artifact:
+  - `pbi-input.md`
+  - `design.md`
+  - `test-cases.md`
+
+## Scope
+
+### In Scope
+
+- {今回やること}
+
+### Out of Scope
+
+- {今回やらないこと}
+
+## Global Constraints
+
+- {既存設計・命名規則・依存追加・セキュリティ・後方互換性などの制約}
+- `TBD` / `TODO` / `必要に応じて` / `適切に` のような曖昧な未決事項を残さない
+- 変更対象外ファイルを触る場合は、理由を明記する
+
+## Approach Comparison
+
+| 案 | 内容 | メリット | デメリット | 判定 |
+|---|---|---|---|---|
+| A | {案A} | {メリット} | {デメリット} | 採用 / 不採用 |
+| B | {案B} | {メリット} | {デメリット} | 採用 / 不採用 |
+
+### Recommended Approach
+
+{採用案と理由。既存設計との整合性、実装コスト、保守性、テスト容易性を含める}
+
+## Files / Interfaces
+
+| ファイル | 操作 | 目的 | 公開インターフェース / 依存 |
+|---|---|---|---|
+| `path/to/file.ts` | create / modify | {目的} | `{functionName(args): ReturnType}` |
+| `path/to/test.ts` | create / modify | {テスト目的} | — |
+
+## Work Breakdown
+
+> 各Taskは、独立して検証可能で、reviewerがTask単位で approve / reject できる粒度にする。
+> setup / config / docs は、それを必要とする成果物のTaskに含める。
+
+### Task 1: {タスク名}
+
+**Purpose**: {このTaskで達成すること}
+
+**Files**:
+
+- Create: `path/to/new-file.ts`
+- Modify: `path/to/existing-file.ts`
+- Test: `path/to/test-file.test.ts`
+
+**Interfaces**:
+
+- Consumes: `{前Taskや既存コードから使う関数・型}`
+- Produces: `{後続Taskが使う関数・型・ファイル}`
+
+**Steps**:
+
+- [ ] Step 1: failing test を追加する
+  - 変更: `path/to/test-file.test.ts`
+  - 期待: 対象機能が未実装のため失敗する
+- [ ] Step 2: REDを確認する
+  - command: `pnpm test path/to/test-file.test.ts`
+  - expected: `FAIL` with `{期待する失敗理由}`
+- [ ] Step 3: 最小実装を追加する
+  - 変更: `path/to/new-file.ts`
+  - 方針: テストを通すために必要な最小実装に留める
+- [ ] Step 4: GREENを確認する
+  - command: `pnpm test path/to/test-file.test.ts`
+  - expected: `PASS`
+- [ ] Step 5: 関連検証を実行する
+  - command: `pnpm typecheck`
+  - expected: `PASS`
+
+**Completion Criteria**:
+
+- [ ] 対象テストが成功している
+- [ ] 変更ファイルがScope内に収まっている
+- [ ] Evidence Ledgerに検証結果を記録している
+
+**Rollback**:
+
+- {戻す場合の手順。high-risk / criticalでは必須}
+
+### Task 2: {タスク名}
+
+**Purpose**: {このTaskで達成すること}
+
+**Files**:
+
+- Create: `path/to/file`
+- Modify: `path/to/file`
+- Test: `path/to/test`
+
+**Interfaces**:
+
+- Consumes: `{Task 1で作ったもの}`
+- Produces: `{後続Taskが使うもの}`
+
+**Steps**:
+
+- [ ] Step 1: {具体的な作業}
+  - command: `{必要ならコマンド}`
+  - expected: `{期待結果}`
+
+**Completion Criteria**:
+
+- [ ] {完了条件}
+
+**Rollback**:
+
+- {戻す場合の手順}
+
+## Verification Plan
+
+| 種別 | コマンド / 確認方法 | 期待結果 | Evidence保存先 |
+|---|---|---|---|
+| Unit | `pnpm test path/to/test.ts` | 0 failed | `evidence/tdd/` or `evidence/verification/` |
+| Typecheck | `pnpm typecheck` | exitCode=0 | `evidence/verification/` |
+| Lint | `pnpm lint` | exitCode=0 | `evidence/verification/` |
+| Manual | {必要なら手動確認} | {期待結果} | `evidence/manual/` |
+
+## Replan Triggers
+
+以下に該当した場合はexecを止め、planを更新してC-1を再実行する。
+
+- 想定外の変更対象ファイルが必要になった
+- 既存テストがbaselineで失敗している
+- 受入基準と実装方針に矛盾が見つかった
+- Task間のインターフェースが成立しない
+- セキュリティ・データ損失・後方互換性リスクが見つかった
+
+## Stop Condition
+
+以下に該当した場合は人間判断まで停止する。
+
+- C-3承認前にexecが必要になった
+- rollback不能な変更が必要になった
+- 外部API / 認証情報 / 本番データに触る必要が出た
+- high-risk / criticalでTDD証跡を残せない
+
+## C-1 Self Review Checklist
+
+- [ ] 受入基準がWork Breakdownにマッピングされている
+- [ ] TaskごとのFiles / Interfaces / Steps / Completion Criteriaが具体的
+- [ ] `TBD` / `TODO` / `必要に応じて` / `適切に` / `いい感じに` が残っていない
+- [ ] テストの入力・期待値・検証コマンドが具体的
+- [ ] Out of Scopeに触れていない
+- [ ] Replan Triggers / Stop Condition が書かれている
+- [ ] high-risk / critical の場合、Rollbackが具体的

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -169,7 +169,8 @@ created_by: orchestrator
 
 - [ ] 受入基準がWork Breakdownにマッピングされている
 - [ ] TaskごとのFiles / Interfaces / Steps / Completion Criteriaが具体的
-- [ ] `TBD` / `TODO` / `必要に応じて` / `適切に` / `いい感じに` が残っていない
+- [ ] `TBD` / `TODO` / `後で実装` / `必要に応じて` / `適切に` / `いい感じに` が残っていない
+- [ ] 未定義の関数名・型名・ファイルパス・コマンドを参照していない
 - [ ] テストの入力・期待値・検証コマンドが具体的
 - [ ] Out of Scopeに触れていない
 - [ ] Replan Triggers / Stop Condition が書かれている

--- a/docs/working/templates/review-self.md
+++ b/docs/working/templates/review-self.md
@@ -16,7 +16,7 @@ created_by: orchestrator
 
 | result | 件数 |
 |--------|------|
-| PASS | {17+} |
+| PASS | {22} |
 | WARN | {0} |
 | FAIL | {0} |
 
@@ -94,7 +94,7 @@ created_by: orchestrator
 ### C1-SUP-PLAN-01: No Placeholders Rule
 - **result**: PASS / WARN / FAIL
 - **category**: plan
-- **finding**: {plan.md / todo.md / test-cases.md / design.md に、未解決の `TBD` / `TODO` / `後で実装` / `必要に応じて` / `適切に` / `いい感じに` / 未定義の関数・型・ファイルパスが残っていないか}
+- **finding**: {plan.md / todo.md / test-cases.md / design.md に、未解決の `TBD` / `TODO` / `後で実装` / `必要に応じて` / `適切に` / `いい感じに` / 未定義の関数・型・ファイルパス、および具体性を欠く『エラーハンドリングを追加』『テストを書く』『Task N と同様』が残っていないか}
 - **evidence_ref**: —
 - **impacted_files**: []
 - **failure_policy**: {standard以上は重大な曖昧表現をFAIL。ultra-light/lightでもexecに必要なファイル・コマンド・期待結果が欠ける場合はFAIL}

--- a/docs/working/templates/review-self.md
+++ b/docs/working/templates/review-self.md
@@ -16,7 +16,7 @@ created_by: orchestrator
 
 | result | 件数 |
 |--------|------|
-| PASS | {17} |
+| PASS | {17+} |
 | WARN | {0} |
 | FAIL | {0} |
 
@@ -86,6 +86,26 @@ created_by: orchestrator
 - **finding**: {plan の Replan Triggers に機械値が1つ以上記入されているか（未記入は WARN。強制は Phase2/#543）}
 - **evidence_ref**: —
 - **impacted_files**: []
+
+## Plan 品質追加チェック（Superpowers 由来 / #581）
+
+> Superpowers を依存として導入するのではなく、`writing-plans` の考え方を PlanGate の C-1 に翻訳する。目的は、plan を「説明文」ではなく、AI実装者が安全に実行できる作業指示書にすること。
+
+### C1-SUP-PLAN-01: No Placeholders Rule
+- **result**: PASS / WARN / FAIL
+- **category**: plan
+- **finding**: {plan.md / todo.md / test-cases.md / design.md に、未解決の `TBD` / `TODO` / `後で実装` / `必要に応じて` / `適切に` / `いい感じに` / 未定義の関数・型・ファイルパスが残っていないか}
+- **evidence_ref**: —
+- **impacted_files**: []
+- **failure_policy**: {standard以上は重大な曖昧表現をFAIL。ultra-light/lightでもexecに必要なファイル・コマンド・期待結果が欠ける場合はFAIL}
+
+### C1-SUP-PLAN-02: Task Sizing Rules
+- **result**: PASS / WARN / FAIL
+- **category**: plan
+- **finding**: {各Taskが独立して検証可能で、reviewerがTask単位でapprove/rejectできる粒度か。変更対象ファイル、公開インターフェース、検証コマンド、期待結果、依存関係が具体的か}
+- **evidence_ref**: —
+- **impacted_files**: []
+- **failure_policy**: {high-risk/criticalではTask単位の検証不能・責務混在・依存不明をFAIL}
 
 ## ToDo チェック（6項目）
 
@@ -178,7 +198,7 @@ created_by: orchestrator
 
 <!--
 共通schema フィールド定義:
-- check_id: 一意の識別子（C1-PLAN-01〜C1-B1B2-17）
+- check_id: 一意の識別子（C1-PLAN-01〜C1-B1B2-17 / C1-SUP-PLAN-01〜02）
 - category: plan / todo / test
 - result: PASS / WARN / FAIL
 - finding: 発見内容（1-2文）

--- a/plugin/plangate/skills/plan-review-gate/SKILL.md
+++ b/plugin/plangate/skills/plan-review-gate/SKILL.md
@@ -23,6 +23,42 @@ PlanGate の **plan ゲート（C-1 セルフレビュー / C-2 外部レビュ�
 
 mode に応じた適用範囲・項目数（17 項目構成）は `.claude/rules/working-context.md` の C-1 節および `.claude/rules/mode-classification.md` フェーズ適用マトリクスを正本とする。FAIL があれば修正後再実行。evidence は FAIL 時必須（`evidence/c1-review/`）。
 
+### C-1 追加品質ゲート: Plan 実行可能性
+
+Superpowers の `writing-plans` から取り込む観点。ここでは Superpowers を依存として導入せず、PlanGate の C-1 に **plan を実行可能な作業指示書として読めるか** を確認する観点だけを吸収する。
+
+#### Task Sizing Rules
+
+各 Task / Step は以下を満たすこと。
+
+- 独立して検証可能な成果物を持つ
+- reviewer が単独で approve / reject できる粒度である
+- setup / config / docs は、それを必要とする成果物の Task に含める
+- 1 Task に複数の責務を詰め込まない
+- Task 間の依存関係・公開インターフェース・順序制約が明示されている
+- 変更対象ファイル、検証コマンド、期待結果が具体的に書かれている
+
+#### No Placeholders Rule
+
+以下が `plan.md` / `todo.md` / `test-cases.md` / `design.md` に残っている場合は C-1 FAIL として扱う。
+
+- `TBD`
+- `TODO`（未解決の実装TODO。チェックリスト用途は除く）
+- `後で実装`
+- `必要に応じて`
+- `適切に`
+- `いい感じに`
+- `エラーハンドリングを追加` だけで具体的な失敗条件・期待挙動がない
+- `テストを書く` だけで具体的な入力・期待値・検証コマンドがない
+- `Task N と同様` だけで、当該 Task 単独で実行できない
+- 未定義の関数名・型名・ファイルパス・コマンドを参照している
+
+#### 判定
+
+- `ultra-light` / `light`: 不備は WARN 可。ただし exec に必要なファイル・検証コマンドが欠ける場合は FAIL。
+- `standard`: Task Sizing / No Placeholders の重大不備は FAIL。
+- `high-risk` / `critical`: Task Sizing / No Placeholders の不備は FAIL。C-3 承認前に必ず修正する。
+
 ## C-2 外部レビュー
 
 - 2 レーン責務（設計妥当性 / コードベース整合）と R-NNN 採番・追記専用集約の規約は `.claude/rules/review-principles.md` §7-bis を正本とする


### PR DESCRIPTION
## Summary

Issue #581 の最初の小さなPRとして、Superpowersの `writing-plans` から取り込める要素をPlanGateのPlan品質ゲートへ反映します。

今回は **Superpowersを依存として導入しません**。PlanGateの既存アーキテクチャに合わせて、以下の考え方だけを文書・テンプレートへ吸収します。

- planを「説明文」ではなく「実行可能な作業指示書」として扱う
- Taskをreviewerがapprove/rejectできる粒度にする
- `TBD` / `TODO` / `必要に応じて` / `適切に` などの曖昧表現をC-1で検出する
- 変更対象ファイル、公開インターフェース、検証コマンド、期待結果をplanに明示する

## Why

AI実装が速くなるほど、失敗はコード生成そのものよりも、以下に集中します。

- planの曖昧さ
- Task粒度の大きさ
- 検証コマンド・期待結果の不足
- reviewerが判断できない作業単位
- `TODO` や「適切に」のような未決事項がexecに流れること

PlanGateはすでに C-1 / C-2 / C-3 ゲートを持っていますが、Superpowersの `writing-plans` にある **実行可能なPlanの作法** を取り込むことで、exec前の品質を上げられます。

## What

### 変更内容

- `plugin/plangate/skills/plan-review-gate/SKILL.md`
  - C-1追加品質ゲートとして `Task Sizing Rules` と `No Placeholders Rule` を追加
  - mode別の判定方針を明記

- `docs/working/templates/review-self.md`
  - C-1の追加チェックとして `C1-SUP-PLAN-01` / `C1-SUP-PLAN-02` を追加
  - 既存番号体系を壊さないよう、Superpowers由来の追加観点として分離

- `docs/working/templates/plan.md`
  - 新規追加
  - Goal / Context / Scope / Approach Comparison / Files / Interfaces / Work Breakdown / Verification Plan / Replan Triggers / Stop Condition を含む実行可能Planテンプレート

- `docs/working/templates/README.md`
  - `plan.md` テンプレートを必須artifactとして追加

## Non-goals

- Superpowersを依存ライブラリとして入れること
- SuperpowersのSkillファイルをコピーすること
- 全タスクTDDを絶対必須化すること
- CLIの機械検証をこのPRで実装すること
- dispatch成果物やTDD Evidence Ledgerまで一気に実装すること

## Verification

文書・テンプレート変更のみ。

- [x] 変更対象をPlan品質ゲートに限定
- [x] 既存C-1番号体系を壊さず、追加観点として記述
- [x] Issue #581 のPhase 1相当だけにスコープを限定

## Follow-up

後続PR候補:

1. Evidence Ledgerに `tdd_red` / `tdd_green` / `refactor_verify` を追加
2. `docs/working/TASK-XXXX/dispatch/` 配下の task brief / report / review package / progress-ledger を定義
3. `bin/plangate validate` にNo Placeholders / Task Sizingの機械チェックを追加

Refs #581