### PR TITLE
feat(security): SLSA provenance attestation — リリース時 build provenance 生成

### DIFF
--- a/.github/workflows/slsa-attestation.yml
+++ b/.github/workflows/slsa-attestation.yml
@@ -21,13 +21,14 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Create release archive
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          tag="${{ github.event.release.tag_name }}"
           git archive --format=tar.gz \
-            --prefix="plangate-${tag}/" \
+            --prefix="plangate-${RELEASE_TAG}/" \
             HEAD \
-            -o "plangate-${tag}.tar.gz"
-          echo "ARCHIVE=plangate-${tag}.tar.gz" >> "$GITHUB_ENV"
+            -o "plangate-${RELEASE_TAG}.tar.gz"
+          echo "ARCHIVE=plangate-${RELEASE_TAG}.tar.gz" >> "$GITHUB_ENV"
 
       - name: Generate SLSA provenance attestation
         uses: actions/attest-build-provenance@e8d4baa0b41c87f71bb46de40f28fe2e2aaee96f # v2.4.0
@@ -37,6 +38,7 @@ jobs:
       - name: Upload archive to release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            "${{ env.ARCHIVE }}" --clobber
+          gh release upload "${RELEASE_TAG}" \
+            "${ARCHIVE}" --clobber

--- a/.github/workflows/slsa-attestation.yml
+++ b/.github/workflows/slsa-attestation.yml
@@ -1,0 +1,42 @@
+name: SLSA Provenance
+
+# リリース公開時に SLSA build provenance を生成し release asset に添付する。
+# Scorecard CII-Best-Practices / SLSA チェック対応。
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  provenance:
+    permissions:
+      id-token: write      # SLSA signing (OIDC token)
+      contents: write      # release asset upload
+      attestations: write  # GitHub Attestations API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create release archive
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          git archive --format=tar.gz \
+            --prefix="plangate-${tag}/" \
+            HEAD \
+            -o "plangate-${tag}.tar.gz"
+          echo "ARCHIVE=plangate-${tag}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Generate SLSA provenance attestation
+        uses: actions/attest-build-provenance@e8d4baa0b41c87f71bb46de40f28fe2e2aaee96f # v2.4.0
+        with:
+          subject-path: ${{ env.ARCHIVE }}
+
+      - name: Upload archive to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ env.ARCHIVE }}" --clobber

--- a/scripts/add-slsa-attestation.sh
+++ b/scripts/add-slsa-attestation.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# scripts/add-slsa-attestation.sh — SLSA provenance workflow を追加（OpenSSF Scorecard 対応）
+#
+# .github/workflows/ は Hardening Override 対象のため AI が本スクリプトを生成し、
+# --apply は Human が実行する（docs/ai/responsibility-classes.md AI/Human 分界）。
+#
+# 使い方:
+#   sh scripts/add-slsa-attestation.sh --dry-run   # 差分確認（変更なし）
+#   sh scripts/add-slsa-attestation.sh --apply     # 適用（冪等）
+set -eu
+MODE="${1:---dry-run}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$ROOT/.github/workflows/slsa-attestation.yml"
+
+# 冪等性チェック
+if [ -f "$TARGET" ]; then
+  printf 'SKIP (already applied): %s は既に存在します\n' "$TARGET"
+  exit 0
+fi
+
+CONTENT='name: SLSA Provenance
+
+# リリース公開時に SLSA build provenance を生成し release asset に添付する。
+# Scorecard CII-Best-Practices / SLSA チェック対応。
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  provenance:
+    permissions:
+      id-token: write      # SLSA signing (OIDC token)
+      contents: write      # release asset upload
+      attestations: write  # GitHub Attestations API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Create release archive
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          git archive --format=tar.gz \
+            --prefix="plangate-${tag}/" \
+            HEAD \
+            -o "plangate-${tag}.tar.gz"
+          echo "ARCHIVE=plangate-${tag}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Generate SLSA provenance attestation
+        uses: actions/attest-build-provenance@e8d4baa0b41c87f71bb46de40f28fe2e2aaee96f # v2.4.0
+        with:
+          subject-path: ${{ env.ARCHIVE }}
+
+      - name: Upload archive to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ env.ARCHIVE }}" --clobber
+'
+
+if [ "$MODE" = "--dry-run" ]; then
+  printf '[dry-run] 以下のファイルを新規作成します:\n  %s\n\n' "$TARGET"
+  printf '%s\n' "$CONTENT"
+  exit 0
+elif [ "$MODE" = "--apply" ]; then
+  printf '%s' "$CONTENT" > "$TARGET"
+  printf 'APPLIED: %s を作成しました\n' "$TARGET"
+  printf '次のステップ:\n'
+  printf '  git add .github/workflows/slsa-attestation.yml\n'
+  printf '  git commit -m "feat(security): SLSA provenance attestation workflow 追加"\n'
+else
+  printf 'usage: %s [--dry-run|--apply]\n' "$0" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- リリース公開（`release: published`）時に SLSA build provenance を自動生成・添付
- `actions/attest-build-provenance@v2.4.0` を使用（commit hash pin 済み）
- `git archive` でリリース tarball を作成し、GitHub Attestations API に署名
- OpenSSF Scorecard の **SLSA チェック**対応（0/10 → 5〜7/10 改善見込み）

## 変更ファイル

| ファイル | 種別 | 概要 |
|---------|------|------|
| `scripts/add-slsa-attestation.sh` | 新規（非HO） | apply script |
| `.github/workflows/slsa-attestation.yml` | 新規（HO・Human 適用済み） | SLSA workflow |

## Permissions

```yaml
permissions:
  id-token: write      # SLSA signing (OIDC token)
  contents: write      # release asset upload
  attestations: write  # GitHub Attestations API
```

ジョブ単位で最小権限付与、ルートは `permissions: {}` で全拒否。

## Test plan

- [ ] CI 全 PASS 確認
- [ ] 次回リリース時に `plangate-vX.Y.Z.tar.gz` が release asset に添付されることを確認
- [ ] GitHub Actions の Attestations タブで provenance が確認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)