### PR TITLE
fix(security): SECURITY.md に脆弱性報告 URL を追記 (Scorecard #3)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,10 @@ This repository is maintained from the default branch. Please test against `main
 
 ## Reporting a Vulnerability
 
-Please do not open a public issue for a suspected vulnerability. Use GitHub's private vulnerability reporting flow from the repository Security tab when available.
+Please do not open a public issue for a suspected vulnerability.
+
+**Preferred method:** Use GitHub's private vulnerability reporting:
+[https://github.com/s977043/plangate/security/advisories/new](https://github.com/s977043/plangate/security/advisories/new)
 
 Include:
 


### PR DESCRIPTION
## Summary

- OpenSSF Scorecard `SecurityPolicy` アラート #3 の修正
- 「no linked content found」警告を解消するため GitHub private vulnerability reporting URL を明示追加

## 変更内容

```
- Use GitHub's private vulnerability reporting flow from the repository Security tab when available.
+ **Preferred method:** Use GitHub's private vulnerability reporting:
+ https://github.com/s977043/plangate/security/advisories/new
```

## Test plan

- [ ] CI PASS
- [ ] Scorecard 再スキャン後に #3 SecurityPolicy スコアが改善すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)