### PR TITLE
chore(release): v8.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "PlanGate — AI coding governance OS for Claude Code and Codex. 4-Gate approval system, Intent/Mode classification, Skill Policy Router, and agent control layer.",
-    "version": "8.14.0"
+    "version": "8.15.0"
   },
   "plugins": [
     {
       "name": "plangate",
       "description": "AI coding governance OS. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer for Claude Code.",
-      "version": "8.14.0",
+      "version": "8.15.0",
       "author": {
         "name": "PlanGate contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.15.0 - 2026-06-23
+
+feat: Review Gate 機械化 + EH-3 doc-light + approve 強化 + CLI テスト完備 + OpenSSF Scorecard 対応
+
+外部レビュー結果（Decision / risk）を c3_status へ自動マッピングし承認境界を機械執行する Review Gate（TASK-0129）、EH-3 フックに非 HO `.md` ファイルを記録付きで自動 SKIP する doc-light 経路（TASK-0138）、approve サブコマンドのハードニング（TASK-0139）、CLI サブコマンドの統合テスト完備（TASK-0140）を追加。あわせて OpenSSF Scorecard の 10 件のアラートを解消（SHA ピン・Token-Permissions・SECURITY.md・CodeQL）。
+
+### Added
+
+- **Review Gate 機械化（TASK-0129 / #543）** — 外部レビューの `Decision`（go / revise_plan / human_approval_required / no_go）と `review_risk`（low / medium / high）を `c3_status` へ自動マッピングし、`bin/plangate exec` での機械執行を実現。`apply-task-0129-schema.sh` / `apply-task-0129-wc.sh` で c3-approval スキーマと working-context を更新。C-1 Loop check（計画ループ検出）を同梱。
+- **EH-3 doc-light 経路（TASK-0138 / #528）** — `check-plan-hash.sh` に非 HO `.md` ファイルを記録付き自動 SKIP する doc-light 経路を追加。maintenance ファイル存在時はトークンライフサイクルを優先し doc-light を発火させない。`skip-decision-log.jsonl` に `EH-3_DOC_LIGHT_SKIP` イベントを記録。`ta-39` で 6 TC / 303 PASS。
+- **`plangate approve` ハードニング（TASK-0139 / #550）** — approve サブコマンドに `read -r` による理由・条件・確認の対話入力、`PLANGATE_TEST_MODE` ガード、c3.json 上書きブロック（`--force` で上書き可）を追加。ADR `docs/decisions/adr-001-approve-out-of-band.md` を同梱。`ta-41` で 302 PASS。
+- **CLI サブコマンド統合テスト（TASK-0140 / #515 #529）** — `ta-42` を新規追加し `bin/plangate` の全サブコマンド（plan / exec / review / approve / validate-schemas / metrics / doctor 等）を統合テストでカバー。302 PASS / 0 FAIL。
+- **OpenSSF Scorecard 対応** — Pinned-Dependencies（#25-29/#15/#17）: `actions/checkout@v7` / `actions/setup-python@v6` / pip を SHA ピンに変更（全 5 ワークフロー）。Token-Permissions（#21/#18）: `sync-plugin-plangate.yml` / `release-docs-sync.yml` のワークフローレベル `contents:write` を `permissions:{}` + ジョブレベルへ移動。SecurityPolicy（#3）: `SECURITY.md` に脆弱性報告 URL を追記。SAST（#7）: `codeql.yml` を追加し Python コードを CodeQL `security-extended` で解析。
+
+### Fixed
+
+- **plangate-setup スキル + Codex スキル追加** — plangate-setup スキル修正・Codex スキル追加・リリースフローへのプラグイン同期組み込み（#597）
+- **intent-classifier / skill-policy-router** — PlanGate CLI ops 認識を追加（#593）
+- **Gemini V-3 指摘対応** — ta-39 / ta-41 / ta-42 / apply スクリプト群の HIGH・medium 指摘を複数ラウンドで解消（#607）
+
 ## v8.14.0 - 2026-06-15
 
 feat: C-3 レビュー HTML 出力（plangate render）+ 人間ワンアクション C-3 承認（plangate approve）

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ flowchart LR
 
 ## 最新状態
 
-PlanGate は **v8.14.0**（Latest）で C-3 レビュー HTML 出力（`plangate render`）と人間ワンアクション C-3 承認（`plangate approve`）を導入しました。v8.13.0 で全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）、エージェント model tier、Hook enforcement の実態整合を実施しました。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
+PlanGate は **v8.15.0**（Latest）で Review Gate 機械化・EH-3 doc-light・approve ハードニング・CLI テスト完備・OpenSSF Scorecard 対応を導入しました。v8.14.0 で C-3 レビュー HTML 出力（`plangate render`）と人間ワンアクション C-3 承認（`plangate approve`）を導入しました。v8.13.0 で全体監査駆動の健全化（docs 鮮度・テスト隔離・スリム化）、エージェント model tier、Hook enforcement の実態整合を実施しました。v8.12.0 で並列レビューア実行・Plugin sync 品質ガード・導入促進（Why PlanGate）・運用ガードを整備しました。v8.11.0 で Claude Code / Codex Plugin の正式配布に対応し、v8.10.0 までに Hook enforcement・Metrics v1・Harness Improvement Governance の上に **Reporting & Retrospective v1** を載せ、events.ndjson から sprint retrospective を決定論的に導出できるガバナンスハーネスへ到達しました。これにより [EPIC #193 Harness Improvement Roadmap](https://github.com/s977043/plangate/issues/193) は **完遂（CLOSED / COMPLETED）** しています。
 
 v8.7.0〜v8.10.0 はリリース済みで、外部 OSS 利用者の **「どこまで使えばよいか不明」問題** に応える OSS 整備（段階的導入ガイド / Plugin 成熟化 / バージョニング安定性ポリシー）と、自己評価・context 分離・モデル特性対応・reporting の各基盤を順次投入しました。
 
 | 項目 | 状態 |
 | --- | --- |
-| 最新リリース | **v8.13.0**（Latest, 2026-06-11）— 全体健全化（監査駆動の鮮度・整合・隔離改善）+ エージェント model tier + enforcement 実態整合 |
+| 最新リリース | **v8.15.0**（Latest, 2026-06-23）— Review Gate 機械化 + EH-3 doc-light + approve ハードニング + CLI テスト完備 + OpenSSF Scorecard 対応 |
 | リリース済 | **v8.7.0** OSS 整備 3 主軸 + Run Outcome Review v1 (#228) + Trace Timeline v1 (Experimental, #229) / **v8.8.0** Keep Rate v1・Dynamic Context Engine v1・Model Profile v2・Gate Event Normalization・Dogfooding Eval v1 / **v8.9.0** Reporting & Retrospective v1 / **v8.10.0** Codex CLI parity・Hook/Guard 拡充・Skill 整備 / **v8.11.0** Claude Code / Codex Plugin 正式配布対応 |
 | Roadmap | **EPIC #193 完遂（CLOSED / COMPLETED）** — Phase 0〜6 + Governance + Lightweight Plan Quality Checks 全 Done、子 PBI 12/12 CLOSED |
 | Hook enforcement | **12/12 hooks 実装済み**（EH-1〜EH-9 + EHS-1〜EHS-3。物理配線は 6/12 — 残りは [#500](https://github.com/s977043/plangate/issues/500) で配線予定、詳細は [`docs/ai/hook-enforcement.md`](docs/ai/hook-enforcement.md)） |

--- a/plugin/plangate/.claude-plugin/plugin.json
+++ b/plugin/plangate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plangate",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "description": "PlanGate — AI coding governance OS for Claude Code and Codex. Provides 4-Gate approval system, Intent/Mode classification, Skill Policy Router, Evidence Ledger, and agent control layer.",
   "author": {
     "name": "PlanGate contributors"

--- a/plugin/plangate/README.md
+++ b/plugin/plangate/README.md
@@ -3,7 +3,7 @@
 PlanGate — a governance OS for AI-assisted coding.
 Provides Intent/Mode classification, a 4-Gate approval system, and an agent control layer as a Claude Code plugin.
 
-- **Version**: v8.13.0
+- **Version**: v8.15.0
 - **Source**: <https://github.com/s977043/plangate>
 
 ## Install

--- a/plugin/plangate/rules/working-context.md
+++ b/plugin/plangate/rules/working-context.md
@@ -199,6 +199,7 @@ confirmed_by）。人間 confirm 済のみ追記。#200 期間集計の入力源
 - ⚠️ 依存関係（Agent ↔ Human）
 - 各タスクに Owner（agent / human）と 🚩チェックポイントを明記
 - L-0〜V-4, PR作成はworkflow-conductorが自動制御するため含めない
+- 各タスクに `rollback:` を記載（戻し手順）。**必須=high-risk / critical の実装タスク**。standard 以下は任意、検証/読取のみは `rollback:不要` と明記可
 
 ### test-cases.md（テストケース定義）
 

--- a/plugin/plangate/skills/plan-review-gate/SKILL.md
+++ b/plugin/plangate/skills/plan-review-gate/SKILL.md
@@ -23,42 +23,6 @@ PlanGate の **plan ゲート（C-1 セルフレビュー / C-2 外部レビュ�
 
 mode に応じた適用範囲・項目数（17 項目構成）は `.claude/rules/working-context.md` の C-1 節および `.claude/rules/mode-classification.md` フェーズ適用マトリクスを正本とする。FAIL があれば修正後再実行。evidence は FAIL 時必須（`evidence/c1-review/`）。
 
-### C-1 追加品質ゲート: Plan 実行可能性
-
-Superpowers の `writing-plans` から取り込む観点。ここでは Superpowers を依存として導入せず、PlanGate の C-1 に **plan を実行可能な作業指示書として読めるか** を確認する観点だけを吸収する。
-
-#### Task Sizing Rules
-
-各 Task / Step は以下を満たすこと。
-
-- 独立して検証可能な成果物を持つ
-- reviewer が単独で approve / reject できる粒度である
-- setup / config / docs は、それを必要とする成果物の Task に含める
-- 1 Task に複数の責務を詰め込まない
-- Task 間の依存関係・公開インターフェース・順序制約が明示されている
-- 変更対象ファイル、検証コマンド、期待結果が具体的に書かれている
-
-#### No Placeholders Rule
-
-以下が `plan.md` / `todo.md` / `test-cases.md` / `design.md` に残っている場合は C-1 FAIL として扱う。
-
-- `TBD`
-- `TODO`（未解決の実装TODO。チェックリスト用途は除く）
-- `後で実装`
-- `必要に応じて`
-- `適切に`
-- `いい感じに`
-- `エラーハンドリングを追加` だけで具体的な失敗条件・期待挙動がない
-- `テストを書く` だけで具体的な入力・期待値・検証コマンドがない
-- `Task N と同様` だけで、当該 Task 単独で実行できない
-- 未定義の関数名・型名・ファイルパス・コマンドを参照している
-
-#### 判定
-
-- `ultra-light` / `light`: 不備は WARN 可。ただし exec に必要なファイル・検証コマンドが欠ける場合は FAIL。
-- `standard`: Task Sizing / No Placeholders の重大不備は FAIL。
-- `high-risk` / `critical`: Task Sizing / No Placeholders の不備は FAIL。C-3 承認前に必ず修正する。
-
 ## C-2 外部レビュー
 
 - 2 レーン責務（設計妥当性 / コードベース整合）と R-NNN 採番・追記専用集約の規約は `.claude/rules/review-principles.md` §7-bis を正本とする


### PR DESCRIPTION
## Summary

v8.15.0 CHANGELOG 追加。

### 含む変更

- TASK-0129: Review Gate 機械化（Decision→c3_status マッピング）
- TASK-0138: EH-3 doc-light 経路（非 HO .md 自動 SKIP）
- TASK-0139: plangate approve ハードニング
- TASK-0140: CLI サブコマンド統合テスト（ta-42）
- OpenSSF Scorecard 対応（SHA ピン / Token-Permissions / SECURITY.md / CodeQL）

## Test plan

- [ ] CI PASS
- [ ] マージ後に `git tag v8.15.0 origin/main && git push origin v8.15.0` で tag を付与（Human-owned）
- [ ] `gh release create v8.15.0` で GitHub Release を発行（Human-owned）

🤖 Generated with [Claude Code](https://claude.com/claude-code)