### PR TITLE
chore: docs/changelog.md v8.15.0 同期（重複ヘッダー削除）

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,43 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+## v8.15.0 - 2026-06-23
+
+feat: Review Gate 機械化 + EH-3 doc-light + approve 強化 + CLI テスト完備 + OpenSSF Scorecard 対応
+
+外部レビュー結果（Decision / risk）を c3_status へ自動マッピングし承認境界を機械執行する Review Gate（TASK-0129）、EH-3 フックに非 HO `.md` ファイルを記録付きで自動 SKIP する doc-light 経路（TASK-0138）、approve サブコマンドのハードニング（TASK-0139）、CLI サブコマンドの統合テスト完備（TASK-0140）を追加。あわせて OpenSSF Scorecard の 10 件のアラートを解消（SHA ピン・Token-Permissions・SECURITY.md・CodeQL）。
+
+### Added
+
+- **Review Gate 機械化（TASK-0129 / #543）** — 外部レビューの `Decision`（go / revise_plan / human_approval_required / no_go）と `review_risk`（low / medium / high）を `c3_status` へ自動マッピングし、`bin/plangate exec` での機械執行を実現。`apply-task-0129-schema.sh` / `apply-task-0129-wc.sh` で c3-approval スキーマと working-context を更新。C-1 Loop check（計画ループ検出）を同梱。
+- **EH-3 doc-light 経路（TASK-0138 / #528）** — `check-plan-hash.sh` に非 HO `.md` ファイルを記録付き自動 SKIP する doc-light 経路を追加。maintenance ファイル存在時はトークンライフサイクルを優先し doc-light を発火させない。`skip-decision-log.jsonl` に `EH-3_DOC_LIGHT_SKIP` イベントを記録。`ta-39` で 6 TC / 303 PASS。
+- **`plangate approve` ハードニング（TASK-0139 / #550）** — approve サブコマンドに `read -r` による理由・条件・確認の対話入力、`PLANGATE_TEST_MODE` ガード、c3.json 上書きブロック（`--force` で上書き可）を追加。ADR `docs/decisions/adr-001-approve-out-of-band.md` を同梱。`ta-41` で 302 PASS。
+- **CLI サブコマンド統合テスト（TASK-0140 / #515 #529）** — `ta-42` を新規追加し `bin/plangate` の全サブコマンド（plan / exec / review / approve / validate-schemas / metrics / doctor 等）を統合テストでカバー。302 PASS / 0 FAIL。
+- **OpenSSF Scorecard 対応** — Pinned-Dependencies（#25-29/#15/#17）: `actions/checkout@v7` / `actions/setup-python@v6` / pip を SHA ピンに変更（全 5 ワークフロー）。Token-Permissions（#21/#18）: `sync-plugin-plangate.yml` / `release-docs-sync.yml` のワークフローレベル `contents:write` を `permissions:{}` + ジョブレベルへ移動。SecurityPolicy（#3）: `SECURITY.md` に脆弱性報告 URL を追記。SAST（#7）: `codeql.yml` を追加し Python コードを CodeQL `security-extended` で解析。
+
+### Fixed
+
+- **plangate-setup スキル + Codex スキル追加** — plangate-setup スキル修正・Codex スキル追加・リリースフローへのプラグイン同期組み込み（#597）
+- **intent-classifier / skill-policy-router** — PlanGate CLI ops 認識を追加（#593）
+- **Gemini V-3 指摘対応** — ta-39 / ta-41 / ta-42 / apply スクリプト群の HIGH・medium 指摘を複数ラウンドで解消（#607）
+
+## v8.14.0 - 2026-06-15
+
+feat: C-3 レビュー HTML 出力（plangate render）+ 人間ワンアクション C-3 承認（plangate approve）
+
+利用者の声「MD は確認しづらい / ファイルが多い / ブラウザで見たい」に応え、C-3 レビュー成果物をブラウザで横断把握できる HTML 出力を導入。あわせて「人間は承認の判断のみ、JSON/CLI 作業は負わない」という PlanGate コンセプトを実機化する承認 CLI を追加。
+
+### Added
+
+- **`plangate render`（C-3 レビュー HTML 出力 / TASK-0127・#546・#552）** — C-3 対象 7 種 MD（pbi-input / plan / todo / test-cases / review-self / review-external / handoff）を **1 枚の自己完結 HTML** に集約。目次アンカー / GFM 表 / チェックボックス / コードブロック / インラインをレンダリングし、HTML エスケープで XSS を防止。外部 CDN / script / 画像参照ゼロ（オフライン・ブラウザ直開き可）。実装 `scripts/render_review.py` は **Python 標準ライブラリのみ**（新規依存なし）。
+- **`plangate approve`（人間ワンアクション C-3 承認 / TASK-0128・#546）** — 対話 TTY で承認意思を示すだけで、plan_hash 自動算出・approved_by を git config 解決・`schemas/c3-approval.schema.json` 準拠の c3.json を自動生成（JSON 手書き不要）。`maintenance` 由来の L1-L4 Human-presence 検証（**best-effort**）で非対話実行からの自己承認を抑止。`check-approval-token-write.sh` を Edit\|Write + Bash matcher で配線し承認トークンへの直接書込を block。
+- **Loop 安全制御 討議メモ**（#544 / #545）— Loop Engineering の安全制御要素（Verification / Stop Condition / Replan Rule）の PlanGate 取り込み方針。
+
+### Notes
+
+- `plangate approve` の L1-L4 は **best-effort 多層防御**（疑似 TTY バイパスが理論上残る）。out-of-band 化（HMAC 署名 + OS keychain）による strict enforcement は #550 / #527 で継続。
+- `plangate render` の SVG 図解（html-diagram）・構造化 html-plan ナビは #548 / #549 で継続。
+
 ## v8.13.0 - 2026-06-11
 
 feat: 全体健全化リリース — 監査駆動の鮮度・整合・隔離改善 + エージェント model tier


### PR DESCRIPTION
## Summary

- `docs/changelog.md` に v8.15.0 内容を同期（`scripts/sync-release-docs.sh` 実行）
- v8.15.0 内容が欠落していた（origin/main では v8.13.0 止まり）
- 重複していた空の `## v8.15.0 - 2026-06-22` セクションは CHANGELOG.md ソース側で既修正済み → sync 結果は `## v8.15.0 - 2026-06-23` 単一セクションのみ

## Test plan

- [ ] CI PASS（markdownlint / link-check）
- [ ] `grep "## v8.15" docs/changelog.md` → `## v8.15.0 - 2026-06-23` が1件のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)