### PR TITLE
chore(#530): trap→register_cleanup / gen-codex-agents.sh / ta-33 TC-04 + sandbox drift fix

### DIFF
--- a/.codex/agents/qa_reviewer.toml
+++ b/.codex/agents/qa_reviewer.toml
@@ -3,7 +3,7 @@
 name = "qa_reviewer"
 description = "要件適合・回帰・未考慮ケースを確認し V1/V2 境界を整理する責務ベース Agent。WF-02 の締め（AC 最終化）と WF-05 Verify & Handoff の主担当（PlanGate v7）"
 
-sandbox_mode = "workspace-write"
+sandbox_mode = "read-only"
 model_reasoning_effort = "medium"
 
 developer_instructions = """

--- a/.codex/agents/requirements_analyst.toml
+++ b/.codex/agents/requirements_analyst.toml
@@ -3,7 +3,7 @@
 name = "requirements_analyst"
 description = "初期要求を仕様に変換し、曖昧さ・抜け漏れ・対象外を整理する責務ベース Agent（PlanGate v7 ハイブリッドアーキテクチャ）"
 
-sandbox_mode = "workspace-write"
+sandbox_mode = "read-only"
 model_reasoning_effort = "medium"
 
 developer_instructions = """

--- a/.codex/agents/retrospective_analyst.toml
+++ b/.codex/agents/retrospective_analyst.toml
@@ -3,7 +3,7 @@
 name = "retrospective_analyst"
 description = "exec 完了後の振り返りデータ分析。計画精度・プロセス改善点を抽出し改善提案を行う"
 
-sandbox_mode = "read-only"
+sandbox_mode = "workspace-write"
 model_reasoning_effort = "low"
 
 developer_instructions = """

--- a/.codex/agents/setup_coordinator.toml
+++ b/.codex/agents/setup_coordinator.toml
@@ -3,7 +3,7 @@
 name = "setup_coordinator"
 description = "PlanGate 初期セットアップ対話エージェント。doctor を単一検証源として、Human-owned 操作の検知・提示・再検証ループ・進捗の永続記録を担う。settings wiring 等の Human-owned 操作は提示のみで実行しない（PlanGate v7 ハイブリッドアーキテクチャ）"
 
-sandbox_mode = "workspace-write"
+sandbox_mode = "read-only"
 model_reasoning_effort = "low"
 
 developer_instructions = """

--- a/.codex/agents/solution_architect.toml
+++ b/.codex/agents/solution_architect.toml
@@ -3,7 +3,7 @@
 name = "solution_architect"
 description = "仕様を実装可能な構造に落とし、モジュール境界 / データフロー / 状態管理 / 失敗時挙動 / テスト観点 / 依存制約を明文化する責務ベース Agent（PlanGate v7）"
 
-sandbox_mode = "workspace-write"
+sandbox_mode = "read-only"
 model_reasoning_effort = "medium"
 
 developer_instructions = """

--- a/scripts/gen-codex-agents.sh
+++ b/scripts/gen-codex-agents.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# scripts/gen-codex-agents.sh — .claude/agents/*.md と .codex/agents/*.toml の同期
+# 既存 toml: sandbox_mode / model_reasoning_effort のみ更新（description/developer_instructions は保持）
+# 欠落 toml: thin pointer テンプレートを新規生成
+# 使い方: sh scripts/gen-codex-agents.sh [--check] [--agent NAME]
+# #530 項目4
+
+set -eu
+
+_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+_agents_md="$_root/.claude/agents"
+_agents_toml="$_root/.codex/agents"
+_check=0; _target=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) _check=1; shift ;;
+    --agent) _target="$2"; shift 2 ;;
+    *) printf 'Usage: gen-codex-agents.sh [--check] [--agent NAME]\n' >&2; exit 2 ;;
+  esac
+done
+
+# model tier → model_reasoning_effort (docs/ai/model-profiles.md §11)
+_effort_for() {
+  case "$1" in
+    explorer-agent|linter-fixer|retrospective-analyst|setup-coordinator|documentation-writer|skill-designer)
+      printf 'low' ;;
+    *) printf 'medium' ;;
+  esac
+}
+
+# tools → sandbox_mode (valid: read-only | workspace-write)
+_sandbox_for() {
+  case "$1" in *Edit*|*Write*) printf 'workspace-write' ;; *) printf 'read-only' ;; esac
+}
+
+_updated=0; _created=0; _ok=0
+
+for _md in "$_agents_md"/*.md; do
+  [ -f "$_md" ] || continue
+  _base="$(basename "$_md" .md)"
+  case "$_base" in README) continue ;; esac
+  [ -z "$_target" ] || [ "$_base" = "$_target" ] || continue
+
+  _name="$(grep -m1 '^name:' "$_md" | sed 's/^name: *//')"
+  _tools="$(grep -m1 '^tools:' "$_md" | sed 's/^tools: *//')"
+  _name_snake="$(printf '%s' "$_name" | tr '-' '_')"
+  _effort="$(_effort_for "$_name")"
+  _sandbox="$(_sandbox_for "$_tools")"
+  _toml="$_agents_toml/${_name_snake}.toml"
+
+  if [ -f "$_toml" ]; then
+    # 既存 toml: sandbox_mode と model_reasoning_effort のみ更新
+    _cur_sandbox="$(grep -m1 'sandbox_mode' "$_toml" | sed 's/.*= *"\(.*\)".*/\1/')"
+    _cur_effort="$(grep -m1 'model_reasoning_effort' "$_toml" | sed 's/.*= *"\(.*\)".*/\1/')"
+    if [ "$_cur_sandbox" = "$_sandbox" ] && [ "$_cur_effort" = "$_effort" ]; then
+      _ok=$((_ok + 1))
+      continue
+    fi
+    if [ "$_check" = "1" ]; then
+      printf 'DRIFT %s: sandbox=%s(want %s) effort=%s(want %s)\n' \
+        "$_name_snake.toml" "$_cur_sandbox" "$_sandbox" "$_cur_effort" "$_effort"
+      _updated=$((_updated + 1))
+    else
+      sed -i.bak \
+        -e "s|^sandbox_mode = .*|sandbox_mode = \"${_sandbox}\"|" \
+        -e "s|^model_reasoning_effort = .*|model_reasoning_effort = \"${_effort}\"|" \
+        "$_toml" && rm -f "${_toml}.bak"
+      printf 'updated %s (sandbox: %s→%s, effort: %s→%s)\n' \
+        "$_name_snake.toml" "$_cur_sandbox" "$_sandbox" "$_cur_effort" "$_effort"
+      _updated=$((_updated + 1))
+    fi
+  else
+    # 欠落 toml: thin pointer テンプレートを生成
+    _desc="$(grep -m1 '^description:' "$_md" | sed 's/^description: *//' | cut -c1-100)"
+    if [ "$_check" = "1" ]; then
+      printf 'MISSING %s.toml\n' "$_name_snake"
+      _created=$((_created + 1))
+    else
+      cat > "$_toml" <<TOML
+#:schema https://developers.openai.com/codex/config-schema.json
+
+name = "${_name_snake}"
+description = "${_desc}"
+
+sandbox_mode = "${_sandbox}"
+model_reasoning_effort = "${_effort}"
+
+developer_instructions = """
+詳細定義: \`.claude/agents/${_base}.md\` を必ず読む。本 TOML は thin pointer であり、実行時規約は markdown 側を正とする。
+"""
+TOML
+      printf 'created %s.toml\n' "$_name_snake"
+      _created=$((_created + 1))
+    fi
+  fi
+done
+
+if [ "$_check" = "1" ]; then
+  printf 'check: %d drift, %d missing, %d ok\n' "$_updated" "$_created" "$_ok"
+  [ "$_updated" -eq 0 ] && [ "$_created" -eq 0 ]
+else
+  printf 'gen-codex-agents: %d updated, %d created, %d ok\n' "$_updated" "$_created" "$_ok"
+fi

--- a/tests/extras/ta-26-plugin-sync.sh
+++ b/tests/extras/ta-26-plugin-sync.sh
@@ -46,7 +46,7 @@ fi
 
 # TC-05: 実行後に .claude/agents/ の全 .md が plugin/plangate/agents/ に存在
 _t26_tmpdir=$(mktemp -d)
-trap 'rm -rf "$_t26_tmpdir"' EXIT INT TERM
+register_cleanup "$_t26_tmpdir"  # trap 非依存 (#530-3)
 cp -r "$PG_T26_PLUGIN" "$_t26_tmpdir/plugin_backup"
 sh "$PG_T26_SCRIPT" >/dev/null 2>&1 || true
 _t26_missing=0
@@ -60,8 +60,7 @@ done
 # restore
 rm -rf "$PG_T26_PLUGIN"
 cp -r "$_t26_tmpdir/plugin_backup" "$PG_T26_PLUGIN"
-rm -rf "$_t26_tmpdir"
-trap - EXIT INT TERM
+rm -rf "$_t26_tmpdir"  # 早期解放（register_cleanup との二重実行は冪等）
 if [ "$_t26_missing" = "0" ]; then
   t26_pass "TC-05 実行後 .claude/agents/ の全 .md が plugin に存在"
 else

--- a/tests/extras/ta-33-agent-model-tier.sh
+++ b/tests/extras/ta-33-agent-model-tier.sh
@@ -69,3 +69,14 @@ else
   printf '[FAIL] TA-33 TC-03: tier 不一致:%s\n' "$_t33_bad"
   fail=$((fail + 1))
 fi
+
+# TC-04: md agent 数 と toml 数の一致（drift 検出）
+_t33_md_count="$(ls "$_t33_root"/.claude/agents/*.md 2>/dev/null | grep -v 'README' | wc -l | tr -d ' ')"
+_t33_toml_cnt="$(ls "$_t33_root"/.codex/agents/*.toml 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$_t33_md_count" = "$_t33_toml_cnt" ]; then
+  printf '[PASS] TA-33 TC-04: .claude/agents md(%s) = .codex/agents toml(%s)\n' "$_t33_md_count" "$_t33_toml_cnt"
+  pass=$((pass + 1))
+else
+  printf '[FAIL] TA-33 TC-04: drift md=%s toml=%s — scripts/gen-codex-agents.sh を実行してください\n' "$_t33_md_count" "$_t33_toml_cnt"
+  fail=$((fail + 1))
+fi


### PR DESCRIPTION
## Summary

- **#530 項目3**: `ta-26` の `trap 'rm -rf ...' EXIT INT TERM` を `register_cleanup` パターンに移行（`tests/run-tests.sh` の既存 API を活用）
- **#530 項目4**: `scripts/gen-codex-agents.sh` 新規作成 — `.claude/agents/*.md` frontmatter から `.codex/agents/*.toml` を同期。既存 toml の `sandbox_mode`/`model_reasoning_effort` のみ更新し、`description`/`developer_instructions` は保持
- **ta-33 TC-04**: `.claude/agents` md 数 vs `.codex/agents` toml 数の drift 検出テストを追加
- **sandbox drift 修正**: gen スクリプト実行により 5 件の実 drift を解消（`qa_reviewer`, `requirements_analyst`, `setup_coordinator`, `solution_architect`: workspace-write→read-only / `retrospective_analyst`: read-only→workspace-write）

## Scope（#530 中の AI 実施範囲）

| 項目 | 担当 | 本 PR |
|------|------|-------|
| 項目1: ブランチ棚卸し | Human-owned | — |
| 項目2: docs/working アーカイブポリシー（working-context.md = HO） | HO適用はHuman | — |
| **項目3: trap→register_cleanup** | AI | ✅ |
| **項目4: gen-codex-agents.sh** | AI | ✅ |

項目1・2 は Human-owned タスクのため AI PR 対象外。AI 実施可能な 項目3+4 の完了をもって本 PR で close する。

## Test plan

- [ ] `sh tests/run-tests.sh` で ta-26 PASS 確認
- [ ] `sh scripts/gen-codex-agents.sh --check` → `0 drift, 0 missing` 確認
- [ ] ta-33 TC-04 が PASS であること

closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)