### PR TITLE
plan(#500): TASK-0141 EH-2 strict JSON + stdin fallback

### DIFF
--- a/docs/working/TASK-0141/INDEX.md
+++ b/docs/working/TASK-0141/INDEX.md
@@ -1,0 +1,21 @@
+# INDEX — TASK-0141
+
+## 現在フェーズ: C-1 完了 → C-3 ゲート待ち
+
+| ファイル | 役割 | 状態 |
+|---------|------|------|
+| pbi-input.md | A: PBI INPUT PACKAGE | 完了 |
+| plan.md | B: EXECUTION PLAN | 完了（high-risk）|
+| todo.md | B: EXECUTION TODO | 完了 |
+| test-cases.md | B: テストケース定義 | 完了 |
+| review-self.md | C-1: セルフレビュー | PASS |
+| current-state.md | 現在状態スナップショット | 未作成 |
+
+## 関連 Issue
+
+- #500: 承認境界の強制実態ギャップ是正（親）
+- EPIC #527: Enforcement Integrity Roadmap
+
+## Plan Hash
+
+`sha256:9cd4f16a9896b1e390d11a6e8fb8c3a107be0fbb3331c166fd417deb7390e628`

--- a/docs/working/TASK-0141/current-state.md
+++ b/docs/working/TASK-0141/current-state.md
@@ -1,0 +1,21 @@
+# current-state.md — TASK-0141
+
+## 現在フェーズ: C-3 ゲート待ち
+
+- C-1 セルフレビュー: PASS（critical/major なし、WARN 2 件は許容）
+- 次アクション: **Human が plan/todo/test-cases/review-self を確認し C-3 APPROVE**
+  → 承認後 exec フェーズへ
+
+## ブロッカー
+
+- H-01: C-3 ゲート（Human APPROVE 必須、high-risk モードのため autonomous APPROVE 不可）
+
+## 成果物
+
+| ファイル | 状態 |
+|---------|------|
+| pbi-input.md | 完了 |
+| plan.md | 完了 |
+| todo.md | 完了 |
+| test-cases.md | 完了 |
+| review-self.md | C-1 PASS |

--- a/docs/working/TASK-0141/pbi-input.md
+++ b/docs/working/TASK-0141/pbi-input.md
@@ -1,0 +1,72 @@
+# PBI INPUT PACKAGE — TASK-0141
+
+## Context / Why
+
+Issue #500「承認境界の強制実態ギャップ是正」の最優先サブセット。
+EPIC #527 最終 open child。
+
+EH-2（check-c3-approval.sh）は `grep|sed` による c3_status 抽出を使っており、
+壊れた/細工された c3.json（コメント行や別キーに "c3_status": "APPROVED"）で
+**承認判定が誤って通過するリスク**がある。EH-3 は既に python3 strict JSON 化済みのため、
+EH-2 が非対称に脆い状態になっている。
+
+また EH-1/EH-2 は `PLANGATE_HOOK_TASK` 環境変数が未設定 + arg なしの場合に
+**無条件 SKIP（allow）** するため、Claude Code が native に env を注入しない
+セッションでは**発火しない**。stdin `tool_input.file_path` から TASK-ID を解決する
+fallback が必要。
+
+Codex 設計相談 (2026-06-23):
+- AC-1〜2 (settings wiring / doctor) は別 TASK に分離
+- 本 TASK は AC-3/AC-4/テスト追加に集中
+
+## What（Scope）
+
+### In scope
+
+- **AC-1**: EH-2（check-c3-approval.sh）の c3_status を python3 strict JSON 解析に変更
+  - 壊れた JSON / 非 object / フィールド欠落 → fail-safe で空文字（= 非APPROVED）
+  - EH-3（check-plan-hash.sh）と対称化
+  - apply-script: `scripts/apply-task-0141-eh2-strict.sh`
+- **AC-2**: EH-1/EH-2 に stdin `tool_input.file_path` fallback を追加
+  - env `PLANGATE_HOOK_TASK` → arg → stdin JSON パースの優先順
+  - `docs/working/TASK-XXXX/` パターンで TASK-ID を抽出
+  - apply-script: 同スクリプトに統合（EH-1/EH-2 両方をパッチ）
+- **AC-3**: `tests/extras/ta-06-hooks.sh` のログ握りつぶし解消
+  - `>/dev/null 2>&1` を排除 → `[PASS]/[FAIL]` を run-tests.sh が確認できる形式に
+  - 直接編集可（test ファイルは HO 非対象）
+- **AC-4**: ta-43 新設（EH-2 strict JSON の自動テスト）
+  - 壊れた JSON → allow（warn）
+  - コメント埋め込み → allow（warn）
+  - 正常 APPROVED JSON → pass
+  - run-tests.sh に自動 include
+
+### Out of scope
+
+- AC-1,2 of #500 (settings-wiring-contract / doctor --check-settings) → 別 TASK
+- EH-4/5/7 配線、EHS-1/2/3 発火条件 → 別 TASK
+- maintenance.json 大規模 fixture（→ 既存 ta-06 の unsilence で先行カバー）
+
+## 受入基準
+
+| ID | 基準 |
+|----|------|
+| AC-1 | check-c3-approval.sh の c3_status が python3 strict JSON 解析（壊れた JSON → 非APPROVED 扱い） |
+| AC-2 | EH-1/EH-2 が stdin `tool_input.file_path` から TASK-ID を解決（env/arg なし時） |
+| AC-3 | ta-06 が hook テスト結果を PASS/FAIL として run-tests.sh に報告 |
+| AC-4 | ta-43 が壊れた JSON・コメント埋め込み・正常 JSON の 3 ケースを検証 |
+| AC-5 | 全テスト（run-tests.sh）が 300+ PASS、FAIL=0 |
+
+## Notes from Refinement
+
+- apply-script は HO パス（scripts/hooks/）をパッチするため Human が実行
+- EH-1/EH-2 の stdin 読み込みは `cat 2>/dev/null || true` でハングしない実装必須
+- python3 パターンは check-plan-hash.sh の既存実装を参照
+- ta-43 はテスト専用の hooks copy を使って実環境を汚染しない（ta-39 パターン踏襲）
+
+## Estimation Evidence
+
+- Risks: HO apply-script のテストが困難（本体 hooks をコピーして dry-run）
+- Unknowns: check-plan-exists.sh (EH-1) の stdin 構造（既読済み・同型のため低リスク）
+- Assumptions: python3 は CI 環境に存在（既存 hooks で使用中）
+
+**モード判定**: high-risk（承認境界 + HO apply-script + Hardening Override 対象パス）

--- a/docs/working/TASK-0141/plan.md
+++ b/docs/working/TASK-0141/plan.md
@@ -1,0 +1,83 @@
+# EXECUTION PLAN — TASK-0141
+
+## Goal
+
+EH-2 の承認判定を python3 strict JSON 化し、EH-1/EH-2 に stdin fallback を追加する。
+ta-06 ログ握りつぶしを解消し、ta-43 で EH-2 strict を自動テスト化する。
+
+## Constraints / Non-goals
+
+- scripts/hooks/*.sh は HO → apply-script パターン（AI 作成、Human 適用）
+- settings wiring / doctor 変更・EH-4/5/7/EHS 群は別 TASK
+
+## Work Breakdown
+
+### Step 1: apply-script 生成（AC-1/AC-2）
+
+Output: scripts/apply-task-0141-eh2-strict.sh
+
+EH-2 python3 strict JSON 化:
+  - check-c3-approval.sh の grep/sed を python3 json.load に置換
+  - 壊れた JSON / 非 object / フィールド欠落 → 空文字（fail-safe）
+  - EH-3（check-plan-hash.sh）と対称
+
+stdin fallback（EH-1/EH-2 共通）:
+  - env PLANGATE_HOOK_TASK → arg → stdin tool_input.file_path の優先順
+  - python3 で file_path から TASK-XXXX を抽出
+  - cat 2>/dev/null || true でハング防止
+
+Owner: AI（apply は Human）
+CP1: dry-run で期待差分が出ること
+
+### Step 2: ta-43 新設（AC-4）
+
+Output: tests/extras/ta-43-eh2-strict-json.sh
+
+- TC-01: 正常 APPROVED c3.json → allow
+- TC-02: 壊れた JSON → warn + allow（非 APPROVED 扱い）
+- TC-03: コメント行に "c3_status":"APPROVED" 埋め込み → 非 APPROVED
+- TC-04: c3_status フィールドなし → 非 APPROVED
+- TC-05: stdin file_path から TASK-ID 解決 → APPROVED 判定
+- TC-06: stdin なし + env なし → SKIP（allow）
+
+Owner: AI（test ファイルは非 HO）
+CP2: run-tests.sh で ta-43 が認識される
+
+### Step 3: ta-06 修正（AC-3）
+
+Output: tests/extras/ta-06-hooks.sh（直接編集・非 HO）
+
+- [>/dev/null 2>&1] を排除
+- hook test 結果を [PASS]/[FAIL] 形式で run-tests.sh に報告
+Owner: AI
+CP3: run-tests.sh で ta-06 の結果が PASS/FAIL として見える
+
+## Files / Components to Touch
+
+- scripts/apply-task-0141-eh2-strict.sh  (新規, AI 作成)
+- tests/extras/ta-43-eh2-strict-json.sh  (新規, AI 作成)
+- tests/extras/ta-06-hooks.sh            (修正, AI 直接編集・非 HO)
+- scripts/hooks/check-c3-approval.sh     (HO パッチ対象, Human 適用)
+- scripts/hooks/check-plan-exists.sh     (HO パッチ対象, Human 適用)
+
+## Testing Strategy
+
+- Unit: ta-43（hooks コピーで直接実行）
+- Integration: apply-script --dry-run でパッチ差分検証
+- V-1: sh tests/run-tests.sh 全 PASS、FAIL=0
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| python3 エラーで c3_status が空文字 | 2>/dev/null で保護（空文字=非 APPROVED が fail-safe） |
+| stdin 読み込みでハング | cat 2>/dev/null || true で防御 |
+| ta-06 unsilence で hook テスト失敗露出 | 意図的（露出が目的）|
+
+## Mode 判定
+
+モード: high-risk
+- 変更ファイル数: 5
+- 受入基準数: 5
+- リスク: 承認境界・Hardening Override 対象パス
+- lite_eligible: false（Hardening Override パス含む）

--- a/docs/working/TASK-0141/review-self.md
+++ b/docs/working/TASK-0141/review-self.md
@@ -1,0 +1,42 @@
+# SELF REVIEW — TASK-0141 (C-1)
+
+## Plan チェック（7項目）
+
+| ID | 観点 | 判定 | 備考 |
+|----|------|------|------|
+| C1-PLAN-01 | 受入基準の網羅性（AC-1〜AC-5 全て plan に対応） | PASS | Step 1〜3 が AC-1〜5 を網羅 |
+| C1-PLAN-02 | Unknowns の処理（リスク欄に記載） | PASS | python3 エラー・stdin ハング・ta-06 露出を列挙 |
+| C1-PLAN-03 | スコープ制御（settings wiring / doctor / EH-4/5/7 を明示 Out of scope） | PASS | Non-goals に明記 |
+| C1-PLAN-04 | テスト戦略（ta-43 / --dry-run / run-tests.sh） | PASS | Testing Strategy 節に記載 |
+| C1-PLAN-05 | Work Breakdown の Output 明示 | PASS | 各 Step に Output 明記 |
+| C1-PLAN-06 | 依存関係（A-07 は A-03 の後、H-01 は A-03〜A-05 後） | PASS | todo.md depends_on 記載 |
+| C1-PLAN-07 | 動作検証自動化（ta-43 + run-tests.sh） | PASS | |
+
+## ToDo チェック（5項目）
+
+| ID | 観点 | 判定 | 備考 |
+|----|------|------|------|
+| C1-TODO-01 | タスク粒度（各 Step が 1 commit 相当） | PASS | A-03/A-04/A-05 が独立 |
+| C1-TODO-02 | depends_on 設定（H-01 が A-03〜A-05 に依存） | PASS | |
+| C1-TODO-03 | CP（チェックポイント）設定（CP1〜CP3 あり） | PASS | |
+| C1-TODO-04 | Iron Law 遵守（HO apply は Human、c3.json 代理発行しない） | PASS | H-02 で明示 |
+| C1-TODO-05 | 完了条件（V-1 PASS + handoff.md） | PASS | A-08 に明記 |
+
+## TestCases チェック（3項目）
+
+| ID | 観点 | 判定 | 備考 |
+|----|------|------|------|
+| C1-TC-01 | 受入基準との紐付き（AC-1〜5 全て TC に対応） | PASS | マッピング表あり |
+| C1-TC-02 | Edge case 網羅（空ファイル・CONDITIONAL・解析失敗） | PASS | エッジケース節に記載 |
+| C1-TC-03 | 自動化可否（ta-43 で自動、ta-06 は run-tests.sh で確認） | PASS | |
+
+## 総合判定
+
+**PASS**（critical/major 指摘なし）
+
+## 軽微 WARN
+
+- W-01: stdin fallback の TC-05 は apply 後のみ検証可能（apply 前は SKIP になる）
+  → ta-43 は hook コピーで apply 済み状態をシミュレートするため許容
+- W-02: ta-06 unsilence によりフック系テストの既存失敗が露出する可能性あり
+  → 意図的（露出 = 改善のため）、別 TASK で対処

--- a/docs/working/TASK-0141/test-cases.md
+++ b/docs/working/TASK-0141/test-cases.md
@@ -1,0 +1,29 @@
+# TEST CASES — TASK-0141
+
+## 受入基準 → テストケースマッピング
+
+| AC | テストケース |
+|----|------------|
+| AC-1 (EH-2 strict JSON) | TC-01〜TC-04（ta-43）|
+| AC-2 (stdin fallback) | TC-05〜TC-06（ta-43）|
+| AC-3 (ta-06 unsilence) | TC-07（run-tests.sh で PASS/FAIL 確認）|
+| AC-4 (ta-43 自動テスト) | ta-43 の自己証明（TC-08）|
+| AC-5 (全テスト PASS) | run-tests.sh FAIL=0 |
+
+## テストケース一覧（ta-43）
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|---------|------|---------|------|
+| TC-01 | 正常 c3.json (c3_status: APPROVED) | env TASK | continue:true（PASS/allow）| 正常系 |
+| TC-02 | 壊れた JSON (not valid JSON) | env TASK | continue:true（warn + allow）| 異常系 |
+| TC-03 | c3.json にコメント行あり + c3_status 埋め込み | env TASK | continue:true（warn, non-APPROVED）| 異常系 |
+| TC-04 | c3.json に c3_status フィールドなし | env TASK | continue:true（warn）| 異常系 |
+| TC-05 | stdin file_path に TASK-XXXX パス | stdin のみ | continue:true（APPROVED）| 正常系 |
+| TC-06 | stdin なし + env なし | なし | continue:true（SKIP）| 正常系 |
+
+## エッジケース
+
+- c3.json が空ファイル → python3 は ValueError → 空文字 → 非 APPROVED（WARN）
+- c3_status が APPROVED 以外（CONDITIONAL など）→ ブロック/warn
+- stdin JSON 解析失敗 → task_id 空文字 → SKIP（false-positive 防止）
+- file_path に TASK-XXXX が複数含まれる → 最初のマッチを使用

--- a/docs/working/TASK-0141/todo.md
+++ b/docs/working/TASK-0141/todo.md
@@ -1,0 +1,43 @@
+# EXECUTION TODO — TASK-0141
+
+## 🤖 Agent タスク
+
+### Phase 1: 準備
+
+- [x] A-01 issue #500 / #527 の現状確認（check-c3-approval.sh / check-plan-exists.sh / ta-06 精読）
+- [x] A-02 Codex 設計相談（python3 パターン / stdin fallback 方針）
+
+### Phase 2: 実装
+
+- [ ] A-03 apply-script 生成: scripts/apply-task-0141-eh2-strict.sh
+  - EH-2: grep/sed → python3 strict JSON（check-c3-approval.sh）
+  - EH-2: stdin fallback 追加
+  - EH-1: stdin fallback 追加（check-plan-exists.sh）
+  - --dry-run / --apply 両対応・冪等ガード
+  - rollback: スクリプト削除で元 hooks はそのまま（適用前は変化なし）
+
+- [ ] A-04 ta-43 新設: tests/extras/ta-43-eh2-strict-json.sh
+  - TC-01〜06 実装（hooks コピーで fixture テスト、ta-39 パターン踏襲）
+  - rollback: ファイル削除
+
+- [ ] A-05 ta-06 修正: tests/extras/ta-06-hooks.sh
+  - >/dev/null 2>&1 を除去、PASS/FAIL 計上形式に変更
+  - rollback: git restore tests/extras/ta-06-hooks.sh
+
+### Phase 3: 検証
+
+- [ ] A-06 tests/run-tests.sh で全 PASS 確認（FAIL=0）
+- [ ] A-07 apply-script --dry-run で期待差分確認
+
+### Phase 4: 完了
+
+- [ ] A-08 handoff.md 生成（V-1 PASS 後）
+
+## 👤 Human タスク
+
+- [ ] H-01 C-3 ゲート: plan/todo/test-cases/review-self 確認・APPROVE
+  - depends_on: A-03/A-04/A-05 完了後
+  - 承認: bin/plangate approve TASK-0141（別ターミナルで実行）
+- [ ] H-02 HO 適用: sh scripts/apply-task-0141-eh2-strict.sh --dry-run → --apply
+  - depends_on: H-01 APPROVED + PR マージ後
+- [ ] H-03 C-4 ゲート: GitHub PR レビュー・マージ


### PR DESCRIPTION
## Summary

- TASK-0141 計画一式（plan / todo / test-cases / C-1 セルフレビュー）
- Issue #500「承認境界の強制実態ギャップ是正」EPIC #527 最終 open child
- Codex 設計相談（2026-06-23）に基づき EH-2/EH-1 コード修正に特化

## 変更内容

- `docs/working/TASK-0141/pbi-input.md` — PBI INPUT PACKAGE (AC-1〜5 定義)
- `docs/working/TASK-0141/plan.md` — 実行計画（high-risk / apply-script パターン）
- `docs/working/TASK-0141/todo.md` — タスクリスト (A-03〜07 + H-01〜03)
- `docs/working/TASK-0141/test-cases.md` — TC-01〜06 (ta-43 新設 + ta-06 unsilence)
- `docs/working/TASK-0141/review-self.md` — C-1 セルフレビュー PASS (WARN-W01/W02 軽微)
- `docs/working/TASK-0141/INDEX.md` — チケット索引
- `docs/working/TASK-0141/current-state.md` — 現状スナップショット

## スコープ

**In scope**: EH-2 strict JSON (python3) / EH-1+EH-2 stdin fallback / ta-06 unsilence / ta-43 新設テスト  
**Out of scope**: settings-wiring-contract / doctor --check-settings (別 TASK)

## 次のステップ（C-3 Gate）

`high-risk` モード + Hardening Override パス含む → autonomous APPROVE 不可。  
C-3 承認: `bin/plangate approve TASK-0141`

## Test plan

- [ ] plan.md の plan_hash が `sha256:9cd4f16a9896b1e390d11a6e8fb8c3a107be0fbb3331c166fd417deb7390e628` と一致
- [ ] AC-1〜5 が pbi-input.md の受入基準に対応している
- [ ] review-self.md が全項目 PASS（WARN-W01/W02 軽微のみ）
- [ ] C-3 承認後 exec 開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)