### PR TITLE
fix(#527): EHS-3/2 BLOCK コメント追加（Gemini medium 対応）

### DIFF
--- a/scripts/_apply_task_0146_patches.py
+++ b/scripts/_apply_task_0146_patches.py
@@ -66,6 +66,7 @@ P1_OLD = (
 P1_NEW = (
     "    # EHS-3 (TASK-0146 / #527): fix-loop カウンタ increment + strict 時 block\n"
     "    if [ \"${PLANGATE_VALIDATION_BIAS:-normal}\" = \"strict\" ]; then\n"
+    "      # EHS-3 BLOCK\n"
     "      PLANGATE_HOOK_STRICT=1 sh \"$plangate_root/scripts/hooks/check-fix-loop.sh\" \"$task_id\" increment || return 1\n"
     "    else\n"
     "      sh \"$plangate_root/scripts/hooks/check-fix-loop.sh\" \"$task_id\" increment 2>/dev/null || true\n"
@@ -100,6 +101,7 @@ P2_NEW = (
     "  done\n"
     "  if [ \"$_handoff_verify\" = \"1\" ]; then\n"
     "    if [ \"${PLANGATE_VALIDATION_BIAS:-normal}\" = \"strict\" ]; then\n"
+    "      # EHS-2 BLOCK\n"
     "      PLANGATE_HOOK_STRICT=1 sh \"$plangate_root/scripts/hooks/check-handoff-elements.sh\" \"$task_id\" || return 1\n"
     "    else\n"
     "      sh \"$plangate_root/scripts/hooks/check-handoff-elements.sh\" \"$task_id\" 2>/dev/null || true\n"


### PR DESCRIPTION
## Summary

- PR#637（TASK-0146 EHS-2/3 配線）の Gemini medium レビュー対応
- `scripts/_apply_task_0146_patches.py` の P1_NEW/P2_NEW に `# EHS-3 BLOCK` / `# EHS-2 BLOCK` コメントを追加
- hook スクリプト自体が詳細なエラーを stderr に出力するため冗長な printf は不要（PR#637 で除去済み）
- コメント追加により static analysis TC-02/TC-05 も引き続き PASS（検出パターン変更なし）

closes #527

## Test plan

- [ ] CI 全 PASS 確認（plangate CLI tests / markdown lint / settings wiring drift）
- [ ] `python3 scripts/_apply_task_0146_patches.py . 1` dry-run で `# EHS-3 BLOCK` / `# EHS-2 BLOCK` が diff に含まれること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)