### PR TITLE
fix(#500): TASK-0141 EH-2 strict JSON + EH-1/2 stdin fallback

### DIFF
--- a/scripts/hooks/check-c3-approval.sh
+++ b/scripts/hooks/check-c3-approval.sh
@@ -66,6 +66,17 @@ if [ -z "$task_id" ] && [ ! -t 0 ]; then
         | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \
         | head -1 || true)
     fi
+    if [ -z "$_eh2_fp" ] && command -v python3 >/dev/null 2>&1; then
+      _eh2_fp=$(printf '%s' "$_eh2_stdin" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if isinstance(d, dict):
+        print(d.get("tool_input", {}).get("file_path") or d.get("file_path") or "")
+except Exception:
+    pass
+' 2>/dev/null || true)
+    fi
     if [ -z "$_eh2_fp" ]; then
       _eh2_fp=$(printf '%s' "$_eh2_stdin" \
         | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
@@ -114,7 +125,7 @@ fi
 c3_status=$(python3 - "$c3_file" <<'PYC3' 2>/dev/null || true
 import sys, json
 try:
-    with open(sys.argv[1]) as f:
+    with open(sys.argv[1], encoding="utf-8") as f:
         data = json.load(f)
     if isinstance(data, dict):
         print(data.get("c3_status", ""))

--- a/scripts/hooks/check-c3-approval.sh
+++ b/scripts/hooks/check-c3-approval.sh
@@ -56,8 +56,32 @@ if [ -z "$task_id" ]; then
   task_id=${1:-}
 fi
 
+# stdin fallback: env/arg なし時に tool_input.file_path から TASK-ID を抽出
+if [ -z "$task_id" ] && [ ! -t 0 ]; then
+  _eh2_stdin=$(cat 2>/dev/null || true)
+  if [ -n "$_eh2_stdin" ]; then
+    _eh2_fp=""
+    if command -v jq >/dev/null 2>&1; then
+      _eh2_fp=$(printf '%s' "$_eh2_stdin" \
+        | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \
+        | head -1 || true)
+    fi
+    if [ -z "$_eh2_fp" ]; then
+      _eh2_fp=$(printf '%s' "$_eh2_stdin" \
+        | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 \
+        | sed 's/.*"\([^"]*\)"$/\1/')
+    fi
+    if [ -n "$_eh2_fp" ]; then
+      task_id=$(printf '%s' "$_eh2_fp" \
+        | grep -o 'TASK-[0-9][0-9][0-9][0-9]' \
+        | head -1 || true)
+    fi
+  fi
+fi
+
 if [ -z "$task_id" ]; then
-  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg, skipping"
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg / stdin, skipping"
   emit_judgment "allow"
   exit 0
 fi
@@ -87,8 +111,17 @@ if [ ! -f "$c3_file" ]; then
   exit 0
 fi
 
-c3_status=$(grep '"c3_status"' "$c3_file" 2>/dev/null \
-  | sed 's/.*"c3_status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "")
+c3_status=$(python3 - "$c3_file" <<'PYC3' 2>/dev/null || true
+import sys, json
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        print(data.get("c3_status", ""))
+except Exception:
+    pass
+PYC3
+)
 
 if [ "$c3_status" != "APPROVED" ]; then
   reason="C-3 status is '$c3_status', not APPROVED (Hook EH-2)"

--- a/scripts/hooks/check-plan-exists.sh
+++ b/scripts/hooks/check-plan-exists.sh
@@ -69,6 +69,17 @@ if [ -z "$task_id" ] && [ ! -t 0 ]; then
         | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \
         | head -1 || true)
     fi
+    if [ -z "$_eh1_fp" ] && command -v python3 >/dev/null 2>&1; then
+      _eh1_fp=$(printf '%s' "$_eh1_stdin" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if isinstance(d, dict):
+        print(d.get("tool_input", {}).get("file_path") or d.get("file_path") or "")
+except Exception:
+    pass
+' 2>/dev/null || true)
+    fi
     if [ -z "$_eh1_fp" ]; then
       _eh1_fp=$(printf '%s' "$_eh1_stdin" \
         | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \

--- a/scripts/hooks/check-plan-exists.sh
+++ b/scripts/hooks/check-plan-exists.sh
@@ -59,8 +59,32 @@ if [ -z "$task_id" ]; then
   task_id=${1:-}
 fi
 
+# stdin fallback: env/arg なし時に tool_input.file_path から TASK-ID を抽出
+if [ -z "$task_id" ] && [ ! -t 0 ]; then
+  _eh1_stdin=$(cat 2>/dev/null || true)
+  if [ -n "$_eh1_stdin" ]; then
+    _eh1_fp=""
+    if command -v jq >/dev/null 2>&1; then
+      _eh1_fp=$(printf '%s' "$_eh1_stdin" \
+        | jq -r '.tool_input.file_path // .file_path // empty' 2>/dev/null \
+        | head -1 || true)
+    fi
+    if [ -z "$_eh1_fp" ]; then
+      _eh1_fp=$(printf '%s' "$_eh1_stdin" \
+        | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 \
+        | sed 's/.*"\([^"]*\)"$/\1/')
+    fi
+    if [ -n "$_eh1_fp" ]; then
+      task_id=$(printf '%s' "$_eh1_fp" \
+        | grep -o 'TASK-[0-9][0-9][0-9][0-9]' \
+        | head -1 || true)
+    fi
+  fi
+fi
+
 if [ -z "$task_id" ]; then
-  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg, skipping (false-positive guard)"
+  log_event "SKIP" "no PLANGATE_HOOK_TASK / arg / stdin, skipping (false-positive guard)"
   emit_judgment "allow"
   exit 0
 fi


### PR DESCRIPTION
## Summary

`scripts/hooks/check-c3-approval.sh`:
- `grep/sed` による c3_status 抽出を `python3 json.load` strict 解析に置換（コメント入り・壊れた JSON を正確に reject）
- env 未注入時に stdin `tool_input.file_path` から TASK-ID を取得する fallback を追加（jq なし時 python3 フォールバック追加）
- `open()` に `encoding="utf-8"` を追加（ロケール依存の UnicodeDecodeError を防止）

`scripts/hooks/check-plan-exists.sh`:
- 同様の stdin file_path fallback 追加（jq なし時 python3 フォールバック追加）

`scripts/apply-task-0141-eh2-strict.sh --apply` で適用した結果をコミット。
Wiring Integrity Enforcement のステップ: EH-2 strict 化 + EH-1/2 stdin fallback。

fixes #500

## Test plan

- [ ] `sh tests/run-tests.sh` → ta-43 6 PASS, 0 failed
- [ ] `bin/plangate doctor` で Hook 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)