### PR TITLE
fix(#528): TASK-0138 EH-3 doc-light 経路 — 非 HO .md ファイル自動 SKIP

### DIFF
--- a/docs/working/TASK-0138/handoff.md
+++ b/docs/working/TASK-0138/handoff.md
@@ -1,0 +1,109 @@
+---
+task_id: TASK-0138
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-06-22
+author: implementer
+v1_release: "feat/task-0138-528-eh3-doc-light (a87cca7)"
+---
+
+# Handoff Package — TASK-0138 (#528)
+
+## メタ情報
+
+```yaml
+task: TASK-0138
+related_issue: https://github.com/s977043/plangate/issues/528
+author: implementer
+issued_at: 2026-06-22
+v1_release: (PR merge SHA)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-01: 非 HO .md → EH-3_DOC_LIGHT_SKIP ログ記録付き通過 | PASS | ta-39 TC-01/TC-02 PASS |
+| AC-02: HO パス → BLOCK | PASS | ta-39 TC-03/TC-06 PASS（.claude/rules/*.md, CLAUDE.md → exit 2） |
+| AC-03: plan.md → BLOCK | PASS | ta-39 TC-04 PASS（上流ロジック不変） |
+| AC-04: skip-decision-log に EH-3_DOC_LIGHT_SKIP 記録 | PASS | ta-39 TC-01 副次 PASS（sandbox log） |
+| AC-05: ta-39 全 TC PASS + run-tests.sh 認識 | PASS | run-tests.sh 300 PASS / 0 FAIL、TA-39 7 TC 全 PASS |
+| AC-06: ta-12（maintenance + EH-3 v2）回帰 PASS | PASS | maintenance guard 修正（a87cca7）後 300/0 PASS |
+
+**総合**: `6/6 PASS`
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| apply-script 適用は Human 実行が必要（HO 制約） | minor | resolved（実行済み） | No |
+| maintenance guard 追加が必要だったことが apply 後テストで判明（TA-12 7件 FAIL） | minor | resolved（a87cca7 fix-eh3-doc-light-maint-guard.sh で修正） | No |
+| ta-39 TC-01 副次は sandbox log を確認するため実 audit log 汚染なし（意図通り） | info | accepted | No |
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue |
+|--------|------|----------|-----------|
+| ta-14（ta-12: maintenance + EH-3 v2）の ta-39 内での回帰テスト統合 | 現在は run-tests.sh 全体で担保、ta-39 内には含まない | Low | — |
+| TASK 文脈あり（task_id 非空）の .md ファイルの doc-light 適用 | 現在は task_id 空のみが対象 | Low | #528 follow-up |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| apply-script 経由の Human 適用 | AI が直接 check-plan-hash.sh を編集 | HO 制約（scripts/hooks/*.sh は AI 編集不可） |
+| ta-39 は apply 前 SKIP / apply 後 PASS の二相設計 | apply 前 FAIL にして強制 | 未適用状態でも suite 全体を壊さない設計が優先 |
+| sed 経由の拡張子判定 (`sed 's/.*\.//'`) | bash parameter expansion | sh POSIX 互換性（bash 非依存） |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0138 は EH-3 hook (`scripts/hooks/check-plan-hash.sh`) に doc-light 経路を追加する PBI。
+対象ファイルが HO（Hardening Override）パスのため、AI は `scripts/apply-eh3-doc-light.sh`（apply-script）を生成し、Human が `sh scripts/apply-eh3-doc-light.sh --apply` で適用する設計。
+
+現状: `check-plan-hash.sh` へのパッチ適用済み（Human が `apply-eh3-doc-light.sh --apply` を実行）。
+その後 TA-12 FAIL が判明したため `fix-eh3-doc-light-maint-guard.sh --apply` を追加実行して修正。
+全 3 コミット（8485765, 14320d3, a87cca7）が `feat/task-0138-528-eh3-doc-light` ブランチに含まれる。
+
+### Human のアクション（完了済み）
+
+1. ~~`sh scripts/apply-eh3-doc-light.sh --apply` — 実行済み~~
+2. ~~`sh scripts/fix-eh3-doc-light-maint-guard.sh --apply` — 実行済み~~
+3. `sh tests/run-tests.sh` — 300 PASS / 0 FAIL 確認済み
+
+### 触れないでほしいファイル
+
+- `scripts/hooks/check-plan-hash.sh`: HO 対象。apply-script 経由のみ変更
+- `scripts/apply-eh3-doc-light.sh`: 内容を変更すると Human 適用時に壊れる可能性
+
+### 次に手を入れるなら
+
+- apply 後の ta-39 は `前提確認: doc-light 経路が check-plan-hash.sh に存在` が PASS になる
+- ta-39 の TC-01 副次はサンドボックス log（_T39_TMP）を確認するため実 audit log を汚染しない
+- `skip-decision-log.jsonl` の `EH-3_DOC_LIGHT_SKIP` エントリは `acknowledged_by: null` のまま（AC に合致）
+
+### 参照リンク
+
+- 関連 Issue: https://github.com/s977043/plangate/issues/528
+- pbi-input.md: `docs/working/TASK-0138/pbi-input.md`
+- plan.md: `docs/working/TASK-0138/plan.md`
+- test-cases.md: `docs/working/TASK-0138/test-cases.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit (ta-39 TC-01〜06) | 7 | 7 | 0 FAIL | AC-01〜04 |
+| Integration (run-tests.sh) | 300 | 300 | 0 | — |
+| Regression (ta-12 maintenance, ta-14 skip-acknowledge) | 既存 suite に包含 | PASS | 0 | EH-3 回帰 |
+
+**ブランチのコミット構成**:
+- `8485765`: apply-script + ta-39 テスト（HO ファイル以外）
+- `14320d3`: check-plan-hash.sh パッチ適用（Human 実行）
+- `a87cca7`: maintenance guard 追加 + TA-12 TC-10 修正（regression fix）
+
+## 7. Metrics summary
+
+該当なし（opt-in 未設定）

--- a/scripts/apply-eh3-doc-light.sh
+++ b/scripts/apply-eh3-doc-light.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# scripts/apply-eh3-doc-light.sh — check-plan-hash.sh に doc-light 経路を追加（TASK-0138）
+#
+# check-plan-hash.sh は Hardening Override 対象のため AI が本スクリプトを生成し、
+# --apply は Human が実行する（docs/ai/responsibility-classes.md AI/Human 分界）。
+#
+# 使い方:
+#   sh scripts/apply-eh3-doc-light.sh --dry-run   # 差分確認（変更なし）
+#   sh scripts/apply-eh3-doc-light.sh --apply     # 適用（冪等）
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/check-plan-hash.sh"
+
+[ -f "$HOOK" ] || { printf 'ERROR: %s not found\n' "$HOOK" >&2; exit 1; }
+
+# 冪等性チェック
+if grep -q 'EH-3_DOC_LIGHT_SKIP' "$HOOK" 2>/dev/null; then
+  printf 'SKIP (already applied): doc-light 経路は既に存在します\n'
+  exit 0
+fi
+
+# アンカー検証
+if ! grep -qF '# (iii)-(v) maintenance valid' "$HOOK"; then
+  printf 'ERROR: アンカー行が見つかりません（hook 構造が変化している可能性あり）\n' >&2
+  exit 1
+fi
+
+DOC_LIGHT_BLOCK='
+  # [TASK-0138] doc-light 経路: 非 HO .md ファイルを記録付き自動 SKIP
+  # HO 判定後（_override=0 が確定）かつ maintenance 判定前に評価。
+  # 拡張子判定: POSIX case 文（外部プロセス不要・大文字小文字非感応・false positive 防止）
+  case "$_norm_target" in
+    *.[mM][dD])
+    _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"
+    mkdir -p "$(dirname "$_dlog_dl")"
+    _ts_dl=$(date -u '"'"'+%Y-%m-%dT%H:%M:%SZ'"'"')
+    _esc_dl=$(printf '"'"'%s'"'"' "${_norm_target:-unknown}" | sed '"'"'s/\\/\\\\/g; s/"/\\"/g'"'"' | tr -d '"'"'\n\r\t'"'"')
+    printf '"'"'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\n'"'"' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"
+      reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) — auto-skipped"
+      log_event "DOC_LIGHT_SKIP" "$reason"
+      printf '"'"'[Hook EH-3 DOC_LIGHT_SKIP] %s\n'"'"' "$reason"
+      exit 0
+    ;;
+  esac
+
+'
+
+if [ "$MODE" = "--dry-run" ]; then
+  printf '[dry-run] HO 判定直後・maintenance 判定前に以下のブロックを挿入します:\n\n'
+  printf '%s\n' "$DOC_LIGHT_BLOCK"
+  exit 0
+elif [ "$MODE" = "--apply" ]; then
+  python3 - "$HOOK" "$DOC_LIGHT_BLOCK" << 'PY'
+import sys, pathlib
+hook = pathlib.Path(sys.argv[1])
+block = sys.argv[2]
+anchor = '  # (iii)-(v) maintenance valid'
+content = hook.read_text(encoding='utf-8')
+if anchor not in content:
+    print('ERROR: anchor not found', file=sys.stderr); sys.exit(1)
+hook.write_text(content.replace(anchor, block + anchor, 1), encoding='utf-8')
+print('APPLIED: doc-light block inserted')
+PY
+  printf '次のステップ: sh tests/extras/ta-39-eh3-doc-light.sh\n'
+else
+  printf 'usage: %s [--dry-run|--apply]\n' "$0" >&2; exit 1
+fi

--- a/scripts/fix-eh3-doc-light-maint-guard.sh
+++ b/scripts/fix-eh3-doc-light-maint-guard.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# scripts/fix-eh3-doc-light-maint-guard.sh
+# TASK-0138 フォロー: doc-light ブロックを maintenance ファイル非存在条件付きに修正
+#
+# 問題: 現在の doc-light が maintenance チェック前に発火するため、
+#   一-shot トークン消費・スコープチェック・TTL 期限切れ検証が迂回される（TA-12 7件 FAIL）
+# 修正: _maint 存在チェックを追加し、maintenance ファイルがある場合は doc-light を発火させない
+#
+# 使い方:
+#   sh scripts/fix-eh3-doc-light-maint-guard.sh --dry-run
+#   sh scripts/fix-eh3-doc-light-maint-guard.sh --apply
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/check-plan-hash.sh"
+
+[ -f "$HOOK" ] || { printf 'ERROR: %s not found\n' "$HOOK" >&2; exit 1; }
+
+# 冪等性チェック: 修正済みか確認
+if grep -q '! -f "\$_maint"' "$HOOK" 2>/dev/null; then
+  printf 'SKIP (already fixed): maintenance guard already present\n'
+  exit 0
+fi
+
+# 旧ブロックの存在確認
+if ! grep -q '# \[TASK-0138\] doc-light path:' "$HOOK"; then
+  printf 'ERROR: TASK-0138 doc-light block not found in hook\n' >&2
+  exit 1
+fi
+if ! grep -q '# (iii)-(v) maintenance valid' "$HOOK"; then
+  printf 'ERROR: maintenance anchor not found\n' >&2
+  exit 1
+fi
+
+if [ "$MODE" = "--dry-run" ]; then
+  printf '[dry-run] 以下の修正を適用します:\n'
+  printf '  - doc-light ブロックを _maint 定義後に移動\n'
+  printf '  - [ ! -f "$_maint" ] で maintenance 非存在時のみ発火するよう変更\n'
+  exit 0
+elif [ "$MODE" = "--apply" ]; then
+  python3 - "$HOOK" << 'PY'
+import sys, pathlib
+
+hook = pathlib.Path(sys.argv[1])
+content = hook.read_text(encoding='utf-8')
+
+old = (
+    '  # [TASK-0138] doc-light path: auto-SKIP for non-HO .md files\n'
+    '  # Inserted after HO check (_override=0 confirmed), before maintenance check.\n'
+    "  _dl_ext=$(printf '%s' \"$_norm_target\" | sed 's/.*\\.//; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')\n"
+    '  if [ "$_dl_ext" = "md" ]; then\n'
+    '    _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"\n'
+    '    mkdir -p "$(dirname "$_dlog_dl")"\n'
+    "    _ts_dl=$(date -u '+%Y-%m-%dT%H:%M:%SZ')\n"
+    "    _esc_dl=$(printf '%s' \"${_norm_target:-unknown}\" | tr -d '\\n\\r\\t')\n"
+    '    printf \'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\\n\' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"\n'
+    '    reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) -- auto-skipped"\n'
+    '    log_event "DOC_LIGHT_SKIP" "$reason"\n'
+    '    printf \'[Hook EH-3 DOC_LIGHT_SKIP] %s\\n\' "$reason"\n'
+    '    exit 0\n'
+    '  fi\n'
+    '\n'
+    '  # (iii)-(v) maintenance valid + scope + one-shot atomic consume\n'
+    '  _maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"\n'
+    '  if [ -f "$_maint" ]; then\n'
+)
+
+new = (
+    '  # (iii)-(v) maintenance valid + scope + one-shot atomic consume\n'
+    '  _maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"\n'
+    '  # [TASK-0138] doc-light path: auto-SKIP for non-HO .md files\n'
+    '  # maintenance ファイルが存在する場合は token ライフサイクル（one-shot 消費等）を優先し\n'
+    '  # doc-light は発火させない。no-maint 時のみ非 HO .md を記録付き自動 SKIP。\n'
+    '  if [ ! -f "$_maint" ]; then\n'
+    "    _dl_ext=$(printf '%s' \"$_norm_target\" | sed 's/.*\\.//; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')\n"
+    '    if [ "$_dl_ext" = "md" ]; then\n'
+    '      _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"\n'
+    '      mkdir -p "$(dirname "$_dlog_dl")"\n'
+    "      _ts_dl=$(date -u '+%Y-%m-%dT%H:%M:%SZ')\n"
+    "      _esc_dl=$(printf '%s' \"${_norm_target:-unknown}\" | tr -d '\\n\\r\\t')\n"
+    '      printf \'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\\n\' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"\n'
+    '      reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) -- auto-skipped"\n'
+    '      log_event "DOC_LIGHT_SKIP" "$reason"\n'
+    '      printf \'[Hook EH-3 DOC_LIGHT_SKIP] %s\\n\' "$reason"\n'
+    '      exit 0\n'
+    '    fi\n'
+    '  fi\n'
+    '  if [ -f "$_maint" ]; then\n'
+)
+
+if old not in content:
+    print('ERROR: expected old block not found', file=sys.stderr)
+    sys.exit(1)
+
+hook.write_text(content.replace(old, new, 1), encoding='utf-8')
+print('APPLIED: doc-light now fires only when no maintenance file present')
+PY
+  printf '次のステップ: sh tests/run-tests.sh\n'
+else
+  printf 'usage: %s [--dry-run|--apply]\n' "$0" >&2; exit 1
+fi

--- a/scripts/hooks/check-plan-hash.sh
+++ b/scripts/hooks/check-plan-hash.sh
@@ -139,8 +139,26 @@ if [ -z "$task_id" ]; then
     exit 2
   fi
 
+
   # (iii)-(v) maintenance valid + scope + one-shot atomic consume
   _maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"
+  # [TASK-0138] doc-light path: auto-SKIP for non-HO .md files
+  # maintenance ファイルが存在する場合は token ライフサイクル（one-shot 消費等）を優先し
+  # doc-light は発火させない。no-maint 時のみ非 HO .md を記録付き自動 SKIP。
+  if [ ! -f "$_maint" ]; then
+    _dl_ext=$(printf '%s' "$_norm_target" | sed 's/.*\.//; y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
+    if [ "$_dl_ext" = "md" ]; then
+      _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"
+      mkdir -p "$(dirname "$_dlog_dl")"
+      _ts_dl=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+      _esc_dl=$(printf '%s' "${_norm_target:-unknown}" | tr -d '\n\r\t')
+      printf '{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\n' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"
+      reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) -- auto-skipped"
+      log_event "DOC_LIGHT_SKIP" "$reason"
+      printf '[Hook EH-3 DOC_LIGHT_SKIP] %s\n' "$reason"
+      exit 0
+    fi
+  fi
   if [ -f "$_maint" ]; then
     _mresult=$(MAINT_FILE="$_maint" NORM_TARGET="$_norm_target" python3 - <<'PYM' 2>/dev/null || true
 import json, os, sys, time, fnmatch

--- a/tests/extras/ta-12-maintenance.sh
+++ b/tests/extras/ta-12-maintenance.sh
@@ -134,7 +134,7 @@ printf '%s' "$_out" | grep -q 'SKIP_REASON 未設定' \
 
 # TC-10 (AC-5/AC-10): env 経由有効化不可
 rm -f "$PG_T12_MAINT"
-_out=$(PLANGATE_HOOK_FILE="docs/foo.md" PLANGATE_MAINT_ENABLE=1 sh "$PG_T12_HOOK" 2>&1 || true)
+_out=$(PLANGATE_HOOK_FILE="docs/foo.ts" PLANGATE_MAINT_ENABLE=1 sh "$PG_T12_HOOK" 2>&1 || true)
 printf '%s' "$_out" | grep -q 'SKIP_REASON 未設定' \
   && t12_pass "TC-10 env 経由有効化不可 (ファイル不在=block 維持)" \
   || t12_fail "TC-10 env-only"

--- a/tests/extras/ta-39-eh3-doc-light.sh
+++ b/tests/extras/ta-39-eh3-doc-light.sh
@@ -1,0 +1,134 @@
+# tests/extras/ta-39-eh3-doc-light.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# TASK-0138 (#528): EH-3 doc-light 経路（非 HO .md ファイル自動 SKIP）の検証
+#
+# 前提: scripts/hooks/check-plan-hash.sh に doc-light 経路が適用済み
+#   （scripts/apply-eh3-doc-light.sh --apply で適用後）
+#
+# サンドボックス方式: check-plan-hash.sh を一時ディレクトリにコピーして
+# 実 audit ログを汚染しない（ta-12 方式に準拠）
+
+printf '\n=== TA-39: EH-3 doc-light 経路 (#528 TASK-0138) ===\n'
+
+# ── セットアップ ──────────────────────────────────────────────────
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T39_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T39_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+_T39_HOOK_SRC="$_T39_ROOT/scripts/hooks/check-plan-hash.sh"
+_T39_TMP=$(mktemp -d)
+if command -v register_cleanup >/dev/null 2>&1; then
+  register_cleanup "$_T39_TMP"
+fi
+
+# サンドボックス：hook を tmp に複製し、REPO_ROOT が tmp を指すよう配置
+# check-plan-hash.sh は $(dirname "$0")/../.. で REPO_ROOT を解決する
+# → _T39_TMP/scripts/hooks/check-plan-hash.sh に置く
+mkdir -p "$_T39_TMP/scripts/hooks"
+mkdir -p "$_T39_TMP/docs/working/_audit"
+
+# docs/working/ シンボリックリンクは作らず、スクリプトを書き換える方法より
+# 実ファイルを複製して _audit log を tmp に向ける（WORKING_DIR は hook 内で固定）
+# → 実 audit ログ汚染のため、hook のコピー内の WORKING_DIR を tmp に書き換える
+cp "$_T39_HOOK_SRC" "$_T39_TMP/scripts/hooks/check-plan-hash.sh"
+# REPO_ROOT / WORKING_DIR を sed で tmp に固定
+_T39_HOOK="$_T39_TMP/scripts/hooks/check-plan-hash.sh"
+
+t39_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t39_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# ── doc-light 経路の存在確認 ─────────────────────────────────────
+if grep -q 'EH-3_DOC_LIGHT_SKIP' "$_T39_HOOK_SRC"; then
+  t39_pass "前提確認: doc-light 経路が check-plan-hash.sh に存在"
+  _T39_SKIP_APPLIED=1
+else
+  # apply 未適用は SKIP（FAIL ではない）。apply-script 実行前のスタック状態を許容する。
+  printf '  [SKIP] 前提確認: doc-light 経路が未適用 — apply-eh3-doc-light.sh を実行してください\n'
+  _T39_SKIP_APPLIED=0
+fi
+
+if [ "$_T39_SKIP_APPLIED" = "0" ]; then
+  # 未適用時は TC-01〜06 をスキップ（カウンタは更新しない）
+  printf '  [SKIP] TC-01〜06: apply-eh3-doc-light.sh --apply 実行後に再テストしてください\n'
+  rm -rf "$_T39_TMP" 2>/dev/null || true
+  # shellcheck disable=SC2317
+  if [ -n "${FIXTURES_DIR:-}" ]; then
+    return 0 2>/dev/null || exit 0
+  else
+    exit 0
+  fi
+fi
+
+# ── hook テスト用共通関数 ─────────────────────────────────────────
+_t39_run_hook() {
+  # $1 = PLANGATE_HOOK_FILE の値
+  # stdout+stderr を出力、終了コードを返す
+  PLANGATE_HOOK_FILE="$1" sh "$_T39_HOOK" 2>&1
+}
+
+# === TC-01: docs 配下 .md → DOC_LIGHT_SKIP (exit 0) ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook "docs/working/TASK-XXXX/status.md") || _t39_rc=$?
+if [ "$_t39_rc" = "0" ] && printf '%s' "$_t39_out" | grep -q 'DOC_LIGHT_SKIP'; then
+  t39_pass "TC-01: docs 配下 .md → exit 0 + DOC_LIGHT_SKIP"
+else
+  t39_fail "TC-01: docs 配下 .md 期待 exit 0+DOC_LIGHT_SKIP, got exit=$_t39_rc out=$_t39_out"
+fi
+
+# === TC-01 副次 (AC-04): skip-decision-log に EH-3_DOC_LIGHT_SKIP エントリ確認 ===
+# サンドボックス方式: hook コピーの WORKING_DIR は _T39_TMP/docs/working を指す
+_t39_dlog="$_T39_TMP/docs/working/_audit/skip-decision-log.jsonl"
+if [ -f "$_t39_dlog" ] && grep -q 'EH-3_DOC_LIGHT_SKIP' "$_t39_dlog"; then
+  t39_pass "TC-01 副次 (AC-04): sandbox skip-decision-log に EH-3_DOC_LIGHT_SKIP あり"
+else
+  t39_fail "TC-01 副次 (AC-04): sandbox skip-decision-log に EH-3_DOC_LIGHT_SKIP なし (log=$_t39_dlog)"
+fi
+
+# === TC-02: .claude/skills 配下 .md → DOC_LIGHT_SKIP (非 HO パス) ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook ".claude/skills/some-skill/SKILL.md") || _t39_rc=$?
+if [ "$_t39_rc" = "0" ] && printf '%s' "$_t39_out" | grep -q 'DOC_LIGHT_SKIP'; then
+  t39_pass "TC-02: .claude/skills .md → exit 0 + DOC_LIGHT_SKIP"
+else
+  t39_fail "TC-02: .claude/skills .md 期待 exit 0+DOC_LIGHT_SKIP, got exit=$_t39_rc"
+fi
+
+# === TC-03: HO パス .md → BLOCK (exit 2) ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook ".claude/rules/working-context.md") || _t39_rc=$?
+if [ "$_t39_rc" = "2" ] && printf '%s' "$_t39_out" | grep -q 'HARDENING_OVERRIDE'; then
+  t39_pass "TC-03: HO .md (.claude/rules/*.md) → exit 2 + HARDENING_OVERRIDE"
+else
+  t39_fail "TC-03: HO パス 期待 exit 2+HARDENING_OVERRIDE, got exit=$_t39_rc"
+fi
+
+# === TC-04: plan.md → BLOCK (exit 2、上流ロジック不変) ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook "docs/working/TASK-XXXX/plan.md") || _t39_rc=$?
+if [ "$_t39_rc" = "2" ]; then
+  t39_pass "TC-04: plan.md → exit 2 (上流 BLOCK 維持)"
+else
+  t39_fail "TC-04: plan.md 期待 exit 2, got exit=$_t39_rc"
+fi
+
+# === TC-05: .MD 大文字拡張子 → DOC_LIGHT_SKIP (ケース非感応) ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook "docs/some/README.MD") || _t39_rc=$?
+if [ "$_t39_rc" = "0" ] && printf '%s' "$_t39_out" | grep -q 'DOC_LIGHT_SKIP'; then
+  t39_pass "TC-05: .MD 大文字拡張子 → exit 0 + DOC_LIGHT_SKIP (ケース非感応)"
+else
+  t39_fail "TC-05: .MD 大文字 期待 exit 0+DOC_LIGHT_SKIP, got exit=$_t39_rc"
+fi
+
+# === TC-06: CLAUDE.md → HO BLOCK ===
+_t39_rc=0
+_t39_out=$(_t39_run_hook "CLAUDE.md") || _t39_rc=$?
+if [ "$_t39_rc" = "2" ] && printf '%s' "$_t39_out" | grep -q 'HARDENING_OVERRIDE'; then
+  t39_pass "TC-06: CLAUDE.md → exit 2 + HARDENING_OVERRIDE"
+else
+  t39_fail "TC-06: CLAUDE.md 期待 exit 2+HARDENING_OVERRIDE, got exit=$_t39_rc"
+fi
+
+# ── cleanup ─────────────────────────────────────────────────────
+rm -rf "$_T39_TMP" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- EH-3 hook に doc-light 経路を追加: 非 HO `.md` ファイルへの書き込みを audit log 記録付きで自動 SKIP
- maintenance 非存在時のみ発火（maintenance 承認優先）
- apply-script で check-plan-hash.sh へパッチ適用（HO ファイル: human apply 必須）

## Changes

| ファイル | 種別 | 説明 |
|---------|------|------|
| `scripts/hooks/check-plan-hash.sh` | HO file | doc-light 経路追加（apply-script で適用） |
| `scripts/apply-eh3-doc-light.sh` | apply script | POSIX case 拡張子判定（Gemini 修正済み） |
| `scripts/fix-eh3-doc-light-maint-guard.sh` | fix script | maintenance guard 修正用 |
| `tests/extras/ta-39-eh3-doc-light.sh` | new test | EH-3 doc-light 経路テスト |
| `tests/extras/ta-12-maintenance.sh` | test update | 軽微更新 |

## Apply instructions

```sh
# マージ後に実行
sh scripts/apply-eh3-doc-light.sh --apply
```

## Test plan

- [ ] `bash tests/run-tests.sh` → TA-39: apply 後にテスト実行 (0 failed)
- [ ] CI 全項目 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)