### PR TITLE
fix(security): CodeQL SAST ワークフロー追加 (Scorecard #7)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# Scorecard #7 SAST: Python コードを CodeQL で静的解析する。
+# スクリプト類 (scripts/*.py) を対象。シェルスクリプトは対象外。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 5 * * 1'  # 毎週月曜 05:30 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: '/language:python'
+


### PR DESCRIPTION
## Summary

OpenSSF Scorecard `SAST` アラート #7「SAST tool is not run on all commits」を修正。

`.github/workflows/codeql.yml` を新規追加し、Python コードに対して CodeQL の `security-extended` クエリを実行する。

### 実行トリガー

- `push` to `main`
- `pull_request` to `main`
- 週次スケジュール（毎週月曜 05:30 UTC）

### ピン済み SHA

| Action | SHA |
|--------|-----|
| `actions/checkout@v4` | `11bd71901bbe5b1630ceea73d27597364c9af683` |
| `github/codeql-action@v3` | `dd903d2e4f5405488e5ef1422510ee31c8b32357` |

### 付随

- `scripts/add-codeql-workflow.sh`: HO 対象のため Human-run apply スクリプトを同梱

## Test plan

- [ ] CI PASS（codeql analyze ジョブ含む）
- [ ] Scorecard 再スキャン後に #7 SAST スコアが改善すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)