### PR TITLE
docs: TASK-0141/0143/0144 handoff.md 発行（WF-05 完了資産）

### DIFF
--- a/docs/working/TASK-0141/handoff.md
+++ b/docs/working/TASK-0141/handoff.md
@@ -1,0 +1,115 @@
+---
+task_id: TASK-0141
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-06-26
+author: qa-reviewer
+v1_release: "5135ceb (PR#630)"
+---
+
+# Handoff Package — TASK-0141
+
+## メタ情報
+
+```yaml
+task: TASK-0141
+related_issue: https://github.com/s977043/plangate/issues/500
+author: qa-reviewer
+issued_at: 2026-06-26
+v1_release: 5135ceb (PR#630 マージコミット / main ブランチ)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-1: EH-2 の c3_status が python3 strict JSON 解析 | PASS | `check-c3-approval.sh` L125〜 に `python3 json.load` 実装。壊れた JSON / 非 object / フィールド欠落 → 2>/dev/null で空文字 → 非 APPROVED 扱い（fail-safe）。EH-3 と対称化済み |
+| AC-2: EH-1/EH-2 が stdin `tool_input.file_path` から TASK-ID 解決 | PASS | `check-c3-approval.sh` L59〜95、`check-plan-exists.sh` L62〜98 に stdin fallback 実装。優先順: env `PLANGATE_HOOK_TASK` → arg → stdin JSON 解析（jq → python3 → grep の 3 段フォールバック）。`cat 2>/dev/null || true` によるハング防止済み |
+| AC-3: ta-06 が hook テスト結果を PASS/FAIL として報告 | PASS | `tests/extras/ta-06-hooks.sh` から `>/dev/null 2>&1` を除去。run-tests.sh が hook テスト結果を PASS/FAIL として認識可能 |
+| AC-4: ta-43 が壊れた JSON・コメント埋め込み・正常 JSON の 3 ケースを検証 | PASS | `tests/extras/ta-43-eh2-strict-json.sh` 新規作成。TC-01〜TC-06 の 6 ケース（正常 APPROVED・壊れた JSON・コメント埋め込み・フィールドなし・stdin 解決・stdin なし+env なし）を自動テスト化。サンドボックス構成（tmp に hook コピー）で実環境汚染なし |
+| AC-5: 全テスト（run-tests.sh）が 300+ PASS、FAIL=0 | PASS | 実測: 349 PASS, 0 FAIL（`sh tests/run-tests.sh`、PR#630 マージ後） |
+
+**総合**: 5/5 基準 PASS
+
+**FAIL / WARN の扱い**: 全 AC が PASS のため V1 リリースにブロッカーなし。C-1 での軽微 WARN（W-01: stdin TC-05 は apply 後のみ完全検証可能、W-02: ta-06 unsilence による既存失敗露出）は意図的であり許容済み。
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| EH-3 stdin fallback 未対応（EH-2/EH-1 のみ対応） | minor | accepted（EH-3 は plan_hash 検証のため別設計が必要） | Yes |
+| jq 非インストール環境での python3 フォールバック依存 | minor | workaround（python3 → grep の多段フォールバックで対応済み） | No |
+| maintenance.json の発行元検証（EH-3 provenance）| major | open（issue #420 で追跡中。本 TASK 対象外） | Yes |
+| EH-4/5/7 配線・EHS-1/2/3 発火条件の未整備 | minor | open（Out of scope として別 TASK に分離済み） | Yes |
+| ta-06 unsilence により既存フック系テスト失敗が露出する可能性 | minor | accepted（意図的露出。個別フック修正は別 TASK） | Yes |
+
+**Critical 課題の対応**: Critical open 課題なし。リリースに支障なし。
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue（あれば） |
+|--------|------|----------|-----------------|
+| EH-3 stdin fallback 追加 | check-plan-hash.sh は python3 strict JSON 化済みだが stdin fallback 未実装。EH-1/EH-2 と対称化 | Medium | #500 |
+| maintenance.json 発行元検証（EH-3 provenance hardening） | HMAC / プロセス系譜 / CI 検証による EH-3 強化。#420 で設計中 | High | #420 |
+| EH-4/EH-5/EH-7 hook 配線 | settings wiring 整合性の残課題（doctor --check-settings との連携含む）| Medium | #500 |
+| EHS-1/2/3 発火条件整備 | shell script 系 hook の発火精度向上 | Low | — |
+| settings-wiring-contract / doctor --check-settings 更新 | AC-1,2 of #500 に該当。本 TASK の Out of scope として分離済み | Medium | #500 |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| stdin 解析を jq → python3 → grep の 3 段フォールバックで実装 | jq 単一依存（jq が必須 requirement） | CI 環境・ローカル環境ともに jq が未インストールのケースがあるため。python3 は既存 hooks で使用中で安全。grep は最終手段として string パターンで抽出 |
+| python3 エラー時は空文字（= 非 APPROVED）を fail-safe として採用 | python3 エラー時はブロック（exit 1） | 承認の false-negative（通るべき承認を弾く）よりも false-positive（不正 JSON を通過させる）を防ぐ方が重要。既存 EH-3 の実装と同方針 |
+| ta-43 で apply-script の patch を hooks コピーに当てるサンドボックス方式 | 実環境 hooks を直接テスト | HO 対象パスのため AI は直接編集不可。apply-script を --dry-run 等せず、コピーに当てる方式で実 audit ログ汚染なし（ta-39 パターン踏襲） |
+| stdin ハング対策として `cat 2>/dev/null \|\| true` を採用 | read タイムアウト付き実装 | bash 環境により timeout 挙動が異なる。`cat 2>/dev/null \|\| true` はシンプルかつ実績あり。EH-3 stdinハング知見（2026-06-10）を踏まえた選択 |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0141 は EPIC #527 の最終 open child（issue #500「承認境界の強制実態ギャップ是正」の最優先サブセット）として実施された。EH-2（check-c3-approval.sh）が grep/sed による c3_status 抽出を使っており、細工された c3.json で承認判定が誤通過するリスクを修正した。また EH-1/EH-2 が `PLANGATE_HOOK_TASK` 未設定時に無条件 SKIP していた問題を、stdin `tool_input.file_path` からの TASK-ID 解決 fallback で解消した。
+
+PR#613（plan）と PR#630（feat/task-0141-500-exec）が main にマージ済み。HO 対象ファイル（check-c3-approval.sh / check-plan-exists.sh）は `scripts/apply-task-0141-eh2-strict.sh` により Human が適用済み。テスト結果は 349 PASS / 0 FAIL で全 AC を充足している。
+
+### 触れないでほしいファイル
+
+- `scripts/hooks/check-c3-approval.sh`: EH-2 承認境界の中核。変更時は Hardening Override 対象のため `scripts/apply-task-0141-eh2-strict.sh` のようなパターンで apply-script を別途作成し Human 適用が必要
+- `scripts/hooks/check-plan-exists.sh`: EH-1 の中核。同上
+- `tests/extras/ta-43-eh2-strict-json.sh`: EH-2 strict JSON の回帰テスト。壊れた JSON テストのサンドボックス構成を維持すること（hooks コピーへの apply-script パッチ）
+
+### 次に手を入れるなら
+
+- EH-3（check-plan-hash.sh）への stdin fallback 追加（V2 候補、本 TASK と同型の実装）
+- issue #420 の EH-3 provenance hardening（HMAC / プロセス系譜）実装
+- ta-06 unsilence で露出した既存フック系テスト失敗の個別修正
+- settings-wiring-contract / doctor --check-settings の更新（issue #500 の残 AC-1,2）
+- 新規 apply-script を作成する際は `scripts/apply-task-0141-eh2-strict.sh` を参照パターンとして活用できる（HO パス パッチ、dry-run 対応、ロールバック手順を含む）
+
+### 参照リンク
+
+- 親 EPIC: https://github.com/s977043/plangate/issues/527
+- 関連 Issue: https://github.com/s977043/plangate/issues/500
+- PR#613 (plan): https://github.com/s977043/plangate/pull/613
+- PR#630 (exec): https://github.com/s977043/plangate/pull/630
+- pbi-input.md: `docs/working/TASK-0141/pbi-input.md`
+- plan.md: `docs/working/TASK-0141/plan.md`
+- status.md: `docs/working/TASK-0141/status.md`
+- EH-3 stdinハング知見: `docs/working/` 2026-06-10 audit session memory
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit (ta-43: EH-2 strict JSON + stdin fallback) | 6 | 6 | 0 | TC-01〜06 全網羅 |
+| Integration (run-tests.sh 全体) | 349 | 349 | 0 | — |
+| E2E | — | — | — | — |
+
+**FAIL / SKIP の詳細**: FAIL=0、SKIP なし。C-1 W-01（TC-05 の stdin fallback は apply 後のみ完全検証可能）は ta-43 のサンドボックスでシミュレートしているため実質カバー済み。
+
+**実行コマンド**: `sh tests/run-tests.sh`（PR#630 マージ後 main で実測）
+
+## 7. Metrics summary
+
+該当なし（metrics --collect 未実施）

--- a/docs/working/TASK-0141/handoff.md
+++ b/docs/working/TASK-0141/handoff.md
@@ -25,7 +25,7 @@ v1_release: 5135ceb (PR#630 マージコミット / main ブランチ)
 | 受入基準 | 判定 | 根拠 / コメント |
 |---------|------|---------------|
 | AC-1: EH-2 の c3_status が python3 strict JSON 解析 | PASS | `check-c3-approval.sh` L125〜 に `python3 json.load` 実装。壊れた JSON / 非 object / フィールド欠落 → 2>/dev/null で空文字 → 非 APPROVED 扱い（fail-safe）。EH-3 と対称化済み |
-| AC-2: EH-1/EH-2 が stdin `tool_input.file_path` から TASK-ID 解決 | PASS | `check-c3-approval.sh` L59〜95、`check-plan-exists.sh` L62〜98 に stdin fallback 実装。優先順: env `PLANGATE_HOOK_TASK` → arg → stdin JSON 解析（jq → python3 → grep の 3 段フォールバック）。`cat 2>/dev/null || true` によるハング防止済み |
+| AC-2: EH-1/EH-2 が stdin `tool_input.file_path` から TASK-ID 解決 | PASS | `check-c3-approval.sh` L59〜92、`check-plan-exists.sh` L62〜95 に stdin fallback 実装。優先順: env `PLANGATE_HOOK_TASK` → arg → stdin JSON 解析（jq → python3 → grep の 3 段フォールバック）。`cat 2>/dev/null || true` によるハング防止済み |
 | AC-3: ta-06 が hook テスト結果を PASS/FAIL として報告 | PASS | `tests/extras/ta-06-hooks.sh` から `>/dev/null 2>&1` を除去。run-tests.sh が hook テスト結果を PASS/FAIL として認識可能 |
 | AC-4: ta-43 が壊れた JSON・コメント埋め込み・正常 JSON の 3 ケースを検証 | PASS | `tests/extras/ta-43-eh2-strict-json.sh` 新規作成。TC-01〜TC-06 の 6 ケース（正常 APPROVED・壊れた JSON・コメント埋め込み・フィールドなし・stdin 解決・stdin なし+env なし）を自動テスト化。サンドボックス構成（tmp に hook コピー）で実環境汚染なし |
 | AC-5: 全テスト（run-tests.sh）が 300+ PASS、FAIL=0 | PASS | 実測: 349 PASS, 0 FAIL（`sh tests/run-tests.sh`、PR#630 マージ後） |

--- a/docs/working/TASK-0143/handoff.md
+++ b/docs/working/TASK-0143/handoff.md
@@ -1,0 +1,136 @@
+---
+task_id: TASK-0143
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-06-26
+author: qa-reviewer
+v1_release: "26a5b60"
+---
+
+# Handoff Package — TASK-0143
+
+## メタ情報
+
+```yaml
+task: TASK-0143
+related_issue: https://github.com/s977043/plangate/issues/528
+  parent_issue: https://github.com/s977043/plangate/issues/500
+  epic: https://github.com/s977043/plangate/issues/527
+author: qa-reviewer
+issued_at: 2026-06-26
+v1_release: 26a5b60 (PR#629 + PR#625 両マージ済み / main)
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-01: `plangate verify` で EH-4 発火 | PASS | `bin/plangate` L2120〜2126: V-1 前に `check-test-cases.sh` を strict=1 で呼び出し。test-cases.md なしは exit 1 でブロック |
+| AC-02: EH-5 が doctor で検証される | PASS | `bin/plangate verify` L2130〜: V-1 後に `check-verification-evidence.sh` を `PLANGATE_HOOK_STRICT=0` (warn) で呼び出し。`bin/plangate doctor` CLI Hook Wiring セクションで EH-5 配線確認も実施 |
+| AC-03: EH-7 が doctor で検証される | PASS | `bin/plangate doctor` L577〜603: `=== CLI Hook Wiring (EH-4/5/7) ===` セクション追加。EH-7 は INFO で手動呼び出しを案内 |
+| AC-04: ta-44 が 0 FAIL で PASS | PASS | `tests/extras/ta-44-eh457-cli-wiring.sh` 5 TC。`sh tests/run-tests.sh` → 349 passed, 0 failed（2026-06-26 実測） |
+| AC-05: settings-wiring-contract.md に CLI 配線セクション追加 | PASS | `docs/ai/settings-wiring-contract.md` §CLI 配線（EH-4/5/7）— TASK-0143 セクション追加済み（`grep -c "CLI 配線"` → 2） |
+| AC-06: EHS-1〜3 設計が hook-enforcement.md に明文化 | PASS | `docs/ai/hook-enforcement.md` §EHS-1〜3 に発火条件・対応・実装状態を記述。`grep -c "EHS-1\|EHS-2\|EHS-3"` → 10 |
+| AC-07: doctor が EH-4/5/7 配線欠落を警告 | PASS | `bin/plangate doctor` が `[PASS]` / `[WARN]` で EH-4/5 の配線状態を報告。EH-7 は `[INFO]` で手動呼び出し手順を案内 |
+| AC-08: events.ndjson 生成・metrics report が動作 | WARN | #529 dogfooding は今回の run で opt-out。V2 候補に移行（詳細は §3） |
+| AC-09: improvement-seeds.md にエントリ追記 | PASS | PR#625 に `docs/working/improvement-seeds.md` への TASK-0143 エントリ追記を含む |
+
+**総合**: `7/9 基準 PASS（1 WARN / 1 V2 移行）`
+
+**WARN / 移行の扱い**:
+- AC-08（WARN）: metrics dogfooding は開発フロー実績が少ない状況での初回試行。本 PBI では opt-out とし、次 PBI 以降の継続実施に委ねる。機能自体（`bin/plangate metrics`）は動作済みで品質上の問題なし
+- AC-09 は improvement-seeds.md への追記（PR#625 内）により PASS 扱い
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| EH-7 が doctor 可視化のみで CLI 強制配線なし | minor | accepted | Yes（#500 後続 PBI） |
+| EH-5 を warn モードのみとしており blocking 不可 | minor | accepted | Yes（EHS-2 実装時に昇格候補） |
+| EHS-1〜3 は設計のみ、実装未着手 | minor | open | Yes（#527 後続子 PBI） |
+| AC-08 metrics dogfooding opt-out | info | accepted | Yes（次 PBI 以降の継続運用試行） |
+
+**Critical 課題**: なし
+
+補足:
+- EH-7 の CLI 強制配線は `bin/plangate pr` / `bin/plangate merge` サブコマンドが存在しないため doctor 可視化に留めた設計判断。GitHub branch protection 連携が整った段階で blocking 化を検討する
+- EH-5 warn モードは「verify 完了直後は evidence がない状態が多い」という運用実態への配慮。EHS-2 で handoff 必須要素チェックと組み合わせてから blocking 化する方針
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue |
+|--------|------|----------|-----------|
+| EH-7 の CLI 強制配線 | `pr` / `merge` サブコマンド未実装、GitHub branch protection 連携が前提 | Medium | #500, #527 |
+| EHS-1〜3 の実装 | 本 PBI は設計・ドキュメント化のみ。`validation_bias: strict` 発火経路の実装は別 PBI | High | #527 子 PBI |
+| EH-5 blocking モード化 | EHS-2（handoff 6 要素チェック）と組み合わせた段階化が必要 | Medium | #527 |
+| metrics dogfooding (#529) 定常化 | 本 PBI で opt-out。次 PBI から継続実施し知見を蓄積する | Low | #529 |
+| apply-script idempotent 検証の自動化 | E-01（2 回 --apply で "already applied" SKIP）は手動確認のみ | Low | — |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| EH-5 を warn（PLANGATE_HOOK_STRICT=0）で呼び出し | EH-5 を strict=1 で blocking | verify 完了直後は evidence が存在しない状態が正常。blocking にすると全 PBI で false positive が発生するため warn 限定 |
+| EH-7 を doctor [INFO] 案内のみ | EH-7 を verify に組み込み blocking | `bin/plangate` に `merge` サブコマンドが存在しないため配線先がない。doctor 可視化で暫定対処し後続 PBI で根治 |
+| apply-script（Python + sh の 2 層）で bin/plangate を Human 適用 | AI が bin/plangate を直接編集 | HO（Hardening Override）対象パスのため AI 直接編集禁止。grep/sed パターンベースで行番号非依存の patch を作成し Human が `--apply` 実行 |
+| EHS-1〜3 を設計・ドキュメント化のみ | EHS-1〜3 の実装まで実施 | `model-profiles.yaml` の `validation_bias: strict` 発火経路が未整備で実装前に設計確定が必要。#527 のスコープ定義に委ねる |
+| ta-44 を 5 TC 構成（apply 前 SKIP）| apply 後の挙動を全 TC で検証 | CI（apply 未適用環境）で全 TC が SKIP になるよう apply 判定を先行させ偽 FAIL を防ぐ（ta-43 パターン踏襲） |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0143 は EPIC #527（Enforcement Integrity Roadmap）の子 PBI 第 1 号として、
+EH-4 / EH-5 / EH-7 の CLI 配線を実施した。
+
+実装は 2 段階 PR 構成で完了:
+- PR#625（`feat/task-0143-581-subagent-review-exec`）: docs/ai/ 更新・ta-44 テスト・apply-script 作成
+- PR#629（`feat/task-0143-581-subagent-review-exec`）: bin/plangate への EH-4/5 CLI 配線適用（Human apply 後）
+
+main ブランチ HEAD は `26a5b60`。テストは 349 passed / 0 failed。
+EH-4 は `plangate verify` の V-1 前で strict=1 発火、EH-5 は V-1 後で warn 発火、
+EH-7 は `plangate doctor` の CLI Hook Wiring セクションで [INFO] 案内のみ。
+EHS-1〜3 は `docs/ai/hook-enforcement.md` §EHS に設計を明文化し実装は後続 PBI に委ねた。
+
+### 触れないでほしいファイル
+
+- `bin/plangate`: HO 対象パス。AI 直接編集禁止。変更が必要な場合は apply-script パターン（`scripts/_apply_task_XXXX_patches.py` + `.sh`）を作成して Human が `--apply` 実行
+- `scripts/apply-task-0143-eh457-wiring.sh` / `scripts/_apply_task_0143_patches.py`: 適用済みの apply-script。再適用すると idempotent 動作で SKIP されるが、内容改変は履歴を壊す
+
+### 次に手を入れるなら
+
+- **EHS-1〜3 の実装**（#527 後続子 PBI）: `docs/ai/hook-enforcement.md §EHS` の設計に従い `validation_bias: strict` 発火経路を実装する。`check-handoff-elements.sh` が EHS-2 の基盤として既存
+- **EH-7 blocking 化**（#500 後続 PBI）: `plangate pr` / `plangate merge` サブコマンドを実装後に `check-merge-approvals.sh` を strict=1 で配線
+- **ta-44 テストの apply 後 TC 追加**: 現行 5 TC は apply 前 SKIP + apply 後基本確認のみ。`plangate verify` が実際に EH-4 block した audit log を検証する TC を追加すると coverage が上がる
+- apply-script パターンを踏む際は `scripts/_apply_task_0143_patches.py` を参照テンプレートとして活用（dry-run / --apply 両対応・idempotent・grep パターンベース）
+
+### 参照リンク
+
+- EPIC: https://github.com/s977043/plangate/issues/527
+- 親 issue: https://github.com/s977043/plangate/issues/500
+- metrics dogfooding: https://github.com/s977043/plangate/issues/529
+- hook-enforcement.md（配線状態正本）: `docs/ai/hook-enforcement.md`
+- settings-wiring-contract.md（CLI 配線セクション）: `docs/ai/settings-wiring-contract.md`
+- pbi-input.md: `docs/working/TASK-0143/pbi-input.md`
+- plan.md: `docs/working/TASK-0143/plan.md`
+- status.md: `docs/working/TASK-0143/status.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit（ta-44 hook スクリプト直接呼び出し） | 5 | 5 | 0 / 0 | EH-4/5/7 各パス・ブロック・warn |
+| Integration（tests/run-tests.sh 全体） | 349 | 349 | 0 / 0 | — |
+| E2E / Manual | — | — | — | apply-script dry-run → --apply → doctor 確認（Human 実施） |
+
+**テスト実行コマンド**: `sh tests/run-tests.sh`
+
+**FAIL / SKIP 詳細**: なし（全 TC PASS）
+
+**注意**: ta-44 は apply-script 適用前の clean 環境では TC-02〜05 が SKIP に変わる設計。
+CI（未適用環境）では SKIP が正常動作。apply 後の本番環境では 5 TC 全 PASS。
+
+## 7. Metrics summary
+
+該当なし（AC-08 / #529 dogfooding は本 PBI では opt-out。V2 候補として次 PBI 以降に継続）

--- a/docs/working/TASK-0144/handoff.md
+++ b/docs/working/TASK-0144/handoff.md
@@ -24,7 +24,7 @@ v1_release: "1f645be (main, PR#632 マージコミット)"
 
 | 受入基準 | 判定 | 根拠 / コメント |
 |---------|------|---------------|
-| AC-01: `.plangate.yml` に `c3_approval: {mode: conversation}` → EH-3 が c3.json SKIP → `bin/plangate exec` 通過 | PASS | `check-plan-hash.sh` L143-174 に conversation モード経路（`^docs/working/TASK-[0-9]+/approvals/c3\.json$` マッチ → exit 0）が実装。ta-45 TC-01 が apply 後 PASS（テスト結果: 349 passed / 0 failed）|
+| AC-01: `.plangate.yml` に `c3_approval: {mode: conversation}` → EH-3 が c3.json SKIP → `bin/plangate exec` 通過 | PASS | `check-plan-hash.sh` L143-177 に conversation モード経路（`^docs/working/TASK-[0-9]+/approvals/c3\.json$` マッチ → exit 0）が実装。ta-45 TC-01 が apply 後 PASS（テスト結果: 349 passed / 0 failed）|
 | AC-02: `c3_approval: {mode: cli}` またはファイル未存在 → 現行動作維持 | PASS | デフォルト `cli`、`.plangate.yml` 未存在時は `_read_plangate_config()` が `cli` にフォールバック。ta-45 TC-02/TC-03 が PASS |
 | AC-03: 生成された c3.json に `source: conversation` フィールド | PASS | `schemas/c3-approval.schema.json` L54-58 に `source: {enum: ["cli", "conversation"]}` が optional フィールドとして追加。`bin/plangate approve` が `source: "cli"` を付与（PR#631 実装済み）|
 | AC-04: `bin/plangate doctor` が現在の承認モードを出力 | PASS | `bin/plangate` L606-611 に `=== C-3 Approval Mode ===` セクション追加。`.plangate.yml` 存在時は `c3_approval.mode=<値>` を表示、未存在時は `default: c3_approval.mode=cli` を表示。ta-45 TC-05 が PASS |
@@ -77,7 +77,7 @@ C-2 レビュー（Codex、R-001〜R-008）で critical 2 件を含む 8 件の�
 
 ### 触れないでほしいファイル
 
-- `scripts/hooks/check-plan-hash.sh`: EH-3 の conversation SKIP 経路（L143-174）は `.plangate.yml` mode 読み込みロジックと密結合。変更する場合は ta-45 TC-01/TC-03 を必ず通すこと
+- `scripts/hooks/check-plan-hash.sh`: EH-3 の conversation SKIP 経路（L143-177）は `.plangate.yml` mode 読み込みロジックと密結合。変更する場合は ta-45 TC-01/TC-03 を必ず通すこと
 - `schemas/c3-approval.schema.json`: `source` フィールドを `required` に変更すると既存 c3.json（source なし）が schema FAIL になる。optional のまま維持すること
 - `bin/plangate` の `_read_plangate_config()` 関数（L113-161): PyYAML fallback ロジックが複雑。変更する場合は python3 未インストール環境でも動作確認すること
 

--- a/docs/working/TASK-0144/handoff.md
+++ b/docs/working/TASK-0144/handoff.md
@@ -1,0 +1,118 @@
+---
+task_id: TASK-0144
+artifact_type: handoff
+schema_version: 1
+status: final
+issued_at: 2026-06-26
+author: qa-reviewer
+v1_release: "1f645be (main)"
+---
+
+# Handoff Package — TASK-0144
+
+## メタ情報
+
+```yaml
+task: TASK-0144
+related_issue: https://github.com/s977043/plangate/issues/626
+author: qa-reviewer
+issued_at: 2026-06-26
+v1_release: "1f645be (main, PR#632 マージコミット)"
+```
+
+## 1. 要件適合確認結果
+
+| 受入基準 | 判定 | 根拠 / コメント |
+|---------|------|---------------|
+| AC-01: `.plangate.yml` に `c3_approval: {mode: conversation}` → EH-3 が c3.json SKIP → `bin/plangate exec` 通過 | PASS | `check-plan-hash.sh` L143-174 に conversation モード経路（`^docs/working/TASK-[0-9]+/approvals/c3\.json$` マッチ → exit 0）が実装。ta-45 TC-01 が apply 後 PASS（テスト結果: 349 passed / 0 failed）|
+| AC-02: `c3_approval: {mode: cli}` またはファイル未存在 → 現行動作維持 | PASS | デフォルト `cli`、`.plangate.yml` 未存在時は `_read_plangate_config()` が `cli` にフォールバック。ta-45 TC-02/TC-03 が PASS |
+| AC-03: 生成された c3.json に `source: conversation` フィールド | PASS | `schemas/c3-approval.schema.json` L54-58 に `source: {enum: ["cli", "conversation"]}` が optional フィールドとして追加。`bin/plangate approve` が `source: "cli"` を付与（PR#631 実装済み）|
+| AC-04: `bin/plangate doctor` が現在の承認モードを出力 | PASS | `bin/plangate` L606-611 に `=== C-3 Approval Mode ===` セクション追加。`.plangate.yml` 存在時は `c3_approval.mode=<値>` を表示、未存在時は `default: c3_approval.mode=cli` を表示。ta-45 TC-05 が PASS |
+| AC-05: `schemas/plangate-config.schema.json` が `c3_approval.mode` を enum 検証 | PASS | `schemas/plangate-config.schema.json` 新規作成済み。`c3_approval.mode` を `enum: ["cli", "conversation"]` で検証。ta-45 TC-06 が PASS（有効値 PASS / 無効値 FAIL を確認）|
+| AC-06: 既存テスト 0 FAIL | PASS | 349 passed / 0 failed（PR#632 マージ後確認済み）|
+
+**総合**: 6/6 基準 PASS
+
+## 2. 既知課題一覧
+
+| 課題 | Severity | 状態 | V2 候補か |
+|------|---------|------|---------|
+| conversation モードの HMAC 署名・セッション検証が未実装 | major | accepted（Out of scope 明記済み） | Yes（issue #420 後続 PBI）|
+| EH-3 provenance 検証（発行元が本当に人間か）が機械的に保証されない | major | accepted（issue #420 で追跡中）| Yes |
+| `_approver_identity_unverified: true` — c3.json の `approved_by` が git-config 由来で暗号署名なし | major | accepted（既存制約・TASK-0128 以来の既知）| Yes（issue #420）|
+| `.plangate.yml` の PyYAML 未インストール時に WARN 止まり（exec を止めない）| minor | accepted（fail-open 設計で安全側フォールバック。doctor で可視化）| No |
+| c3.json スキーマの `source` フィールドが optional のため、source なし c3.json も valid | minor | accepted（後方互換維持の設計判断。既存 c3.json を破壊しない）| No |
+
+**Critical 課題**: なし（V1 リリース可）
+
+## 3. V2 候補
+
+| V2 候補 | 理由 | 推定優先度 | 関連 Issue |
+|--------|------|----------|-----------|
+| EH-3 provenance 完全検証（HMAC + セッション系譜） | 設計複雑度が大きく、本 PBI スコープ外として Out of scope 明記 | Medium | #420 |
+| conversation モードの HMAC 署名・セッション検証 | 「人間 APPROVE 発話 → AI が c3.json 生成」の経路で AI 自己承認リスクが残る。署名による技術的保証が必要 | Medium | #420 |
+| `.plangate.yml` の他設定項目サポート（例: exec_timeout, log_level）| 本 PBI は `c3_approval` のみスコープ | Low | — |
+| GUI / Web UI 承認フロー | 本 PBI スコープ外 | Low | — |
+| `bin/plangate approve` での conversation モード c3.json 生成を `cmd_approve` に組み込む | 現行は会話内 AI 直接 Write。cmd_approve 統合でロジックを一箇所に集約できる | Low | — |
+
+## 4. 妥協点
+
+| 選択した実装 | 諦めた代替案 | 理由 |
+|------------|-----------|------|
+| `cmd_exec` は変更しない（R-001/R-002 反映） | cmd_exec 内で c3.json を自動生成（当初案） | C-3 ゲートの自己充足を防ぐ。「exec が承認を確認する」から「exec が承認を作る」への変質を避けるため Codex critical 指摘に従い再設計 |
+| EH-3 SKIP は「通す」役割のみ（R-003 反映）、中身検証は EH-2 と AI 生成コードに委ねる | EH-3 で schema / plan_hash / source を検証する | EH-3 は write ポリシー制御のみとし、内容検証を exec 時 EH-2 に一元化。責務分離が明確になる |
+| `source` フィールドを optional として schema 追加（R-004 反映） | additionalProperties: false を前提に source なし c3.json を FAIL 扱い | 既存 c3.json との後方互換維持が必須。旧 c3.json（source なし）も引き続き valid |
+| `.plangate.yml` 不正値は fail-open（cli フォールバック）+ stderr WARN（R-005 反映） | 不正値で fail-closed（exec を止める） | ユーザーへの可視化（doctor WARN）を優先しつつ、既存動作を維持。完全 fail-closed は doctor チェック義務化が整備されてから検討 |
+| apply-script 経由の HO パス適用（`scripts/_apply_task_0144_patches.py`） | AI が bin/plangate / hook / schema を直接編集 | HO（Hardening Override）対象パスの AI 自己改変は禁止（settings-wiring-contract）。Human が apply-script を実行することで Shadow Config を防ぐ |
+
+## 5. 引き継ぎ文書
+
+### 概要
+
+TASK-0144 は、C-3 承認を CLI（`bin/plangate approve`）と会話内 APPROVE（AI が exec 前に c3.json を生成）の 2 モードで切り替えるプロジェクト設定機能を実装した。`.plangate.yml` に `c3_approval: {mode: cli|conversation}` を記述することで動作が変わる。デフォルトは `cli`（後方互換）。
+
+主要な実装変更は PR#631（非 HO 変更: `.plangate.yml` サンプル、`schemas/plangate-config.schema.json`、`tests/extras/ta-45-c3-mode-config.sh`、`docs/ai/settings-wiring-contract.md`）と PR#632（HO パス適用: `bin/plangate`、`schemas/c3-approval.schema.json`、`scripts/hooks/check-plan-hash.sh`）の 2 PR に分割されており、両方 main にマージ済み（main HEAD: 1f645be）。テストは 349 passed / 0 failed。
+
+C-2 レビュー（Codex、R-001〜R-008）で critical 2 件を含む 8 件の指摘があり、plan を再設計後に exec した。特に「cmd_exec に c3.json 自動生成を入れるとゲート自己充足になる」という critical 指摘（R-001/R-002）を受けて、c3.json 生成を exec 前の独立したステップとし、cmd_exec は変更しない設計にした。
+
+### 触れないでほしいファイル
+
+- `scripts/hooks/check-plan-hash.sh`: EH-3 の conversation SKIP 経路（L143-174）は `.plangate.yml` mode 読み込みロジックと密結合。変更する場合は ta-45 TC-01/TC-03 を必ず通すこと
+- `schemas/c3-approval.schema.json`: `source` フィールドを `required` に変更すると既存 c3.json（source なし）が schema FAIL になる。optional のまま維持すること
+- `bin/plangate` の `_read_plangate_config()` 関数（L113-161): PyYAML fallback ロジックが複雑。変更する場合は python3 未インストール環境でも動作確認すること
+
+### 次に手を入れるなら
+
+- **issue #420（EH-3 provenance 完全検証）**: conversation モードで AI が生成した c3.json の発行元を機械的に保証する仕組み。HMAC + セッション系譜。本 PBI では暫定対応（`source: conversation` フィールド + 規範層のみ）で、技術層の保証は #420 で実装
+- **`.plangate.yml` スキーマ検証の doctor 統合**: 現行 doctor は `c3_approval.mode` の値表示のみ。`.plangate.yml` が schema に適合するかの自動検証を doctor に組み込むと、不正設定を早期発見できる
+- **conversation モード時の c3.json テンプレート提供**: AI が c3.json を生成するとき、plan_hash を自動算出して正しく埋め込むヘルパーコマンド（例: `bin/plangate conversation-approve TASK-XXXX`）があると誤生成を防げる
+
+### 参照リンク
+
+- 親 issue: https://github.com/s977043/plangate/issues/626
+- PR#631: feat/task-0144-c3-mode（非 HO 変更）
+- PR#632: feat/task-0144-ho-apply-result（HO パス適用）
+- plan.md: `docs/working/TASK-0144/plan.md`
+- pbi-input.md: `docs/working/TASK-0144/pbi-input.md`
+- status.md: `docs/working/TASK-0144/status.md`
+- 関連 PBI: TASK-0143（EH-4/5/7 CLI 配線）
+- 設計正本: `docs/ai/settings-wiring-contract.md`
+
+## 6. テスト結果サマリ
+
+| レイヤー | 件数 | PASS | FAIL / SKIP | カバレッジ |
+|---------|------|------|-----------|----------|
+| Unit（ta-45: TC-04/05/06）| 3 | 3 | 0 | AC-03/04/05 を直接カバー |
+| Integration（ta-45: TC-01/02/03/07）| 4 | 4 | 0 | AC-01/02/06 をカバー |
+| Regression（tests/run-tests.sh 全件）| 349 | 349 | 0 | 既存 TC 全件 0 FAIL |
+
+**FAIL / SKIP の詳細**: なし。ta-45 は apply-script 適用前（PR#631 のみ）は TC-01〜04 が SKIP（apply 未完）となるが、PR#632 マージ後（HO 適用済み）は全 TC PASS に移行。
+
+**外部レビュー（C-2）**:
+- Codex レビュー: R-001(critical)/R-002(critical)/R-003(major)/R-004(major)/R-005(major)/R-006(major) → 全て plan 再設計・test-cases 更新で反映済み
+- Codex R-007(minor)/R-008(minor) → plan.md / test-cases.md の記載修正で反映済み
+- Gemini レビュー: C-2 段階では `IneligibleTierError` で実行不可（WARN）。実装後 Gemini レビュー（PR#632）で high（tr エスケープ）/ medium（2>/dev/null）指摘が検出され対応済み
+
+## 7. Metrics summary（opt-in）
+
+該当なし（metrics 収集未実施）


### PR DESCRIPTION
## Summary

- TASK-0141 / TASK-0143 / TASK-0144 の WF-05 完了資産（handoff.md）を発行
- doc-only 変更（`.md` 3ファイルのみ）、コード変更なし

## AC 判定結果

| TASK | 総合 | テスト |
|------|------|--------|
| TASK-0141: EH-2 strict JSON + EH-1/2 stdin fallback | 5/5 PASS | 349 passed, 0 failed |
| TASK-0143: EH-4/5/7 CLI 配線 + EHS-1〜3 設計 | 7/9 PASS（metrics V2 候補） | 349 passed, 0 failed |
| TASK-0144: C-3 approval mode config (.plangate.yml) | 6/6 PASS | 349 passed, 0 failed |

## Test plan

- [ ] doc-only 変更のため CI lint のみ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)