### PR TITLE
exec(#579): Design Gate — UI デザインシステム準拠 4観点を Addendum/C-1 へ

### DIFF
--- a/docs/ai/design-ui-addendum.md
+++ b/docs/ai/design-ui-addendum.md
@@ -53,6 +53,13 @@ UIタスク と判定（is_ui_task: true）
 5. 視覚的受入基準（検証可能な形）
 6. 視覚的回帰ガード（変えてはいけない既存表示）
 7. 視覚証跡（Figma 対比 or before/after・ビューポート別）
+8. UI 状態網羅（default / hover / focus / disabled / loading / error のうち必要な状態）
+9. design token（使用トークンの明示 + 不足トークンの要否）
+10. component 再利用（再利用候補の列挙 + new variant の要否）
+11. アクセシビリティ（キーボード操作 / フォーカス可視 / コントラスト等の UI 制約）
+
+> **未定義のデザイン値は発明しない**: 必要な token / variant が無い場合、実装で勝手に作らず「提案」として handoff の V2 候補・別 Issue へ分離する（#578 と整合 / #579）。
+> **DESIGN.md**: 存在すれば design system 正本として参照。無ければ既存パターンを正とする（一律必須化しない）。
 
 ## 5. 非 UI タスクの扱い
 
@@ -64,7 +71,7 @@ Figma なし案件のゲート回避も防ぐ。
 
 solution-architect が design.md を書く際、UI タスクなら「視覚設計」
 セクション（[`docs/working/templates/design.md`](../working/templates/design.md)）
-に Addendum の必須フィールド全体（1〜7）を反映する。pbi-input（要求）→ design.md（設計）→
+に Addendum の必須フィールド全体（1〜11）を反映する。pbi-input（要求）→ design.md（設計）→
 受入（証跡）で視覚要件が一貫する。
 
 ## 7. 関連

--- a/docs/working/TASK-0136/handoff.md
+++ b/docs/working/TASK-0136/handoff.md
@@ -1,0 +1,32 @@
+# HANDOFF — TASK-0136 (#579)
+
+> 生成: 2026-06-21T10:02:48Z / exec（C-3 AUTONOMOUS APPROVED・standard・HO 非該当）
+
+## 1. 要件適合確認結果（AC ごと）
+
+| AC | 内容 | 判定 | 根拠 |
+|----|------|------|------|
+| AC-01 | states/token/component/a11y 4 観点（addendum + design.md） | PASS | TC-01（design-ui-addendum §4 8-11 + design.md 視覚設計テーブル 4 行）|
+| AC-02 | 未定義値の提案扱い | PASS | TC-02（「未定義のデザイン値は発明しない」明文化）|
+| AC-03 | is_ui_task 条件付きチェック | PASS | TC-03（plan C-1 + review-self C1-UI-01・N/A 許容）|
+| AC-04 | DESIGN.md 存在時参照・一律必須化しない | PASS | TC-04 |
+| AC-05 | 重複ゼロ・新 SKILL/rule 未作成 | PASS | TC-05（git diff --diff-filter=A に design-gate 新規なし）|
+
+## 2. 既知課題一覧
+- 件数 {25} はテンプレ期待値。is_ui_task=false の PBI では C1-UI-01 が N/A（実数下がる・finding に N/A 明記済）。
+
+## 3. V2 候補
+- design token / variant の機械検証（現状は C-1 観点）。Figma 連携の自動トークン取得。
+
+## 4. 妥協点
+- 新 design-gate SKILL/rule を作らず既存 design-ui-addendum 拡張（命名衝突回避）。
+- bin/plangate(HO) の pbi-input Addendum は触らず addendum 正本(docs/ai)に記述（HO 回避）。
+- DESIGN.md 一律必須化せず存在時参照（Figma なし案件のゲート回避防止）。
+- C-3 は AUTONOMOUS APPROVED（ユーザー「両方進める」明示承認・standard/HO 非該当/Security なし）。
+
+## 5. 引き継ぎ文書（サマリ）
+AI UI 実装前のデザインシステム準拠確認を、既存 design-ui-addendum 拡張で実現。不足 4 観点（states/token/component/a11y）+ 未定義値の提案扱い + DESIGN.md 参照方針を addendum・design.md に追加し、plan/review-self に is_ui_task 条件付きチェック（C1-UI-01）を追加。新ゲートは作らず HO も回避。
+
+## 6. テスト結果サマリ
+- TC-01〜05 全 PASS / 件数 25 / 新 design-gate 新規追加なし（git diff --diff-filter=A）/ 行末空白・tab=0
+- markdownlint: CI 委譲

--- a/docs/working/TASK-0136/status.md
+++ b/docs/working/TASK-0136/status.md
@@ -1,0 +1,15 @@
+# STATUS — TASK-0136 (#579)
+
+## C-3 Gate: AUTONOMOUS APPROVED
+- 日時: 2026-06-21T10:02:03Z
+- ユーザー明示承認（verbatim・AskUserQuestion 回答）: 「両方進める」（#579 を autonomous exec）
+- 根拠: standard・HO 非該当（docs/ai + templates・bin/plangate 非改変）・Security 観点なし → autonomous APPROVE マトリクス可。C-1 PASS・C-2 反映済。
+- 即停止条件: HO 抵触・想定外規模拡大時は即停止。
+
+## exec 進捗
+- [x] T1 精読（design-ui-addendum / design.md / plan / review-self）
+- [x] T2 design-ui-addendum.md に states/token/component/a11y + 提案扱い + DESIGN.md + design.md 視覚設計反映
+- [x] T3 plan.md is_ui_task 条件付き UI チェック
+- [x] T4 review-self.md C1-UI-01 + 件数 24→25
+- [ ] T5 検証（acceptance-tester / V-1）
+- [ ] T6 handoff

--- a/docs/working/templates/design.md
+++ b/docs/working/templates/design.md
@@ -41,6 +41,10 @@ updated: YYYY-MM-DD
 | 視覚的受入基準 | <検証可能な合否条件> |
 | 視覚的回帰ガード | <変更禁止の既存表示> |
 | 視覚証跡 | <Figma 対比 / before-after・ビューポート別> |
+| UI 状態（default/hover/focus/disabled/loading/error） | <必要な状態の表示> |
+| design token（使用 / 不足） | <使用トークン / 新規トークン要否> |
+| component 再利用 / variant | <再利用候補コンポーネント / new variant 要否> |
+| アクセシビリティ | <キーボード操作 / フォーカス可視 / コントラスト> |
 
 ## 2. データフロー
 

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -180,3 +180,4 @@ created_by: orchestrator
 - [ ] Out of Scopeに触れていない
 - [ ] Replan Triggers / Stop Condition が書かれている
 - [ ] high-risk / critical の場合、Rollbackが具体的
+- [ ] （is_ui_task の場合）states / design token / component 再利用+variant / a11y を design.md 視覚設計に明示し、未定義デザイン値は発明せず提案扱い（#579・non-UI は N/A）

--- a/docs/working/templates/review-self.md
+++ b/docs/working/templates/review-self.md
@@ -16,7 +16,7 @@ created_by: orchestrator
 
 | result | 件数 |
 |--------|------|
-| PASS | {24} |
+| PASS | {25} |
 | WARN | {0} |
 | FAIL | {0} |
 
@@ -201,6 +201,13 @@ created_by: orchestrator
 - **result**: PASS / WARN / FAIL
 - **category**: plan
 - **finding**: {実装中に発見したスコープ外の改善・不具合を、その場で直さず別 Issue / メモ（handoff V2 候補・既知課題）へ分離する方針か}
+- **evidence_ref**: —
+- **impacted_files**: []
+
+### C1-UI-01: UI デザインシステム準拠（#579・is_ui_task 時のみ）
+- **result**: PASS / WARN / FAIL / N/A
+- **category**: plan
+- **finding**: {is_ui_task の場合: states(default/hover/focus/disabled/loading/error) / design token / component 再利用+variant / accessibility を design.md 視覚設計に明示し、未定義デザイン値を発明せず提案扱い。DESIGN.md 存在時は参照。non-UI は N/A}
 - **evidence_ref**: —
 - **impacted_files**: []
 


### PR DESCRIPTION
closes #579

## 概要
TASK-0136 の exec。AI UI 実装前のデザインシステム準拠確認を、既存 `design-ui-addendum.md` 拡張で実現（新ゲート作らず・researcher 重複調査準拠）。

## 変更
- **design-ui-addendum.md §4**: states(default/hover/focus/disabled/loading/error)・design token・component 再利用+variant・accessibility（8-11）+ 「未定義デザイン値は発明せず提案扱い」+ DESIGN.md 参照方針（存在時参照・一律必須化しない）
- **design.md 視覚設計テーブル**: 4 観点行を追加
- **plan.md / review-self.md**: is_ui_task 条件付きチェック（`C1-UI-01`・N/A 許容）+ 件数 24→25

## scope 判断（重複排除）
- 既存充足（visual reference/responsive/視覚受入）は重複追加せず
- 新 `design-gate` SKILL/rule を作らない（既存は別物=アーキ設計ゲート・命名衝突回避）
- `bin/plangate`(HO) の Addendum 非改変（docs/ai 側に記述）

## テスト
- TC-01〜05 全 PASS / 件数 25 / `git diff --diff-filter=A` に design-gate 新規追加なし / 行末空白・tab=0

## ゲート
- Mode: standard・**HO 非該当**（docs/ai + templates）
- **C-3: AUTONOMOUS APPROVED**（ユーザー「両方進める」明示承認・Security 観点なし）。詳細 `docs/working/TASK-0136/status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)