### PR TITLE
exec(#500): TASK-0141 EH-2 strict JSON + stdin fallback + ta-06/43

### DIFF
--- a/scripts/apply-task-0141-eh2-strict.sh
+++ b/scripts/apply-task-0141-eh2-strict.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# scripts/apply-task-0141-eh2-strict.sh
+# TASK-0141 AC-1/AC-2 HO パッチ適用スクリプト
+#   AC-1: EH-2 (check-c3-approval.sh) の c3_status を python3 strict JSON 解析に変更
+#   AC-2: EH-1/EH-2 に stdin tool_input.file_path fallback を追加
+#
+# Human が実行する（HO パス scripts/hooks/ を変更するため）
+#
+# 使い方:
+#   sh scripts/apply-task-0141-eh2-strict.sh --dry-run  # 差分確認のみ
+#   sh scripts/apply-task-0141-eh2-strict.sh            # 実際に適用
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+printf '=== apply-task-0141-eh2-strict.sh (dry_run=%s) ===\n' "$DRY_RUN"
+
+python3 - "$REPO_ROOT" "$DRY_RUN" << 'PYEOF'
+import sys, os, difflib
+
+repo_root = sys.argv[1]
+dry_run = sys.argv[2] == "1"
+
+def patch_file(rel_path, old, new):
+    path = os.path.join(repo_root, rel_path)
+    with open(path) as f:
+        content = f.read()
+    if old not in content:
+        print(f"ERROR: target string not found in {rel_path}", file=sys.stderr)
+        sys.exit(1)
+    new_content = content.replace(old, new, 1)
+    if dry_run:
+        old_lines = content.splitlines(keepends=True)
+        new_lines = new_content.splitlines(keepends=True)
+        diff = difflib.unified_diff(old_lines, new_lines,
+                                    fromfile=rel_path, tofile=rel_path + " (patched)")
+        sys.stdout.writelines(diff)
+    else:
+        bak = path + ".bak"
+        with open(bak, "w") as f:
+            f.write(content)
+        with open(path, "w") as f:
+            f.write(new_content)
+        print(f"patched: {rel_path}  (backup: {os.path.basename(bak)})")
+
+# ---- stdin fallback snippet (shared) ----
+STDIN_FALLBACK_EH2 = """\
+# stdin fallback: env/arg なし時に tool_input.file_path から TASK-ID を抽出
+if [ -z "$task_id" ] && [ ! -t 0 ]; then
+  _eh2_stdin=$(cat 2>/dev/null || true)
+  if [ -n "$_eh2_stdin" ]; then
+    _eh2_fp=""
+    if command -v jq >/dev/null 2>&1; then
+      _eh2_fp=$(printf '%s' "$_eh2_stdin" \\
+        | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \\
+        | head -1 || true)
+    fi
+    if [ -z "$_eh2_fp" ]; then
+      _eh2_fp=$(printf '%s' "$_eh2_stdin" \\
+        | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \\
+        | head -1 \\
+        | sed 's/.*"\\([^"]*\\)"$/\\1/')
+    fi
+    if [ -n "$_eh2_fp" ]; then
+      task_id=$(printf '%s' "$_eh2_fp" \\
+        | grep -o 'TASK-[0-9][0-9][0-9][0-9]' \\
+        | head -1 || true)
+    fi
+  fi
+fi
+
+if [ -z "$task_id" ]; then
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg / stdin, skipping"
+  emit_judgment "allow"
+  exit 0
+fi"""
+
+STDIN_FALLBACK_EH1 = """\
+# stdin fallback: env/arg なし時に tool_input.file_path から TASK-ID を抽出
+if [ -z "$task_id" ] && [ ! -t 0 ]; then
+  _eh1_stdin=$(cat 2>/dev/null || true)
+  if [ -n "$_eh1_stdin" ]; then
+    _eh1_fp=""
+    if command -v jq >/dev/null 2>&1; then
+      _eh1_fp=$(printf '%s' "$_eh1_stdin" \\
+        | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \\
+        | head -1 || true)
+    fi
+    if [ -z "$_eh1_fp" ]; then
+      _eh1_fp=$(printf '%s' "$_eh1_stdin" \\
+        | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \\
+        | head -1 \\
+        | sed 's/.*"\\([^"]*\\)"$/\\1/')
+    fi
+    if [ -n "$_eh1_fp" ]; then
+      task_id=$(printf '%s' "$_eh1_fp" \\
+        | grep -o 'TASK-[0-9][0-9][0-9][0-9]' \\
+        | head -1 || true)
+    fi
+  fi
+fi
+
+if [ -z "$task_id" ]; then
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg / stdin, skipping (false-positive guard)"
+  emit_judgment "allow"
+  exit 0
+fi"""
+
+# ======================================================================
+# Patch 1: EH-2 — task_id 解決部分に stdin fallback 追加
+# ======================================================================
+EH2_TASK_OLD = """\
+if [ -z "$task_id" ]; then
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg, skipping"
+  emit_judgment "allow"
+  exit 0
+fi"""
+
+patch_file(
+    "scripts/hooks/check-c3-approval.sh",
+    EH2_TASK_OLD,
+    STDIN_FALLBACK_EH2,
+)
+
+# ======================================================================
+# Patch 2: EH-2 — c3_status を python3 strict JSON 解析に変更
+# ======================================================================
+EH2_GREP_OLD = """\
+c3_status=$(grep '"c3_status"' "$c3_file" 2>/dev/null \\
+  | sed 's/.*"c3_status"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/' || echo "")"""
+
+EH2_PYTHON_NEW = """\
+c3_status=$(python3 - "$c3_file" <<'PYC3' 2>/dev/null || true
+import sys, json
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        print(data.get("c3_status", ""))
+except Exception:
+    pass
+PYC3
+)"""
+
+patch_file(
+    "scripts/hooks/check-c3-approval.sh",
+    EH2_GREP_OLD,
+    EH2_PYTHON_NEW,
+)
+
+# ======================================================================
+# Patch 3: EH-1 — task_id 解決部分に stdin fallback 追加
+# ======================================================================
+EH1_TASK_OLD = """\
+if [ -z "$task_id" ]; then
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg, skipping (false-positive guard)"
+  emit_judgment "allow"
+  exit 0
+fi"""
+
+patch_file(
+    "scripts/hooks/check-plan-exists.sh",
+    EH1_TASK_OLD,
+    STDIN_FALLBACK_EH1,
+)
+
+print("=== all patches applied ===" if not dry_run else "=== dry-run complete ===")
+PYEOF

--- a/tests/extras/ta-06-hooks.sh
+++ b/tests/extras/ta-06-hooks.sh
@@ -6,11 +6,14 @@ printf '\n=== TA-06: hooks (Issue #157) ===\n'
 
 HOOK_TESTS_SCRIPT="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/hooks/run-tests.sh"
 if [ -f "$HOOK_TESTS_SCRIPT" ]; then
-  if sh "$HOOK_TESTS_SCRIPT" >/dev/null 2>&1; then
+  _ta06_rc=0
+  _ta06_out=$(sh "$HOOK_TESTS_SCRIPT" 2>&1) || _ta06_rc=$?
+  if [ "$_ta06_rc" -eq 0 ]; then
     printf '[PASS] tests/hooks/run-tests.sh — all hook unit tests\n'
     pass=$((pass + 1))
   else
-    printf '[FAIL] tests/hooks/run-tests.sh — see "sh tests/hooks/run-tests.sh" output\n'
+    printf '[FAIL] tests/hooks/run-tests.sh (exit %s)\n' "$_ta06_rc"
+    printf '%s\n' "$_ta06_out" | tail -20
     fail=$((fail + 1))
   fi
 else

--- a/tests/extras/ta-43-eh2-strict-json.sh
+++ b/tests/extras/ta-43-eh2-strict-json.sh
@@ -1,0 +1,149 @@
+# tests/extras/ta-43-eh2-strict-json.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# TASK-0141 AC-1/AC-2/AC-4: EH-2 strict JSON + stdin fallback の自動テスト
+#
+# TC-01: 正常 APPROVED c3.json → allow
+# TC-02: 壊れた JSON → warn + allow（非 APPROVED 扱い）
+# TC-03: コメント埋め込み JSON（python3 では parse エラー）→ 非 APPROVED
+# TC-04: c3_status フィールドなし → 非 APPROVED
+# TC-05: stdin file_path から TASK-ID 解決 → APPROVED 判定
+# TC-06: stdin なし + env なし → SKIP（allow）
+#
+# サンドボックス: check-c3-approval.sh を tmp に複製し実 audit ログ汚染なし
+
+printf '\n=== TA-43: EH-2 strict JSON + stdin fallback (TASK-0141) ===\n'
+
+# ── セットアップ ──────────────────────────────────────────────────
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T43_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T43_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+
+_T43_HOOK_SRC="$_T43_ROOT/scripts/hooks/check-c3-approval.sh"
+_T43_APPLY_SCRIPT="$_T43_ROOT/scripts/apply-task-0141-eh2-strict.sh"
+_T43_TMP=$(mktemp -d)
+if command -v register_cleanup >/dev/null 2>&1; then
+  register_cleanup "$_T43_TMP"
+fi
+
+t43_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t43_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# ── 適用済み確認 ─────────────────────────────────────────────────
+_T43_APPLIED=0
+if grep -q 'python3' "$_T43_HOOK_SRC" 2>/dev/null && \
+   grep -q '_eh2_stdin' "$_T43_HOOK_SRC" 2>/dev/null; then
+  _T43_APPLIED=1
+fi
+
+if [ "$_T43_APPLIED" = "0" ]; then
+  # apply 未適用: dry-run で差分が出ることだけ確認して SKIP
+  if [ -f "$_T43_APPLY_SCRIPT" ]; then
+    _dry_out=$(sh "$_T43_APPLY_SCRIPT" --dry-run 2>&1 || true)
+    if printf '%s' "$_dry_out" | grep -q 'python3\|_eh2_stdin'; then
+      printf '  [SKIP] TC-01〜06: apply-task-0141-eh2-strict.sh --apply 実行前 (dry-run 差分 OK)\n'
+    else
+      t43_fail "apply-script が期待差分を生成しない: $_dry_out"
+    fi
+  else
+    printf '  [SKIP] TC-01〜06: apply-script が未作成 (apply-task-0141-eh2-strict.sh)\n'
+  fi
+  rm -rf "$_T43_TMP" 2>/dev/null || true
+  return 0 2>/dev/null || exit 0
+fi
+
+# ── サンドボックス構築 ─────────────────────────────────────────
+mkdir -p "$_T43_TMP/scripts/hooks"
+mkdir -p "$_T43_TMP/docs/working/_audit"
+cp "$_T43_HOOK_SRC" "$_T43_TMP/scripts/hooks/check-c3-approval.sh"
+_T43_HOOK="$_T43_TMP/scripts/hooks/check-c3-approval.sh"
+
+# テスト用 TASK ディレクトリ
+_T43_TASK="TASK-T4300"
+mkdir -p "$_T43_TMP/docs/working/$_T43_TASK/approvals"
+
+run_hook() {
+  # run_hook [env_task] [stdin_json]
+  _rh_task="${1:-}"
+  _rh_stdin="${2:-}"
+  _rh_out=""
+  if [ -n "$_rh_stdin" ]; then
+    _rh_out=$(printf '%s' "$_rh_stdin" \
+      | PLANGATE_HOOK_TASK="$_rh_task" \
+        PLANGATE_HOOK_STRICT="${PLANGATE_HOOK_STRICT:-0}" \
+        PLANGATE_BYPASS_HOOK="" \
+        sh "$_T43_HOOK" 2>&1 || true)
+  else
+    _rh_out=$(PLANGATE_HOOK_TASK="$_rh_task" \
+      PLANGATE_HOOK_STRICT="${PLANGATE_HOOK_STRICT:-0}" \
+      PLANGATE_BYPASS_HOOK="" \
+      sh "$_T43_HOOK" 2>&1 </dev/null || true)
+  fi
+  printf '%s' "$_rh_out"
+}
+
+# ── TC-01: 正常 APPROVED c3.json → allow ──────────────────────
+printf '{"task_id":"%s","c3_status":"APPROVED","phase":"C-3","plan_hash":"sha256:dummy"}\n' \
+  "$_T43_TASK" > "$_T43_TMP/docs/working/$_T43_TASK/approvals/c3.json"
+
+_t01_out=$(run_hook "$_T43_TASK" "")
+if printf '%s' "$_t01_out" | grep -q '"continue":true'; then
+  t43_pass "TC-01 AC-1: 正常 APPROVED c3.json → continue:true"
+else
+  t43_fail "TC-01 AC-1: APPROVED なのに allow されない: $_t01_out"
+fi
+
+# ── TC-02: 壊れた JSON → 非 APPROVED 扱い（warn + allow）─────
+printf 'NOT_JSON_at_all\n' > "$_T43_TMP/docs/working/$_T43_TASK/approvals/c3.json"
+_t02_out=$(run_hook "$_T43_TASK" "")
+if printf '%s' "$_t02_out" | grep -q '"continue":true'; then
+  t43_pass "TC-02 AC-1: 壊れた JSON → 非 APPROVED (warn) + allow"
+else
+  t43_fail "TC-02 AC-1: 壊れた JSON で allow されない: $_t02_out"
+fi
+
+# ── TC-03: コメント行に "c3_status":"APPROVED" 埋め込み → 非 APPROVED ──
+printf '// comment: "c3_status":"APPROVED"\n{"task_id":"%s","c3_status":"PENDING"}\n' \
+  "$_T43_TASK" > "$_T43_TMP/docs/working/$_T43_TASK/approvals/c3.json"
+_t03_out=$(run_hook "$_T43_TASK" "")
+# PENDING または parse エラー（コメント行があるため json.load が失敗 → c3_status=""）→ 非 APPROVED
+if printf '%s' "$_t03_out" | grep -q '"continue":true'; then
+  t43_pass "TC-03 AC-1: コメント埋め込み JSON → python3 parse 失敗 → 非 APPROVED (allow/warn)"
+else
+  t43_fail "TC-03 AC-1: コメント埋め込み JSON で allow されない: $_t03_out"
+fi
+
+# ── TC-04: c3_status フィールドなし → 非 APPROVED ────────────
+printf '{"task_id":"%s","phase":"C-3"}\n' "$_T43_TASK" \
+  > "$_T43_TMP/docs/working/$_T43_TASK/approvals/c3.json"
+_t04_out=$(run_hook "$_T43_TASK" "")
+if printf '%s' "$_t04_out" | grep -q '"continue":true'; then
+  t43_pass "TC-04 AC-1: c3_status フィールドなし → 非 APPROVED (allow/warn)"
+else
+  t43_fail "TC-04 AC-1: フィールドなし JSON で allow されない: $_t04_out"
+fi
+
+# ── TC-05: stdin file_path から TASK-ID 解決 → APPROVED 判定 ──
+# APPROVED c3.json を restore
+printf '{"task_id":"%s","c3_status":"APPROVED","phase":"C-3","plan_hash":"sha256:dummy"}\n' \
+  "$_T43_TASK" > "$_T43_TMP/docs/working/$_T43_TASK/approvals/c3.json"
+
+_t05_stdin='{"tool_input":{"file_path":"docs/working/TASK-T4300/plan.md"}}'
+_t05_out=$(run_hook "" "$_t05_stdin")
+if printf '%s' "$_t05_out" | grep -q '"continue":true'; then
+  t43_pass "TC-05 AC-2: stdin file_path TASK-T4300 → APPROVED → allow"
+else
+  t43_fail "TC-05 AC-2: stdin fallback が APPROVED を解決できない: $_t05_out"
+fi
+
+# ── TC-06: stdin なし + env なし → SKIP（allow）──────────────
+_t06_out=$(run_hook "" "")
+if printf '%s' "$_t06_out" | grep -q '"continue":true'; then
+  t43_pass "TC-06 AC-2: stdin なし + env なし → SKIP → allow"
+else
+  t43_fail "TC-06 AC-2: no-task で SKIP されない: $_t06_out"
+fi
+
+# ── クリーンアップ ─────────────────────────────────────────────
+rm -rf "$_T43_TMP" 2>/dev/null || true


### PR DESCRIPTION
## Summary

TASK-0141 (#500 承認境界強制実態ギャップ是正) の exec フェーズ。

- **AC-1**: `scripts/apply-task-0141-eh2-strict.sh` — EH-2 (check-c3-approval.sh) の `grep|sed` による c3_status 抽出を python3 strict JSON 解析に変更するパッチスクリプト（Human 実行）
- **AC-2**: 同スクリプトで EH-1/EH-2 に stdin `tool_input.file_path` fallback を追加（env/arg なし時に TASK-ID を解決）
- **AC-3**: `tests/extras/ta-06-hooks.sh` の `>/dev/null 2>&1` 除去 → hook テスト結果を `[PASS]/[FAIL]` として run-tests.sh に報告
- **AC-4**: `tests/extras/ta-43-eh2-strict-json.sh` — EH-2 strict JSON と stdin fallback の自動テスト（TC-01〜06）

## HO 適用待ち（Human）

`scripts/hooks/check-c3-approval.sh` と `scripts/hooks/check-plan-exists.sh` は HO パスのため AI が直接編集不可:

```sh
sh scripts/apply-task-0141-eh2-strict.sh --dry-run  # 差分確認
sh scripts/apply-task-0141-eh2-strict.sh             # 適用
```

apply 後に `sh tests/run-tests.sh` → ta-43 TC-01〜06 が PASS になることを確認。

## Test plan

- [ ] CI PASS（run-tests.sh 332+ PASS, 0 FAIL）
- [ ] ta-06 が `[PASS] tests/hooks/run-tests.sh` を出力
- [ ] ta-43 が apply 前は `[SKIP]`（dry-run 差分 OK）を出力
- [ ] Human が apply-script を実行後、ta-43 TC-01〜06 全 PASS

Closes: TASK-0141 exec / Issue #500 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)