### PR TITLE
feat(#493): TASK-0142 WF-07 探索的デバッグ対応 docs 先行定義

### DIFF
--- a/docs/workflows/07_exploratory_debug.md
+++ b/docs/workflows/07_exploratory_debug.md
@@ -1,0 +1,133 @@
+# WF-07 Exploratory Debug（opt-in フェーズ）
+
+> PlanGate × Workflow/Skill/Agent ハイブリッドアーキテクチャ 実行層 / 探索フェーズ（opt-in）
+> 起源: issue #493（Expo SDK 移行での 4 層入れ子障害を PlanGate で扱えなかった経験）
+
+## 目的
+
+「やってみて初めて問題が露呈する」探索的タスクに対し、**仮説→検証→学習→AC 更新**
+のループを PlanGate の構造として扱えるようにする。
+
+標準フロー（WF-01〜06）は「要件が固まってから計画・実装」を前提とするため、
+探索的タスク・長時間外部検証を含むタスク・インシデント駆動の計画修正には本フェーズを opt-in する。
+
+## opt-in 起動（既定 OFF）
+
+本フェーズは **既定で発火しない**。
+
+起動条件（いずれか）:
+- C-3 承認済み pbi-input の `exploratory: true` を明示
+- WF-00 Intent Intake で Mode が `exploratory` と判定される
+- 探索的タスクであることを人間が明示（`/ai-dev-workflow TASK-XXXX explore`、将来 CLI）
+
+未指定 run は WF-01〜06 の標準フローで処理される。
+
+## 3 フェーズ定義
+
+### Phase E-1: 探索ループ（仮説→検証→学習→AC 更新）
+
+探索的タスクでは AC（受入基準）が固定されず、検証ごとに更新される。
+
+**ループ構造**:
+```
+仮説定義（Hypothesis）
+    ↓
+検証実行（Verify）
+    ↓
+学習（Learn）
+    ↓
+AC 更新（Update AC）← 前の仮説が解消されると次の層が露呈することがある
+    ↓
+次の仮説 or 完了
+```
+
+**運用ルール**:
+- 各 `Hypothesis` は `status.md` の残タスクとして `仮説-N:` プレフィックスで記録する
+- 検証結果は `evidence/exploratory/hypothesis-N-result.md` に記録する
+- AC 更新時は `pbi-input.md` と `test-cases.md` に差分追記する（削除しない、append-only）
+- 1 ループの完了条件は「仮説の解消または棄却が記録されたこと」
+
+### Phase E-2: 長時間外部検証待機（waiting_external_verification）
+
+CI / EAS ビルド / デプロイ等、20分以上かかる外部検証を含む場合のサブ状態。
+
+**BLOCKED 状態との連携** (`working-context.md` §BLOCKED 状態 / #498 Deferred ゲート):
+
+```
+status.md 残タスクの記録形式:
+- [ ] BLOCKED: 検証タスク名
+    blocker: <外部サービス名（例: EAS production build #5）>
+    owner: 外部サービス / 時間経過
+    unblock_condition: <完了条件（例: EAS ビルド成功 → 次仮説へ進む）>
+    waiting_external_verification: true
+```
+
+**再開プロトコル**:
+1. 外部検証完了後、結果を `evidence/exploratory/hypothesis-N-result.md` に記録
+2. `status.md` の BLOCKED タスクを `[x]` に更新し、学習内容を記載
+3. 次の仮説または完了に進む（Phase E-1 に戻る）
+
+**上限**:
+- 1 タスクあたりの外部検証待機は最大 5 回まで（5 回を超えたら根本設計を見直すゲート）
+
+### Phase E-3: インシデント駆動の計画修正（AC 改訂フロー）
+
+検証失敗時に spec/design を見直すフィードバックループ。
+
+**発動条件**:
+- Phase E-1 の検証が FAIL かつ「前提の誤り」が判明した場合
+- 想定していなかった問題が露呈した場合（入れ子障害の発見等）
+
+**AC 改訂フロー**:
+```
+検証 FAIL
+    ↓
+根本原因の分類:
+  (a) 実装ミス → Phase E-1 に戻って修正
+  (b) 前提の誤り（設計 / 環境 / 依存関係）→ 以下の AC 改訂
+  (c) 外部サービスの問題 → Phase E-2（待機）
+    ↓
+(b) の場合:
+  1. decision-log.jsonl に前提誤りと根本原因を記録（append-only）
+  2. pbi-input.md の Notes に「前提変更」として追記
+  3. 影響 AC を特定して test-cases.md を更新
+  4. 人間に変更範囲を確認（影響が Out of scope を超える場合は C-3 再承認）
+    ↓
+次の仮説へ
+```
+
+## 入力
+
+- pbi-input.md（初期 AC、柔軟に更新可）
+- WF-01 の context（前提制約）
+
+## 完了条件
+
+- 全仮説が「解消」または「棄却」として記録されている
+- `evidence/exploratory/` に各仮説の結果が記録されている
+- 最終 AC が test-cases.md と整合している
+- 標準フロー（WF-05）への移行条件が満たされている（通常の V-1/handoff）
+
+## 呼び出す Skill
+
+- `hypothesis-logger`（仮説記録 / 将来実装）
+- `acceptance-review`（WF-05 に委譲）
+
+## 主担当 Agent
+
+- `orchestrator`（フェーズ遷移管理）
+- `qa-reviewer`（AC 整合確認・WF-05 移行判断）
+
+## 既存 WF との接続
+
+| 既存 WF | 接続点 |
+|---------|--------|
+| WF-00 Intent Intake | `Mode: exploratory` を出力すると本フェーズを推奨 |
+| WF-01 Context Bootstrap | 前提制約を読み込む（変更なし）|
+| WF-05 Verify & Handoff | 全仮説解消後に標準移行（変更なし）|
+| working-context.md §BLOCKED | `waiting_external_verification: true` を BLOCKED の拡張フィールドとして使用 |
+
+## 制約（Rule 1 準拠）
+
+本フェーズ定義は順序と完了条件のみ。探索ループの具体的な観点・記録フォーマットは
+Skill / Agent に委譲。全 run への強制適用は禁止（opt-in 原則）。

--- a/docs/workflows/07_exploratory_debug.md
+++ b/docs/workflows/07_exploratory_debug.md
@@ -16,6 +16,7 @@
 本フェーズは **既定で発火しない**。
 
 起動条件（いずれか）:
+
 - C-3 承認済み pbi-input の `exploratory: true` を明示
 - WF-00 Intent Intake で Mode が `exploratory` と判定される
 - 探索的タスクであることを人間が明示（`/ai-dev-workflow TASK-XXXX explore`、将来 CLI）
@@ -29,7 +30,8 @@
 探索的タスクでは AC（受入基準）が固定されず、検証ごとに更新される。
 
 **ループ構造**:
-```
+
+```text
 仮説定義（Hypothesis）
     ↓
 検証実行（Verify）
@@ -42,6 +44,7 @@ AC 更新（Update AC）← 前の仮説が解消されると次の層が露呈�
 ```
 
 **運用ルール**:
+
 - 各 `Hypothesis` は `status.md` の残タスクとして `仮説-N:` プレフィックスで記録する
 - 検証結果は `evidence/exploratory/hypothesis-N-result.md` に記録する
 - AC 更新時は `pbi-input.md` と `test-cases.md` に差分追記する（削除しない、append-only）
@@ -53,7 +56,7 @@ CI / EAS ビルド / デプロイ等、20分以上かかる外部検証を含む
 
 **BLOCKED 状態との連携** (`working-context.md` §BLOCKED 状態 / #498 Deferred ゲート):
 
-```
+```text
 status.md 残タスクの記録形式:
 - [ ] BLOCKED: 検証タスク名
     blocker: <外部サービス名（例: EAS production build #5）>
@@ -63,11 +66,13 @@ status.md 残タスクの記録形式:
 ```
 
 **再開プロトコル**:
+
 1. 外部検証完了後、結果を `evidence/exploratory/hypothesis-N-result.md` に記録
 2. `status.md` の BLOCKED タスクを `[x]` に更新し、学習内容を記載
 3. 次の仮説または完了に進む（Phase E-1 に戻る）
 
 **上限**:
+
 - 1 タスクあたりの外部検証待機は最大 5 回まで（5 回を超えたら根本設計を見直すゲート）
 
 ### Phase E-3: インシデント駆動の計画修正（AC 改訂フロー）
@@ -75,11 +80,13 @@ status.md 残タスクの記録形式:
 検証失敗時に spec/design を見直すフィードバックループ。
 
 **発動条件**:
+
 - Phase E-1 の検証が FAIL かつ「前提の誤り」が判明した場合
 - 想定していなかった問題が露呈した場合（入れ子障害の発見等）
 
 **AC 改訂フロー**:
-```
+
+```text
 検証 FAIL
     ↓
 根本原因の分類:

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -19,6 +19,7 @@ PlanGate（統制の外殻）の内側で動作する **実行層（Execution Ar
 | **WF-04** Build & Refine | 設計に従って最小単位で実装 | [`04_build_and_refine.md`](./04_build_and_refine.md) |
 | **WF-05** Verify & Handoff | 品質確認し、次フェーズへ渡せる状態にする | [`05_verify_and_handoff.md`](./05_verify_and_handoff.md) |
 | **WF-06** Retro（opt-in・既定OFF） | run 完了時に振り返りドラフト生成・改善ネタ蓄積 | [`06_retro.md`](./06_retro.md) |
+| **WF-07** Exploratory Debug（opt-in・既定OFF） | 探索的タスク・長時間外部検証・インシデント駆動 AC 更新 | [`07_exploratory_debug.md`](./07_exploratory_debug.md) |
 
 ## Artifact クラス（Phase 間受け渡し）
 

--- a/docs/workflows/execution-sequence.md
+++ b/docs/workflows/execution-sequence.md
@@ -85,7 +85,6 @@ sequenceDiagram
 | 既存 PlanGate ワークフローを継続 | 既存 PlanGate Agent |
 | 両方混在 | プロジェクトの CLAUDE.md で使い分けを明示 |
 
-
 ## 探索モード分岐（WF-07 opt-in）
 
 exploratory タスク（仮説→検証→学習ループ）の場合、WF-00 Intent Intake で

--- a/docs/workflows/execution-sequence.md
+++ b/docs/workflows/execution-sequence.md
@@ -84,3 +84,34 @@ sequenceDiagram
 | 新プロジェクトでハイブリッドアーキテクチャを採用 | 責務ベース 5 体 |
 | 既存 PlanGate ワークフローを継続 | 既存 PlanGate Agent |
 | 両方混在 | プロジェクトの CLAUDE.md で使い分けを明示 |
+
+
+## 探索モード分岐（WF-07 opt-in）
+
+exploratory タスク（仮説→検証→学習ループ）の場合、WF-00 Intent Intake で
+`Mode: exploratory` と判定されると WF-07 を opt-in する。
+
+```mermaid
+sequenceDiagram
+    participant O as orchestrator
+    participant R as requirements-analyst
+    participant Q as qa-reviewer
+
+    Note over O: WF-00: Mode=exploratory 検出
+    O->>R: 初期 AC 定義（柔軟・更新可）
+    loop 探索ループ（Phase E-1）
+        R->>R: 仮説定義
+        R->>Q: 検証実行
+        Q-->>R: 検証結果 (PASS/FAIL)
+        alt FAIL + 前提誤り
+            R->>R: AC 改訂（Phase E-3）
+        else FAIL + 外部検証待機
+            R->>R: BLOCKED: waiting_external_verification（Phase E-2）
+        else PASS
+            R->>R: 学習記録 → 次仮説 or 完了
+        end
+    end
+    Note over O: 全仮説解消 → WF-05 Verify & Handoff
+```
+
+詳細仕様: [`07_exploratory_debug.md`](./07_exploratory_debug.md)

--- a/docs/working/TASK-0141/current-state.md
+++ b/docs/working/TASK-0141/current-state.md
@@ -1,21 +1,37 @@
 # current-state.md — TASK-0141
 
-## 現在フェーズ: C-3 ゲート待ち
+## 現在フェーズ: exec（D フェーズ）— HO 適用 + C-3 ゲート待ち
 
-- C-1 セルフレビュー: PASS（critical/major なし、WARN 2 件は許容）
-- 次アクション: **Human が plan/todo/test-cases/review-self を確認し C-3 APPROVE**
-  → 承認後 exec フェーズへ
+- plan PR (#613): **MERGED**（2026-06-23）
+- exec PR (#615): CI 全 PASS、C-4 マージ待ち
+- 非 HO ファイル: 実装完了（ta-06/ta-43/apply-script）
+- run-tests.sh: 332 PASS, 0 FAIL
 
 ## ブロッカー
 
-- H-01: C-3 ゲート（Human APPROVE 必須、high-risk モードのため autonomous APPROVE 不可）
+| ID | 内容 | Owner |
+|----|------|-------|
+| H-01 | C-3 APPROVE: `bin/plangate approve TASK-0141`（high-risk, autonomous 不可） | Human |
+| H-02 | HO 適用: `sh scripts/apply-task-0141-eh2-strict.sh`（PR #615 マージ後） | Human |
+| H-03 | C-4 PR レビュー: PR #615 | Human |
 
 ## 成果物
 
 | ファイル | 状態 |
 |---------|------|
 | pbi-input.md | 完了 |
-| plan.md | 完了 |
+| plan.md | 完了 (PR #613 MERGED) |
 | todo.md | 完了 |
 | test-cases.md | 完了 |
 | review-self.md | C-1 PASS |
+| apply-task-0141-eh2-strict.sh | 完了 (PR #615) |
+| tests/extras/ta-06-hooks.sh | 完了 (PR #615) |
+| tests/extras/ta-43-eh2-strict-json.sh | 完了 (PR #615) |
+| status.md | 更新済み |
+
+## 次アクション
+
+1. Human: `bin/plangate approve TASK-0141`（C-3 APPROVE）
+2. Human: PR #615 C-4 マージ
+3. Human: `sh scripts/apply-task-0141-eh2-strict.sh`（HO 適用）
+4. AI: `sh tests/run-tests.sh` → ta-43 TC-01〜06 PASS 確認（V-1）

--- a/docs/working/TASK-0141/status.md
+++ b/docs/working/TASK-0141/status.md
@@ -1,0 +1,41 @@
+# status.md — TASK-0141
+
+## フェーズ履歴
+
+| フェーズ | 日時 | 結果 |
+|---------|------|------|
+| A: PBI INPUT PACKAGE | 2026-06-22 22:00 | 完了 |
+| B: Plan + ToDo + TestCases | 2026-06-22 23:00 | 完了 |
+| C-1: セルフレビュー | 2026-06-22 23:30 | PASS（WARN-W01/W02）|
+| PR #613（plan） | 2026-06-23 00:00 | MERGED |
+| D: exec（非 HO） | 2026-06-23 01:30 | ta-06/ta-43/apply-script 完了 |
+| PR #615（exec） | 2026-06-23 01:45 | CI PASS, C-4 待ち |
+
+## ## C-3 Gate: PENDING
+
+Human 承認待ち（high-risk mode, autonomous APPROVE 不可）。
+`bin/plangate approve TASK-0141` で承認。
+
+## 残タスク
+
+- [ ] H-01: C-3 APPROVE（`bin/plangate approve TASK-0141`）
+- [ ] H-02: PR #615 C-4 マージ
+- [ ] H-03: `sh scripts/apply-task-0141-eh2-strict.sh`（HO 適用）
+- [ ] A-07: `sh tests/run-tests.sh` → ta-43 TC-01〜06 PASS（V-1 受け入れ検査）
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| scripts/apply-task-0141-eh2-strict.sh | 新規（AI 作成, Human 適用）|
+| tests/extras/ta-06-hooks.sh | >/dev/null 2>&1 除去 |
+| tests/extras/ta-43-eh2-strict-json.sh | 新規（EH-2 strict JSON テスト）|
+| scripts/hooks/check-c3-approval.sh | HO パッチ適用待ち（Human）|
+| scripts/hooks/check-plan-exists.sh | HO パッチ適用待ち（Human）|
+
+## PR 一覧
+
+| PR | ブランチ | 内容 | 状態 |
+|----|---------|------|------|
+| #613 | plan/task-0141-500-wiring-integrity | plan 成果物 | MERGED |
+| #615 | feat/task-0141-500-exec | exec（非 HO 3 ファイル）| CI PASS, C-4 待ち |

--- a/docs/working/TASK-0142/INDEX.md
+++ b/docs/working/TASK-0142/INDEX.md
@@ -1,0 +1,15 @@
+# TASK-0142 INDEX
+
+> 生成日: 2026-06-23
+> フェーズ: A
+
+## ファイル一覧
+
+| ファイル | 状態 |
+| --- | --- |
+| pbi-input.md | draft |
+| plan.md | - |
+| todo.md | - |
+| test-cases.md | - |
+| review-self.md | - |
+| handoff.md | - |

--- a/docs/working/TASK-0142/current-state.md
+++ b/docs/working/TASK-0142/current-state.md
@@ -1,0 +1,13 @@
+# TASK-0142 現在状態
+
+> 更新日: 2026-06-23
+> フェーズ: A — PBI INPUT 作成中
+
+## 中断地点
+
+pbi-input.md を記入してください。
+
+## 次のアクション
+
+1. `docs/working/TASK-0142/pbi-input.md` の Why / What / AC を埋める
+2. `/ai-dev-workflow TASK-0142 plan` で plan / todo / test-cases を生成する

--- a/docs/working/TASK-0142/pbi-input.md
+++ b/docs/working/TASK-0142/pbi-input.md
@@ -1,0 +1,59 @@
+# PBI INPUT PACKAGE — TASK-0142
+
+## Context / Why
+
+Issue #493「探索的デバッグタスク対応強化」の PBI-493-02。
+
+「仮説→検証→学習→AC 更新」の**探索ループ**と、CI/EAS ビルド等の**長時間外部検証待機**、
+**インシデント駆動の計画修正**という3要件を、docs のみで先行定義する。
+
+PlanGate の既存 workflow（WF-01〜06）は「要件が固まってから計画・実装」を前提にしており、
+「やってみて初めて問題が露呈する」探索的タスクへの対応指針が不足している。
+
+Codex 設計相談（2026-06-23）で確認:
+- PBI-493-02 は docs 追加のみ・HO 非対象・独立実装可能
+- 探索フェーズを WF-07 として新規定義し、既存 BLOCKED/Deferred と連携させる
+
+## What（Scope）
+
+### In scope
+
+- **AC-1**: `docs/workflows/07_exploratory_debug.md` 新規作成（WF-07）
+  - 探索フェーズ定義: 仮説→検証→学習→AC 更新ループ
+  - 長時間外部検証: `waiting_external_verification` サブ状態（BLOCKED と連携）
+  - インシデント駆動の計画修正: 検証失敗時の AC 更新手順
+  - 既存 WF との接続（WF-01 からの分岐条件）
+- **AC-2**: `docs/workflows/README.md` に WF-07 の参照を追加
+- **AC-3**: `docs/workflows/execution-sequence.md` に探索モードの分岐を追記
+
+### Out of scope
+
+- acceptance-tester エージェントの改修（HO 対象）→ 別 PBI
+- workflow-conductor.md の変更（HO 対象）→ 別 PBI
+- PBI-493-01（長時間検証の bin/plangate コマンド）→ 別 PBI
+- PBI-493-03（検証失敗ゲートの機械的強制）→ 別 PBI
+
+## 受入基準
+
+| ID | 基準 |
+|----|------|
+| AC-1 | `docs/workflows/07_exploratory_debug.md` が存在し、探索ループ・待機・修正ゲートの3要件を定義する |
+| AC-2 | `docs/workflows/README.md` に WF-07 が追記される |
+| AC-3 | `docs/workflows/execution-sequence.md` に探索モード分岐が追記される |
+| AC-4 | markdownlint PASS（L-0）|
+
+## Notes from Refinement
+
+- WF-07 は WF-01〜06 と同列の「opt-in ワークフロー」として位置づける
+- 「仮説」と「AC」は PlanGate の acceptance criteria と同一概念として扱う
+- `waiting_external_verification` は working-context.md §BLOCKED 状態の拡張として記述
+
+## Estimation Evidence
+
+- Risks: doc の新設は markdownlint / リンク切れに注意
+- Unknowns: execution-sequence.md の既存構造（読んでから判断）
+- Assumptions: docs/workflows/ は HO 非対象（確認済み）
+
+**モード判定**: light（doc 新設 + 既存 doc 更新 2 件、HO なし）
+**変更種別**: doc
+**doc-light 対象**: ✅（doc のみ、承認境界パスなし）

--- a/docs/working/TASK-0142/plan.md
+++ b/docs/working/TASK-0142/plan.md
@@ -1,0 +1,87 @@
+# EXECUTION PLAN — TASK-0142
+
+## Goal
+
+issue #493 PBI-493-02。探索的デバッグ対応の docs 先行定義。
+WF-07（探索ループ・長時間外部検証待機・インシデント駆動 AC 更新）を新設し、
+既存 WF と連携できる状態にする。
+
+## Constraints / Non-goals
+
+- docs（`docs/workflows/`）のみ変更、HO パス非対象
+- acceptance-tester / workflow-conductor.md の改修は別 PBI
+- bin/plangate への待機コマンド追加は別 PBI（PBI-493-01）
+
+## Approach Overview
+
+doc-light モードで WF-07 を新設し、README.md と execution-sequence.md に参照を追加する。
+WF-07 は WF-01〜06 と同列の opt-in ワークフローとして位置づける。
+
+## Work Breakdown
+
+### Step 1: WF-07 ドキュメント新設
+
+Output: `docs/workflows/07_exploratory_debug.md`
+
+内容:
+- 目的（探索的タスクへの対応）
+- 3 フェーズ定義:
+  - 探索ループ（仮説→検証→学習→AC 更新）
+  - 長時間外部検証待機（`waiting_external_verification` / BLOCKED 連携）
+  - インシデント駆動の計画修正（検証失敗→AC 改訂フロー）
+- 既存 WF との接続（WF-00 Intent Intake から分岐する条件）
+- 完了条件
+- 呼び出す Skill（既存 acceptance-review / doc 追加のみ）
+
+Owner: AI
+
+### Step 2: README.md 更新
+
+Output: `docs/workflows/README.md`（既存に WF-07 行を追加）
+
+Owner: AI
+
+### Step 3: execution-sequence.md 更新
+
+Output: `docs/workflows/execution-sequence.md`（探索モード分岐を追記）
+
+Owner: AI
+
+### Step 4: L-0 リンター
+
+sh scripts/lint.sh または markdownlint
+
+Owner: AI
+
+## Files / Components to Touch
+
+- `docs/workflows/07_exploratory_debug.md`  (新規)
+- `docs/workflows/README.md`                (追記)
+- `docs/workflows/execution-sequence.md`    (追記)
+
+## Testing Strategy
+
+- L-0: markdownlint PASS（AC-4）
+- V-1: ファイル存在 + 内容確認（3要件が定義されているか）
+- E2E: 不要（docs のみ）
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| markdownlint 違反 | 書き方を既存 WF-06 に合わせる |
+| リンク切れ | 相互参照は相対パスで記述、L-0 で確認 |
+
+## Mode 判定
+
+**モード**: light
+**変更種別**: doc
+**doc-light**: ✅（docs/workflows/ のみ、HO 非対象）
+**lite_eligible**: true（既存構造の枠内、新規設計ゼロ・doc 追加のみ）
+
+**判定根拠**:
+- 変更ファイル数: 3 → light
+- 受入基準数: 4 → light
+- 変更種別: doc → doc-light
+- リスク: 低（HO なし）
+- **最終判定**: light / doc-light

--- a/docs/working/TASK-0142/review-self.md
+++ b/docs/working/TASK-0142/review-self.md
@@ -1,0 +1,188 @@
+# C-1 セルフレビュー — TASK-0142
+
+実施日時: 2026-06-23
+モード: light / doc-light
+レビュアー: orchestrator（C-1 実施）
+
+---
+
+## Plan チェック（7項目）
+
+### C1-PLAN-01: 受入基準網羅性
+
+pbi-input.md の AC（4件）が plan の Work Breakdown / Testing Strategy にすべて対応しているか。
+
+| AC | 対応箇所 |
+|----|---------|
+| AC-1 (`07_exploratory_debug.md` 新規作成) | Step 1 + TC-01/TC-02/TC-03 |
+| AC-2 (`README.md` 更新) | Step 2 + TC-04 |
+| AC-3 (`execution-sequence.md` 更新) | Step 3 + TC-05 |
+| AC-4 (markdownlint PASS) | Step 4 + TC-06 |
+
+判定: **PASS** — 全 AC が Work Breakdown の Step と test-cases.md に紐づいている。
+
+---
+
+### C1-PLAN-02: Unknowns 処理
+
+pbi-input.md の「Unknowns: execution-sequence.md の既存構造（読んでから判断）」が plan に反映されているか。
+
+判定: **PASS** — plan の Approach Overview と Step 3 に「execution-sequence.md に探索モード分岐を追記」と明記。Work Breakdown で既存構造を確認してから追記する手順になっている。
+
+---
+
+### C1-PLAN-03: スコープ制御
+
+Out of scope（acceptance-tester 改修 / workflow-conductor.md / PBI-493-01 / PBI-493-03）が plan に反映されているか。
+
+判定: **PASS** — plan の Constraints / Non-goals セクションに明記済み（「acceptance-tester / workflow-conductor.md の改修は別 PBI」「bin/plangate への待機コマンド追加は別 PBI」）。
+
+---
+
+### C1-PLAN-04: テスト戦略
+
+Testing Strategy が doc-light モードとして適切か。
+
+判定: **PASS** — L-0（markdownlint PASS）と V-1（ファイル存在 + 内容確認）を明記し、E2E は不要（docs のみ）と合理的に除外している。
+
+---
+
+### C1-PLAN-05: Work Breakdown Output
+
+各 Step に Output が明記されているか。
+
+| Step | Output | 明記 |
+|------|--------|------|
+| Step 1 | `docs/workflows/07_exploratory_debug.md` | ✅ |
+| Step 2 | `docs/workflows/README.md`（追記） | ✅ |
+| Step 3 | `docs/workflows/execution-sequence.md`（追記） | ✅ |
+| Step 4 | lint PASS | ✅ |
+
+判定: **PASS** — 全 Step に Output が明記されている。
+
+---
+
+### C1-PLAN-06: 依存関係
+
+Step 間の依存関係が明確か。
+
+判定: **PASS** — plan の Files / Components to Touch で 3 ファイルが列挙されており、L-0 は全実装後に実行する順序が Step 4 で自明。todo.md の依存関係セクションにも明記（「A-06〜08 は H-01 後に開始」「A-10 は A-06〜09 完了後」）。
+
+---
+
+### C1-PLAN-07: 動作検証自動化
+
+V-1 自動化の可否が明記されているか。
+
+判定: **PASS** — TC-06（markdownlint）は自動実行可能。TC-01〜05 は手動確認 / grep 確認と明記されており、doc-light モードとして適切。
+
+---
+
+## ToDo チェック（5項目）
+
+### C1-TODO-01: タスク粒度
+
+各タスクが 1 セッションで完了できる粒度か。
+
+判定: **PASS** — A-06（WF-07 新規作成）・A-07（README 追記）・A-08（execution-sequence 追記）は各々独立した 1 ファイル操作。A-09（L-0）・A-10（V-1）も単一コマンド / 確認作業。粒度は適切。
+
+---
+
+### C1-TODO-02: depends_on 設定
+
+タスク間依存が depends_on または依存関係セクションに明記されているか。
+
+判定: **PASS** — todo.md の「依存関係」セクションで「A-06〜08 は H-01（C-3）後に開始（doc-light autonomous APPROVE 可）」「A-10 は A-06〜09 完了後」と明記。チェックポイント CP1〜CP3 でも同期点が示されている。
+
+---
+
+### C1-TODO-03: チェックポイント設定
+
+🚩 チェックポイントが設定されているか。
+
+判定: **PASS** — CP1（plan 確認後 → C-3 gate）/ CP2（3 ファイル実装完了後 → L-0）/ CP3（L-0 PASS 後 → V-1）の 3 点が設定されている。
+
+---
+
+### C1-TODO-04: Iron Law 遵守
+
+CLAUDE.md の AI 運用 4 原則（特に第 1 原則: 実行前 y/n）が todo.md の構造に反映されているか。
+
+判定: **PASS** — H-01（C-3 承認）が実装フェーズ開始前の Human タスクとして分離されている。doc-light autonomous APPROVE 条件（lite_eligible=true、C-1 PASS のみ）を todo.md に明記しており、第 1 原則の例外条件を正しく扱っている。
+
+---
+
+### C1-TODO-05: 完了条件
+
+各タスクに完了条件（明確な Done の定義）が存在するか。
+
+判定: **WARN** — A-06〜A-08 の rollback 手順は記載されているが、各タスクの「完了判定基準」が明示的に記されていない。ただし test-cases.md の TC-01〜TC-06 が完了条件の代替として機能しており、致命的な欠落ではない。
+
+---
+
+## TestCases チェック（3項目）
+
+### C1-TC-01: 受入基準との紐づき
+
+全 AC が少なくとも 1 件のテストケースに紐づいているか。
+
+| AC | TC | 紐づき |
+|----|-----|-------|
+| AC-1 | TC-01, TC-02, TC-03 | ✅ |
+| AC-2 | TC-04 | ✅ |
+| AC-3 | TC-05 | ✅ |
+| AC-4 | TC-06 | ✅ |
+
+判定: **PASS** — 全 AC が TC に紐づいている。
+
+---
+
+### C1-TC-02: Edge case 網羅
+
+エッジケースが適切に定義されているか。
+
+エッジケースとして以下が記載:
+- WF-07 が WF-06 との番号衝突がないか（06_retro.md が既存、07 は新規）
+- 相互リンクが正しい相対パスになっているか
+
+判定: **PASS** — doc 新設として発生しうるリンク切れ / 番号衝突の両エッジケースが捕捉されている。
+
+---
+
+### C1-TC-03: 自動化可否
+
+各テストケースの自動化可否が明記されているか。
+
+| TC | 種別 | 明記 |
+|----|------|------|
+| TC-01 | 手動確認 | ✅ |
+| TC-02 | 手動確認 | ✅ |
+| TC-03 | grep 確認 | ✅ |
+| TC-04 | grep 確認 | ✅ |
+| TC-05 | grep 確認 | ✅ |
+| TC-06 | 自動 | ✅ |
+
+判定: **PASS** — 全 TC に種別（手動 / grep / 自動）が明記されている。
+
+---
+
+## 指摘事項
+
+### WARN-01（C1-TODO-05 / minor）
+
+todo.md の A-06〜A-08 に各タスクの「Done 判定基準」の明記が薄い。rollback 手順は記載されているが、「何をもって完了とするか」が TC 参照を前提とした暗黙定義になっている。
+
+対応方針: exec 開始前に修正するほどではない（test-cases.md が補完）。V-1 時に TC 参照で代替確認可能。指摘を認識しつつ exec 継続可。
+
+---
+
+## 総合判定
+
+**PASS**（WARN 1 件 / FAIL 0 件）
+
+- Plan 7 項目: 全 PASS
+- ToDo 5 項目: PASS 4 / WARN 1（C1-TODO-05）
+- TestCases 3 項目: 全 PASS
+
+WARN-01 は minor（test-cases.md で補完済み）。FAIL なし。
+doc-light autonomous APPROVE 条件（C-1 PASS のみ）を満たす。exec 継続可。

--- a/docs/working/TASK-0142/test-cases.md
+++ b/docs/working/TASK-0142/test-cases.md
@@ -1,0 +1,26 @@
+# TEST CASES — TASK-0142
+
+## 受入基準 → テストケースマッピング
+
+| AC | テストケース |
+|----|------------|
+| AC-1 | TC-01, TC-02, TC-03 |
+| AC-2 | TC-04 |
+| AC-3 | TC-05 |
+| AC-4 | TC-06 |
+
+## テストケース一覧
+
+| ID | 前提条件 | 入力 | 期待出力 | 種別 |
+|----|---------|------|---------|------|
+| TC-01 | — | `docs/workflows/07_exploratory_debug.md` が存在する | ファイルが存在する | 手動確認 |
+| TC-02 | TC-01 PASS | WF-07 の目次を確認 | 「探索ループ」「長時間外部検証待機」「インシデント駆動 AC 更新」の3セクションが存在 | 手動確認 |
+| TC-03 | TC-01 PASS | `waiting_external_verification` キーワードを確認 | ファイル内に存在する | grep 確認 |
+| TC-04 | — | `docs/workflows/README.md` に WF-07 の参照行が存在する | `07_exploratory_debug.md` への参照が存在 | grep 確認 |
+| TC-05 | — | `docs/workflows/execution-sequence.md` に探索モード分岐が存在する | 「探索」または「exploratory」のキーワードが存在 | grep 確認 |
+| TC-06 | 全ファイル実装後 | `sh scripts/lint.sh` または markdownlint | PASS / エラーなし | 自動 |
+
+## エッジケース
+
+- WF-07 が WF-06 との番号衝突がないか確認（06_retro.md が既存、07 は新規）
+- 相互リンクが正しい相対パス（`./07_exploratory_debug.md`）になっているか

--- a/docs/working/TASK-0142/todo.md
+++ b/docs/working/TASK-0142/todo.md
@@ -1,0 +1,47 @@
+# EXECUTION TODO — TASK-0142
+
+## 🤖 Agent タスク
+
+### 準備フェーズ
+
+- [x] A-01: pbi-input.md 作成
+- [x] A-02: plan.md 生成
+- [x] A-03: todo.md 生成（本ファイル）
+- [x] A-04: test-cases.md 生成
+- [ ] A-05: C-1 セルフレビュー
+  - rollback: 不要（plan 再生成のみ）
+
+### 実装フェーズ
+
+- [ ] A-06: `docs/workflows/07_exploratory_debug.md` 作成（AC-1）
+  - rollback: ファイル削除
+- [ ] A-07: `docs/workflows/README.md` 更新（AC-2）
+  - rollback: git restore
+- [ ] A-08: `docs/workflows/execution-sequence.md` 更新（AC-3）
+  - rollback: git restore
+- [ ] A-09: L-0 markdownlint（AC-4）
+  - rollback: 不要
+
+### 検証フェーズ
+
+- [ ] A-10: V-1 受け入れ検査（ファイル存在 + 内容確認）
+
+### 完了フェーズ
+
+- [ ] A-11: PR 作成
+
+## 👤 Human タスク
+
+- [ ] H-01: C-3 承認（diff 確認・APPROVE）
+- [ ] H-02: C-4 PR レビュー
+
+## ⚠️ 依存関係
+
+- A-06〜08 は H-01（C-3）後に開始（doc-light autonomous APPROVE 可）
+- A-10 は A-06〜09 完了後
+
+## 🚩 チェックポイント
+
+- **CP1**: plan.md 確認後 → H-01 C-3 gate
+- **CP2**: 3ファイル実装完了後 → A-09 L-0
+- **CP3**: L-0 PASS 後 → A-10 V-1


### PR DESCRIPTION
## Summary

Issue #493 PBI-493-02。探索的デバッグ対応の docs 先行定義。

- `docs/workflows/07_exploratory_debug.md`（WF-07 新設）: 探索フェーズの3要件を定義
  - **Phase E-1**: 探索ループ（仮説→検証→学習→AC 更新）
  - **Phase E-2**: 長時間外部検証待機（`waiting_external_verification` / BLOCKED 連携）
  - **Phase E-3**: インシデント駆動の計画修正（検証失敗→AC 改訂フロー）
- `docs/workflows/README.md`: WF-07 行を追加
- `docs/workflows/execution-sequence.md`: 探索モード分岐（mermaid シーケンス図）を追記
- `docs/working/TASK-0141/status.md + current-state.md`: exec フェーズ進行記録更新
- `docs/working/TASK-0142/`: TASK-0142 の planning artifact 一式

## Out of scope

- acceptance-tester / workflow-conductor.md 改修（HO対象）→ 別 PBI
- bin/plangate への待機コマンド追加 → PBI-493-01

## Test plan

- [ ] CI PASS（markdownlint / link-check）
- [ ] `docs/workflows/07_exploratory_debug.md` に Phase E-1/E-2/E-3 の3要件が存在
- [ ] `grep "07_exploratory_debug" docs/workflows/README.md` → マッチあり
- [ ] `grep "exploratory" docs/workflows/execution-sequence.md` → マッチあり

Closes: TASK-0142 / Related: #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)