### PR TITLE
fix: plangate-setup スキル修正・Codex スキル追加・リリースフローへのプラグイン同期組み込み

### DIFF
--- a/.agents/skills/plangate-setup/SKILL.md
+++ b/.agents/skills/plangate-setup/SKILL.md
@@ -19,7 +19,7 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 | Global instructions | `.claude/settings.json` wiring | `doctor --check-settings` | 「`sh scripts/apply-claude-settings.sh` を実行してください」 |
 | Folder/Project instructions | `docs/working/` 構造 + TASK 配下 | ディレクトリ存在確認 | 「`mkdir -p docs/working/TASK-XXXX` で新規 TASK を作成してください」 |
 | Plugins | `.claude/agents/` / `.claude/skills/` / `.claude/commands/` | ディレクトリ存在確認 | 「`.claude/` 配下に必要な agents/skills/commands を配置してください」 |
-| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各 Hook 項目を検査 | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
+| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各項目を検査（scope: `v8.6.0 Metrics & Privacy`、EH-8 実行可能属性を含む） | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
 
 ## doctor 出力の解釈観点
 
@@ -38,14 +38,14 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 
 ```
 不足項目  := [c for c in checks if c.ok == false]
-WARN 項目 := [c for c in checks if c.ok == true && c.level == "warn"]
+WARN 項目 := [c for c in checks if c.level == "warn"]
 overall_pass := all(c.ok for c in checks if c.level == "fail")
 ```
 
 ### 提示時の順序
 
 1. `level=fail` の `ok=false` 項目（必須）
-2. `level=warn` の `ok=false` 項目（推奨）
+2. `level=warn` 項目（推奨）
 3. `level=info` の補足
 
 ## Human-owned 操作テンプレ（**提示文のみ・実行禁止**）
@@ -95,4 +95,6 @@ setup が完了したと判定する条件:
 - 次のアクション候補:
   - 新規 PBI 作成: `/ai-dev-workflow <new-task-id> brainstorm`
   - 既存 PBI 確認: `/working-context <task_id>`（Agent が Step 0 で動的解決した値）
+  - C-3 レビュー確認: `bin/plangate render <task_id>`（v8.14.0〜: HTML でレビュー資料を確認）
+  - C-3 承認: `bin/plangate approve <task_id>`（v8.14.0〜: Human ワンアクション承認）
 ```

--- a/.claude/skills/plangate-setup/SKILL.md
+++ b/.claude/skills/plangate-setup/SKILL.md
@@ -19,7 +19,7 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 | Global instructions | `.claude/settings.json` wiring | `doctor --check-settings` | 「`sh scripts/apply-claude-settings.sh` を実行してください」 |
 | Folder/Project instructions | `docs/working/` 構造 + TASK 配下 | ディレクトリ存在確認 | 「`mkdir -p docs/working/TASK-XXXX` で新規 TASK を作成してください」 |
 | Plugins | `.claude/agents/` / `.claude/skills/` / `.claude/commands/` | ディレクトリ存在確認 | 「`.claude/` 配下に必要な agents/skills/commands を配置してください」 |
-| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各 Hook 項目を検査 | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
+| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各項目を検査（scope: `v8.6.0 Metrics & Privacy`、EH-8 実行可能属性を含む） | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
 
 ## doctor 出力の解釈観点
 
@@ -38,14 +38,14 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 
 ```
 不足項目  := [c for c in checks if c.ok == false]
-WARN 項目 := [c for c in checks if c.ok == true && c.level == "warn"]
+WARN 項目 := [c for c in checks if c.level == "warn"]
 overall_pass := all(c.ok for c in checks if c.level == "fail")
 ```
 
 ### 提示時の順序
 
 1. `level=fail` の `ok=false` 項目（必須）
-2. `level=warn` の `ok=false` 項目（推奨）
+2. `level=warn` 項目（推奨）
 3. `level=info` の補足
 
 ## Human-owned 操作テンプレ（**提示文のみ・実行禁止**）
@@ -95,4 +95,6 @@ setup が完了したと判定する条件:
 - 次のアクション候補:
   - 新規 PBI 作成: `/ai-dev-workflow <new-task-id> brainstorm`
   - 既存 PBI 確認: `/working-context <task_id>`（Agent が Step 0 で動的解決した値）
+  - C-3 レビュー確認: `bin/plangate render <task_id>`（v8.14.0〜: HTML でレビュー資料を確認）
+  - C-3 承認: `bin/plangate approve <task_id>`（v8.14.0〜: Human ワンアクション承認）
 ```

--- a/.codex/skills/context-packager/SKILL.md
+++ b/.codex/skills/context-packager/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: context-packager
+description: タスク委譲前に Allowed Context を構造化して出力する。対象ファイル・仕様・既存テスト・変更制約・実行コマンド・禁止スコープを整理し、サブエージェントに渡す文脈を最小化する。
+---
+
+# Context Packager
+
+タスクを AI エージェントに委譲する前に、必要最小限の文脈（Allowed Context）を構造化して出力するスキル。
+「コンテキスト汚染」（不要な文脈が意思決定を歪める）を防ぐ。
+
+## 目的
+
+サブエージェントが受け取る情報を最小化することで、以下を防ぐ。
+
+- スコープ外のファイル変更
+- 無関係な仕様への解釈迷い
+- 設計判断の越権（実装者が設計決定をしてしまう）
+
+## Allowed Context の 6 要素
+
+| 要素 | 内容 | 情報源 |
+|------|------|--------|
+| **対象ファイル（Target Files）** | 変更・参照が許可されるファイルパス一覧 | `plan.md` の Files/Components to Touch |
+| **仕様（Spec）** | 受入基準・設計書・API 仕様の要点 | `pbi-input.md` / `design.md` |
+| **既存テスト（Existing Tests）** | 関連するテストケース・`test-cases.md` の参照 | `test-cases.md` |
+| **変更制約（Constraints）** | 変更してはいけないこと、後方互換性要件 | `plan.md` の Constraints / Non-goals |
+| **実行コマンド（Commands）** | ビルド・テスト・lint コマンド | `plan.md` の Testing Strategy |
+| **禁止スコープ（Out of Scope）** | このタスクで触れてはいけない領域 | `pbi-input.md` の Out of scope |
+
+## 手順
+
+1. `pbi-input.md` の受入基準・スコープ定義を読む
+2. `plan.md` の Work Breakdown・変更ファイル一覧・制約を読む
+3. `test-cases.md` から関連テストケースを抽出する
+4. 6 要素を構造化して出力形式に整形する
+5. Target Files 以外の情報が混入していないか最終確認する
+
+## 出力形式
+
+```markdown
+## Allowed Context
+
+### Target Files
+
+- {ファイルパス}: {変更目的}
+
+### Spec
+
+{受入基準・要点（箇条書き）}
+
+### Existing Tests
+
+- {テストファイルパス}: {テスト内容の要約}
+
+### Constraints
+
+- {制約 1}
+- {制約 2}
+
+### Commands
+
+- build: {コマンド}
+- test: {コマンド}
+- lint: {コマンド}
+
+### Out of Scope
+
+- {禁止スコープ 1}
+- {禁止スコープ 2}
+```
+
+## 入力
+
+- `docs/working/TASK-XXXX/pbi-input.md`（仕様・受入基準）
+- `docs/working/TASK-XXXX/plan.md`（変更ファイル一覧・制約）
+- `docs/working/TASK-XXXX/test-cases.md`（テストケース）
+
+## 出力
+
+- Allowed Context ブロック（Markdown 形式）
+- サブエージェントへの委譲プロンプトに埋め込んで使用する
+
+## 想定 phase
+
+- WF-03 Solution Design（タスク分解後）
+- WF-04 Build & Refine（エージェント委譲前）
+
+## カテゴリ
+
+- context-engineering
+- subagent-control
+
+## dispatch/ へのファイル保存（#581 要素3）
+
+Allowed Context（6 要素）は委譲プロンプトに埋め込むだけでなく、`docs/working/TASK-XXXX/dispatch/task-NNN-brief.md` に**ファイルとして保存**する。これにより実装者の唯一の要件ファイルとなり、会話 compaction / モデル切替後も再現可能。テンプレは `docs/working/templates/dispatch/task-NNN-brief.md`。
+
+## 関連
+
+- Skill: `subagent-dispatch`（Allowed Context を使ってエージェントに分配）
+- Rule: `plugin/plangate/rules/subagent-roles.md`（ロール別の受け取り方を定義）

--- a/.codex/skills/context-packager/agents/openai.yaml
+++ b/.codex/skills/context-packager/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "context-packager"
+  short_description: "タスク委譲前に Allowed Context を構造化して出力する。対象ファイル・仕様・既存テスト・変更制約・実行コマンド・禁止スコープを整理し、サブエージェントに渡す文脈を最小化する。"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $context-packager to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/context-packager/assets/plangate-small.svg
+++ b/.codex/skills/context-packager/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/design-gate/SKILL.md
+++ b/.codex/skills/design-gate/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: design-gate
+description: "Design Gate を実施し、設計書（Design Artifact）を生成・評価する。Use when: high-risk 以上のタスクで実装前に設計を整理したい時。「設計書を作りたい」「Design Gate を通したい」「実装前に設計レビューをしたい」。"
+---
+
+# Design Gate
+
+high-risk 以上のタスクで実装前に設計書（Design Artifact）を生成・評価する。
+
+## Iron Law
+
+`NO CODE WITHOUT APPROVED DESIGN FIRST`
+
+high-risk 以上のモードでは、Design Artifact の 8 項目が揃い承認されるまで実装を開始しない。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「シンプルだから設計不要」 | シンプルなほど設計は速い。10 分の設計が数時間の手戻りを防ぐ |
+| 「急いでいるから省略」 | 設計なしの実装は後で手戻りになる。急ぐほど設計が必要 |
+| 「前に似たことをやった」 | コードベースは変化する。前回の前提が今回も成立するとは限らない |
+| 「PoC だから後で直す」 | PoC は往々にして本番コードになる。設計の借金は複利で増える |
+
+## Design Artifact 8 項目の入力フォーム
+
+以下の質問にすべて答えることで Design Artifact が完成する。
+
+### 1. 問題定義
+
+**質問**: 何が問題か？
+
+- 現状はどうなっているか
+- どのような課題・不便が発生しているか
+- なぜ今対応が必要か（背景・トリガー）
+
+### 2. 目的
+
+**質問**: なぜ解決するか？
+
+- このタスクで達成したいゴールは何か
+- 解決後にどのような状態になっていてほしいか（期待効果）
+
+### 3. 非目的
+
+**質問**: 今回対応しないことは？
+
+- スコープ外として明示的に除外するもの
+- 「やらない」と決めた理由
+
+### 4. 仕様
+
+**質問**: 何を作るか？（具体的な機能要件）
+
+- 実装する機能・コンポーネントを列挙する
+- 入力・処理・出力を明示する
+- 受入基準（Acceptance Criteria）を記述する
+
+### 5. 代替案
+
+**質問**: 他に検討したアプローチは？（最低 2 案）
+
+| 案 | 概要 | メリット | デメリット |
+|---|------|--------|---------|
+| 案 1 | ... | ... | ... |
+| 案 2 | ... | ... | ... |
+
+### 6. 採用案
+
+**質問**: 選んだアプローチと選択理由は？
+
+- 採用するアプローチを明示する
+- 代替案と比較した場合の優位点を述べる
+- トレードオフを認識した上で選択した旨を記述する
+
+### 7. リスク
+
+**質問**: 実装・運用上のリスクは？（影響度・対策付き）
+
+| リスク | 影響度 | 発生確率 | 対策 |
+|-------|-------|---------|------|
+| リスク 1 | High / Medium / Low | High / Medium / Low | ... |
+| リスク 2 | ... | ... | ... |
+
+### 8. テスト方針
+
+**質問**: どう検証するか？
+
+| レイヤー | テスト種別 | カバー範囲 |
+|---------|----------|----------|
+| Unit | Unit | ... |
+| Integration | Integration | ... |
+| E2E | E2E | ... |
+
+## 手順
+
+1. `/pg-think` を実行して論点整理を行う（Problem Restatement / Assumptions / Options / Recommended Approach / Risks）
+2. `/pg-think` の出力を元に 8 項目を補完する
+   - Problem Restatement → 問題定義・目的
+   - Assumptions → 非目的（スコープ外の前提）
+   - Options → 代替案
+   - Recommended Approach → 採用案
+   - Risks → リスク
+3. 設計書を `docs/working/TASK-XXXX/design.md` に保存する（`docs/working/templates/design.md` を参照）
+4. **high-risk の場合**: チームへレビュー依頼（推奨）
+5. **critical の場合**: 人間の明示的承認を待つ（必須）。承認前に実装を開始しない
+
+## Mode 別の扱い
+
+| Mode | Design Gate | 承認要件 |
+|------|------------|---------|
+| `ultra-light` | スキップ可 | 不要 |
+| `light` | スキップ可 | 不要 |
+| `standard` | スキップ可 | 不要 |
+| `high-risk` | **必須** | 推奨（承認記録を design.md に残す） |
+| `critical` | **必須** | **必須**（承認なしに実装開始不可） |
+
+## 出力フォーマット
+
+設計書は `docs/working/TASK-XXXX/design.md` に保存する。
+テンプレート `docs/working/templates/design.md` の形式に従い、8 項目を Markdown で記述する。
+
+```markdown
+## メタ情報
+
+task: TASK-XXXX
+related_issue: <issue URL>
+author: <担当者>
+updated: YYYY-MM-DD
+approved_by: <承認者>（high-risk 以上で記入）
+approved_at: YYYY-MM-DD（high-risk 以上で記入）
+
+## 1. 問題定義
+<記述>
+
+## 2. 目的
+<記述>
+
+## 3. 非目的
+<記述>
+
+## 4. 仕様
+<記述>
+
+## 5. 代替案
+<代替案テーブル>
+
+## 6. 採用案
+<記述>
+
+## 7. リスク
+<リスクテーブル>
+
+## 8. テスト方針
+<テストテーブル>
+```
+
+## 関連
+
+- Rule: `plugin/plangate/rules/design-gate.md`（適用条件・ブロック条件の正本）
+- Command: `plugin/plangate/commands/pg-think.md`（論点整理の初段）
+- Template: `docs/working/templates/design.md`（design.md の保存形式）
+- Skill: `plugin/plangate/skills/skill-policy-router/SKILL.md`（GatePolicy との連携）

--- a/.codex/skills/design-gate/agents/openai.yaml
+++ b/.codex/skills/design-gate/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "design-gate"
+  short_description: "Design Gate を実施し、設計書（Design Artifact）を生成・評価する。Use when: high-risk 以上のタスクで実装前に設計を整理したい時。「設計書を作りたい」「De"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $design-gate to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/design-gate/assets/plangate-small.svg
+++ b/.codex/skills/design-gate/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/evidence-ledger/SKILL.md
+++ b/.codex/skills/evidence-ledger/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: evidence-ledger
+description: "完了主張を証拠付きで記録し、EvidenceLedger を出力する。Use when: 「完了した」「修正した」「テストが通った」と言う前に証拠を記録したい時。/pg verify の出力先として使用。「証拠を残したい」「完了判定をしたい」「TDD証跡を残したい」「Completion Gateに渡したい」。"
+---
+
+# Evidence Ledger
+
+完了主張を証拠付きで記録し、EvidenceLedger として出力する。
+
+## Iron Law
+
+`NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE`
+
+「should work now」「probably fixed」「テスト通るはず」等の推測的完了宣言は禁止。
+コマンド実行結果・終了コード・出力抜粋を証拠として記録せよ。
+
+TDD 必須 mode では、単なる「テストが通った」だけでは不十分。
+**RED（期待通り失敗）→ GREEN（最小実装で成功）→ REFACTOR VERIFY（整理後も成功）** の証跡を分けて記録する。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「CIが通ったから証拠不要」 | CI はカバレッジの保証ではない。claim ごとに証拠を記録せよ |
+| 「小さな修正だから証拠不要」 | 規模は関係ない。exitCode=0 を確認して記録せよ |
+| 「レビューしたから大丈夫」 | review type の EvidenceItem として記録せよ |
+| 「テストが通ったからTDD済み」 | GREENだけではTDD証跡にならない。REDの失敗理由も記録せよ |
+| 「REDは見たがログは残していない」 | high-risk / critical では RED 証跡がなければ Completion Gate で block 対象 |
+
+## データスキーマ
+
+### EvidenceStatus
+
+```json
+"passed" | "failed" | "skipped" | "unknown"
+```
+
+### EvidenceType
+
+```json
+"command" | "diff" | "test" | "review" | "manual"
+```
+
+### EvidencePhase
+
+`phase` は任意フィールド。ただし `type="test"` かつ TDD 証跡として使う場合は必須。
+
+```json
+"tdd_red" | "tdd_green" | "refactor_verify" | "verification" | "baseline"
+```
+
+| phase | 用途 | 期待する exitCode |
+|---|---|---|
+| `baseline` | 実装前の既存テスト確認 | `0` |
+| `tdd_red` | failing test が期待通り失敗することの確認 | `!= 0` |
+| `tdd_green` | 最小実装で対象テストが成功することの確認 | `0` |
+| `refactor_verify` | refactor後も対象テスト・関連検証が成功することの確認 | `0` |
+| `verification` | TDD以外の通常検証 | `0` |
+
+`tdd_red` の `exitCode != 0` は失敗ではなく、**期待されたRED証跡**として扱う。ただし、`conclusion` には「なぜ期待通りの失敗と言えるか」を必ず書く。
+
+### EvidenceItem
+
+```json
+{
+  "id": "string（例: ev-001）",
+  "type": "command | diff | test | review | manual",
+  "phase": "baseline | tdd_red | tdd_green | refactor_verify | verification（任意。TDD証跡では必須）",
+  "command": "string（type=command/test の場合）",
+  "exitCode": "number（type=command/test の場合）",
+  "outputExcerpt": "string（出力の一部抜粋）",
+  "filePath": "string（type=diff/test の場合）",
+  "reviewer": "string（type=review の場合）",
+  "conclusion": "string（必須 - この証拠から何が言えるか）",
+  "createdAt": "string（ISO 8601）"
+}
+```
+
+### EvidenceLedger
+
+```json
+{
+  "claim": "string（完了したという主張）",
+  "status": "EvidenceStatus",
+  "evidence": "EvidenceItem[]",
+  "missingEvidence": "string[]（必須だが欠けている証拠の説明）"
+}
+```
+
+### TddEvidenceLedger
+
+TDD必須modeの実装タスクでは、EvidenceLedgerに以下のTDD証跡が含まれていること。
+
+```json
+{
+  "claim": "Task N の実装はTDDで完了した",
+  "status": "passed",
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "test",
+      "phase": "tdd_red",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 1,
+      "outputExcerpt": "Expected failure: function is not defined",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "未実装の対象関数が存在しないため、追加したテストが期待通り失敗した",
+      "createdAt": "2026-06-21T10:00:00+09:00"
+    },
+    {
+      "id": "ev-002",
+      "type": "test",
+      "phase": "tdd_green",
+      "command": "pnpm test path/to/test.test.ts",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "最小実装により対象テストが成功した",
+      "createdAt": "2026-06-21T10:03:00+09:00"
+    },
+    {
+      "id": "ev-003",
+      "type": "test",
+      "phase": "refactor_verify",
+      "command": "pnpm test path/to/test.test.ts && pnpm typecheck",
+      "exitCode": 0,
+      "outputExcerpt": "1 passed; typecheck passed",
+      "filePath": "path/to/test.test.ts",
+      "conclusion": "refactor後も対象テストと型検査が成功した",
+      "createdAt": "2026-06-21T10:06:00+09:00"
+    }
+  ],
+  "missingEvidence": []
+}
+```
+
+## 手順
+
+### ステップ 1: claim を宣言する
+
+完了を主張したい事柄を 1 文で記述する。
+
+例: `"ログイン 500 エラーを修正した"`
+
+TDD必須modeの例:
+
+```json
+"Task 3: validation helper はTDDで実装完了した"
+```
+
+### ステップ 2: evidence を収集する
+
+claim に対して実行したコマンド・確認した差分・レビュー結果を記録する。
+
+**command type**:
+```bash
+# コマンドを実行して exitCode と出力を記録
+pnpm test auth.test.ts
+# exitCode=0, outputExcerpt="12 passed"
+```
+
+**test type**: テストファイルのパス、phase、コマンド、exitCode、結果を記録
+
+**TDD RED**:
+```bash
+pnpm test path/to/test.test.ts
+# exitCode != 0, outputExcerpt="期待した失敗理由"
+```
+
+**TDD GREEN**:
+```bash
+pnpm test path/to/test.test.ts
+# exitCode=0, outputExcerpt="1 passed"
+```
+
+**refactor verify**:
+```bash
+pnpm test path/to/test.test.ts && pnpm typecheck
+# exitCode=0, outputExcerpt="pass"
+```
+
+**diff type**: 変更ファイルのパスと差分サマリを記録
+
+**review type**: レビュアー名と結論を記録
+
+**manual type**: 手動確認した内容と結論を記録
+
+### ステップ 3: status を計算する
+
+以下のルールを順番に適用する:
+
+1. `missingEvidence` が 1 件でもある → Completion Gate がブロックされる
+2. `phase` が未指定、または `phase != "tdd_red"` の EvidenceItem で `exitCode != 0` が 1 件でもある → `status = "failed"`（`phase` 省略時は tdd_red 以外として扱う）
+3. `phase = "tdd_red"` で `exitCode = 0` → `status = "failed"`（REDになっていない）
+4. `phase = "tdd_red"` で `exitCode != 0` かつ `conclusion` が期待失敗を説明している → RED証跡として有効
+5. `evidence` が空 → `status = "unknown"`
+6. 上記いずれでもない → `status = "passed"`
+
+### ステップ 4: TDD必須modeの不足証跡を判定する
+
+`requiresFailingTestFirst=true` の場合、以下の欠落は `missingEvidence` に追加する。
+
+- `phase="tdd_red"` のEvidenceItemがない
+- `phase="tdd_green"` のEvidenceItemがない
+- REDの失敗理由が期待失敗として説明されていない（判定方針: `conclusion` が非空かつ失敗内容に言及していること。期待との厳密一致は LLM 補助判定とし、機械チェックの最低条件は `conclusion` 非空 + `exitCode != 0`）
+- GREENの成功コマンド・exitCode・出力抜粋がない
+- refactorを行ったのに `phase="refactor_verify"` がない（判定方針: 直前の `tdd_green` 証跡以降に**ソースコード変更ありかつテストコード変更なし**を refactor とみなす。機械判定が不能な場合は安全側で `refactor_verify` を必須化せず任意とする）
+
+### ステップ 5: EvidenceLedger を出力する
+
+```json
+{
+  "claim": "ログイン 500 エラーを修正した",
+  "status": "passed",
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "command",
+      "phase": "verification",
+      "command": "pnpm test auth.test.ts",
+      "exitCode": 0,
+      "outputExcerpt": "12 passed",
+      "conclusion": "auth 関連テストは全て成功",
+      "createdAt": "2026-04-26T10:00:00Z"
+    },
+    {
+      "id": "ev-002",
+      "type": "command",
+      "phase": "verification",
+      "command": "pnpm typecheck",
+      "exitCode": 0,
+      "outputExcerpt": "No errors",
+      "conclusion": "型エラーなし",
+      "createdAt": "2026-04-26T10:01:00Z"
+    }
+  ],
+  "missingEvidence": []
+}
+```
+
+## 保存先
+
+### 通常検証
+
+`/pg verify` コマンドは Evidence Ledger を出力形式として使用する。
+verify コマンド実行時は本スキルの手順に従い EvidenceLedger JSON を生成し、
+`docs/working/TASK-XXXX/evidence/verification/` に保存する。
+
+### TDD証跡
+
+TDD必須modeでは、TDD証跡を以下に保存する。
+
+```text
+docs/working/TASK-XXXX/evidence/tdd/
+├── task-001-red.json
+├── task-001-green.json
+├── task-001-refactor-verify.json
+└── task-001-ledger.json
+```
+
+`task-N-ledger.json` は、RED / GREEN / REFACTOR VERIFY をまとめた EvidenceLedger とする。
+
+## 出力フォーマット
+
+EvidenceLedger JSON を出力する。
+`status = "failed"` または `missingEvidence` が存在する場合は、
+Completion Gate へ「ブロック」として通知する。

--- a/.codex/skills/evidence-ledger/agents/openai.yaml
+++ b/.codex/skills/evidence-ledger/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "evidence-ledger"
+  short_description: "完了主張を証拠付きで記録し、EvidenceLedger を出力する。Use when: 「完了した」「修正した」「テストが通った」と言う前に証拠を記録したい時。/pg verify の出力先として使"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $evidence-ledger to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/evidence-ledger/assets/plangate-small.svg
+++ b/.codex/skills/evidence-ledger/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/intent-classifier/SKILL.md
+++ b/.codex/skills/intent-classifier/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: intent-classifier
+description: "ユーザーの依頼文から開発 Intent を 7 分類し、structured JSON で返す。Use when: ユーザーの依頼を受け取った直後に意図を分類したい時。「この依頼は何を求めているか判定して」「Intent を分類して」「依頼の種別を教えて」。"
+---
+
+# Intent Classifier
+
+> 正本: `.claude/skills/intent-classifier/SKILL.md`（`plugin/plangate/skills/` はミラー・export 用）。
+
+ユーザーの依頼文を読み取り、開発 Intent を 7 分類のいずれかに判定して structured JSON で返す。
+
+## Iron Law
+
+`CLASSIFY BASED ON EXPLICIT SIGNALS, NOT ASSUMPTIONS`
+
+依頼文に存在しないシグナルで分類を変えてはならない。
+曖昧な場合は confidence を下げて reasoning に根拠を示せ。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「文脈から明らかだから confidence=1.0 でいい」 | 曖昧さは必ず confidence に反映しろ |
+| 「どちらにも取れるが多分 feature だろう」 | 複数候補時は上位 2 件を candidates に列挙しろ |
+| 「short な依頼文だから判定できない」 | 情報不足でも最良推定で判定し、confidence を下げる |
+
+## Intent 分類定義
+
+| Intent | 説明 | キーワード例 |
+|--------|------|------------|
+| `feature` | 新機能・新動作の追加 | 追加, 実装, 作成, 新しい, 追加してほしい |
+| `bug` | 既存機能の欠陥修正 | 直す, 修正, エラー, バグ, 壊れている, 失敗する |
+| `refactor` | 動作を変えずにコード構造を改善 | リファクタ, 整理, 整頓, 分割, 綺麗にする, 改善 |
+| `research` | 技術調査・設計調査・情報収集 | 調査, 調べる, 比較, 評価, どうすべきか, 方針 |
+| `review` | コード・設計・ドキュメントのレビュー | レビュー, 確認, チェック, 問題ないか, 品質 |
+| `docs` | ドキュメント・コメント・README の追加・更新 | ドキュメント, README, コメント, 説明, 記述 |
+| `ops` | CI/CD・デプロイ・監視・インフラ・設定変更・**PlanGate CLI 操作**（render/approve/exec/doctor） | デプロイ, CI, CD, インフラ, 設定, 環境, リリース, render, HTML 確認, C-3 確認, C-3 HTML, approve, plangate render, plangate approve, doctor |
+
+## PlanGate CLI 操作の認識（ops 補足）
+
+「C-3 の確認を HTML で行いたい」「render して」「plangate render」「C-3 HTML を出して」などは `ops` に分類し、検出したら即座に以下を実行する:
+
+| ユーザー表現 | 実行コマンド |
+|-------------|------------|
+| C-3 確認を HTML / render / HTML 出力 | `bin/plangate render <TASK>` |
+| C-3 承認 / approve | `bin/plangate approve <TASK>`（別ターミナル必須） |
+| doctor / 健全性確認 | `bin/plangate doctor` |
+| exec 開始 / exec して | `bin/plangate exec <TASK>`（C-3 APPROVED 確認後） |
+
+`<TASK>` はコンテキストから推定（不明なら確認）。**intent=ops と判定した時点で plangate コマンドの候補を提示し、承認を待たずに実行する**（render は読み取り専用）。
+
+## 手順
+
+### Step 1: 依頼文の読み取り
+
+ユーザーの依頼文（または直前の会話コンテキスト）を入力として受け取る。
+依頼文が複数文の場合は全体を読み取り、主目的を抽出する。
+
+### Step 2: シグナル抽出
+
+依頼文から以下のシグナルを特定する:
+
+1. **動詞シグナル**: 「追加する」「修正する」「調査する」「レビューする」等
+2. **名詞シグナル**: 「バグ」「機能」「ドキュメント」「設定」等
+3. **状態シグナル**: 「壊れている」「存在しない」「改善したい」等
+
+### Step 3: 分類判定
+
+シグナルを Intent 分類定義と照合し、最も一致する Intent を選択する。
+
+**優先順位ルール**:
+
+- bug シグナル（エラー・壊れている・失敗）が明示されていれば `bug` を優先
+- 「追加」+ 「新しい」の組み合わせは `feature` を優先
+- 動作変更なしの「整理」「分割」は `refactor` を優先
+- 「どうすべきか」「比較」「評価」は `research` を優先
+- ドキュメント・コメントのみの変更は `docs` を優先
+- CI/CD・デプロイ・インフラ変更は `ops` を優先
+
+### Step 4: confidence 算定
+
+| シグナル強度 | confidence 範囲 |
+|------------|----------------|
+| 複数の一致シグナルあり | 0.85 〜 1.0 |
+| 1 つの明確なシグナルあり | 0.65 〜 0.84 |
+| シグナルが弱い / 複数候補 | 0.40 〜 0.64 |
+| ほぼ判断不能 | 0.10 〜 0.39 |
+
+### Step 5: 出力生成
+
+以下のフォーマットで structured JSON を出力する。
+
+## 出力フォーマット
+
+```json
+{
+  "intent": "<feature|bug|refactor|research|review|docs|ops>",
+  "confidence": <0.0〜1.0>,
+  "reasoning": "<判定根拠を1〜2文で説明>",
+  "candidates": [
+    {
+      "intent": "<第2候補>",
+      "confidence": <0.0〜1.0>
+    }
+  ]
+}
+```
+
+**フィールド仕様**:
+
+- `intent`: 7 分類のいずれか（必須）
+- `confidence`: 0.0〜1.0 の実数（必須）
+- `reasoning`: 判定根拠の説明（必須）
+- `candidates`: confidence < 0.7 の場合は上位 2 件まで列挙（任意、省略時は空配列）
+
+## 使用例
+
+**入力**: 「ログイン機能を追加してほしい」
+
+**出力**:
+
+```json
+{
+  "intent": "feature",
+  "confidence": 0.95,
+  "reasoning": "「追加してほしい」という動詞と「機能」という名詞から、新機能追加の依頼と判定した。",
+  "candidates": []
+}
+```
+
+**入力**: 「認証画面でエラーが出ているのを直してほしい」
+
+**出力**:
+
+```json
+{
+  "intent": "bug",
+  "confidence": 0.92,
+  "reasoning": "「エラー」「直してほしい」というバグ修正シグナルが明示されている。",
+  "candidates": []
+}
+```
+
+## 責務境界（Mode / lite_eligible は判定しない）
+
+intent-classifier は **Intent 7 分類のみ**を担う。Mode 判定・`lite_eligible` 算定は行わない（それらは [`mode-classification.md`](../../rules/mode-classification.md) 正本 + 後段の mode 判定ステップが担当）。本スキルの出力 Intent は skill-policy-router の入力の一部となる（WF-00 advisory）。
+
+## 関連 Skill
+
+- **skill-policy-router**: Intent + Mode を受け取り GatePolicy を返す。intent-classifier の出力をそのまま渡せる

--- a/.codex/skills/intent-classifier/agents/openai.yaml
+++ b/.codex/skills/intent-classifier/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "intent-classifier"
+  short_description: "ユーザーの依頼文から開発 Intent を 7 分類し、structured JSON で返す。Use when: ユーザーの依頼を受け取った直後に意図を分類したい時。「この依頼は何を求めているか判定"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $intent-classifier to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/intent-classifier/assets/plangate-small.svg
+++ b/.codex/skills/intent-classifier/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/plan-review-gate/SKILL.md
+++ b/.codex/skills/plan-review-gate/SKILL.md
@@ -23,6 +23,42 @@ PlanGate の **plan ゲート（C-1 セルフレビュー / C-2 外部レビュ�
 
 mode に応じた適用範囲・項目数（17 項目構成）は `.claude/rules/working-context.md` の C-1 節および `.claude/rules/mode-classification.md` フェーズ適用マトリクスを正本とする。FAIL があれば修正後再実行。evidence は FAIL 時必須（`evidence/c1-review/`）。
 
+### C-1 追加品質ゲート: Plan 実行可能性
+
+Superpowers の `writing-plans` から取り込む観点。ここでは Superpowers を依存として導入せず、PlanGate の C-1 に **plan を実行可能な作業指示書として読めるか** を確認する観点だけを吸収する。
+
+#### Task Sizing Rules
+
+各 Task / Step は以下を満たすこと。
+
+- 独立して検証可能な成果物を持つ
+- reviewer が単独で approve / reject できる粒度である
+- setup / config / docs は、それを必要とする成果物の Task に含める
+- 1 Task に複数の責務を詰め込まない
+- Task 間の依存関係・公開インターフェース・順序制約が明示されている
+- 変更対象ファイル、検証コマンド、期待結果が具体的に書かれている
+
+#### No Placeholders Rule
+
+以下が `plan.md` / `todo.md` / `test-cases.md` / `design.md` に残っている場合は C-1 FAIL として扱う。
+
+- `TBD`
+- `TODO`（未解決の実装TODO。チェックリスト用途は除く）
+- `後で実装`
+- `必要に応じて`
+- `適切に`
+- `いい感じに`
+- `エラーハンドリングを追加` だけで具体的な失敗条件・期待挙動がない
+- `テストを書く` だけで具体的な入力・期待値・検証コマンドがない
+- `Task N と同様` だけで、当該 Task 単独で実行できない
+- 未定義の関数名・型名・ファイルパス・コマンドを参照している
+
+#### 判定
+
+- `ultra-light` / `light`: 不備は WARN 可。ただし exec に必要なファイル・検証コマンドが欠ける場合は FAIL。
+- `standard`: Task Sizing / No Placeholders の重大不備は FAIL。
+- `high-risk` / `critical`: Task Sizing / No Placeholders の不備は FAIL。C-3 承認前に必ず修正する。
+
 ## C-2 外部レビュー
 
 - 2 レーン責務（設計妥当性 / コードベース整合）と R-NNN 採番・追記専用集約の規約は `.claude/rules/review-principles.md` §7-bis を正本とする

--- a/.codex/skills/plangate-setup/SKILL.md
+++ b/.codex/skills/plangate-setup/SKILL.md
@@ -19,7 +19,7 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 | Global instructions | `.claude/settings.json` wiring | `doctor --check-settings` | 「`sh scripts/apply-claude-settings.sh` を実行してください」 |
 | Folder/Project instructions | `docs/working/` 構造 + TASK 配下 | ディレクトリ存在確認 | 「`mkdir -p docs/working/TASK-XXXX` で新規 TASK を作成してください」 |
 | Plugins | `.claude/agents/` / `.claude/skills/` / `.claude/commands/` | ディレクトリ存在確認 | 「`.claude/` 配下に必要な agents/skills/commands を配置してください」 |
-| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各 Hook 項目を検査 | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
+| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各項目を検査（scope: `v8.6.0 Metrics & Privacy`、EH-8 実行可能属性を含む） | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
 
 ## doctor 出力の解釈観点
 
@@ -38,14 +38,14 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 
 ```
 不足項目  := [c for c in checks if c.ok == false]
-WARN 項目 := [c for c in checks if c.ok == true && c.level == "warn"]
+WARN 項目 := [c for c in checks if c.level == "warn"]
 overall_pass := all(c.ok for c in checks if c.level == "fail")
 ```
 
 ### 提示時の順序
 
 1. `level=fail` の `ok=false` 項目（必須）
-2. `level=warn` の `ok=false` 項目（推奨）
+2. `level=warn` 項目（推奨）
 3. `level=info` の補足
 
 ## Human-owned 操作テンプレ（**提示文のみ・実行禁止**）
@@ -95,4 +95,6 @@ setup が完了したと判定する条件:
 - 次のアクション候補:
   - 新規 PBI 作成: `/ai-dev-workflow <new-task-id> brainstorm`
   - 既存 PBI 確認: `/working-context <task_id>`（Agent が Step 0 で動的解決した値）
+  - C-3 レビュー確認: `bin/plangate render <task_id>`（v8.14.0〜: HTML でレビュー資料を確認）
+  - C-3 承認: `bin/plangate approve <task_id>`（v8.14.0〜: Human ワンアクション承認）
 ```

--- a/.codex/skills/pr-decision/SKILL.md
+++ b/.codex/skills/pr-decision/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: pr-decision
+description: gate status + evidence status + review findings + unresolved risks + rollback plan から PR 可否を判定する。判定根拠を structured output で出力し、マージ可能かどうかを明示する。
+---
+
+# PR Decision Skill
+
+Evidence Ledger + Review Gate + GateStatus + Rollback Plan の状態から PR 可否を判定し、
+判定根拠を structured output で出力する。
+
+## Iron Law
+
+`NO PR WITHOUT EVIDENCE-BASED GATE PASSAGE`
+
+証拠なしの PR 作成を防ぐ。全ての Gate が通過していることを確認してから PR を作成する。
+
+## 入力（5 つ）
+
+1. **Gate Status**: Completion Gate の `checks` オブジェクト（PASSED / BLOCKED）
+2. **Evidence Status**: EvidenceLedger の `status`（passed / failed / skipped）
+3. **Review Findings**: Review Gate の finding 一覧（severity 付き）
+4. **Unresolved Risks**: `plan.md` の Risks & Mitigations で未解決のもの
+5. **Rollback Plan**: 存在するか、内容は適切か
+
+## 出力: PR 判定レポート
+
+```markdown
+## PR 判定レポート
+
+### 判定: {APPROVE | BLOCK | CONDITIONAL}
+
+### Gate Status
+
+| Gate | 状態 |
+|------|------|
+| Design Gate | {passed / blocked / skipped} |
+| TDD Gate | {passed / blocked / skipped} |
+| Review Gate | {passed / blocked / skipped} |
+| Completion Gate | {PASSED / BLOCKED} |
+
+### Evidence Status
+
+- Overall: {passed / failed / skipped}
+- Missing: {欠落している証拠（なければ "なし"）}
+
+### Review Findings サマリ
+
+| Severity | 件数 |
+|----------|------|
+| critical | {N} |
+| major | {N} |
+| minor | {N} |
+| info | {N} |
+
+### Unresolved Risks
+
+- {未解決リスクのリスト（なければ "なし"）}
+
+### Rollback Plan
+
+- 存在: {あり / なし}
+- 内容の妥当性: {適切 / 不足}
+
+### 判定根拠
+
+{判定理由を 3〜5 行で記述}
+
+### アクション
+
+- {次のアクション（マージ可能 / 修正が必要な項目）}
+```
+
+## 判定基準
+
+| 判定 | 条件 |
+|------|------|
+| **APPROVE** | Completion Gate PASSED + Evidence Ledger passed + critical finding = 0 + Rollback Plan あり（critical モード） |
+| **BLOCK** | Completion Gate BLOCKED、または critical finding >= 1、または Evidence Ledger failed |
+| **CONDITIONAL** | major finding >= 1 かつ critical = 0、または minor リスクが残存 → 条件付き承認（担当者の判断） |
+
+## 手順
+
+### Step 1: 入力収集
+
+以下の形式で入力を収集する:
+
+```json
+{
+  "gateStatus": {
+    "completionGate": "PASSED | BLOCKED",
+    "checks": {
+      "designGate": "passed | blocked | skipped",
+      "tddEvidence": "passed | blocked | skipped",
+      "reviewGate": "passed | blocked | skipped",
+      "evidenceLedger": "passed | blocked | skipped",
+      "humanApproval": "passed | blocked | skipped",
+      "rollbackPlan": "passed | n/a | blocked"
+    }
+  },
+  "evidenceStatus": {
+    "status": "passed | failed | skipped",
+    "missingEvidence": ["<欠落している証拠>"]
+  },
+  "reviewFindings": [
+    {
+      "severity": "critical | major | minor | info",
+      "description": "<finding の説明>",
+      "resolved": true
+    }
+  ],
+  "unresolvedRisks": ["<未解決リスクの説明>"],
+  "rollbackPlan": {
+    "exists": true,
+    "adequate": true
+  }
+}
+```
+
+### Step 2: BLOCK 条件チェック（優先）
+
+以下のいずれかに該当する場合、判定を **BLOCK** とする:
+
+1. `gateStatus.completionGate === "BLOCKED"`
+2. `reviewFindings` に `severity === "critical"` が 1 件以上ある
+3. `evidenceStatus.status === "failed"`
+
+### Step 3: CONDITIONAL 条件チェック
+
+BLOCK でない場合、以下のいずれかに該当する場合、判定を **CONDITIONAL** とする:
+
+1. `reviewFindings` に `severity === "major"` が 1 件以上ある
+2. `unresolvedRisks` が 1 件以上ある
+3. Rollback Plan が critical モードで存在しない
+
+### Step 4: APPROVE 判定
+
+BLOCK でも CONDITIONAL でもない場合、判定を **APPROVE** とする。
+
+### Step 5: 判定レポート生成
+
+「出力: PR 判定レポート」のフォーマットで結果を出力する。
+
+## 使用例
+
+**入力例（APPROVE）**:
+
+```json
+{
+  "gateStatus": {
+    "completionGate": "PASSED",
+    "checks": {
+      "designGate": "passed",
+      "tddEvidence": "passed",
+      "reviewGate": "passed",
+      "evidenceLedger": "passed",
+      "humanApproval": "passed",
+      "rollbackPlan": "n/a"
+    }
+  },
+  "evidenceStatus": { "status": "passed", "missingEvidence": [] },
+  "reviewFindings": [
+    { "severity": "minor", "description": "変数名の改善提案", "resolved": false }
+  ],
+  "unresolvedRisks": [],
+  "rollbackPlan": { "exists": false, "adequate": false }
+}
+```
+
+**出力例（APPROVE）**:
+
+```markdown
+## PR 判定レポート
+
+### 判定: APPROVE
+
+### Gate Status
+
+| Gate | 状態 |
+|------|------|
+| Design Gate | passed |
+| TDD Gate | passed |
+| Review Gate | passed |
+| Completion Gate | PASSED |
+
+### Evidence Status
+
+- Overall: passed
+- Missing: なし
+
+### Review Findings サマリ
+
+| Severity | 件数 |
+|----------|------|
+| critical | 0 |
+| major | 0 |
+| minor | 1 |
+| info | 0 |
+
+### Unresolved Risks
+
+- なし
+
+### Rollback Plan
+
+- 存在: なし
+- 内容の妥当性: — （standard モードのため任意）
+
+### 判定根拠
+
+Completion Gate が PASSED となっており、全ての必須 Gate を通過している。
+Evidence Ledger の status は passed で証拠が揃っている。
+critical / major finding は 0 件であり、minor finding 1 件はマージの障害とならない。
+Rollback Plan は standard モードのため必須ではない。
+
+### アクション
+
+- PR 作成・マージ可能
+- minor finding（変数名改善）は次スプリントの V2 候補として記録推奨
+```
+
+## 想定 phase
+
+- WF-05 Verify & Handoff
+
+## カテゴリ
+
+- quality-gate
+- release-control
+
+## 関連
+
+- Rule: `completion-gate.md`（Gate Status の詳細）
+- Rule: `evidence-ledger.md`（Evidence Status の詳細）
+- Rule: `review-gate.md`（Review Findings の詳細）
+- Skill: `skill-policy-router`（GatePolicy・requiresWorktree）
+- Workflow: `docs/workflows/05_verify_and_handoff.md`

--- a/.codex/skills/pr-decision/agents/openai.yaml
+++ b/.codex/skills/pr-decision/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "pr-decision"
+  short_description: "gate status + evidence status + review findings + unresolved risks + rollback plan から PR 可否を判定する。判定根"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $pr-decision to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/pr-decision/assets/plangate-small.svg
+++ b/.codex/skills/pr-decision/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/review-gate/SKILL.md
+++ b/.codex/skills/review-gate/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: review-gate
+description: "Review Gate を実施し、実装の仕様準拠・品質・セキュリティを 6 観点でレビューする。Use when: 実装完了後にレビューをしたい時。「Review Gate を通したい」「コードレビューをして」「実装の品質確認をしたい」「severity を確認したい」。"
+---
+
+# Review Gate
+
+実装後に 6 観点でレビューを行い、critical finding を Completion Gate に伝達する。
+
+## Iron Law
+
+`NO MERGE WITHOUT TWO-STAGE REVIEW`
+
+severity=critical の finding がある場合、fix なしに Completion Gate を通過させない。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「テストが通ったからレビュー不要」 | テスト通過はロジック正確性の一部に過ぎない。セキュリティ・仕様準拠は別途確認が必要 |
+| 「小さな変更だから critical は出ない」 | 規模に関わらず 6 観点でチェックせよ。1 行の変更でも脆弱性は混入する |
+| 「外部レビューを受けたから大丈夫」 | review type の EvidenceItem として記録せよ。記録なき承認は存在しない |
+
+## 手順
+
+### ステップ 1: `/pg-check` を実行して finding を収集する
+
+```bash
+# 差分レビューを実行して severity 付き finding を取得する
+/pg-check <対象ブランチ or PR番号>
+```
+
+### ステップ 2: 6 観点で finding を分類・severity を付与する
+
+`/pg-check` の Findings を以下の 6 観点に分類する:
+
+| # | 観点 | チェック内容 |
+|---|------|------------|
+| 1 | **仕様準拠** | 受入基準・設計書との一致 |
+| 2 | **コード品質** | 可読性・命名・構造の明確さ |
+| 3 | **セキュリティ** | 入力バリデーション・認証・認可・機密情報 |
+| 4 | **パフォーマンス** | N+1 クエリ・ループ内 I/O・不要データ取得 |
+| 5 | **テスト不足** | カバレッジ・エッジケース・重要パスの未テスト |
+| 6 | **破壊的変更** | 後方互換性・API 変更・スキーマ変更 |
+
+### ステップ 3: critical finding の有無を判定する
+
+- `severity=critical` が 1 件以上 → Completion Gate をブロック
+- `severity=major` が 1 件以上（high-risk / critical Mode）→ 推奨または強制ブロック
+- それ以外 → PASS
+
+### ステップ 4: Review Gate レポートを出力する
+
+以下のフォーマットで出力する（「出力フォーマット」セクション参照）。
+
+### ステップ 5: critical finding がある場合は Completion Gate ブロック通知を出力する
+
+```
+[REVIEW GATE] BLOCKED
+reason: severity=critical の finding が <N> 件あります。fix 後に再レビューが必要です。
+```
+
+## 出力フォーマット
+
+### Review Gate レポート
+
+#### Findings（6 観点）
+
+| 観点 | Finding | Severity | 対応 |
+|-----|---------|---------|------|
+| 仕様準拠 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| コード品質 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| セキュリティ | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| パフォーマンス | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| テスト不足 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| 破壊的変更 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+
+#### 総合判定
+
+```
+**総合判定**: PASS / BLOCK（critical: N件, major: N件）
+
+→ Completion Gate: PASS / BLOCKED
+```
+
+#### EvidenceItem（Evidence Ledger への記録）
+
+```json
+{
+  "id": "review-gate-001",
+  "type": "review",
+  "reviewer": "review-gate skill",
+  "outputExcerpt": "critical: 0件, major: N件",
+  "conclusion": "Review Gate PASS / BLOCKED"
+}
+```
+
+## Plan Alignment レビュー（#581 要素4）
+
+> 5 観点・Severity・判定基準（`.claude/rules/review-principles.md` §2-4）は**不変**。本ブロックは Plan 正本との突合観点を補う追加レーン（観点数を増やさず C-2 設計妥当性レーン §7-bis と整合）。
+
+### Plan Alignment
+- plan.md の Task 要件を満たしているか
+- design.md の設計判断から逸脱していないか（逸脱なら理由明示）
+- Target Files 外を変更していないか
+- Out of Scope に抵触していないか
+- 余計な機能を追加していないか（scope creep）
+
+### Evidence Alignment
+- test-cases.md と Evidence Ledger が対応しているか
+- TDD 必須 mode で RED/GREEN 証跡があるか（#584 の tdd_red/green phase。証跡なしは **major**）
+
+### Production Readiness
+- エラー処理の具体性 / 後方互換 / セキュリティ・データ損失 / ドキュメント更新
+
+## 関連
+
+- Rule: `review-gate.md`（正本 - ブロック条件・Mode 別適用条件）
+- Command: `/pg-check`（差分レビュー・finding 収集）
+- Skill: `evidence-ledger`（EvidenceItem 記録手順）
+- Rule: `review-principles.md`（レビューの姿勢・禁止事項・False-positive ガード）

--- a/.codex/skills/review-gate/agents/openai.yaml
+++ b/.codex/skills/review-gate/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "review-gate"
+  short_description: "Review Gate を実施し、実装の仕様準拠・品質・セキュリティを 6 観点でレビューする。Use when: 実装完了後にレビューをしたい時。「Review Gate を通したい」「コードレビュ"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $review-gate to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/review-gate/assets/plangate-small.svg
+++ b/.codex/skills/review-gate/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/skill-creator/SKILL.md
+++ b/.codex/skills/skill-creator/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: skill-creator
+description: Design a new repo-owned skill from a concrete use case and produce a repo-ready skill package. Use when the user asks to create a new skill, define a skill's responsibility, draft SKILL.md, choose frontmatter, design supporting files, or prepare eval criteria for a new skill. Also trigger on "スキルを作りたい", "スキルを作って", "スキルを追加して", "新しいスキル", "SKILL.md生成".
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+## Purpose
+
+Create a new skill only after the use case is concrete enough.
+
+Your job is to:
+
+1. identify the smallest useful responsibility
+2. define when the skill should trigger
+3. choose safe frontmatter defaults
+4. draft a minimal but strong `SKILL.md`
+5. propose supporting files only when they add clear value
+6. define an initial eval set
+
+## Safety constraints
+
+Write output files only to `.agents/skills/` unless the user explicitly specifies a different path.
+Do not modify existing skills without user confirmation.
+
+Note: this skill does not set `disable-model-invocation: true` because file creation is its primary purpose, not an incidental side effect. The settings.json deny list and user confirmation prompts provide sufficient guardrails.
+
+## Core rule
+
+Do not create a broad or fuzzy skill.
+
+Prefer:
+
+- one responsibility
+- one primary workflow
+- one clear success condition
+
+If the requested scope is too broad, split it into multiple skills.
+
+## Phase 0: Gate（ヒアリング）
+
+Before drafting, confirm the following through interactive dialogue. Ask naturally — do not dump all questions at once.
+
+1. **ゴール**: このスキルで何を達成したいか？
+2. **ユースケース**: 具体的な利用シーン（2〜3個）
+3. **カテゴリ判定**: 以下のどれに最も近いか？
+   - Category 1: ドキュメント・アセット生成（テンプレート型）
+   - Category 2: ワークフロー自動化（ステップ型）
+   - Category 3: MCP連携強化（ツール活用型）
+4. **トリガー**: ユーザーがどんな言葉でこのスキルを呼び出すか？（日本語・英語両方）
+5. **入力**: スキルが受け取る情報は何か？
+6. **出力**: スキルが生成・実行する成果物は何か？
+7. **allowed tools**: 必要なツール
+8. **auto vs manual**: 自動起動か手動起動か
+9. **品質基準**: 成功をどう判定するか？
+10. **definition of done**
+
+If any item is unclear:
+
+- ask the minimum focused questions, or
+- inspect available files first if the answer can be found without asking
+
+Do not draft the full skill until the gate passes.
+
+## Phase 1: Skill boundary design
+
+Produce a short working summary with:
+
+- skill name candidate
+- single responsibility
+- in-scope tasks
+- out-of-scope tasks
+- likely trigger language
+- risk level
+- pattern selection:
+
+| パターン | 用途 |
+| :--- | :--- |
+| Sequential Workflow | 順序固定の多段階プロセス |
+| Multi-MCP Coordination | 複数サービスを横断する連携 |
+| Iterative Refinement | 品質を反復改善するループ |
+| Context-aware Selection | 状況に応じてツール・手法を切り替え |
+| Domain Intelligence | 専門知識を判断ロジックに埋め込み |
+
+Reject designs that combine unrelated workflows.
+
+## Phase 2: Frontmatter & Progressive Disclosure設計
+
+Choose frontmatter intentionally.
+
+Defaults:
+
+- include `name`
+- include `description`
+- omit extra fields unless clearly needed
+
+Use:
+
+- `disable-model-invocation: true` for side-effecting, sensitive, or timing-dependent workflows
+- `allowed-tools` only when safe pre-approval is clearly useful
+- `model` only when there is a concrete reason to override the default
+
+For every chosen field, state why it is needed.
+
+### Progressive Disclosure（3レベル情報開示）
+
+Design information at three levels:
+
+- **Level 1（Frontmatter）**: 常にロードされる。トリガー判定に必要な最小限の情報
+- **Level 2（SKILL.md本文）**: スキル発動時にロードされる。コア指示
+- **Level 3（references/）**: 必要時のみ参照される詳細ドキュメント
+
+## Phase 3: Structure design
+
+Draft the skill with this order:
+
+1. purpose
+2. gate
+3. workflow phases
+4. output contract
+5. review step
+6. failure handling
+7. additional resources
+
+Keep the main file compact.
+Move heavy references, examples, and templates into separate files.
+
+Use `${CLAUDE_SKILL_ROOT}/assets/basic-skill-template.md` as the starting skeleton.
+
+## Phase 4: Eval design
+
+Create an initial eval plan with:
+
+- 10 to 20 realistic test prompts
+- 3 to 6 pass/fail criteria
+- likely failure modes
+- what should be checked by code vs by reviewer
+
+Include at least:
+
+- one trigger test
+- one under-specified request
+- one boundary case
+- one anti-pattern case
+
+Use `${CLAUDE_SKILL_ROOT}/assets/eval-rubric-template.md` as the rubric structure.
+
+## Phase 5: Review
+
+Check the draft against:
+
+- `${CLAUDE_SKILL_ROOT}/references/review-default.md`
+- `${CLAUDE_SKILL_ROOT}/references/design-principles.md`
+
+Fix any issue before finalizing.
+
+## Phase 6: Registration & Quality Gates
+
+After the skill files are written:
+
+1. verify the directory name matches the `name` field in frontmatter
+2. verify `description` is under 1024 characters and includes trigger keywords
+3. verify SKILL.md is under 500 lines
+4. verify all `${CLAUDE_SKILL_ROOT}/` references point to existing files
+5. check the repository AGENTS.md or CLAUDE.md for additional registration steps
+6. if the repository uses a skills index or registry, update it
+
+### Quality Gates
+
+- SKILL.md本文が5,000語を超えたらreferences/への分離を提案
+- descriptionが50文字未満なら「トリガーフレーズが不足」と警告
+- descriptionが1024文字を超えたらトリミングを要求
+- 利用例（Examples）が0件なら追加を促す
+
+## Phase 7: TDD検証（任意）
+
+スキルの品質をRed→Green→Refactorサイクルで検証する。
+
+### Red: ベースライン確認
+
+1. スキルが解決すべきタスクを、**スキルなしで**エージェントに実行させる
+2. 失敗する箇所・品質が低い箇所を記録する
+3. これが「スキルが必要な理由」のエビデンスになる
+
+### Green: 効果検証
+
+1. SKILL.mdを配置した状態で同じタスクを再実行する
+2. ベースラインとの差分を確認する
+
+### Refactor: 改善サイクル
+
+1. 効果検証の結果を基にSKILL.mdを改善
+2. undertrigger（トリガーされるべき時にされない）を確認
+3. overtrigger（トリガーされるべきでない時にされる）を確認
+4. descriptionのトリガーフレーズを調整
+
+## Output format
+
+Return exactly these sections:
+
+### Skill summary
+
+### Recommended directory structure
+
+### SKILL.md draft
+
+### Supporting files to add
+
+### Eval plan
+
+### Known risks
+
+## Anti-patterns
+
+Do not:
+
+- create a "do everything" skill
+- invent company-specific rules
+- write a vague description
+- skip the gate
+- omit eval planning
+- hide trade-offs
+- put all content in SKILL.md without references/ separation
+- create README.md inside skill folder (unnecessary — SKILL.md is the entry point)
+
+## Failure handling
+
+If the request is too broad:
+
+- propose 2 to 4 smaller skills
+- explain the split by responsibility
+- recommend which one to build first

--- a/.codex/skills/skill-creator/agents/openai.yaml
+++ b/.codex/skills/skill-creator/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "skill-creator"
+  short_description: "Design a new repo-owned skill from a concrete use case and produce a repo-ready skill package. Use w"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $skill-creator to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/skill-creator/assets/plangate-small.svg
+++ b/.codex/skills/skill-creator/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/skill-policy-router/SKILL.md
+++ b/.codex/skills/skill-policy-router/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: skill-policy-router
+description: "Intent と Mode を受け取り、必要な Skill・ゲート要件（GatePolicy）を返す。Use when: 依頼の Intent と Mode が確定した後、どの Skill とゲートが必要かを決定したい時。「どのスキルが必要か教えて」「ゲートポリシーを決めて」「Mode に応じた手順を教えて」。"
+---
+
+# Skill Policy Router
+
+> 正本: `.claude/skills/skill-policy-router/SKILL.md`（`plugin/plangate/skills/` はミラー・export 用）。
+
+Intent と Mode を入力として受け取り、必要な Skill とゲート要件（GatePolicy）を structured JSON で返す。
+
+## Iron Law
+
+`GATE POLICY IS DETERMINED BY MODE, NOT BY INTENT`
+
+GatePolicy の必須 / 任意判定は Mode によって決まる。
+Intent はスキルの優先度や追加推奨にのみ影響する。
+
+> **Mode の定義・判定基準（変更ファイル数・リスク・`lite_eligible`）は [`mode-classification.md`](../../rules/mode-classification.md) が単一正本**。本スキルは確定済み Mode を入力として受け取り GatePolicy へ写像するのみで、**Mode 自体は判定しない**。下の「Mode 別ポリシー表」は Mode→GatePolicy の*写像*であり Mode の定義ではない（重複定義ではない）。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「小さな feature だから approval 不要」 | Mode が high-risk ならば Intent に関わらず approval は必須 |
+| 「docs なら worktree は不要では？」 | Mode が high-risk なら docs でも worktree が必要 |
+| 「ultra-light なら全部スキップでいい」 | verify は ultra-light でも必須 |
+
+## GatePolicy 型定義
+
+```json
+{
+  "requiredSkills": ["<skill-name>", "..."],
+  "optionalSkills": ["<skill-name>", "..."],
+  "requiresUserApproval": "<boolean>",
+  "requiresEvidence": "<boolean>",
+  "requiresFailingTestFirst": "<boolean>",
+  "requiresWorktree": "<boolean>"
+}
+```
+
+**Skill 識別子**:
+
+| 識別子 | 対応 Skill / 行動 |
+|--------|----------------|
+| `think` | 設計・計画の立案（plan.md 生成） |
+| `hunt` | コードベース調査（Grep / Glob 探索） |
+| `check` | セルフレビュー（self-review Skill） |
+| `tdd` | テスト駆動開発（failing test first） |
+| `verify` | 受け入れ検査（test-cases.md 突合） |
+| `worktree` | 独立ブランチでの作業（worktree 分離） |
+| `review` | 外部レビュー（human / external AI） |
+| `approval` | 人間の明示的承認取得 |
+
+## Mode 別ポリシー表
+
+| フィールド | ultra-light | light | standard | high-risk | critical |
+|-----------|------------|-------|----------|-----------|---------|
+| requiredSkills | verify | check, verify | think, check, verify | think, approval, worktree, tdd, check, review, verify | think, approval, worktree, tdd, check, review, verify |
+| optionalSkills | check | think, hunt | hunt, tdd | — | — |
+| requiresUserApproval | false | false | recommended | true | true |
+| requiresEvidence | false | false | true | true | true |
+| requiresFailingTestFirst | false | false | conditional | true | true |
+| requiresWorktree | false | false | false | true | true |
+
+**`standard` の補足**:
+
+- `requiresUserApproval=recommended`: 人間確認を強く推奨するが必須ではない
+- `requiresFailingTestFirst=conditional`: TDD が optional として推奨される
+
+**`critical` の追加要件**:
+
+- ロールバック計画の策定が必要
+- セキュリティレビューを含む多角的レビューを推奨
+- 段階的デプロイ計画の策定を推奨
+
+## 手順
+
+### Step 1: 入力検証
+
+以下のフォーマットで入力を受け取る:
+
+```json
+{
+  "intent": "<feature|bug|refactor|research|review|docs|ops>",
+  "mode": "<ultra-light|light|standard|high-risk|critical>"
+}
+```
+
+`mode` が不明な場合は `standard` をデフォルトとして使用する。
+`intent` が不明な場合は `feature` をデフォルトとして使用する（Intent は GatePolicy に影響しない）。
+
+### Step 2: Mode によるベースポリシー決定
+
+「Mode 別ポリシー表」から対応する行を読み取り、ベース GatePolicy を構築する。
+
+### Step 3: Intent による調整（任意）
+
+Intent に応じて optionalSkills を追加・調整する:
+
+| Intent | 推奨 optionalSkills 追加 |
+|--------|------------------------|
+| `feature` | think（未追加の場合） |
+| `bug` | hunt（原因調査のため） |
+| `refactor` | check（品質確認のため） |
+| `research` | — |
+| `review` | check |
+| `docs` | — |
+| `ops` | verify（デプロイ検証のため、未追加の場合）。**PlanGate CLI 操作**（render/approve/doctor/exec）は skill でなく直接 `bin/plangate <cmd>` を実行する |
+
+ただし、requiredSkills に既に含まれている Skill は optionalSkills に重複追加しない。
+
+### Step 4: GatePolicy 出力
+
+構築した GatePolicy を structured JSON で出力する。
+
+## 出力フォーマット
+
+```json
+{
+  "input": {
+    "intent": "<intent>",
+    "mode": "<mode>"
+  },
+  "policy": {
+    "requiredSkills": ["<skill-name>"],
+    "optionalSkills": ["<skill-name>"],
+    "requiresUserApproval": true,
+    "requiresEvidence": true,
+    "requiresFailingTestFirst": true,
+    "requiresWorktree": true
+  },
+  "notes": "<特記事項（critical の追加要件等）>"
+}
+```
+
+## 使用例
+
+**入力**: `{ "intent": "docs", "mode": "ultra-light" }`
+
+**出力**:
+
+```json
+{
+  "input": {
+    "intent": "docs",
+    "mode": "ultra-light"
+  },
+  "policy": {
+    "requiredSkills": ["verify"],
+    "optionalSkills": ["check"],
+    "requiresUserApproval": false,
+    "requiresEvidence": false,
+    "requiresFailingTestFirst": false,
+    "requiresWorktree": false
+  },
+  "notes": ""
+}
+```
+
+**入力**: `{ "intent": "feature", "mode": "high-risk" }`
+
+**出力**:
+
+```json
+{
+  "input": {
+    "intent": "feature",
+    "mode": "high-risk"
+  },
+  "policy": {
+    "requiredSkills": ["think", "approval", "worktree", "tdd", "check", "review", "verify"],
+    "optionalSkills": [],
+    "requiresUserApproval": true,
+    "requiresEvidence": true,
+    "requiresFailingTestFirst": true,
+    "requiresWorktree": true
+  },
+  "notes": ""
+}
+```
+
+## lite_eligible の扱い（責務分界）
+
+`lite_eligible`（Lite ゲート可否）は [`mode-classification.md`](../../rules/mode-classification.md) の派生属性で、**判定は mode-classification 正本が担う**。本スキルは確定した `lite_eligible` を入力として受け取り、`true` のとき Lite ゲート構成（例: C-2 外部レビューを 1 本に絞る・観点固定）を GatePolicy に反映する。router は `lite_eligible` を**判定せず使用するのみ**。判定不能時は安全側（`lite_eligible=false` 相当の full ゲート）。
+
+## 関連 Skill
+
+- **intent-classifier**: ユーザー依頼文から Intent を判定する。このスキルの前段として使用

--- a/.codex/skills/skill-policy-router/agents/openai.yaml
+++ b/.codex/skills/skill-policy-router/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "skill-policy-router"
+  short_description: "Intent と Mode を受け取り、必要な Skill・ゲート要件（GatePolicy）を返す。Use when: 依頼の Intent と Mode が確定した後、どの Skill とゲートが"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $skill-policy-router to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/skill-policy-router/assets/plangate-small.svg
+++ b/.codex/skills/skill-policy-router/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/.codex/skills/subagent-dispatch/SKILL.md
+++ b/.codex/skills/subagent-dispatch/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: subagent-dispatch
+description: high-risk/critical モードでタスクをロール別エージェントに分配する。依存関係グラフを生成し、並列実行可能タスクを特定して Allowed Context と共に dispatch する。
+---
+
+# Subagent Dispatch
+
+high-risk/critical モードでタスクをロール別エージェントに分配するスキル。
+依存関係グラフを生成し、並列実行可能なタスクを特定する。
+
+## 目的
+
+マルチエージェント実行を安全に行うために、以下を保証する。
+
+- 各エージェントが適切なロールを担う（`subagent-roles.md` に基づく）
+- 並列実行による競合（同一ファイルの同時変更）を防ぐ
+- 依存関係のある処理が正しい順序で実行される
+
+## 手順（5 ステップ）
+
+1. `plan.md` の Work Breakdown からタスクを列挙する
+2. 各タスクに `subagent-roles.md` のロールを割り当てる
+3. タスク間の依存関係を特定し、依存関係グラフを生成する
+4. 依存がないタスクを「並列実行可能」としてグループ化する
+5. 各タスクに `context-packager` を適用して Allowed Context を生成する
+
+## 並列実行判定基準
+
+| 条件 | 判定 |
+|------|------|
+| Allowed Context（Target Files）が重複しない | 並列可 |
+| 共有状態（同一ファイル）を変更する | 逐次 |
+| reviewee が実装完了するまで reviewer は待機 | 逐次 |
+| 同一 pbi-input.md への仕様参照のみ | 並列可 |
+
+## 入力
+
+- 実行モード（high-risk / critical）
+- `docs/working/TASK-XXXX/plan.md`（Work Breakdown）
+- `docs/working/TASK-XXXX/test-cases.md`
+- `plugin/plangate/rules/subagent-roles.md`（ロール定義）
+
+## 出力: Dispatch パッケージ
+
+```markdown
+## Dispatch パッケージ
+
+### Mode: {high-risk | critical}
+
+### フェーズ構成
+
+#### Phase A（並列実行可能）
+
+| エージェント | ロール | 担当タスク | Allowed Context |
+|------------|--------|----------|----------------|
+| Agent-1 | implementer | {タスク名} | {context-packager 出力へのリンク} |
+| Agent-2 | implementer | {タスク名} | {context-packager 出力へのリンク} |
+
+#### Phase B（Phase A 完了後）
+
+| エージェント | ロール | 担当タスク | 入力 |
+|------------|--------|----------|-----|
+| Agent-3 | reviewer | 全実装のレビュー | Phase A の出力 |
+| Agent-4 | security-reviewer | セキュリティレビュー | Phase A の出力 |
+
+### 依存関係グラフ（Mermaid）
+
+\`\`\`mermaid
+graph TD
+  A[planner] --> B[implementer-1]
+  A --> C[implementer-2]
+  B --> D[reviewer]
+  C --> D
+  D --> E[Completion Gate]
+\`\`\`
+
+### 並列実行判定結果
+
+- Agent-1 と Agent-2: Target Files が重複しない → 並列可
+- Agent-3 と Agent-4: 同じ実装を入力として受け取る → 並列可
+- Agent-1/2 → Agent-3/4: 実装完了後にレビュー開始 → 逐次
+```
+
+## 想定 phase
+
+- WF-03 Solution Design（マルチエージェント設計時）
+- WF-04 Build & Refine（実行前）
+
+## カテゴリ
+
+- multi-agent
+- orchestration
+
+## ファイルベース受け渡し（#581 要素3）
+
+subagent へは会話履歴でなく **`dispatch/` 配下のファイル**で渡す:
+
+- task brief: `dispatch/task-NNN-brief.md`（context-packager の Allowed Context）
+- report: `dispatch/task-NNN-report.md`（実行コマンド・テスト結果・変更サマリ・懸念）
+- review package: `dispatch/task-NNN-review-package.md`（reviewer 入力を brief/report/diff/evidence へのリンクで固定）
+- progress ledger: `dispatch/progress-ledger.md`（進捗。compaction・モデル切替後はここから再開）
+
+reviewer は review-package ファイルのみを入力とし、会話履歴は渡さない。テンプレは `docs/working/templates/dispatch/`。
+
+## 関連
+
+- Skill: `context-packager`（各エージェントへの Allowed Context 生成）
+- Rule: `plugin/plangate/rules/subagent-roles.md`（ロール定義）
+- Rule: `plugin/plangate/rules/completion-gate.md`（全エージェント完了の統合判定）

--- a/.codex/skills/subagent-dispatch/agents/openai.yaml
+++ b/.codex/skills/subagent-dispatch/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "subagent-dispatch"
+  short_description: "high-risk/critical モードでタスクをロール別エージェントに分配する。依存関係グラフを生成し、並列実行可能タスクを特定して Allowed Context と共に dispatch す"
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $subagent-dispatch to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/subagent-dispatch/assets/plangate-small.svg
+++ b/.codex/skills/subagent-dispatch/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/plugin/plangate/skills/plangate-setup/SKILL.md
+++ b/plugin/plangate/skills/plangate-setup/SKILL.md
@@ -19,7 +19,7 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 | Global instructions | `.claude/settings.json` wiring | `doctor --check-settings` | 「`sh scripts/apply-claude-settings.sh` を実行してください」 |
 | Folder/Project instructions | `docs/working/` 構造 + TASK 配下 | ディレクトリ存在確認 | 「`mkdir -p docs/working/TASK-XXXX` で新規 TASK を作成してください」 |
 | Plugins | `.claude/agents/` / `.claude/skills/` / `.claude/commands/` | ディレクトリ存在確認 | 「`.claude/` 配下に必要な agents/skills/commands を配置してください」 |
-| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各 Hook 項目を検査 | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
+| Connectors | Hook（EH-3, EH-8, …）/ CI / MCP | `doctor --json` の `checks[]` で各項目を検査（scope: `v8.6.0 Metrics & Privacy`、EH-8 実行可能属性を含む） | 「該当 Hook を `.claude/settings.json` の hooks セクションに wire してください」 |
 
 ## doctor 出力の解釈観点
 
@@ -38,14 +38,14 @@ description: PlanGate 初期セットアップを対話的に進めるための�
 
 ```
 不足項目  := [c for c in checks if c.ok == false]
-WARN 項目 := [c for c in checks if c.ok == true && c.level == "warn"]
+WARN 項目 := [c for c in checks if c.level == "warn"]
 overall_pass := all(c.ok for c in checks if c.level == "fail")
 ```
 
 ### 提示時の順序
 
 1. `level=fail` の `ok=false` 項目（必須）
-2. `level=warn` の `ok=false` 項目（推奨）
+2. `level=warn` 項目（推奨）
 3. `level=info` の補足
 
 ## Human-owned 操作テンプレ（**提示文のみ・実行禁止**）
@@ -95,4 +95,6 @@ setup が完了したと判定する条件:
 - 次のアクション候補:
   - 新規 PBI 作成: `/ai-dev-workflow <new-task-id> brainstorm`
   - 既存 PBI 確認: `/working-context <task_id>`（Agent が Step 0 で動的解決した値）
+  - C-3 レビュー確認: `bin/plangate render <task_id>`（v8.14.0〜: HTML でレビュー資料を確認）
+  - C-3 承認: `bin/plangate approve <task_id>`（v8.14.0〜: Human ワンアクション承認）
 ```

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -55,11 +55,21 @@ check_changelog_sync() {
   fi
 }
 
+check_plugin_cache_sync() {
+  out="$(sh "$ROOT/scripts/sync-plugin-installed.sh" --dry-run 2>/dev/null || true)"
+  if printf '%s' "$out" | grep -q "no-op"; then
+    ok "plugin インストール済みキャッシュ同期済み（Claude Code + Codex）"
+  else
+    ng "plugin キャッシュ未同期 — 実行: sh scripts/sync-plugin-installed.sh"
+  fi
+}
+
 run_checks() {
   note "=== release readiness 検査 ==="
   check_versions
   check_pending_applies
   check_changelog_sync
+  check_plugin_cache_sync
   note "=== 手動確認 TODO（機械化対象外） ==="
   note "- README / README_en の最新リリース行（散文）が対象 version か"
   note "- CLAUDE.md の最新リリース節（HO — apply スクリプトで Human 適用）"

--- a/scripts/sync-plugin-installed.sh
+++ b/scripts/sync-plugin-installed.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# sync-plugin-installed.sh — plugin/plangate/ → インストール済みキャッシュ・shared に同期
+#
+# リリース後にローカルの ~/.claude/plugins/ キャッシュと
+# ~/.codex/skills/ を最新 plugin/plangate/ に揃える Human 向けスクリプト。
+# CI は ~/.claude/ / ~/.codex/ にアクセスできないため、ローカル実行専用。
+#
+# 使い方:
+#   sh scripts/sync-plugin-installed.sh [--dry-run]
+#
+# リリースフロー内での位置付け:
+#   release-prep.sh --check → (NG なら) このスクリプトを実行 → --check 再実行 → READY
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+_log()    { printf '[sync-installed] %s\n' "$*"; }
+_drylog() { printf '[sync-installed][dry-run] %s\n' "$*"; }
+
+PLUGIN_SRC="$REPO_ROOT/plugin/plangate"
+
+# plugin.json からバージョンを取得
+PLUGIN_VER=""
+if command -v python3 >/dev/null 2>&1; then
+  PLUGIN_VER=$(python3 - "$PLUGIN_SRC/.claude-plugin/plugin.json" << 'PY' 2>/dev/null || echo ""
+import json, sys
+try:
+    print(json.load(open(sys.argv[1], encoding='utf-8')).get('version', ''))
+except Exception:
+    print('')
+PY
+)
+fi
+
+if [ -z "$PLUGIN_VER" ]; then
+  _log "ERROR: plugin.json からバージョン取得失敗"
+  exit 1
+fi
+_log "plugin version: $PLUGIN_VER"
+
+changed_cc=0
+changed_codex=0
+
+# ── Claude Code: cache + shared ──────────────────────────────────────────────
+
+CC_CACHE="${HOME}/.claude/plugins/cache/Growth-Teams-Agent/plangate/$PLUGIN_VER"
+CC_SHARED="${HOME}/.claude/plugins/marketplaces/Growth-Teams-Agent/shared/plangate"
+
+_sync_file() {
+  # $1=src $2=dst $3=label
+  if [ ! -f "$1" ]; then return 0; fi
+  if [ ! -f "$2" ] || ! cmp -s "$1" "$2"; then
+    if [ "$DRY_RUN" = "1" ]; then
+      _drylog "WOULD COPY (CC): $3"
+    else
+      cp "$1" "$2"
+      _log "COPY (CC): $3"
+    fi
+    changed_cc=1
+  fi
+}
+
+if [ -d "$CC_CACHE" ] || [ -d "$CC_SHARED" ]; then
+  # skills のみ対象（commands/agents/rules は shared にのみ存在）
+  for skill_dir in "$PLUGIN_SRC/skills"/*/; do
+    [ -d "$skill_dir" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    src_md="$skill_dir/SKILL.md"
+    [ -f "$src_md" ] || continue
+
+    if [ -d "$CC_CACHE/skills/$skill_name" ]; then
+      _sync_file "$src_md" "$CC_CACHE/skills/$skill_name/SKILL.md" "cache/skills/$skill_name/SKILL.md"
+    fi
+    if [ -d "$CC_SHARED/skills/$skill_name" ]; then
+      _sync_file "$src_md" "$CC_SHARED/skills/$skill_name/SKILL.md" "shared/skills/$skill_name/SKILL.md"
+    fi
+  done
+
+  # agents / commands / README を shared に同期
+  for file in agents/*.md commands/*.md README.md; do
+    src="$PLUGIN_SRC/$file"
+    [ -f "$src" ] || continue
+    dst="$CC_SHARED/$file"
+    dir="$(dirname "$dst")"
+    [ -d "$dir" ] && _sync_file "$src" "$dst" "shared/$file"
+  done
+
+  if [ "$changed_cc" = "1" ]; then
+    _log "Claude Code 同期完了"
+  else
+    _log "Claude Code: 差分なし"
+  fi
+else
+  _log "Claude Code plugin キャッシュ未検出（スキップ）"
+fi
+
+# ── Codex: .codex/skills ─────────────────────────────────────────────────────
+
+CODEX_SKILLS="${HOME}/.codex/skills"
+REPO_CODEX_SKILLS="$REPO_ROOT/.codex/skills"
+
+if [ -d "$CODEX_SKILLS" ] && [ -d "$REPO_CODEX_SKILLS" ]; then
+  for skill_dir in "$REPO_CODEX_SKILLS"/*/; do
+    [ -d "$skill_dir" ] || continue
+    skill_name="$(basename "$skill_dir")"
+    [ "$skill_name" = ".system" ] && continue
+    src_md="$skill_dir/SKILL.md"
+    [ -f "$src_md" ] || continue
+    dst_dir="$CODEX_SKILLS/$skill_name"
+    dst_md="$dst_dir/SKILL.md"
+    if [ -d "$dst_dir" ]; then
+      if [ ! -f "$dst_md" ] || ! cmp -s "$src_md" "$dst_md"; then
+        if [ "$DRY_RUN" = "1" ]; then
+          _drylog "WOULD COPY (Codex): skills/$skill_name/SKILL.md"
+        else
+          cp "$src_md" "$dst_md"
+          _log "COPY (Codex): skills/$skill_name/SKILL.md"
+        fi
+        changed_codex=1
+      fi
+    fi
+  done
+
+  if [ "$changed_codex" = "1" ]; then
+    _log "Codex skills 同期完了"
+  else
+    _log "Codex skills: 差分なし"
+  fi
+else
+  _log "Codex skills ディレクトリ未検出（スキップ）"
+fi
+
+# ── サマリ ────────────────────────────────────────────────────────────────────
+if [ "$changed_cc" = "0" ] && [ "$changed_codex" = "0" ]; then
+  printf '[sync-installed] no-op\n'
+else
+  printf '[sync-installed] done\n'
+fi


### PR DESCRIPTION
## Summary

- **plangate-setup SKILL.md バグ修正＋v8.14.0対応**: WARN判定ロジック修正（`ok==true &&` を除去）、Connectors欄にdoctor実スコープを追記、`plangate render/approve` コマンド案内を追加（`.agents/.claude/.codex/plugin` 全4箇所同期）
- **`.codex/skills/` 不足9スキル追加**: `plugin/plangate/skills/` に存在するが未追加だった9スキルを配置（context-packager / design-gate / evidence-ledger / intent-classifier / pr-decision / review-gate / skill-creator / skill-policy-router / subagent-dispatch）
- **`scripts/sync-plugin-installed.sh` 新規作成**: `plugin/plangate/` → `~/.claude/plugins/` (cache+shared) と `~/.codex/skills/` を一括同期するリリース後 Human 実行スクリプト（`--dry-run` 付き）
- **`scripts/release-prep.sh` 更新**: `check_plugin_cache_sync` を追加。`--check` でプラグインキャッシュ未同期を自動検出

## Background

`~/.claude/plugins/` キャッシュと `~/.codex/skills/` はリリース後に手動同期が必要だが、従来フローに組み込まれていなかった。本 PR でリリース前検査（`release-prep.sh --check`）に組み込み、未同期を NG として検出できるようにした。

## Release Flow (変更後)

```
sh scripts/release-prep.sh vX.Y.Z
  → version bump / CHANGELOG
  → check: plugin version / apply待ち / changelog / plugin cache sync ← NEW
  → (NG なら) sh scripts/sync-plugin-installed.sh
sh scripts/release-prep.sh --check → READY
  → tag push → gh release create
```

## Test plan

- [ ] `sh scripts/release-prep.sh --check` で `check_plugin_cache_sync` が OK/NG を正しく返すことを確認
- [ ] `sh scripts/sync-plugin-installed.sh --dry-run` で差分が正しく検出されることを確認
- [ ] `sh scripts/sync-plugin-installed.sh` 実行後に `--check` が OK になることを確認
- [ ] `.codex/skills/` の追加9スキルに SKILL.md / openai.yaml / assets が揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)