### PR TITLE
feat(#527): TASK-0145/0146 EHS-1/2/3 bin/plangate 実適用

### DIFF
--- a/bin/plangate
+++ b/bin/plangate
@@ -2124,6 +2124,13 @@ cmd_verify() {
   fi
   printf '[verify] Running V-1 (validate)...\n'
   if ! "$0" validate "$task_id"; then
+    # EHS-3 (TASK-0146 / #527): fix-loop カウンタ increment + strict 時 block
+    if [ "${PLANGATE_VALIDATION_BIAS:-normal}" = "strict" ]; then
+      # EHS-3 BLOCK
+      PLANGATE_HOOK_STRICT=1 sh "$plangate_root/scripts/hooks/check-fix-loop.sh" "$task_id" increment || return 1
+    else
+      sh "$plangate_root/scripts/hooks/check-fix-loop.sh" "$task_id" increment 2>/dev/null || true
+    fi
     printf '[verify] V-1 FAILED — stop\n' >&2
     return 1
   fi
@@ -2137,7 +2144,16 @@ cmd_verify() {
   case "$mode_flag" in
     standard|high-risk|critical)
       printf '[verify] Running V-3 (external review)...\n'
-      "$0" review "$task_id" --phase v3 || printf '[verify] V-3 returned non-zero\n' >&2
+      if "$0" review "$task_id" --phase v3; then
+        :
+      else
+        # EHS-1 (TASK-0145 / #527): validation_bias=strict は V-3 合格を必須化
+        if [ "${PLANGATE_VALIDATION_BIAS:-normal}" = "strict" ]; then
+          printf '[verify] EHS-1 BLOCK -- validation_bias=strict requires a passing V-3 external review\n' >&2
+          return 1
+        fi
+        printf '[verify] V-3 returned non-zero\n' >&2
+      fi
       ;;
   esac
   printf '[verify] Running 8-aspect eval...\n'
@@ -2152,6 +2168,20 @@ cmd_handoff() {
   if [ -z "$task_id" ]; then
     printf 'Usage: plangate handoff <TASK-XXXX>\n' >&2
     return 2
+  fi
+  # EHS-2 (TASK-0146 / #527): --verify で handoff.md の 6 要素を検査
+  _handoff_verify=0
+  for _harg in "$@"; do
+    case "$_harg" in --verify) _handoff_verify=1 ;; esac
+  done
+  if [ "$_handoff_verify" = "1" ]; then
+    if [ "${PLANGATE_VALIDATION_BIAS:-normal}" = "strict" ]; then
+      # EHS-2 BLOCK
+      PLANGATE_HOOK_STRICT=1 sh "$plangate_root/scripts/hooks/check-handoff-elements.sh" "$task_id" || return 1
+    else
+      sh "$plangate_root/scripts/hooks/check-handoff-elements.sh" "$task_id" 2>/dev/null || true
+    fi
+    return 0
   fi
   work_dir="$plangate_working_dir/$task_id"
   template="$plangate_root/docs/working/templates/handoff.md"

--- a/tests/extras/ta-46-ehs-wiring.sh
+++ b/tests/extras/ta-46-ehs-wiring.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # TC-02: strict 時の V-3 不合格は return 1（block）
-if awk '/EHS-1 BLOCK/{flag=2} flag && --flag && /return 1/{found=1} END{exit !found}' "$_T46_PG" 2>/dev/null; then
+if awk '/EHS-1 BLOCK/{flag=3} flag && --flag && /return 1/{found=1} END{exit !found}' "$_T46_PG" 2>/dev/null; then
   printf '  [PASS] TC-02 EHS-1 strict 時 V-3 不合格を block（return 1）\n'; pass=$((pass + 1))
 else
   printf '  [FAIL] TC-02 EHS-1 block 動作の欠落\n'; fail=$((fail + 1))


### PR DESCRIPTION
## Summary

- `apply-task-0145-ehs-wiring.sh --apply` および `apply-task-0146-ehs23-wiring.sh --apply` の適用結果を main に反映
- **EHS-1**: `PLANGATE_VALIDATION_BIAS=strict` 時に V-3 不合格を block（`return 1`）
- **EHS-3**: `strict` 時に V-1 fix-loop 上限超過を block（`# EHS-3 BLOCK` + `return 1`）
- **EHS-2**: `plangate handoff --verify` で handoff.md 6 要素不足を `strict` 時に block（`# EHS-2 BLOCK` + `return 1`）
- `ta-46` TC-02: `awk flag=2→3` に修正（EHS-1 BLOCK 直後の `return 1` を正しく検出）

## Test plan

- [x] テストローカル確認: 359 PASS / 0 FAIL（ta-46 / ta-47 全 PASS）
- [ ] CI 全 PASS（plangate CLI tests / markdown lint / settings wiring drift）

🤖 Generated with [Claude Code](https://claude.com/claude-code)