### PR TITLE
feat(#543): Decision→c3_status mapping + C-1 Loop check + apply-scripts (TASK-0129)

### DIFF
--- a/.claude/skills/plan-quality-check/SKILL.md
+++ b/.claude/skills/plan-quality-check/SKILL.md
@@ -30,6 +30,15 @@ Design
 > 補足: `done_check` は**停止条件（completion / stop condition）**の記述有無を、`risk_check` は**再計画トリガ（前提崩壊・逸脱を検知する定量条件）**の記述有無を確認観点に含める。いずれも汎用観点であり、具体のチェック項目はプロジェクト側テンプレート（例 review-self）で定義する。
 
 > 補足2: high-risk / critical の実装タスクでは **rollback（戻し手順）の記述有無**を `done_check` の確認観点に含める。rollback 欠落は安全側（`needs_clarification`）に倒す。具体項目は review-self テンプレで定義（C1-TODO-RB）。
+> 補足3（TASK-0129 / #543）: **Loop 安全制御チェック**を `done_check` / `risk_check` 観点に追加する:
+>
+> | ID | チェック内容 | 判定 |
+> |----|------------|------|
+> | C1-LOOP-01 | plan に Stop Condition（停止条件）が記入されているか | 未記入 → `WARN`（high-risk/critical では `FAIL`）|
+> | C1-LOOP-02 | plan に Replan Triggers と機械値（閾値）が記入されているか | 未記入 → `WARN`、機械値なし → `WARN`（high-risk/critical では `FAIL`）|
+>
+> これらは `#544/#551` の Loop 安全制御（Phase1 検出）と連動し、
+> C-3 承認不可の strict Gate（Phase2）へ接続する（`docs/ai/review-gate-decision-mapping.md` §5 参照）。
 
 ## 入力
 

--- a/docs/ai/review-gate-decision-mapping.md
+++ b/docs/ai/review-gate-decision-mapping.md
@@ -1,0 +1,123 @@
+# Review Gate Decision Mapping（TASK-0129）
+
+> **Status**: 実装済み（TASK-0129 / #543）
+> **位置づけ**: 外部レビュー結果（Decision/Risk/Stop-Work）を C-3 判定に接続し
+> #544 の plan 充足を強制する Phase2 Gate の正本。
+> **関連**: #543 #544 #527 / 設計: PR #553 (`docs/working/discussions/2026-06-15-543-plan-review-gate-design.md`)
+
+## 1. 目的
+
+PlanGate の責務はレビューそのものでなく「**レビュー結果で進行可否を判定し止める・通す**」こと。
+外部レビューア（river-reviewer / Gemini / Codex 等）が返す `Decision` フィールドを
+`c3_status` に接続し、進行可否を「止める・通す」強制層とする。
+
+## 2. Decision → c3_status Mapping（正本）
+
+| 外部 Decision | c3_status | 挙動 |
+|---------------|-----------|------|
+| `go` | `APPROVED` 候補 | 他条件（Risk / Stop-Work 等）が問題なければ exec 可 |
+| `revise_plan` | `CONDITIONAL` | Required Plan Changes を R-NNN 集約 → 反映 → 再判定（既存 CONDITIONAL フローに乗せる） |
+| `human_approval_required` | 人間 C-3 強制 | autonomous APPROVE 無効化。mode-classification の Hardening Override 同等の格上げ |
+| `no_go` | `REJECTED` | plan 再生成 |
+| （未知 / 欠落） | 人間 C-3 強制（安全側） | 不明な Decision は `human_approval_required` と同等に扱う |
+
+### 2.1 設計原則
+
+- **安全側倒し**: 未知 Decision 値・欠落は人間 C-3 強制（autonomous APPROVE 不可）
+- **additive 拡張**: `review_decision` は `c3.json` の optional フィールド（既存 c3.json は後方互換）
+- **R-NNN 集約フロー**: `revise_plan` → CONDITIONAL 時は `review-external.md` に R-NNN で集約し、確定反映後に `c3.json` を APPROVED で発行（既存 CONDITIONAL フロー不変）
+
+## 3. Risk → mode/autonomous 接続
+
+| Risk 値 | 影響 |
+|---------|------|
+| `high` | mode 最低 `high-risk`・autonomous APPROVE 無効化（`mode-classification.md` と整合） |
+| `medium` | mode 最低 `standard` 推奨（既存フロー）|
+| `low` | mode 判定は通常通り |
+| （欠落） | 安全側: `medium` 相当として扱う |
+
+## 4. Stop-Work Conditions ↔ #544/#551 機械トリガー対応表
+
+> 外部レビューが `Stop-Work Conditions` を列挙した場合、以下の機械トリガーへ接続する。
+> 検知方式は **post-flight（ツール実行後の事後検知）** が基本（`codex-guarded.sh` は
+> 非対話セッション中のリアルタイムフックを持たないため）。実行層実装は #527 配下。
+
+| Stop-Work Condition（外部レビュー記述） | #544/#551 機械トリガー | 発火時の動作 |
+|----------------------------------------|----------------------|-------------|
+| 変更ファイル数が計画の 2 倍超 / +5 件超 | `file_count_exceeded`（変更ファイル 2 倍 or +5） | 次サイクルで Replan 要求 |
+| テスト/実行が連続 3 回失敗 | `consecutive_failures`（連続失敗 3 回） | 停止・Replan 要求 |
+| 同一処理ループが 3 回反復 | `loop_repetition`（反復 3 回） | 停止・Resume 待機 |
+| plan 外ファイルへの波及 | `out_of_plan_scope`（plan 外波及） | 停止・scope 再確認 |
+| 受入基準（AC）の変更 | `ac_mutation`（AC 変更） | 停止・人間判断必須 |
+
+### 4.1 Do Not Touch → forbidden_files（EH-6）
+
+外部レビューの `Do Not Touch` リスト（ファイルパス列挙）は、
+`forbidden_files`（EH-6 / `scripts/hooks/check-forbidden-files.sh`）に接続する。
+実装着手前に plan の `forbidden_files` セクションへ明記し、EH-6 が発火時にブロックする。
+
+### 4.2 Verification Required → Verification Automation
+
+外部レビューの `Verification Required` 列挙は、plan の `Testing Strategy` /
+`Verification Automation` セクションへの **必須注入**とする。
+C-1 充足チェック（§5）で未記入を検出する。
+
+## 5. C-1 充足チェック拡張（Stop Condition / Replan Triggers 検出）
+
+> `plan-quality-check` Skill の `done_check` / `risk_check` 観点を拡張し、
+> 以下の未記入を `WARN/FAIL` として検出する。
+
+| チェック項目 | 対応観点 | 判定 |
+|-------------|---------|------|
+| Stop Condition の記入（いつ停止するか） | `done_check` 拡張 | 未記入 → WARN |
+| Replan Triggers の機械値（具体的な閾値） | `risk_check` 拡張 | 未記入 → WARN |
+| Loop Attempts の上限記入 | `done_check` 拡張 | 未記入 → INFO |
+
+### 5.1 review-self テンプレート追加チェック項目（C1-LOOP-01/02）
+
+| ID | チェック内容 | 判定基準 |
+|----|------------|---------|
+| C1-LOOP-01 | plan に Stop Condition（停止条件）が記入されているか | 未記入 → WARN |
+| C1-LOOP-02 | plan に Replan Triggers（再計画トリガー）と機械値が記入されているか | 未記入 → WARN、機械値なし → WARN |
+
+これらは high-risk / critical モードでは **FAIL** として扱う（安全側）。
+
+## 6. schema 拡張フィールド（apply-script 経由で人間適用）
+
+> `schemas/c3-approval.schema.json` は Hardening Override 対象。
+> AI は apply-script（`scripts/apply-task-0129-schema.sh`）を生成し、
+> **人間が適用**する（responsibility-classes.md: Human-owned）。
+
+追加フィールド（additive・`required` に追加しない）:
+
+| フィールド | 型 | 説明 |
+|----------|---|------|
+| `review_decision` | string（enum） | 外部レビューの Decision（`go` / `revise_plan` / `human_approval_required` / `no_go`）|
+| `review_risk` | string（enum） | 外部レビューの Risk（`low` / `medium` / `high`）|
+| `review_stop_works` | array of string | 外部レビューの Stop-Work Conditions リスト |
+| `review_source` | string | レビューアの識別子（例: `river-reviewer` / `gemini`）|
+| `lite_eligible` | boolean | `false` 固定（承認境界変更 PBI は常に Standard C-3 同期）|
+
+## 7. 承認境界整合（AC-06）
+
+本 PBI（TASK-0129）は承認境界の中核（c3-approval.schema / working-context.md）を変更する。
+
+| 項目 | 値 |
+|------|---|
+| mode | `high-risk`（承認境界周辺の変更 → 最低 high / mode-classification.md 例外ルール）|
+| lite_eligible | `false`（強制）|
+| C-3 | Standard 同期（autonomous APPROVE 不可）|
+| HO 適用 | Human が apply-script を実行（AI 直接編集不可）|
+
+## 8. 関連
+
+- `schemas/c3-approval.schema.json` — 機械可読スキーマ（apply-script 拡張）
+- `.claude/rules/working-context.md` — C-3 ゲート定義・CONDITIONAL フロー（HO 対象）
+- `.claude/rules/mode-classification.md` — 5 段階モード・autonomous APPROVE 無効化条件
+- `docs/working/discussions/2026-06-15-543-plan-review-gate-design.md` — 設計ノート
+- `docs/ai/external-reviewer-interface.md` — 外部レビューア接続規約（#227 / TASK-0089）
+- `scripts/apply-task-0129-schema.sh` — schema 拡張 apply-script（Human 適用）
+- `scripts/apply-task-0129-wc.sh` — working-context 追記 apply-script（Human 適用）
+- Issue [#543](https://github.com/s977043/plangate/issues/543) — Plan Review Gate 判定連携
+- Issue [#544](https://github.com/s977043/plangate/issues/544) — Loop 安全制御（#551 機械トリガー）
+- Issue [#527](https://github.com/s977043/plangate/issues/527) — Enforcement Integrity（実行層実装）

--- a/docs/working/TASK-0129/handoff.md
+++ b/docs/working/TASK-0129/handoff.md
@@ -1,0 +1,102 @@
+---
+task_id: TASK-0129
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-06-22
+author: implementer
+v1_release: "9a08cdb"
+---
+
+# Handoff Package: TASK-0129 (#543 Plan Review Gate 判定連携)
+
+## メタ情報
+
+```yaml
+task: TASK-0129
+related_issue: https://github.com/s977043/plangate/issues/543
+author: implementer (Claude Sonnet 4.6)
+issued_at: 2026-06-22
+v1_release: 9a08cdb
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-01: Decision → c3_status マッピング定義（schema/doc） | PASS | `docs/ai/review-gate-decision-mapping.md` §2 に正本定義。go/revise_plan/human_approval_required/no_go の4値を c3_status に接続。TC-01〜04 PASS |
+| AC-02: Risk=high で mode 最低 high / autonomous APPROVE 無効化 | PASS | `docs/ai/review-gate-decision-mapping.md` §3 に定義。`mode-classification.md` との整合を明記。TC-05 PASS |
+| AC-03: C-1 が Stop Condition / Replan Triggers 未記入を検出 | PASS | `plan-quality-check` SKILL.md に C1-LOOP-01/02 追加。TC-06 PASS |
+| AC-04: Stop-Work ↔ #544/#551 機械トリガー対応表 | PASS | `docs/ai/review-gate-decision-mapping.md` §4 に5トリガー対応表。TC-07 PASS |
+| AC-05: schema 変更は apply-script 経由（AI 直接編集しない） | PASS | `scripts/apply-task-0129-schema.sh` 生成済み。AI は schema 本体未変更。TC-08 PASS |
+| AC-06: 全変更が承認境界整合（mode=high-risk / Standard C-3 / lite_eligible=false） | PASS | `docs/ai/review-gate-decision-mapping.md` §7 に承認境界整合表。TC-09b + AC06 PASS |
+
+**総合**: `6/6 基準 PASS`
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| HO apply-script（schema/working-context）は Human 手動適用が必要 | minor | accepted（設計上の責務分界） | No（仕様）|
+| C1-LOOP-01/02 は助言レベル（strict Gate への接続は #527 実行層） | minor | accepted（Non-goal として plan に明記） | Yes（#527）|
+| working-context.md の C1-LOOP/Decision mapping 追記は Human 適用待ち | minor | pending（apply-task-0129-wc.sh 生成済み） | No |
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue |
+|--------|------|----------|------------|
+| C1-LOOP-01/02 の strict Gate 強制（C-3 承認不可）| 本 PBI は mapping まで、実行層は #527 | High | #527 |
+| review_decision を `bin/plangate exec` が機械チェック | 実行層実装（codex-guarded.sh / doctor）| High | #527 |
+| Stop-Work 機械トリガーの post-flight 実行層 | `codex-guarded.sh` 拡張 | Medium | #527 #550 |
+| `plan/plangate approve` が review_decision を c3_status に自動変換 | 人間の手間削減 | Medium | #543 |
+
+## 4.妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| doc 正本 + apply-script（HO 制約） | c3-approval.schema.json の直接編集 | schemas/ は HO 対象。AI 直接編集不可 |
+| SKILL.md への補足追加 | review-self.md テンプレートへの直接追加 | working-context.md 本文は HO 対象。SKILL は非 HO で即時編集可 |
+| ドキュメント定義（mapping の「正本」） | bin/plangate への機械判定埋め込み | 実行層は #527 Non-goal。本 PBI は判定 mapping まで |
+| post-flight 検知（設計ノート準拠） | リアルタイム PreToolUse hook | codex-guarded.sh は非対話セッション中のリアルタイムフックを持たない |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0129 は #543「Plan Review Gate 判定連携」の Phase2 として、外部レビュー結果（Decision/Risk/Stop-Work）を C-3 判定に接続するための **mapping 定義層** を実装した。
+
+実装した内容:
+1. **Decision→c3_status mapping 正本**（`docs/ai/review-gate-decision-mapping.md`）: go/revise_plan/human_approval_required/no_go の4 Decision を c3_status に接続する定義。安全側（未知値→人間C-3強制）を明記。
+2. **C-1 Loop 安全制御チェック**（`plan-quality-check` SKILL.md）: C1-LOOP-01（Stop Condition）/ C1-LOOP-02（Replan Triggers + 機械値）を追加。
+3. **schema 拡張 apply-script**（`scripts/apply-task-0129-schema.sh`）: HO 対象の `schemas/c3-approval.schema.json` に review_decision 等5フィールドを additive 追加。Human が実行。
+4. **working-context 追記 apply-script**（`scripts/apply-task-0129-wc.sh`）: HO 対象の `working-context.md` に C1-LOOP-01/02 と Decision mapping 参照を追加。Human が実行。
+
+### 触れないでほしいファイル
+- `schemas/c3-approval.schema.json`: HO 対象。apply-task-0129-schema.sh 経由で Human が適用する
+- `.claude/rules/working-context.md`: HO 対象。apply-task-0129-wc.sh 経由で Human が適用する
+
+### 次に手を入れるなら
+- Human が `sh scripts/apply-task-0129-schema.sh` を実行（schema に review_decision 等追加）
+- Human が `sh scripts/apply-task-0129-wc.sh` を実行（working-context に Loop check 参照追加）
+- `#527` で実行層（bin/plangate exec / codex-guarded.sh）を実装し、mapping を機械強制化する
+
+### 参照リンク
+- 設計ノート: `docs/working/discussions/2026-06-15-543-plan-review-gate-design.md`
+- mapping 正本: `docs/ai/review-gate-decision-mapping.md`
+- schema apply-script: `scripts/apply-task-0129-schema.sh`
+- wc apply-script: `scripts/apply-task-0129-wc.sh`
+- plan.md: `docs/working/TASK-0129/plan.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit/doc検証（TA-40 TC-01〜09） | 12 | 12 | 0 | TC-01〜04（mapping）, TC-05（Risk）, TC-06（C-1 check）, TC-07（Stop-Work表）, TC-08（apply-script）, TC-09/09b（後方互換/lite_eligible）|
+| 全体テストスイート（run-tests.sh） | 309 | 309 | 0 | — |
+
+テスト実行コマンド: `sh tests/run-tests.sh`
+結果: `309 passed, 0 failed`
+
+## 7. Metrics summary
+
+該当なし（metrics opt-in 未設定）

--- a/scripts/apply-task-0129-schema.sh
+++ b/scripts/apply-task-0129-schema.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# apply-task-0129-schema.sh — TASK-0129 (#543) schema 拡張適用スクリプト
+#
+# schemas/c3-approval.schema.json は Hardening Override 対象。AI は直接編集不可。
+# 本スクリプトを AI が生成し、Human が dry-run で差分確認のうえ適用する。
+#
+# 追加内容（additive・後方互換・required に追加しない）:
+#   - review_decision: 外部レビュー Decision（go/revise_plan/human_approval_required/no_go）
+#   - review_risk:     外部レビュー Risk（low/medium/high）
+#   - review_stop_works: Stop-Work Conditions リスト（array of string）
+#   - review_source:   レビューア識別子
+#   - lite_eligible:   false 固定（承認境界変更 PBI）
+#
+# 使い方:
+#   sh scripts/apply-task-0129-schema.sh --dry-run   # 差分プレビュー
+#   sh scripts/apply-task-0129-schema.sh             # 実適用（Human が実行）
+#
+# べき等: review_decision が既に存在すれば SKIP。
+# 後方互換検証: 既存の APPROVED/CONDITIONAL/REJECTED c3.json が拡張後も valid。
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TARGET="$REPO_ROOT/schemas/c3-approval.schema.json"
+DRY_RUN=0
+
+if [ $# -gt 0 ]; then
+  if [ "$1" = "--dry-run" ] && [ $# -eq 1 ]; then
+    DRY_RUN=1
+  else
+    echo "ERROR: 不正な引数です。Usage: $0 [--dry-run]" >&2
+    exit 1
+  fi
+fi
+
+[ -f "$TARGET" ] || { echo "ERROR: $TARGET が見つかりません"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 が必要です"; exit 1; }
+
+# べき等チェック
+if python3 -c "import json; d=json.load(open('$TARGET', encoding='utf-8')); exit(0 if 'review_decision' in d.get('properties',{}) else 1)" 2>/dev/null; then
+  echo "SKIP: review_decision は既に適用済み（べき等）"
+  exit 0
+fi
+
+python3 - "$TARGET" "$DRY_RUN" <<'PY'
+import json, sys, difflib
+
+target, dry = sys.argv[1], sys.argv[2] == "1"
+with open(target, encoding='utf-8') as f:
+    src_text = f.read()
+d = json.loads(src_text)
+
+# additive 拡張フィールドを properties に追加
+new_props = {
+    "review_decision": {
+        "type": "string",
+        "enum": ["go", "revise_plan", "human_approval_required", "no_go"],
+        "description": (
+            "外部レビューの Decision。go→APPROVED候補 / revise_plan→CONDITIONAL / "
+            "human_approval_required→人間C-3強制 / no_go→REJECTED。"
+            "未知値・欠落は安全側（人間C-3強制）として扱う（TASK-0129 / #543）。"
+        )
+    },
+    "review_risk": {
+        "type": "string",
+        "enum": ["low", "medium", "high"],
+        "description": (
+            "外部レビューの Risk。high→mode最低high-risk・autonomous APPROVE無効化。"
+            "欠落は安全側（medium相当）として扱う（TASK-0129 / #543）。"
+        )
+    },
+    "review_stop_works": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": (
+            "外部レビューの Stop-Work Conditions リスト。"
+            "#544/#551 機械トリガーへのマッピングは "
+            "docs/ai/review-gate-decision-mapping.md §4 参照（TASK-0129 / #543）。"
+        )
+    },
+    "review_source": {
+        "type": "string",
+        "description": "外部レビューアの識別子（例: river-reviewer / gemini / codex）。"
+    },
+    "lite_eligible": {
+        "type": "boolean",
+        "description": (
+            "Lite ゲート適用可否。承認境界変更 PBI では false 固定 "
+            "（mode-classification.md AC-10 Hardening Override / TASK-0129 / #543）。"
+        )
+    }
+}
+
+for key, val in new_props.items():
+    d["properties"][key] = val
+
+new_text = json.dumps(d, ensure_ascii=False, indent=2) + "\n"
+
+if dry:
+    diff = list(difflib.unified_diff(
+        src_text.splitlines(True),
+        new_text.splitlines(True),
+        fromfile="schemas/c3-approval.schema.json",
+        tofile="schemas/c3-approval.schema.json (after)"
+    ))
+    sys.stdout.write("".join(diff))
+    sys.stderr.write("\n[dry-run] 上記差分。適用するには --dry-run なしで実行。\n")
+else:
+    with open(target, "w", encoding="utf-8", newline="\n") as f:
+        f.write(new_text)
+    sys.stderr.write("[applied] review_decision 等 5 フィールドを schemas/c3-approval.schema.json に追加しました。\n")
+PY
+
+# 後方互換検証（実適用後）
+if [ "$DRY_RUN" = "0" ]; then
+  echo ""
+  echo "=== 後方互換検証（既存 c3.json が拡張後も valid か） ==="
+  SCHEMA_VALIDATE="$REPO_ROOT/scripts/validate-schemas.py"
+  if [ -f "$SCHEMA_VALIDATE" ]; then
+    python3 -c "import jsonschema" >/dev/null 2>&1 || {
+      echo "[SKIP] jsonschema 未インストール（後方互換検証スキップ）"
+      exit 0
+    }
+    FIXTURE_VALID="$REPO_ROOT/tests/fixtures/schema-validate/valid/c3.json"
+    if [ -f "$FIXTURE_VALID" ]; then
+      if python3 "$SCHEMA_VALIDATE" "$FIXTURE_VALID" >/dev/null 2>&1; then
+        echo "[PASS] 後方互換: tests/fixtures/schema-validate/valid/c3.json → valid"
+      else
+        echo "[FAIL] 後方互換検証失敗: $FIXTURE_VALID が拡張後 schema で invalid" >&2
+        exit 1
+      fi
+    else
+      echo "[WARN] fixture が見つかりません: $FIXTURE_VALID"
+    fi
+  else
+    echo "[SKIP] validate-schemas.py が見つかりません"
+  fi
+fi

--- a/scripts/apply-task-0129-wc.sh
+++ b/scripts/apply-task-0129-wc.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# apply-task-0129-wc.sh — TASK-0129 (#543) working-context.md 追記適用スクリプト
+#
+# .claude/rules/working-context.md は Hardening Override 対象。AI は直接編集不可。
+# 本スクリプトを AI が生成し、Human が dry-run で差分確認のうえ適用する。
+#
+# 追加内容:
+#   1. review-self.md セクション: C1-LOOP-01/02 チェック項目を Planチェック内に追加
+#   2. C-3ゲート セクション: review_decision → c3_status mapping の参照を追加
+#
+# 使い方:
+#   sh scripts/apply-task-0129-wc.sh --dry-run   # 差分プレビュー
+#   sh scripts/apply-task-0129-wc.sh             # 実適用（Human が実行）
+#
+# べき等: C1-LOOP-01 が既に存在すれば SKIP。
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TARGET="$REPO_ROOT/.claude/rules/working-context.md"
+DRY_RUN=0
+
+if [ $# -gt 0 ]; then
+  if [ "$1" = "--dry-run" ] && [ $# -eq 1 ]; then
+    DRY_RUN=1
+  else
+    echo "ERROR: 不正な引数です。Usage: $0 [--dry-run]" >&2
+    exit 1
+  fi
+fi
+
+[ -f "$TARGET" ] || { echo "ERROR: $TARGET が見つかりません"; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 が必要です"; exit 1; }
+
+# べき等チェック
+if grep -q 'C1-LOOP-01' "$TARGET" 2>/dev/null; then
+  echo "SKIP: C1-LOOP-01 は既に適用済み（べき等）"
+  exit 0
+fi
+
+python3 - "$TARGET" "$DRY_RUN" <<'PY'
+import sys, difflib
+
+target, dry = sys.argv[1], sys.argv[2] == "1"
+with open(target, encoding="utf-8") as f:
+    src_text = f.read()
+
+# Patch 1: review-self.md セクションの Planチェック後に Loop チェック項目を追記
+OLD1 = "- Planチェック（7項目）: 受入基準網羅性、Unknowns処理、スコープ制御、テスト戦略、Work Breakdown Output、依存関係、動作検証自動化"
+NEW1 = (
+    "- Planチェック（7項目）: 受入基準網羅性、Unknowns処理、スコープ制御、テスト戦略、Work Breakdown Output、依存関係、動作検証自動化\n"
+    "  - **C1-LOOP-01（TASK-0129 / #543）**: plan に Stop Condition（停止条件）が記入されているか（未記入 → WARN、high-risk/critical では FAIL）\n"
+    "  - **C1-LOOP-02（TASK-0129 / #543）**: plan に Replan Triggers と機械値（閾値）が記入されているか（未記入 → WARN、機械値なし → WARN、high-risk/critical では FAIL）"
+)
+
+if OLD1 not in src_text:
+    print(f"ERROR: Patch 1 のアンカーが見つかりません", file=sys.stderr)
+    sys.exit(1)
+
+new_text = src_text.replace(OLD1, NEW1, 1)
+
+# Patch 2: C-3ゲートセクションの判定基準の後に Decision mapping 参照を追記
+OLD2 = "- C-2（`review-external.md`）は任意。C-2をスキップする場合はC-1のみで判断可"
+NEW2 = (
+    "- C-2（`review-external.md`）は任意。C-2をスキップする場合はC-1のみで判断可\n"
+    "- **外部レビュー Decision → c3_status マッピング（TASK-0129 / #543）**:\n"
+    "  外部レビューア（river-reviewer / Gemini / Codex 等）が返す `Decision` は以下で c3_status に接続する:\n"
+    "  `go`→APPROVED候補 / `revise_plan`→CONDITIONAL / `human_approval_required`→人間C-3強制 / `no_go`→REJECTED。\n"
+    "  未知値・欠落は安全側（人間C-3強制）。詳細: [`docs/ai/review-gate-decision-mapping.md`](../../docs/ai/review-gate-decision-mapping.md)"
+)
+
+if OLD2 not in new_text:
+    print(f"ERROR: Patch 2 のアンカーが見つかりません", file=sys.stderr)
+    sys.exit(1)
+
+new_text = new_text.replace(OLD2, NEW2, 1)
+
+if dry:
+    diff = list(difflib.unified_diff(
+        src_text.splitlines(True),
+        new_text.splitlines(True),
+        fromfile=".claude/rules/working-context.md",
+        tofile=".claude/rules/working-context.md (after)"
+    ))
+    sys.stdout.write("".join(diff))
+    sys.stderr.write("\n[dry-run] 上記差分。適用するには --dry-run なしで実行。\n")
+else:
+    with open(target, "w", encoding="utf-8", newline="\n") as f:
+        f.write(new_text)
+    sys.stderr.write("[applied] working-context.md に C1-LOOP-01/02 と Decision mapping 参照を追加しました。\n")
+PY

--- a/tests/extras/ta-40-task-0129-review-gate.sh
+++ b/tests/extras/ta-40-task-0129-review-gate.sh
@@ -1,0 +1,151 @@
+# tests/extras/ta-40-task-0129-review-gate.sh
+# Sourced by tests/run-tests.sh
+# TASK-0129 (#543): Plan Review Gate 判定連携テスト（TC-01〜TC-09）
+
+printf '\n=== TA-40: TASK-0129 Review Gate Decision Mapping ===\n'
+
+_t40_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+if [ ! -f "$_t40_root/schemas/c3-approval.schema.json" ]; then
+  _t40_root="$(CDPATH= cd -- "$_t40_root/.." && pwd)"
+fi
+_t40_doc="$_t40_root/docs/ai/review-gate-decision-mapping.md"
+_t40_schema="$_t40_root/schemas/c3-approval.schema.json"
+_t40_schema_script="$_t40_root/scripts/apply-task-0129-schema.sh"
+_t40_wc_script="$_t40_root/scripts/apply-task-0129-wc.sh"
+_t40_skill="$_t40_root/.claude/skills/plan-quality-check/SKILL.md"
+
+# ── TC-01: go → APPROVED 候補 ──────────────────────────────────────────────
+if grep -q '`go` | `APPROVED` 候補' "$_t40_doc" 2>/dev/null || \
+   grep -q "go.*APPROVED" "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-01: Decision=go → APPROVED 候補がドキュメントに定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-01: Decision=go → APPROVED 候補が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-02: revise_plan → CONDITIONAL ──────────────────────────────────────
+if grep -q 'revise_plan.*CONDITIONAL' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-02: Decision=revise_plan → CONDITIONAL がドキュメントに定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-02: Decision=revise_plan → CONDITIONAL が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-03: human_approval_required → 人間 C-3 強制 ────────────────────────
+if grep -q 'human_approval_required.*人間C-3強制\|human_approval_required.*人間 C-3 強制' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-03: Decision=human_approval_required → 人間C-3強制がドキュメントに定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-03: Decision=human_approval_required → 人間C-3強制が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-04: no_go → REJECTED ───────────────────────────────────────────────
+if grep -q 'no_go.*REJECTED' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-04: Decision=no_go → REJECTED がドキュメントに定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-04: Decision=no_go → REJECTED が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-05: Risk=high → autonomous APPROVE 無効化 ──────────────────────────
+if grep -q 'autonomous APPROVE 無効化' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-05: Risk=high → autonomous APPROVE 無効化が定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-05: Risk=high → autonomous APPROVE 無効化の定義が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-06: C-1 充足チェック（C1-LOOP-01/02）──────────────────────────────
+if grep -q 'C1-LOOP-01' "$_t40_skill" 2>/dev/null && \
+   grep -q 'C1-LOOP-02' "$_t40_skill" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-06: C1-LOOP-01/02 が plan-quality-check SKILL.md に定義されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-06: C1-LOOP-01/02 が plan-quality-check SKILL.md に見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── TC-07: Stop-Work Conditions ↔ 機械トリガー対応表 ───────────────────────
+_t40_ok=1
+for _t40_trigger in 'file_count_exceeded' 'consecutive_failures' 'loop_repetition' 'out_of_plan_scope' 'ac_mutation'; do
+  if ! grep -q "$_t40_trigger" "$_t40_doc" 2>/dev/null; then
+    _t40_ok=0
+    printf '[FAIL] TA-40 TC-07: 機械トリガー %s が見つからない\n' "$_t40_trigger"; fail=$((fail + 1))
+  fi
+done
+if [ "$_t40_ok" = "1" ]; then
+  printf '[PASS] TA-40 TC-07: 5 機械トリガーすべてが対応表に定義されている\n'; pass=$((pass + 1))
+fi
+
+# ── TC-08: schema は apply-script 経由（--dry-run で差分・本体未変更）──────
+if [ ! -f "$_t40_schema_script" ]; then
+  printf '[FAIL] TA-40 TC-08: apply-task-0129-schema.sh が見つからない\n'; fail=$((fail + 1))
+else
+  # --dry-run を実行しスクリプトが終了 0 で差分を出力すること（本体は未変更）
+  _t40_dry_out="" ; _t40_dry_rc=0
+  _t40_dry_out="$(sh "$_t40_schema_script" --dry-run 2>&1)" || _t40_dry_rc=$?
+
+  # SKIP（べき等）または diff 出力があれば PASS
+  if printf '%s' "$_t40_dry_out" | grep -q 'review_decision\|SKIP'; then
+    printf '[PASS] TA-40 TC-08: apply-script --dry-run が差分またはSKIPを出力（本体未変更）\n'; pass=$((pass + 1))
+  else
+    printf '[FAIL] TA-40 TC-08: --dry-run の出力が期待と異なる: %s\n' "$_t40_dry_out"; fail=$((fail + 1))
+  fi
+fi
+
+# ── TC-09: 後方互換（既存 c3.json が拡張後 schema で valid）────────────────
+if python3 -c 'import jsonschema' >/dev/null 2>&1; then
+  # Python で後方互換を直接検証（apply 不要・テンポラリで拡張 schema を生成して確認）
+  _t40_compat_out="" ; _t40_compat_rc=0
+  _t40_compat_out="$(python3 - "$_t40_schema" "$_t40_root/tests/fixtures/schema-validate/valid/c3.json" <<'PY40' 2>&1
+import json, sys, copy
+import jsonschema
+
+schema_path, c3_path = sys.argv[1], sys.argv[2]
+with open(schema_path, encoding='utf-8') as f:
+    schema = json.load(f)
+with open(c3_path, encoding='utf-8') as f:
+    c3 = json.load(f)
+
+# 拡張フィールドを schema に一時追加（apply-script と同じ内容）
+new_props = {
+    "review_decision": {"type": "string", "enum": ["go", "revise_plan", "human_approval_required", "no_go"]},
+    "review_risk": {"type": "string", "enum": ["low", "medium", "high"]},
+    "review_stop_works": {"type": "array", "items": {"type": "string"}},
+    "review_source": {"type": "string"},
+    "lite_eligible": {"type": "boolean"}
+}
+schema_extended = copy.deepcopy(schema)
+schema_extended["properties"].update(new_props)
+
+try:
+    jsonschema.validate(c3, schema_extended)
+    print("COMPAT_OK")
+except jsonschema.ValidationError as e:
+    print(f"COMPAT_FAIL: {e.message}")
+    sys.exit(1)
+PY40
+  )" || _t40_compat_rc=$?
+
+  if [ "$_t40_compat_rc" -eq 0 ] && printf '%s' "$_t40_compat_out" | grep -q 'COMPAT_OK'; then
+    printf '[PASS] TA-40 TC-09: 既存 c3.json が拡張後 schema でも valid（後方互換）\n'; pass=$((pass + 1))
+  else
+    printf '[FAIL] TA-40 TC-09: 後方互換検証失敗: %s\n' "$_t40_compat_out"; fail=$((fail + 1))
+  fi
+else
+  printf '[SKIP] TA-40 TC-09: jsonschema 未インストール（CI で再検証）\n'
+fi
+
+# ── lite_eligible=false 強制の記録（TC-09 後半）──────────────────────────
+if grep -q 'lite_eligible.*false\|false.*承認境界\|lite_eligible=false' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 TC-09b: lite_eligible=false 強制がドキュメントに明記されている\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 TC-09b: lite_eligible=false 強制の記述が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── apply-task-0129-wc.sh の存在検証 ──────────────────────────────────────
+if [ -f "$_t40_wc_script" ]; then
+  printf '[PASS] TA-40 WC-01: apply-task-0129-wc.sh が存在する\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 WC-01: apply-task-0129-wc.sh が見つからない\n'; fail=$((fail + 1))
+fi
+
+# ── mapping doc の承認境界整合（AC-06）────────────────────────────────────
+if grep -q 'high-risk\|高リスク\|Standard 同期\|Standard C-3' "$_t40_doc" 2>/dev/null; then
+  printf '[PASS] TA-40 AC06: 承認境界整合（mode=high-risk / Standard C-3）がドキュメントに明記\n'; pass=$((pass + 1))
+else
+  printf '[FAIL] TA-40 AC06: 承認境界整合の記述が見つからない\n'; fail=$((fail + 1))
+fi


### PR DESCRIPTION
## Summary

- C-3 Review Gate Decision → `c3_status` マッピング表新設 (`docs/ai/review-gate-decision-mapping.md`)
- plan-quality-check スキルに C-1 Loop 検出チェック追加 (R-001)
- apply-script で c3-approval スキーマ更新 / working-context.md 文言更新
- Gemini 修正済み: UTF-8 encoding 明示 / ta-40 root path fallback

## Changes

| ファイル | 種別 | 説明 |
|---------|------|------|
| `.claude/skills/plan-quality-check/SKILL.md` | skill update | C-1 Loop チェック追加 |
| `docs/ai/review-gate-decision-mapping.md` | new doc | Decision マッピング表 |
| `scripts/apply-task-0129-schema.sh` | apply script | c3-approval スキーマ verdict フィールド追加 |
| `scripts/apply-task-0129-wc.sh` | apply script | working-context.md 文言更新 |
| `tests/extras/ta-40-task-0129-review-gate.sh` | new test | Review Gate 決定マッピングテスト |

## Apply instructions

```sh
# マージ後に実行（順番を守ること）
sh scripts/apply-task-0129-schema.sh
sh scripts/apply-task-0129-wc.sh
```

## Test plan

- [ ] `bash tests/run-tests.sh` → TA-40: 0 failed
- [ ] CI 全項目 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)