### PR TITLE
exec(#578): AIエージェント反パターン 未カバー3観点を Plan/C-1 へ追加

### DIFF
--- a/docs/working/TASK-0135/handoff.md
+++ b/docs/working/TASK-0135/handoff.md
@@ -1,0 +1,33 @@
+# HANDOFF — TASK-0135 (#578)
+
+> 生成: 2026-06-21T09:09:34Z / exec（C-3 AUTONOMOUS APPROVED・standard・HO 非該当）
+
+## 1. 要件適合確認結果（AC ごと）
+
+| AC | 内容 | 判定 | 根拠 |
+|----|------|------|------|
+| AC-01 | Verification 実行不能時の理由+代替確認欄 | PASS | plan.md Verification Plan 直後に注記追加（TC-01） |
+| AC-02 | Security 観点（秘密情報/.env 非接触・secret scan） | PASS | review-self C1-SEC-01 追加（TC-02） |
+| AC-03 | Scope 発見事項の予防分離 | PASS | review-self C1-SCOPE-DISC-01 + plan Out of Scope 注記（TC-03） |
+| AC-04 | 既存参照で役割分担 Done 充足・_docs 新設しない | PASS | plan に decision-log.jsonl/AGENT_LEARNINGS.md/_audit//documentation-management.md の 4 参照・_docs 未新設（TC-04） |
+| AC-05 | 重複ゼロ（過剰実装なし） | PASS | Explore 重複マッピング準拠で新規 3 観点のみ。既存（C1-PLAN-03/AEE/No Placeholders/privacy/decision-log）と直交 |
+
+## 2. 既知課題一覧
+- 件数 {24} はテンプレ上の期待値。実 PBI で B-1/B-2/AEE/SEC/SCOPE-DISC が N/A の場合は実数が下がる（finding に N/A 許容を明記済）。
+
+## 3. V2 候補
+- secret scan ツール（gitleaks 等）の実導入（本 PBI は「Plan に含める要件」まで）。
+- C1-SEC-01 / C1-SCOPE-DISC-01 の機械強制（現状は C-1 観点）。
+
+## 4. 妥協点
+- #578 提案のうち既存充足分（スコープ制御・test/lint/typecheck・Done=検証完了・設計判断 repo 化・AGENTS.md 恒常ルール）は**追加せず既存参照**（過剰実装回避・Done4）。
+- `_docs/`（sop / decisions / logs / learned）は decision-log.jsonl / AGENT_LEARNINGS.md / `_audit/` と方式衝突のため**新設せず**、役割分担 Done は plan の参照リンクで充足。
+- AGENTS.md 役割再定義（HO）は scope 外（別 PBI）。
+- **C-3 は autonomous APPROVED**（ユーザー明示解除「autonomous で exec→クローズ」。#578 は templates への doc 追加で HO 非該当・実質安全）。
+
+## 5. 引き継ぎ文書（サマリ）
+AIエージェント反パターンのうち既存未カバーの 3 観点（Verification 実行不能時の代替 / Security 秘密情報非接触 / Scope 発見事項の予防分離）を plan.md / review-self.md テンプレに追加。大半は既存充足のため重複排除し新規最小に限定。役割分担は既存正本への参照で充足、_docs 新設・AGENTS.md 改訂はしない。
+
+## 6. テスト結果サマリ
+- TC-01〜05 全 PASS / 件数 24 / 参照リンク 4 件実在 / _docs 未新設 / 行末空白・tab=0
+- markdownlint: CI 委譲

--- a/docs/working/TASK-0135/status.md
+++ b/docs/working/TASK-0135/status.md
@@ -1,0 +1,16 @@
+# STATUS — TASK-0135 (#578)
+
+## C-3 Gate: AUTONOMOUS APPROVED
+- 日時: 2026-06-21T09:08:18Z
+- ユーザー明示解除（verbatim・AskUserQuestion 回答）: 「autonomous で exec→クローズ」
+- 根拠: #578 は templates（plan.md / review-self.md）への doc チェック項目追加・**HO 非該当**・standard。plan が安全側で張った人間 C-3 gate を**ユーザーが明示解除**（self-imposed gate 非緩和原則の明示解除に該当）。Security 観点は「チェック観点の doc」であり機能実装でない。
+- C-1: PASS（review-self.md）/ C-2: Codex critical/major 0・minor 1 反映済
+- 即停止条件: HO 抵触・想定外規模拡大時は即停止。
+
+## exec 進捗
+- [x] T1 精読（plan.md / review-self.md 現状）
+- [x] T2 plan.md: Verification 実行不能時欄 + Scope 予防注記
+- [x] T3 review-self.md: C1-SEC-01 + C1-SCOPE-DISC-01 + 件数 22→24
+- [x] T4 既存参照リンク追記（役割分担 Done を参照で充足）
+- [ ] T5 検証
+- [ ] T6 handoff

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -43,7 +43,7 @@ created_by: orchestrator
 - {既存設計・命名規則・依存追加・セキュリティ・後方互換性などの制約}
 - `TBD` / `TODO` / `必要に応じて` / `適切に` のような曖昧な未決事項を残さない
 - 変更対象外ファイルを触る場合は、理由を明記する
-- 重要な設計判断は [`decision-log.jsonl`](./decision-log.jsonl)（正本）に記録する。学び/再発防止は [`AGENT_LEARNINGS.md`](../../../AGENT_LEARNINGS.md)、監査ログは [`_audit/`](../_audit/)、docs 配置規約は [`documentation-management.md`](../../pages/guides/governance/documentation-management.md) に従う（保存先を分離し AGENTS.md に恒常ルール以外を足さない / #578）
+- 重要な設計判断は同タスクの `decision-log.jsonl`（正本・各 TASK ディレクトリ直下）に記録する。学び/再発防止は [`AGENT_LEARNINGS.md`](../../../AGENT_LEARNINGS.md)、監査ログは [`_audit/`](../_audit/)、docs 配置規約は [`documentation-management.md`](../../pages/guides/governance/documentation-management.md) に従う（保存先を分離し AGENTS.md に恒常ルール以外を足さない / #578）
 
 ## Approach Comparison
 

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -36,11 +36,14 @@ created_by: orchestrator
 
 - {今回やらないこと}
 
+> 実装中に**スコープ外の改善・不具合を発見**した場合は、その場で直さず**別 Issue / メモ（handoff の V2 候補・既知課題）へ分離**する（依頼外変更・便乗リファクタの混入防止 / #578）。
+
 ## Global Constraints
 
 - {既存設計・命名規則・依存追加・セキュリティ・後方互換性などの制約}
 - `TBD` / `TODO` / `必要に応じて` / `適切に` のような曖昧な未決事項を残さない
 - 変更対象外ファイルを触る場合は、理由を明記する
+- 重要な設計判断は [`decision-log.jsonl`](./decision-log.jsonl)（正本）に記録する。学び/再発防止は [`AGENT_LEARNINGS.md`](../../../AGENT_LEARNINGS.md)、監査ログは [`_audit/`](../_audit/)、docs 配置規約は [`documentation-management.md`](../../pages/guides/governance/documentation-management.md) に従う（保存先を分離し AGENTS.md に恒常ルール以外を足さない / #578）
 
 ## Approach Comparison
 
@@ -145,6 +148,8 @@ created_by: orchestrator
 | Typecheck | `pnpm typecheck` | exitCode=0 | `evidence/verification/` |
 | Lint | `pnpm lint` | exitCode=0 | `evidence/verification/` |
 | Manual | {必要なら手動確認} | {期待結果} | `evidence/manual/` |
+
+> **検証が実行不能な場合**（環境制約・依存未整備等）は、その**理由**と**代替確認方法**を明記する（「Done = 検証完了」を満たせない検証を黙って省略しない / #578）。
 
 ## Replan Triggers
 

--- a/docs/working/templates/review-self.md
+++ b/docs/working/templates/review-self.md
@@ -16,7 +16,7 @@ created_by: orchestrator
 
 | result | 件数 |
 |--------|------|
-| PASS | {22} |
+| PASS | {24} |
 | WARN | {0} |
 | FAIL | {0} |
 
@@ -187,6 +187,20 @@ created_by: orchestrator
 - **result**: PASS / WARN / FAIL
 - **category**: plan
 - **finding**: {2案以上のアプローチを比較し、推薦案の選定理由を明記したか}
+- **evidence_ref**: —
+- **impacted_files**: []
+
+### C1-SEC-01: 秘密情報 非接触（#578）
+- **result**: PASS / WARN / FAIL / N/A
+- **category**: plan
+- **finding**: {`.env` / APIキー / トークン / 個人パス / ローカル設定に触れない設計か。扱う可能性がある場合、secret scan / `git diff` 確認を Verification Plan に含めているか。秘密情報を扱わない変更は N/A}
+- **evidence_ref**: —
+- **impacted_files**: []
+
+### C1-SCOPE-DISC-01: 発見事項の予防的分離（#578）
+- **result**: PASS / WARN / FAIL
+- **category**: plan
+- **finding**: {実装中に発見したスコープ外の改善・不具合を、その場で直さず別 Issue / メモ（handoff V2 候補・既知課題）へ分離する方針か}
 - **evidence_ref**: —
 - **impacted_files**: []
 


### PR DESCRIPTION
closes #578

## 概要
TASK-0135 の exec。AIエージェント開発の反パターンのうち**既存 PlanGate で未カバーの 3 観点**を plan.md / review-self.md テンプレに追加。Explore 重複マッピングにより既存充足分は重複追加せず参照に留め、過剰実装を回避（#578 Done4）。

## 変更
- **plan.md**:
  - Verification Plan 直後に「検証が実行不能な場合は理由 + 代替確認を明記」注記
  - Out of Scope に「実装中の発見はその場で直さず別 Issue/メモへ分離」予防注記
  - Global Constraints に既存正本（decision-log.jsonl / AGENT_LEARNINGS.md / `_audit/` / documentation-management.md）への参照リンク（役割分担 Done を参照で充足）
- **review-self.md**: `C1-SEC-01`（秘密情報/.env 非接触・扱う場合 secret scan）+ `C1-SCOPE-DISC-01`（発見事項の予防分離）+ 件数 22→24

## scope 判断（重複排除）
既存充足のため**追加しない**: スコープ制御（C1-PLAN-03/EH-6）・test/lint/typecheck・Done=検証完了（AEE）・設計判断 repo 化（decision-log）・AGENTS.md 恒常ルール。`_docs/{sop,decisions,logs,learned}` は decision-log/AGENT_LEARNINGS/_audit と方式衝突のため**新設せず**。AGENTS.md 改訂（HO）は scope 外。

## テスト
- TC-01〜05 全 PASS / 件数 24 / 参照リンク 4 件実在 / `_docs/` 未新設 / 行末空白・tab=0
- markdownlint: CI 委譲

## ゲート
- Mode: standard・**HO 非該当**（templates のみ）
- **C-3: AUTONOMOUS APPROVED**（ユーザー明示解除「autonomous で exec→クローズ」。#578 は doc チェック追加で実質安全）。詳細 `docs/working/TASK-0135/status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)