### PR TITLE
fix(security): pip hash pinning — schema-validate.txt + apply script

### DIFF
--- a/requirements/schema-validate.txt
+++ b/requirements/schema-validate.txt
@@ -1,0 +1,15 @@
+# Requirements for .github/workflows/schema-validate.yml
+# Pinned with SHA-256 hashes for Scorecard Pinned-Dependencies compliance
+# Platform: ubuntu-latest (x86_64) + python 3.12
+# Regenerate: see scripts/apply-pip-hash-schema-validate.sh comments
+jsonschema==4.23.0 \
+    --hash=sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566
+attrs==24.2.0 \
+    --hash=sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2
+jsonschema-specifications==2023.12.1 \
+    --hash=sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c
+referencing==0.35.1 \
+    --hash=sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de
+rpds-py==0.20.1 \
+    --hash=sha256:ecd27a66740ffd621d20b9a2f2b5ee4129a56e27bfb9458a3bcc2e45794c96cb \
+    --hash=sha256:3c6afcf2338e7f374e8edc765c79fbcb4061d02b15dd5f8f314a4af2bdc7feb5

--- a/scripts/apply-pip-hash-schema-validate.sh
+++ b/scripts/apply-pip-hash-schema-validate.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# scripts/apply-pip-hash-schema-validate.sh
+# .github/workflows/schema-validate.yml の pip install を hash 付きに変更（Scorecard #17）
+#
+# .github/workflows/*.yml は Hardening Override 対象のため AI が直接編集できない。
+# このスクリプトを生成し、--apply は Human が実行する。
+#
+# 使い方:
+#   sh scripts/apply-pip-hash-schema-validate.sh --dry-run
+#   sh scripts/apply-pip-hash-schema-validate.sh --apply
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$ROOT/.github/workflows/schema-validate.yml"
+
+[ -f "$TARGET" ] || { printf 'ERROR: %s not found\n' "$TARGET" >&2; exit 1; }
+
+# 冪等チェック
+if grep -q 'require-hashes' "$TARGET" 2>/dev/null; then
+  printf 'SKIP (already applied): --require-hashes は既に存在します\n'
+  exit 0
+fi
+
+# アンカー確認
+if ! grep -qF "pip install 'jsonschema==4.23.0'" "$TARGET"; then
+  printf 'ERROR: アンカー行が見つかりません（workflow 構造が変化している可能性あり）\n' >&2
+  exit 1
+fi
+
+OLD="      - name: Install jsonschema
+        run: pip install 'jsonschema==4.23.0'"
+
+NEW="      - name: Install jsonschema
+        run: pip install --require-hashes -r requirements/schema-validate.txt"
+
+if [ "$MODE" = "--dry-run" ]; then
+  printf '[dry-run] 以下の変更を適用します:\n'
+  printf '  FROM: %s\n' "$OLD"
+  printf '  TO:   %s\n' "$NEW"
+  exit 0
+elif [ "$MODE" = "--apply" ]; then
+  python3 - "$TARGET" << 'PY'
+import sys, pathlib
+target = pathlib.Path(sys.argv[1])
+old = "      - name: Install jsonschema\n        run: pip install 'jsonschema==4.23.0'"
+new = "      - name: Install jsonschema\n        run: pip install --require-hashes -r requirements/schema-validate.txt"
+content = target.read_text(encoding='utf-8')
+if old not in content:
+    print('ERROR: anchor not found', file=sys.stderr); sys.exit(1)
+target.write_text(content.replace(old, new, 1), encoding='utf-8')
+print('APPLIED: pip install → --require-hashes -r requirements/schema-validate.txt')
+PY
+else
+  printf 'usage: %s [--dry-run|--apply]\n' "$0" >&2; exit 1
+fi


### PR DESCRIPTION
## Summary

OpenSSF Scorecard Pinned-Dependencies 対応（スコア 8→10）。

- `requirements/schema-validate.txt`: `jsonschema 4.23.0` と全依存パッケージを SHA-256 hash pin
  - 対象: jsonschema / attrs / jsonschema-specifications / referencing / rpds-py
- `scripts/apply-pip-hash-schema-validate.sh`: `.github/workflows/schema-validate.yml` の `pip install` を `--require-hashes -r requirements/schema-validate.txt` に変更するスクリプト（HO 対象のため Human 適用）

## Test plan

- [ ] CI PASS
- [ ] Human: `sh scripts/apply-pip-hash-schema-validate.sh --apply` 実行後にコミット

🤖 Generated with [Claude Code](https://claude.com/claude-code)