### PR TITLE
exec(#581): 残要素3/4 Subagentファイルベース + Review Gate Plan Alignment

### DIFF
--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -127,6 +127,10 @@ FAIL → Implementerに差し戻し → 修正 → 再レビュー
 - **worktreeで隔離**: 可能な場合はgit worktreeで作業を隔離する
 - **mainブランチでは作業しない**: ユーザー同意なしにmainで作業開始しない
 
+## ファイルベース復元（#581 要素3）
+
+実装者・reviewer への受け渡しは会話履歴でなく `dispatch/` 配下のファイル（brief / report / review-package / progress-ledger）で行う。compaction・モデル切替後は `progress-ledger.md` から再開し、完了済みタスクの再実行・要件の曖昧化・責務の混在を防ぐ。テンプレは `docs/working/templates/dispatch/`。
+
 ## 関連スキル
 
 - **ai-dev-workflow**: 計画生成（plan/todo）に使用

--- a/docs/working/TASK-0137/handoff.md
+++ b/docs/working/TASK-0137/handoff.md
@@ -1,0 +1,34 @@
+# HANDOFF — TASK-0137 (#581 残要素3/4)
+
+> 生成: 2026-06-21T10:16:26Z / exec（C-3 AUTONOMOUS APPROVED・high-risk・HO 非該当）
+
+## 1. 要件適合確認結果（AC ごと）
+
+| AC | 内容 | 判定 | 根拠 |
+|----|------|------|------|
+| AC-01 | dispatch/ 4 テンプレ | PASS | TC-01（brief/report/review-package/progress-ledger 新設）|
+| AC-02 | context-packager brief 保存 | PASS | TC-02（dispatch/task-NNN-brief.md 保存規定）|
+| AC-03 | ファイルベース原則 | PASS | TC-03（subagent-dispatch/driven-development に progress-ledger 再開明文化）|
+| AC-04 | Review Gate Plan Alignment | PASS | TC-04（review-gate + review-external に Plan/Evidence/Production Readiness ブロック）|
+| AC-05 | 5 観点不変・HO 非改変 | PASS | TC-05（review-principles.md / qa-reviewer.md / plugin rules diff 0）|
+| AC-06 | #583/#584 と非重複 | PASS | 要素3・4 のみ（要素1/2 は完了済・触れていない）|
+
+## 2. 既知課題一覧
+- dispatch/ テンプレは最小枠。実運用で項目調整の余地（V2）。
+- Plan Alignment の機械強制は未（現状は review 観点）。
+
+## 3. V2 候補
+- dispatch/ 成果物の自動生成（context-packager → ファイル書き出しの CLI 化）。
+- Plan Alignment / Evidence Alignment の Completion Gate 機械判定。
+
+## 4. 妥協点
+- review-principles.md（HO・§2-4「5 観点不変」）本体は改変せず、skill/template に**追加レーン**として実装（HO 回避）。
+- qa-reviewer.md（HO）/ plugin/plangate/rules/*（本ツリー不在）は触らず。
+- C-3 は **AUTONOMOUS APPROVED**（ユーザー「autonomous で exec→クローズ」明示・high-risk リスク承知の上での委任。HO 非該当）。
+
+## 5. 引き継ぎ文書（サマリ）
+#581 残要素3（Subagent ファイルベース復元）と要素4（Review Gate Plan Alignment）を実装。要素3 は dispatch/ テンプレ（brief/report/review-package/progress-ledger）+ context-packager/subagent SKILL のファイルベース明文化。要素4 は review-gate/review-external に Plan/Evidence/Production Readiness ブロック（review-principles §2-4 不変の追加レーン）。要素1/2（#583/#584）と合わせ #581 完了。
+
+## 6. テスト結果サマリ
+- TC-01〜06 全 PASS / HO 非改変（diff 0）/ 行末空白・tab=0
+- markdownlint: CI 委譲

--- a/docs/working/TASK-0137/status.md
+++ b/docs/working/TASK-0137/status.md
@@ -1,0 +1,16 @@
+# STATUS — TASK-0137 (#581 残要素3/4)
+
+## C-3 Gate: AUTONOMOUS APPROVED
+- 日時: 2026-06-21T10:12:22Z
+- ユーザー明示承認（verbatim・AskUserQuestion 回答）: 「autonomous で exec→クローズ」（high-risk の self-gate を明示解除）
+- 根拠: high-risk だが **HO 非該当**（skills/templates・rules 参照のみ・review-principles §2-4 不変）。ユーザーが high-risk リスクを承知で autonomous を明示選択。C-1 PASS・C-2 反映済。
+- 即停止条件: HO 抵触（rules/qa-reviewer 改変）・想定外規模拡大時は即停止。
+
+## exec 進捗
+- [x] T1 精読（context-packager/subagent-dispatch/driven-development/review-gate/review-external）
+- [x] T2 dispatch/ テンプレ 4 種新設
+- [x] T3 context-packager に dispatch/brief 保存規定
+- [x] T4 subagent-dispatch/driven-development にファイルベース原則
+- [x] T5 review-gate + review-external に Plan/Evidence/Production Readiness ブロック（§2-4 不変）
+- [ ] T6 検証（acceptance-tester / V-1）
+- [ ] T7 handoff

--- a/docs/working/templates/dispatch/progress-ledger.md
+++ b/docs/working/templates/dispatch/progress-ledger.md
@@ -1,0 +1,7 @@
+# Progress Ledger — TASK-XXXX
+
+> タスク進捗を**会話でなくファイル**に残す。compaction・モデル切替後はここから再開し、完了済みタスクの再実行を防ぐ。
+
+| Task | status | brief | report | reviewed | notes |
+|------|--------|-------|--------|----------|-------|
+| T-01 | planned/in_progress/done | ✓/- | ✓/- | ✓/- | |

--- a/docs/working/templates/dispatch/task-NNN-brief.md
+++ b/docs/working/templates/dispatch/task-NNN-brief.md
@@ -1,0 +1,21 @@
+# Task Brief — TASK-XXXX / T-NNN
+
+> context-packager が生成する Allowed Context のファイル版。実装者の**唯一の要件ファイル**。会話履歴に依存せず、compaction/モデル切替後も再現可能。
+
+## 1. Target Files（変更してよいファイル）
+- <path>
+
+## 2. Spec（仕様・受入基準）
+- <このタスクの完了条件>
+
+## 3. Existing Tests（参照すべき既存テスト）
+- <path>
+
+## 4. Constraints（変更制約）
+- <既存パターン準拠・依存追加可否など>
+
+## 5. Commands（実行コマンド）
+- <test/lint/typecheck コマンド>
+
+## 6. Out of Scope（触ってはいけない範囲）
+- <禁止スコープ>

--- a/docs/working/templates/dispatch/task-NNN-report.md
+++ b/docs/working/templates/dispatch/task-NNN-report.md
@@ -1,0 +1,15 @@
+# Task Report — TASK-XXXX / T-NNN
+
+> 実装者（subagent）が完了時に残すファイル。reviewer はこれと diff/evidence を入力にする。
+
+## 実行コマンドと結果
+- <command> → <exitCode / 結果>
+
+## 変更ファイルサマリ
+- <path>: <変更概要>
+
+## テスト結果
+- <RED/GREEN・pass/fail>
+
+## 懸念・残課題
+- <あれば>

--- a/docs/working/templates/dispatch/task-NNN-review-package.md
+++ b/docs/working/templates/dispatch/task-NNN-review-package.md
@@ -1,0 +1,11 @@
+# Review Package — TASK-XXXX / T-NNN
+
+> reviewer の入力を固定するファイル。会話履歴を渡さず、以下のリンクのみを参照させる。
+
+- Brief: `dispatch/task-NNN-brief.md`
+- Report: `dispatch/task-NNN-report.md`
+- Diff: <git diff の範囲 / commit>
+- Evidence: `evidence/`（tdd/verification）
+
+## レビュー観点（review-gate / Plan Alignment 参照）
+- plan 要件充足 / design.md 逸脱 / Target Files 外 / Out of Scope / 過剰機能 / Evidence 対応

--- a/docs/working/templates/review-external.md
+++ b/docs/working/templates/review-external.md
@@ -71,6 +71,14 @@ created_by: orchestrator
 - **evidence_ref**: —
 - **impacted_files**: [{影響ファイルパス}]
 
+## Plan Alignment / Evidence Alignment / Production Readiness（#581 要素4）
+
+> 5 観点・Severity・判定基準（review-principles.md §2-4）不変の追加レーン。
+
+- **Plan Alignment**: plan 要件充足 / design.md 逸脱（理由明示）/ Target Files 外 / Out of Scope / 過剰機能
+- **Evidence Alignment**: test-cases ↔ Evidence Ledger 対応 / TDD 必須 mode の RED/GREEN 証跡（なしは major）
+- **Production Readiness**: エラー処理 / 後方互換 / セキュリティ・データ損失 / ドキュメント更新
+
 ## 自動修正ログ
 
 | check_id | 修正内容 | 修正先ファイル |

--- a/plugin/plangate/skills/context-packager/SKILL.md
+++ b/plugin/plangate/skills/context-packager/SKILL.md
@@ -90,6 +90,10 @@ description: タスク委譲前に Allowed Context を構造化して出力す�
 - context-engineering
 - subagent-control
 
+## dispatch/ へのファイル保存（#581 要素3）
+
+Allowed Context（6 要素）は委譲プロンプトに埋め込むだけでなく、`docs/working/TASK-XXXX/dispatch/task-NNN-brief.md` に**ファイルとして保存**する。これにより実装者の唯一の要件ファイルとなり、会話 compaction / モデル切替後も再現可能。テンプレは `docs/working/templates/dispatch/task-NNN-brief.md`。
+
 ## 関連
 
 - Skill: `subagent-dispatch`（Allowed Context を使ってエージェントに分配）

--- a/plugin/plangate/skills/review-gate/SKILL.md
+++ b/plugin/plangate/skills/review-gate/SKILL.md
@@ -95,6 +95,24 @@ reason: severity=critical の finding が <N> 件あります。fix 後に再レ
 }
 ```
 
+## Plan Alignment レビュー（#581 要素4）
+
+> 5 観点・Severity・判定基準（`.claude/rules/review-principles.md` §2-4）は**不変**。本ブロックは Plan 正本との突合観点を補う追加レーン（観点数を増やさず C-2 設計妥当性レーン §7-bis と整合）。
+
+### Plan Alignment
+- plan.md の Task 要件を満たしているか
+- design.md の設計判断から逸脱していないか（逸脱なら理由明示）
+- Target Files 外を変更していないか
+- Out of Scope に抵触していないか
+- 余計な機能を追加していないか（scope creep）
+
+### Evidence Alignment
+- test-cases.md と Evidence Ledger が対応しているか
+- TDD 必須 mode で RED/GREEN 証跡があるか（#584 の tdd_red/green phase。証跡なしは **major**）
+
+### Production Readiness
+- エラー処理の具体性 / 後方互換 / セキュリティ・データ損失 / ドキュメント更新
+
 ## 関連
 
 - Rule: `review-gate.md`（正本 - ブロック条件・Mode 別適用条件）

--- a/plugin/plangate/skills/subagent-dispatch/SKILL.md
+++ b/plugin/plangate/skills/subagent-dispatch/SKILL.md
@@ -91,6 +91,17 @@ graph TD
 - multi-agent
 - orchestration
 
+## ファイルベース受け渡し（#581 要素3）
+
+subagent へは会話履歴でなく **`dispatch/` 配下のファイル**で渡す:
+
+- task brief: `dispatch/task-NNN-brief.md`（context-packager の Allowed Context）
+- report: `dispatch/task-NNN-report.md`（実行コマンド・テスト結果・変更サマリ・懸念）
+- review package: `dispatch/task-NNN-review-package.md`（reviewer 入力を brief/report/diff/evidence へのリンクで固定）
+- progress ledger: `dispatch/progress-ledger.md`（進捗。compaction・モデル切替後はここから再開）
+
+reviewer は review-package ファイルのみを入力とし、会話履歴は渡さない。テンプレは `docs/working/templates/dispatch/`。
+
 ## 関連
 
 - Skill: `context-packager`（各エージェントへの Allowed Context 生成）


### PR DESCRIPTION
closes #581

## 概要
TASK-0137 exec。#581（Superpowers 強化）残要素3・4 を実装。要素1(#583)/要素2(#584)と合わせ #581 完了。

## 変更内容
**要素3（Subagent ファイルベース復元）**
- `docs/working/templates/dispatch/` に brief/report/review-package/progress-ledger テンプレ新設
- context-packager: Allowed Context を dispatch/brief にファイル保存する規定を追加
- subagent-dispatch / subagent-driven-development: progress-ledger から再開・会話非依存を明文化

**要素4（Review Gate Plan Alignment）**
- review-gate SKILL に Plan/Evidence/Production Readiness ブロック追加
- review-external テンプレに同ブロック追加

## HO 回避
review-principles.md(§2-4「5観点不変」)/qa-reviewer.md/plugin rules は非改変（diff 0 確認済み）。追加レーンは skill/template 側のみ。

## テスト
TC-01〜06 全 PASS / HO 非改変(diff0) / 行末空白・tab=0

## ゲート
- Mode: high-risk・HO 非該当（skills/templates）
- C-3: AUTONOMOUS APPROVED（ユーザー「autonomous で exec→クローズ」明示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)