### PR TITLE
Evidence LedgerにTDD RED/GREEN証跡フェーズを追加

### DIFF
--- a/docs/working/templates/README.md
+++ b/docs/working/templates/README.md
@@ -25,6 +25,7 @@ PlanGate ワークフローで使うテンプレート群。
 | [`current-state.md`](./current-state.md) | 現在状態スナップショット | タスク完了毎に上書き |
 | [`design.md`](./design.md) | WF-03 設計成果物 | UI タスク時 視覚設計セクション併用 |
 | [`review-self.md`](./review-self.md) / [`review-external.md`](./review-external.md) | C-1 / C-2 レビュー結果 | |
+| [`evidence-tdd-ledger.json`](./evidence-tdd-ledger.json) | TDD RED/GREEN/REFACTOR VERIFY 証跡 | high-risk / critical mode のTDD必須時に使用 |
 
 > `run-outcome-review.md` は v8.6.0 以前の利用者に**移行コストゼロ**（任意・後方互換）。
 

--- a/docs/working/templates/evidence-tdd-ledger.json
+++ b/docs/working/templates/evidence-tdd-ledger.json
@@ -1,0 +1,40 @@
+{
+  "claim": "Task N の実装はTDDで完了した",
+  "status": "passed",
+  "evidence": [
+    {
+      "id": "ev-task-N-red",
+      "type": "test",
+      "phase": "tdd_red",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 1,
+      "outputExcerpt": "Expected failure: function is not defined",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "未実装の対象関数が存在しないため、追加したテストが期待通り失敗した",
+      "createdAt": "YYYY-MM-DDTHH:mm:ss+09:00"
+    },
+    {
+      "id": "ev-task-N-green",
+      "type": "test",
+      "phase": "tdd_green",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "最小実装により対象テストが成功した",
+      "createdAt": "YYYY-MM-DDTHH:mm:ss+09:00"
+    },
+    {
+      "id": "ev-task-N-refactor-verify",
+      "type": "test",
+      "phase": "refactor_verify",
+      "command": "pnpm test path/to/test.test.ts && pnpm typecheck",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed; typecheck passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "refactor後も対象テストと型検査が成功した",
+      "createdAt": "YYYY-MM-DDTHH:mm:ss+09:00"
+    }
+  ],
+  "missingEvidence": []
+}

--- a/plugin/plangate/skills/evidence-ledger/SKILL.md
+++ b/plugin/plangate/skills/evidence-ledger/SKILL.md
@@ -190,7 +190,7 @@ pnpm test path/to/test.test.ts && pnpm typecheck
 以下のルールを順番に適用する:
 
 1. `missingEvidence` が 1 件でもある → Completion Gate がブロックされる
-2. `phase != "tdd_red"` の EvidenceItem で `exitCode != 0` が 1 件でもある → `status = "failed"`
+2. `phase` が未指定、または `phase != "tdd_red"` の EvidenceItem で `exitCode != 0` が 1 件でもある → `status = "failed"`（`phase` 省略時は tdd_red 以外として扱う）
 3. `phase = "tdd_red"` で `exitCode = 0` → `status = "failed"`（REDになっていない）
 4. `phase = "tdd_red"` で `exitCode != 0` かつ `conclusion` が期待失敗を説明している → RED証跡として有効
 5. `evidence` が空 → `status = "unknown"`
@@ -202,9 +202,9 @@ pnpm test path/to/test.test.ts && pnpm typecheck
 
 - `phase="tdd_red"` のEvidenceItemがない
 - `phase="tdd_green"` のEvidenceItemがない
-- REDの失敗理由が期待失敗として説明されていない
+- REDの失敗理由が期待失敗として説明されていない（判定方針: `conclusion` が非空かつ失敗内容に言及していること。期待との厳密一致は LLM 補助判定とし、機械チェックの最低条件は `conclusion` 非空 + `exitCode != 0`）
 - GREENの成功コマンド・exitCode・出力抜粋がない
-- refactorを行ったのに `phase="refactor_verify"` がない
+- refactorを行ったのに `phase="refactor_verify"` がない（判定方針: 直前の `tdd_green` 証跡以降に**ソースコード変更ありかつテストコード変更なし**を refactor とみなす。機械判定が不能な場合は安全側で `refactor_verify` を必須化せず任意とする）
 
 ### ステップ 5: EvidenceLedger を出力する
 

--- a/plugin/plangate/skills/evidence-ledger/SKILL.md
+++ b/plugin/plangate/skills/evidence-ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: evidence-ledger
-description: "完了主張を証拠付きで記録し、EvidenceLedger を出力する。Use when: 「完了した」「修正した」「テストが通った」と言う前に証拠を記録したい時。/pg verify の出力先として使用。「証拠を残したい」「完了判定をしたい」「Completion Gateに渡したい」。"
+description: "完了主張を証拠付きで記録し、EvidenceLedger を出力する。Use when: 「完了した」「修正した」「テストが通った」と言う前に証拠を記録したい時。/pg verify の出力先として使用。「証拠を残したい」「完了判定をしたい」「TDD証跡を残したい」「Completion Gateに渡したい」。"
 ---
 
 # Evidence Ledger
@@ -14,6 +14,9 @@ description: "完了主張を証拠付きで記録し、EvidenceLedger を出力
 「should work now」「probably fixed」「テスト通るはず」等の推測的完了宣言は禁止。
 コマンド実行結果・終了コード・出力抜粋を証拠として記録せよ。
 
+TDD 必須 mode では、単なる「テストが通った」だけでは不十分。
+**RED（期待通り失敗）→ GREEN（最小実装で成功）→ REFACTOR VERIFY（整理後も成功）** の証跡を分けて記録する。
+
 ## Common Rationalizations
 
 | こう思ったら | 現実 |
@@ -21,6 +24,8 @@ description: "完了主張を証拠付きで記録し、EvidenceLedger を出力
 | 「CIが通ったから証拠不要」 | CI はカバレッジの保証ではない。claim ごとに証拠を記録せよ |
 | 「小さな修正だから証拠不要」 | 規模は関係ない。exitCode=0 を確認して記録せよ |
 | 「レビューしたから大丈夫」 | review type の EvidenceItem として記録せよ |
+| 「テストが通ったからTDD済み」 | GREENだけではTDD証跡にならない。REDの失敗理由も記録せよ |
+| 「REDは見たがログは残していない」 | high-risk / critical では RED 証跡がなければ Completion Gate で block 対象 |
 
 ## データスキーマ
 
@@ -30,14 +35,39 @@ description: "完了主張を証拠付きで記録し、EvidenceLedger を出力
 "passed" | "failed" | "skipped" | "unknown"
 ```
 
+### EvidenceType
+
+```json
+"command" | "diff" | "test" | "review" | "manual"
+```
+
+### EvidencePhase
+
+`phase` は任意フィールド。ただし `type="test"` かつ TDD 証跡として使う場合は必須。
+
+```json
+"tdd_red" | "tdd_green" | "refactor_verify" | "verification" | "baseline"
+```
+
+| phase | 用途 | 期待する exitCode |
+|---|---|---|
+| `baseline` | 実装前の既存テスト確認 | `0` |
+| `tdd_red` | failing test が期待通り失敗することの確認 | `!= 0` |
+| `tdd_green` | 最小実装で対象テストが成功することの確認 | `0` |
+| `refactor_verify` | refactor後も対象テスト・関連検証が成功することの確認 | `0` |
+| `verification` | TDD以外の通常検証 | `0` |
+
+`tdd_red` の `exitCode != 0` は失敗ではなく、**期待されたRED証跡**として扱う。ただし、`conclusion` には「なぜ期待通りの失敗と言えるか」を必ず書く。
+
 ### EvidenceItem
 
 ```json
 {
   "id": "string（例: ev-001）",
   "type": "command | diff | test | review | manual",
-  "command": "string（type=command の場合）",
-  "exitCode": "number（type=command の場合）",
+  "phase": "baseline | tdd_red | tdd_green | refactor_verify | verification（任意。TDD証跡では必須）",
+  "command": "string（type=command/test の場合）",
+  "exitCode": "number（type=command/test の場合）",
   "outputExcerpt": "string（出力の一部抜粋）",
   "filePath": "string（type=diff/test の場合）",
   "reviewer": "string（type=review の場合）",
@@ -57,6 +87,53 @@ description: "完了主張を証拠付きで記録し、EvidenceLedger を出力
 }
 ```
 
+### TddEvidenceLedger
+
+TDD必須modeの実装タスクでは、EvidenceLedgerに以下のTDD証跡が含まれていること。
+
+```json
+{
+  "claim": "Task N の実装はTDDで完了した",
+  "status": "passed",
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "test",
+      "phase": "tdd_red",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 1,
+      "outputExcerpt": "Expected failure: function is not defined",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "未実装の対象関数が存在しないため、追加したテストが期待通り失敗した",
+      "createdAt": "2026-06-21T10:00:00+09:00"
+    },
+    {
+      "id": "ev-002",
+      "type": "test",
+      "phase": "tdd_green",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "最小実装により対象テストが成功した",
+      "createdAt": "2026-06-21T10:03:00+09:00"
+    },
+    {
+      "id": "ev-003",
+      "type": "test",
+      "phase": "refactor_verify",
+      "command": "pnpm test path/to/test.test.ts && pnpm typecheck",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed; typecheck passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "refactor後も対象テストと型検査が成功した",
+      "createdAt": "2026-06-21T10:06:00+09:00"
+    }
+  ],
+  "missingEvidence": []
+}
+```
+
 ## 手順
 
 ### ステップ 1: claim を宣言する
@@ -64,6 +141,12 @@ description: "完了主張を証拠付きで記録し、EvidenceLedger を出力
 完了を主張したい事柄を 1 文で記述する。
 
 例: `"ログイン 500 エラーを修正した"`
+
+TDD必須modeの例:
+
+```json
+"Task 3: validation helper はTDDで実装完了した"
+```
 
 ### ステップ 2: evidence を収集する
 
@@ -76,7 +159,25 @@ pnpm test auth.test.ts
 # exitCode=0, outputExcerpt="12 passed"
 ```
 
-**test type**: テストファイルのパスと結果を記録
+**test type**: テストファイルのパス、phase、コマンド、exitCode、結果を記録
+
+**TDD RED**:
+```bash
+pnpm test path/to/test.test.ts
+# exitCode != 0, outputExcerpt="期待した失敗理由"
+```
+
+**TDD GREEN**:
+```bash
+pnpm test path/to/test.test.ts
+# exitCode=0, outputExcerpt="1 passed"
+```
+
+**refactor verify**:
+```bash
+pnpm test path/to/test.test.ts && pnpm typecheck
+# exitCode=0, outputExcerpt="pass"
+```
 
 **diff type**: 変更ファイルのパスと差分サマリを記録
 
@@ -88,12 +189,24 @@ pnpm test auth.test.ts
 
 以下のルールを順番に適用する:
 
-1. `exitCode != 0` の EvidenceItem が 1 件でもある → `status = "failed"`
-2. `missingEvidence` が 1 件でもある → Completion Gate がブロックされる
-3. `evidence` が空 → `status = "unknown"`
-4. 上記いずれでもない → `status = "passed"`
+1. `missingEvidence` が 1 件でもある → Completion Gate がブロックされる
+2. `phase != "tdd_red"` の EvidenceItem で `exitCode != 0` が 1 件でもある → `status = "failed"`
+3. `phase = "tdd_red"` で `exitCode = 0` → `status = "failed"`（REDになっていない）
+4. `phase = "tdd_red"` で `exitCode != 0` かつ `conclusion` が期待失敗を説明している → RED証跡として有効
+5. `evidence` が空 → `status = "unknown"`
+6. 上記いずれでもない → `status = "passed"`
 
-### ステップ 4: EvidenceLedger を出力する
+### ステップ 4: TDD必須modeの不足証跡を判定する
+
+`requiresFailingTestFirst=true` の場合、以下の欠落は `missingEvidence` に追加する。
+
+- `phase="tdd_red"` のEvidenceItemがない
+- `phase="tdd_green"` のEvidenceItemがない
+- REDの失敗理由が期待失敗として説明されていない
+- GREENの成功コマンド・exitCode・出力抜粋がない
+- refactorを行ったのに `phase="refactor_verify"` がない
+
+### ステップ 5: EvidenceLedger を出力する
 
 ```json
 {
@@ -103,6 +216,7 @@ pnpm test auth.test.ts
     {
       "id": "ev-001",
       "type": "command",
+      "phase": "verification",
       "command": "pnpm test auth.test.ts",
       "exitCode": 0,
       "outputExcerpt": "12 passed",
@@ -112,21 +226,39 @@ pnpm test auth.test.ts
     {
       "id": "ev-002",
       "type": "command",
+      "phase": "verification",
       "command": "pnpm typecheck",
       "exitCode": 0,
       "outputExcerpt": "No errors",
       "conclusion": "型エラーなし",
       "createdAt": "2026-04-26T10:01:00Z"
     }
-  ]
+  ],
+  "missingEvidence": []
 }
 ```
 
-## /pg verify との連携
+## 保存先
+
+### 通常検証
 
 `/pg verify` コマンドは Evidence Ledger を出力形式として使用する。
 verify コマンド実行時は本スキルの手順に従い EvidenceLedger JSON を生成し、
 `docs/working/TASK-XXXX/evidence/verification/` に保存する。
+
+### TDD証跡
+
+TDD必須modeでは、TDD証跡を以下に保存する。
+
+```text
+docs/working/TASK-XXXX/evidence/tdd/
+├── task-001-red.json
+├── task-001-green.json
+├── task-001-refactor-verify.json
+└── task-001-ledger.json
+```
+
+`task-N-ledger.json` は、RED / GREEN / REFACTOR VERIFY をまとめた EvidenceLedger とする。
 
 ## 出力フォーマット
 


### PR DESCRIPTION
## Summary

Issue #581 の後続PRとして、Evidence LedgerにTDD証跡の扱いを追加します。

今回も実装範囲は文書・テンプレート定義に限定し、CLIの機械検証やCompletion Gateの実装変更にはまだ踏み込みません。

## Why

PlanGateでは high-risk / critical mode でTDDを必須にしていますが、現状のEvidence Ledgerでは「テストが通った」という最終結果は記録できても、TDDの重要な前提である **RED → GREEN → REFACTOR VERIFY** を区別できません。

この状態だと、以下が起きます。

- テスト後書きでも「TDD済み」に見えてしまう
- failing testが本当に期待通り失敗したか判断できない
- GREENだけが残り、RED証跡がない
- Completion GateがTDD実施を証拠で判断できない

SuperpowersのTDD運用では、実装前に failing test を書き、期待通り失敗することを確認し、最小実装で通す流れが重視されています。PlanGateではこの思想をそのまま強制するのではなく、**TDD必須modeで証跡として判定できる形に翻訳**します。

## What

### 変更内容

- `plugin/plangate/skills/evidence-ledger/SKILL.md`
  - `EvidencePhase` を追加
  - `baseline` / `tdd_red` / `tdd_green` / `refactor_verify` / `verification` を定義
  - `tdd_red` の `exitCode != 0` は期待されたRED証跡として扱うルールを追加
  - `requiresFailingTestFirst=true` 時の不足証跡判定を追加
  - TDD証跡の保存先を `docs/working/TASK-XXXX/evidence/tdd/` として定義

- `docs/working/templates/evidence-tdd-ledger.json`
  - TDD RED/GREEN/REFACTOR VERIFY をまとめたEvidenceLedgerテンプレートを追加

- `docs/working/templates/README.md`
  - `evidence-tdd-ledger.json` をテンプレート一覧に追加

## Non-goals

- `/pg tdd` コマンドの実装
- `bin/plangate validate` によるTDD証跡チェック実装
- Completion Gateの機械判定変更
- 全modeでのTDD必須化
- 既存EvidenceItemを破壊的に変更すること

## Verification

文書・テンプレート変更のみ。

- [x] 既存EvidenceItemに後方互換の任意フィールド `phase` を追加する形にした
- [x] `tdd_red` は通常の失敗ではなく、期待失敗として評価するルールを明記した
- [x] high-risk / criticalなど `requiresFailingTestFirst=true` の場合の不足証跡を定義した
- [x] 保存先とテンプレートを追加した

## Follow-up

後続PR候補:

1. Completion Gateで `requiresFailingTestFirst=true` のときTDD証跡不足をblockする
2. `bin/plangate validate` にTDD Evidence Ledgerの機械チェックを追加する
3. `/pg tdd` または `ai-dev-verify` とTDD evidence保存先を接続する

Refs #581