### PR TITLE
fix: Gemini post-merge followups (HIGH + security-medium + medium)

### DIFF
--- a/scripts/apply-eh3-doc-light.sh
+++ b/scripts/apply-eh3-doc-light.sh
@@ -20,34 +20,37 @@ if grep -q 'EH-3_DOC_LIGHT_SKIP' "$HOOK" 2>/dev/null; then
   exit 0
 fi
 
-# アンカー検証
-if ! grep -qF '# (iii)-(v) maintenance valid' "$HOOK"; then
+# アンカー検証（_maint 定義行の存在確認）
+if ! grep -qF '_maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"' "$HOOK"; then
   printf 'ERROR: アンカー行が見つかりません（hook 構造が変化している可能性あり）\n' >&2
   exit 1
 fi
 
+# doc-light ブロック: _maint 定義直後に挿入し、maintenance ガード付きで発火
+# _maint 未定義の状態で評価されないよう _maint="..." の後ろに配置する（Gemini HIGH）
 DOC_LIGHT_BLOCK='
   # [TASK-0138] doc-light 経路: 非 HO .md ファイルを記録付き自動 SKIP
-  # HO 判定後（_override=0 が確定）かつ maintenance 判定前に評価。
-  # 拡張子判定: POSIX case 文（外部プロセス不要・大文字小文字非感応・false positive 防止）
-  case "$_norm_target" in
-    *.[mM][dD])
-    _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"
-    mkdir -p "$(dirname "$_dlog_dl")"
-    _ts_dl=$(date -u '"'"'+%Y-%m-%dT%H:%M:%SZ'"'"')
-    _esc_dl=$(printf '"'"'%s'"'"' "${_norm_target:-unknown}" | sed '"'"'s/\\/\\\\/g; s/"/\\"/g'"'"' | tr -d '"'"'\n\r\t'"'"')
-    printf '"'"'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\n'"'"' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"
-      reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) — auto-skipped"
-      log_event "DOC_LIGHT_SKIP" "$reason"
-      printf '"'"'[Hook EH-3 DOC_LIGHT_SKIP] %s\n'"'"' "$reason"
-      exit 0
-    ;;
-  esac
-
+  # maintenance ファイルが存在する場合は token ライフサイクルを優先し doc-light を発火させない。
+  # no-maint 時のみ非 HO .md を記録付き自動 SKIP（POSIX case 文で拡張子判定）。
+  if [ ! -f "$_maint" ]; then
+    case "$_norm_target" in
+      *.[mM][dD])
+        _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"
+        mkdir -p "$(dirname "$_dlog_dl")"
+        _ts_dl=$(date -u '"'"'+%Y-%m-%dT%H:%M:%SZ'"'"')
+        _esc_dl=$(printf '"'"'%s'"'"' "${_norm_target:-unknown}" | tr -d '"'"'\n\r\t'"'"')
+        printf '"'"'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\n'"'"' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"
+        reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) — auto-skipped"
+        log_event "DOC_LIGHT_SKIP" "$reason"
+        printf '"'"'[Hook EH-3 DOC_LIGHT_SKIP] %s\n'"'"' "$reason"
+        exit 0
+        ;;
+    esac
+  fi
 '
 
 if [ "$MODE" = "--dry-run" ]; then
-  printf '[dry-run] HO 判定直後・maintenance 判定前に以下のブロックを挿入します:\n\n'
+  printf '[dry-run] _maint 定義直後に以下のブロックを挿入します:\n\n'
   printf '%s\n' "$DOC_LIGHT_BLOCK"
   exit 0
 elif [ "$MODE" = "--apply" ]; then
@@ -55,12 +58,12 @@ elif [ "$MODE" = "--apply" ]; then
 import sys, pathlib
 hook = pathlib.Path(sys.argv[1])
 block = sys.argv[2]
-anchor = '  # (iii)-(v) maintenance valid'
+anchor = '  _maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"'
 content = hook.read_text(encoding='utf-8')
 if anchor not in content:
     print('ERROR: anchor not found', file=sys.stderr); sys.exit(1)
-hook.write_text(content.replace(anchor, block + anchor, 1), encoding='utf-8')
-print('APPLIED: doc-light block inserted')
+hook.write_text(content.replace(anchor, anchor + '\n' + block, 1), encoding='utf-8')
+print('APPLIED: doc-light block inserted after _maint definition')
 PY
   printf '次のステップ: sh tests/extras/ta-39-eh3-doc-light.sh\n'
 else

--- a/scripts/apply-eh3-doc-light.sh
+++ b/scripts/apply-eh3-doc-light.sh
@@ -38,7 +38,7 @@ DOC_LIGHT_BLOCK='
         _dlog_dl="$WORKING_DIR/_audit/skip-decision-log.jsonl"
         mkdir -p "$(dirname "$_dlog_dl")"
         _ts_dl=$(date -u '"'"'+%Y-%m-%dT%H:%M:%SZ'"'"')
-        _esc_dl=$(printf '"'"'%s'"'"' "${_norm_target:-unknown}" | tr -d '"'"'\n\r\t'"'"')
+        _esc_dl=$(printf '"'"'%s'"'"' "${_norm_target:-unknown}" | tr -d '"'"'\n\r\t'"'"' | sed '"'"'s/\\/\\\\/g; s/"/\\"/g'"'"')
         printf '"'"'{"ts":"%s","event":"EH-3_DOC_LIGHT_SKIP","target":"%s","acknowledged_by":null,"acknowledged_at":null}\n'"'"' "$_ts_dl" "$_esc_dl" >>"$_dlog_dl"
         reason="DOC_LIGHT_SKIP: non-HO .md target (${_norm_target:-unknown}) — auto-skipped"
         log_event "DOC_LIGHT_SKIP" "$reason"
@@ -62,7 +62,7 @@ anchor = '  _maint="$REPO_ROOT/docs/working/_maintenance/maintenance.json"'
 content = hook.read_text(encoding='utf-8')
 if anchor not in content:
     print('ERROR: anchor not found', file=sys.stderr); sys.exit(1)
-hook.write_text(content.replace(anchor, anchor + '\n' + block, 1), encoding='utf-8')
+hook.write_text(content.replace(anchor, anchor + block, 1), encoding='utf-8')
 print('APPLIED: doc-light block inserted after _maint definition')
 PY
   printf '次のステップ: sh tests/extras/ta-39-eh3-doc-light.sh\n'

--- a/scripts/apply-task-0129-schema.sh
+++ b/scripts/apply-task-0129-schema.sh
@@ -37,7 +37,7 @@ fi
 command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 が必要です"; exit 1; }
 
 # べき等チェック
-if python3 -c "import json; d=json.load(open('$TARGET', encoding='utf-8')); exit(0 if 'review_decision' in d.get('properties',{}) else 1)" 2>/dev/null; then
+if python3 -c "import json, sys; d=json.load(open(sys.argv[1], encoding='utf-8')); exit(0 if 'review_decision' in d.get('properties',{}) else 1)" "$TARGET" 2>/dev/null; then
   echo "SKIP: review_decision は既に適用済み（べき等）"
   exit 0
 fi

--- a/scripts/apply-task-0129-schema.sh
+++ b/scripts/apply-task-0129-schema.sh
@@ -56,37 +56,37 @@ new_props = {
         "type": "string",
         "enum": ["go", "revise_plan", "human_approval_required", "no_go"],
         "description": (
-            "外部レビューの Decision。go→APPROVED候補 / revise_plan→CONDITIONAL / "
-            "human_approval_required→人間C-3強制 / no_go→REJECTED。"
-            "未知値・欠落は安全側（人間C-3強制）として扱う（TASK-0129 / #543）。"
+            "Decision of external review. go -> APPROVED candidate / revise_plan -> CONDITIONAL / "
+            "human_approval_required -> Force human C-3 / no_go -> REJECTED. "
+            "Unknown or missing values are treated as force human C-3 for safety (TASK-0129 / #543)."
         )
     },
     "review_risk": {
         "type": "string",
         "enum": ["low", "medium", "high"],
         "description": (
-            "外部レビューの Risk。high→mode最低high-risk・autonomous APPROVE無効化。"
-            "欠落は安全側（medium相当）として扱う（TASK-0129 / #543）。"
+            "Risk of external review. high -> minimum mode high-risk and disable autonomous APPROVE. "
+            "Missing values are treated as medium for safety (TASK-0129 / #543)."
         )
     },
     "review_stop_works": {
         "type": "array",
         "items": {"type": "string"},
         "description": (
-            "外部レビューの Stop-Work Conditions リスト。"
-            "#544/#551 機械トリガーへのマッピングは "
-            "docs/ai/review-gate-decision-mapping.md §4 参照（TASK-0129 / #543）。"
+            "List of Stop-Work Conditions from external review. "
+            "See docs/ai/review-gate-decision-mapping.md §4 for mapping to "
+            "#544/#551 machine triggers (TASK-0129 / #543)."
         )
     },
     "review_source": {
         "type": "string",
-        "description": "外部レビューアの識別子（例: river-reviewer / gemini / codex）。"
+        "description": "Identifier of the external reviewer (e.g., river-reviewer / gemini / codex)."
     },
     "lite_eligible": {
         "type": "boolean",
         "description": (
-            "Lite ゲート適用可否。承認境界変更 PBI では false 固定 "
-            "（mode-classification.md AC-10 Hardening Override / TASK-0129 / #543）。"
+            "Whether Lite gate is eligible. Fixed to false for approval boundary changes "
+            "(mode-classification.md AC-10 Hardening Override / TASK-0129 / #543)."
         )
     }
 }

--- a/tests/extras/ta-39-eh3-doc-light.sh
+++ b/tests/extras/ta-39-eh3-doc-light.sh
@@ -32,7 +32,7 @@ mkdir -p "$_T39_TMP/docs/working/_audit"
 # 実ファイルを複製して _audit log を tmp に向ける（WORKING_DIR は hook 内で固定）
 # → 実 audit ログ汚染のため、hook のコピー内の WORKING_DIR を tmp に書き換える
 cp "$_T39_HOOK_SRC" "$_T39_TMP/scripts/hooks/check-plan-hash.sh"
-# REPO_ROOT / WORKING_DIR を sed で tmp に固定
+# REPO_ROOT / WORKING_DIR はディレクトリ構造の模倣により自動的に tmp を指す
 _T39_HOOK="$_T39_TMP/scripts/hooks/check-plan-hash.sh"
 
 t39_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }

--- a/tests/extras/ta-39-eh3-doc-light.sh
+++ b/tests/extras/ta-39-eh3-doc-light.sh
@@ -30,7 +30,6 @@ mkdir -p "$_T39_TMP/docs/working/_audit"
 
 # docs/working/ シンボリックリンクは作らず、スクリプトを書き換える方法より
 # 実ファイルを複製して _audit log を tmp に向ける（WORKING_DIR は hook 内で固定）
-# → 実 audit ログ汚染のため、hook のコピー内の WORKING_DIR を tmp に書き換える
 cp "$_T39_HOOK_SRC" "$_T39_TMP/scripts/hooks/check-plan-hash.sh"
 # REPO_ROOT / WORKING_DIR はディレクトリ構造の模倣により自動的に tmp を指す
 _T39_HOOK="$_T39_TMP/scripts/hooks/check-plan-hash.sh"

--- a/tests/extras/ta-41-approve-hardening.sh
+++ b/tests/extras/ta-41-approve-hardening.sh
@@ -119,18 +119,18 @@ else
 fi
 
 # ── TC-06: AC-05 — ADR ファイルの存在 ──
-_t40_adr="$PG_T41_ROOT/docs/decisions/adr-001-approve-out-of-band.md"
-if [ -f "$_t40_adr" ]; then
+_t41_adr="$PG_T41_ROOT/docs/decisions/adr-001-approve-out-of-band.md"
+if [ -f "$_t41_adr" ]; then
   t41_pass "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md exists"
 else
   t41_fail "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md NOT found"
 fi
 
 # ── TC-07: AC-06 — apply-script の存在と syntax ──
-_t40_script="$PG_T41_ROOT/scripts/apply-approve-hardening.sh"
-if [ -f "$_t40_script" ]; then
+_t41_script="$PG_T41_ROOT/scripts/apply-approve-hardening.sh"
+if [ -f "$_t41_script" ]; then
   t41_pass "TC-07 AC-06: scripts/apply-approve-hardening.sh exists"
-  if sh -n "$_t40_script" 2>/dev/null; then
+  if sh -n "$_t41_script" 2>/dev/null; then
     t41_pass "TC-07 AC-06: apply-approve-hardening.sh shell syntax OK"
   else
     t41_fail "TC-07 AC-06: apply-approve-hardening.sh shell syntax error"

--- a/tests/extras/ta-41-approve-hardening.sh
+++ b/tests/extras/ta-41-approve-hardening.sh
@@ -12,23 +12,23 @@
 
 printf '\n=== TA-41: plangate approve hardening (TASK-0139 / #550) ===\n'
 
-PG_T40_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
-PG_T40_BIN="$PG_T40_ROOT/bin/plangate"
+PG_T41_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T41_BIN="$PG_T41_ROOT/bin/plangate"
 
-t40_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
-t40_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
-t40_skip() { printf '  [SKIP] %s\n' "$1"; }
+t41_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t41_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+t41_skip() { printf '  [SKIP] %s\n' "$1"; }
 
 # ── TC-01: AC-01 — cmd_approve の read -r 化 (static check) ──
 # TASK-0139 が apply 済みかどうかを確認する
-if grep -q 'read -r _ap_reason' "$PG_T40_BIN" && grep -q 'read -r _ap_conditions' "$PG_T40_BIN"; then
-  t40_pass "TC-01 AC-01: read -r _ap_reason and read -r _ap_conditions present"
+if grep -q 'read -r _ap_reason' "$PG_T41_BIN" && grep -q 'read -r _ap_conditions' "$PG_T41_BIN"; then
+  t41_pass "TC-01 AC-01: read -r _ap_reason and read -r _ap_conditions present"
 else
   # apply 未適用の場合: apply-script を dry-run して差分が出ることを確認
-  if sh "$PG_T40_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'read -r _ap_reason\|read -r _ap_conditions'; then
-    t40_skip "TC-01 AC-01: apply-script ready (apply pending); dry-run shows correct diff"
+  if sh "$PG_T41_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'read -r _ap_reason\|read -r _ap_conditions'; then
+    t41_skip "TC-01 AC-01: apply-script ready (apply pending); dry-run shows correct diff"
   else
-    t40_fail "TC-01 AC-01: read -r _ap_reason/conditions NOT present and dry-run shows no diff"
+    t41_fail "TC-01 AC-01: read -r _ap_reason/conditions NOT present and dry-run shows no diff"
   fi
 fi
 
@@ -36,112 +36,108 @@ fi
 # maintenance の read _ack が read -r _ack に変更されているか
 # maintenance L4 には 'read -r _ack' が存在するはず (apply 後)
 # apply 前は 'read _ack' が maintenance 内に存在する
-if grep -q 'read -r _ack' "$PG_T40_BIN"; then
-  t40_pass "TC-02 AC-02: read -r _ack present in bin/plangate"
+if grep -q 'read -r _ack' "$PG_T41_BIN"; then
+  t41_pass "TC-02 AC-02: read -r _ack present in bin/plangate"
 else
-  if sh "$PG_T40_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q '+      read -r _ack'; then
-    t40_skip "TC-02 AC-02: apply-script ready (apply pending); dry-run shows correct diff"
+  if sh "$PG_T41_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q '+      read -r _ack'; then
+    t41_skip "TC-02 AC-02: apply-script ready (apply pending); dry-run shows correct diff"
   else
-    t40_fail "TC-02 AC-02: read -r _ack NOT present and dry-run shows no diff"
+    t41_fail "TC-02 AC-02: read -r _ack NOT present and dry-run shows no diff"
   fi
 fi
 
 # ── TC-03: AC-03 — FAKE_PPID_COMM が TEST_MODE=1 なしでは L3 に影響しない ──
 # bin/plangate に PLANGATE_TEST_MODE=1 のガードが含まれているか (static check)
-if grep -q 'PLANGATE_TEST_MODE:-0.*PLANGATE_FAKE_PPID_COMM\|PLANGATE_TEST_MODE.*=.*1.*PLANGATE_FAKE_PPID_COMM' "$PG_T40_BIN"; then
-  t40_pass "TC-03 AC-03: PLANGATE_TEST_MODE guard present in bin/plangate"
+if grep -q 'PLANGATE_TEST_MODE:-0.*PLANGATE_FAKE_PPID_COMM\|PLANGATE_TEST_MODE.*=.*1.*PLANGATE_FAKE_PPID_COMM' "$PG_T41_BIN"; then
+  t41_pass "TC-03 AC-03: PLANGATE_TEST_MODE guard present in bin/plangate"
 else
-  if sh "$PG_T40_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'PLANGATE_TEST_MODE.*PLANGATE_FAKE_PPID_COMM'; then
-    t40_skip "TC-03 AC-03: apply-script ready (apply pending); dry-run shows correct diff"
+  if sh "$PG_T41_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'PLANGATE_TEST_MODE.*PLANGATE_FAKE_PPID_COMM'; then
+    t41_skip "TC-03 AC-03: apply-script ready (apply pending); dry-run shows correct diff"
   else
-    t40_fail "TC-03 AC-03: PLANGATE_TEST_MODE guard NOT present and dry-run shows no diff"
+    t41_fail "TC-03 AC-03: PLANGATE_TEST_MODE guard NOT present and dry-run shows no diff"
   fi
 fi
 
 # ── TC-04: AC-04 — c3.json overwrite block (--force なし → abort) ──
 # bin/plangate に TASK-0139 AC-04 の overwrite block が含まれているか
-if grep -q 'TASK-0139 AC-04: abort if c3.json exists' "$PG_T40_BIN"; then
-  t40_pass "TC-04 AC-04: c3.json overwrite block present (static check)"
+if grep -q 'TASK-0139 AC-04: abort if c3.json exists' "$PG_T41_BIN"; then
+  t41_pass "TC-04 AC-04: c3.json overwrite block present (static check)"
 
   # 動作検証: 既存 c3.json あり + --force なし → exit 非0
-  _t40_tmpdir=$(mktemp -d)
-  register_cleanup "$_t40_tmpdir"
-  _t40_task="TASK-APPROVE-HARDEN-TEST"
-  _t40_taskdir="$PG_T40_ROOT/docs/working/$_t40_task"
-  mkdir -p "$_t40_taskdir/approvals"
-  printf '# plan\n' > "$_t40_taskdir/plan.md"
+  _t41_task="TASK-APPROVE-HARDEN-TEST"
+  _t41_taskdir="$PG_T41_ROOT/docs/working/$_t41_task"
+  mkdir -p "$_t41_taskdir/approvals"
+  printf '# plan\n' > "$_t41_taskdir/plan.md"
   printf '{"task_id":"%s","c3_status":"APPROVED","phase":"C-3","plan_hash":"sha256:dummy"}\n' \
-    "$_t40_task" > "$_t40_taskdir/approvals/c3.json"
-  register_cleanup "$_t40_taskdir"
+    "$_t41_task" > "$_t41_taskdir/approvals/c3.json"
+  register_cleanup "$_t41_taskdir"
 
   # 非 interactive stdin で呼ぶ (L1 で弾かれるが、その前に overwrite block が先に発動するか確認)
   # Note: overwrite block は presence gate より前に実行される
-  _t40_out=$(sh "$PG_T40_BIN" approve "$_t40_task" 2>&1 </dev/null || true)
-  if printf '%s' "$_t40_out" | grep -q 'error: existing c3.json found'; then
-    t40_pass "TC-04 AC-04: --force なし + 既存 c3.json → abort (error: existing c3.json found)"
+  _t41_out=$(sh "$PG_T41_BIN" approve "$_t41_task" 2>&1 </dev/null || true)
+  if printf '%s' "$_t41_out" | grep -q 'error: existing c3.json found'; then
+    t41_pass "TC-04 AC-04: --force なし + 既存 c3.json → abort (error: existing c3.json found)"
   else
     # L1 で弾かれた場合は overwrite block まで到達しないため skip
-    if printf '%s' "$_t40_out" | grep -q 'L1 interactive TTY required\|L1\|L2\|L3'; then
-      t40_skip "TC-04 AC-04: overwrite check reachability: blocked at L1/L2/L3 gate (expected in non-TTY env)"
+    if printf '%s' "$_t41_out" | grep -q 'L1 interactive TTY required\|L1\|L2\|L3'; then
+      t41_skip "TC-04 AC-04: overwrite check reachability: blocked at L1/L2/L3 gate (expected in non-TTY env)"
     else
-      t40_fail "TC-04 AC-04: --force なし + 既存 c3.json: expected 'error: existing c3.json found', got: $_t40_out"
+      t41_fail "TC-04 AC-04: --force なし + 既存 c3.json: expected 'error: existing c3.json found', got: $_t41_out"
     fi
   fi
 
   # cleanup は register_cleanup に委託済み
 else
-  if sh "$PG_T40_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'TASK-0139 AC-04'; then
-    t40_skip "TC-04 AC-04: apply-script ready (apply pending); dry-run shows correct diff"
+  if sh "$PG_T41_ROOT/scripts/apply-approve-hardening.sh" --dry-run 2>/dev/null | grep -q 'TASK-0139 AC-04'; then
+    t41_skip "TC-04 AC-04: apply-script ready (apply pending); dry-run shows correct diff"
   else
-    t40_fail "TC-04 AC-04: overwrite block NOT present and dry-run shows no diff"
+    t41_fail "TC-04 AC-04: overwrite block NOT present and dry-run shows no diff"
   fi
 fi
 
 # ── TC-05: AC-04 — c3.json 上書き --force 付き → abort しない（apply 後のみ検証）
-if grep -q 'TASK-0139 AC-04: abort if c3.json exists' "$PG_T40_BIN"; then
+if grep -q 'TASK-0139 AC-04: abort if c3.json exists' "$PG_T41_BIN"; then
   # --force フラグを渡した場合は overwrite block をスキップする（エラーメッセージが出ない）
   # 非 interactive なので L1 で弾かれることが期待値
-  _t40_tmpdir2=$(mktemp -d)
-  register_cleanup "$_t40_tmpdir2"
-  _t40_task2="TASK-FORCE-OVERWRITE-TEST"
-  _t40_taskdir2="$PG_T40_ROOT/docs/working/$_t40_task2"
-  mkdir -p "$_t40_taskdir2/approvals"
-  printf '# plan\n' > "$_t40_taskdir2/plan.md"
+  _t41_task2="TASK-FORCE-OVERWRITE-TEST"
+  _t41_taskdir2="$PG_T41_ROOT/docs/working/$_t41_task2"
+  mkdir -p "$_t41_taskdir2/approvals"
+  printf '# plan\n' > "$_t41_taskdir2/plan.md"
   printf '{"task_id":"%s","c3_status":"APPROVED","phase":"C-3","plan_hash":"sha256:dummy"}\n' \
-    "$_t40_task2" > "$_t40_taskdir2/approvals/c3.json"
-  register_cleanup "$_t40_taskdir2"
+    "$_t41_task2" > "$_t41_taskdir2/approvals/c3.json"
+  register_cleanup "$_t41_taskdir2"
 
-  _t40_out2=$(sh "$PG_T40_BIN" approve "$_t40_task2" --force 2>&1 </dev/null || true)
-  if printf '%s' "$_t40_out2" | grep -q 'error: existing c3.json found'; then
-    t40_fail "TC-05 AC-04: --force 付き + 既存 c3.json: should NOT abort but got 'error: existing c3.json found'"
+  _t41_out2=$(sh "$PG_T41_BIN" approve "$_t41_task2" --force 2>&1 </dev/null || true)
+  if printf '%s' "$_t41_out2" | grep -q 'error: existing c3.json found'; then
+    t41_fail "TC-05 AC-04: --force 付き + 既存 c3.json: should NOT abort but got 'error: existing c3.json found'"
   else
-    t40_pass "TC-05 AC-04: --force 付き + 既存 c3.json → overwrite block をスキップ（abort なし）"
+    t41_pass "TC-05 AC-04: --force 付き + 既存 c3.json → overwrite block をスキップ（abort なし）"
   fi
   # cleanup は register_cleanup に委託済み
 else
-  t40_skip "TC-05 AC-04: apply pending (will be verified after apply)"
+  t41_skip "TC-05 AC-04: apply pending (will be verified after apply)"
 fi
 
 # ── TC-06: AC-05 — ADR ファイルの存在 ──
-_t40_adr="$PG_T40_ROOT/docs/decisions/adr-001-approve-out-of-band.md"
+_t40_adr="$PG_T41_ROOT/docs/decisions/adr-001-approve-out-of-band.md"
 if [ -f "$_t40_adr" ]; then
-  t40_pass "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md exists"
+  t41_pass "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md exists"
 else
-  t40_fail "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md NOT found"
+  t41_fail "TC-06 AC-05: docs/decisions/adr-001-approve-out-of-band.md NOT found"
 fi
 
 # ── TC-07: AC-06 — apply-script の存在と syntax ──
-_t40_script="$PG_T40_ROOT/scripts/apply-approve-hardening.sh"
+_t40_script="$PG_T41_ROOT/scripts/apply-approve-hardening.sh"
 if [ -f "$_t40_script" ]; then
-  t40_pass "TC-07 AC-06: scripts/apply-approve-hardening.sh exists"
+  t41_pass "TC-07 AC-06: scripts/apply-approve-hardening.sh exists"
   if sh -n "$_t40_script" 2>/dev/null; then
-    t40_pass "TC-07 AC-06: apply-approve-hardening.sh shell syntax OK"
+    t41_pass "TC-07 AC-06: apply-approve-hardening.sh shell syntax OK"
   else
-    t40_fail "TC-07 AC-06: apply-approve-hardening.sh shell syntax error"
+    t41_fail "TC-07 AC-06: apply-approve-hardening.sh shell syntax error"
   fi
 else
-  t40_fail "TC-07 AC-06: scripts/apply-approve-hardening.sh NOT found"
+  t41_fail "TC-07 AC-06: scripts/apply-approve-hardening.sh NOT found"
 fi
 
 # ── TC-08: ta-41 が run-tests.sh で認識されている（自己証明） ──
-t40_pass "TC-08 AC-06: ta-41 is recognized by run-tests.sh (this test is running)"
+t41_pass "TC-08 AC-06: ta-41 is recognized by run-tests.sh (this test is running)"


### PR DESCRIPTION
## Summary

- fix: Gemini V-3 HIGH/medium 指摘への対応（post-merge followups）
- fix: OpenSSF Scorecard セキュリティアラート修正

### OpenSSF Scorecard 修正内容

**Pinned-Dependencies (#25/#26/#27/#28/#29)**
- `actions/checkout@v7` → `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7` (全5 workflow)

**Pinned-Dependencies (#15)**
- `actions/setup-python@v6` → `@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6` (schema-validate.yml)

**Pinned-Dependencies (#17)**
- `pip install 'jsonschema>=4,<5'` → `pip install 'jsonschema==4.23.0'` (exact version pin)

**Token-Permissions (#21/#18)**
- `sync-plugin-plangate.yml` / `release-docs-sync.yml`: workflow-level `contents: write` → `permissions: {}` + job-level permissions に移動

### 適用スクリプト

`.github/workflows/*.yml` は HO (Hardening Override) 対象のため `scripts/fix-workflow-security.sh` 経由で Human が適用。

## Test plan

- [x] 全 CI チェック PASS（settings wiring drift / check / privacy / validate / plangate CLI tests / SKIP_REASON 追認 / Markdown lint）
- [x] OpenSSF Scorecard アラート 7件 対応済み（Pinned-Dependencies 5件 + pip 1件 + Token-Permissions 2件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)