### PR TITLE
plan(#527): TASK-0147 validation_bias conductor export 配線（follow-up plan）

### DIFF
--- a/docs/working/TASK-0147/plan.md
+++ b/docs/working/TASK-0147/plan.md
@@ -1,0 +1,73 @@
+# TASK-0147 EXECUTION PLAN — validation_bias の conductor export 配線（#527 follow-up）
+
+> EPIC #527（CLOSED）の受容済み Non-goal を follow-up として正規化。
+> TASK-0145/0146 で EHS-1/2/3 は `bin/plangate` に配線・適用済みだが、発火条件
+> `PLANGATE_VALIDATION_BIAS` を **実 run で誰も export していない**ため、strict
+> profile でも EHS が発火しない。本 PBI でその最後の経路を埋める。
+
+## Goal
+
+`model-profiles.yaml` の active/指定 profile の `validation_bias` を解決し、
+`bin/plangate verify` / `handoff --verify` 実行時に `PLANGATE_VALIDATION_BIAS`
+として自動 export する機構を配線する。strict profile で EHS-1/2/3 が実 run 発火し、
+normal/lenient では従来どおり非発火（既存挙動不変）。
+
+## Approach Overview
+
+| 案 | 内容 | 評価 |
+|----|------|------|
+| A（採用）| `bin/plangate verify`/`handoff` が `--profile <key>` を受理し、`model-profiles.yaml` から `validation_bias` を解決して内部で `PLANGATE_VALIDATION_BIAS` を export | 既存 `--profile`（context/eval）と一貫・最小侵襲 |
+| B | conductor agent (`workflow-conductor.md`) が手順として env export を指示 | プロンプト依存＝強制力なし（Hook 哲学に反する）。補助のみ |
+| C | `model-profiles.yaml` の "active" を別途持たせ常時自動解決 | active 概念が未定義・スコープ増。将来拡張 |
+
+→ **案A を主、案B を補助文書**として併用。env を明示注入済みなら尊重（上書きしない）。
+
+## Work Breakdown
+
+| Step | Output | Owner | Risk | 🚩 |
+|------|--------|-------|------|----|
+| 1 | `_resolve_validation_bias.py`（profile key → bias 解決ヘルパー、yaml 読取） | agent | low | yaml parse 健全性 |
+| 2 | apply-script: `cmd_verify`/`cmd_handoff` 冒頭で `--profile` 解決し `PLANGATE_VALIDATION_BIAS` を export（env 既設定時は尊重） | agent | **HO** | 🚩 bin/plangate 改変 |
+| 3 | `tests/extras/ta-49-bias-export.sh`（未適用SKIP / 適用後 TC-01〜05） | agent | low | — |
+| 4 | `workflow-conductor.md` に profile→bias 運用補足（補助・非強制） | agent | **HO** | 🚩 .claude/agents 改変 |
+| 5 | hook-enforcement.md の follow-up ギャップ記述を「配線済み」へ更新 | agent | low | PR #642 とのコンフリクト調整 |
+
+## Files / Components to Touch
+
+- `scripts/_resolve_validation_bias.py`（新規・AI 直接可）
+- `scripts/apply-task-0147-bias-export.sh` + `_apply_task_0147_patches.py`（新規・AI 直接可）
+- `bin/plangate`（**HO** / apply-script 経由・Human 適用）
+- `.claude/agents/workflow-conductor.md`（**HO** / apply-script 経由・Human 適用）
+- `tests/extras/ta-49-bias-export.sh`（新規）
+- `docs/ai/hook-enforcement.md`（doc）
+
+## Testing Strategy
+
+- ta-49: TC-01（`--profile` で strict 解決→export）/ TC-02（normal profile は非 export＝既定 normal）/ TC-03（env 明示注入を上書きしない）/ TC-04（不正 profile key はエラーまたは normal fallback・安全側）/ TC-05（patched 構文健全 `sh -n`）。
+- `sh tests/run-tests.sh` 0 FAIL（未適用は SKIP）。
+- strict profile での EHS-1/2/3 実発火を統合確認（sandbox apply）。
+
+## Risks & Mitigations
+
+| Risk | 対策 |
+|------|------|
+| profile→bias 自動解決が誤って strict 化し既存 run を block | env 既定 normal・明示 `--profile` 指定時のみ解決・env 既設定尊重の三重安全側 |
+| HO 2 ファイル（bin/plangate + workflow-conductor）改変でレビュー負荷増 | apply-script + Human 適用、文字列アンカー方式。conductor 変更は非強制の補足のみに限定 |
+| PR #642（doc）と hook-enforcement.md が競合 | #642 マージ後に rebase、または本 PBI で doc 変更を持たない選択 |
+| 閉じた EPIC #527 の再開 | follow-up PBI として新 issue 起票（スコープを export 経路のみに限定） |
+
+## Questions / Unknowns
+
+- `model-profiles.yaml` の「active profile」概念は未定義 → 本 PBI は **明示 `--profile`** に限定し、active 自動選択は別 PBI（案C）に送る。
+- conductor（AI エージェント）が実際に `--profile` を渡す運用フローを強制する手段はプロンプト止まり → 強制は CLI 側（案A）に閉じ、conductor は補助。
+
+## Mode判定
+
+**モード**: high-risk（`bin/plangate` + `.claude/agents/` = Hardening Override パス 2 種）/ `lite_eligible=false`
+
+**判定根拠**:
+
+- 変更ファイル数: 6 → high
+- 変更種別: HO パス配線（承認境界周辺）→ 最低 high（AC-10）
+- リスク: 中〜高（実 run の strict 発火に影響）
+- **最終判定**: high-risk（人間 C-3 必須、autonomous APPROVE 不可）

--- a/docs/working/TASK-0147/plan.md
+++ b/docs/working/TASK-0147/plan.md
@@ -26,7 +26,7 @@ normal/lenient では従来どおり非発火（既存挙動不変）。
 
 | Step | Output | Owner | Risk | 🚩 |
 |------|--------|-------|------|----|
-| 1 | `_resolve_validation_bias.py`（profile key → bias 解決ヘルパー、yaml 読取） | agent | low | yaml parse 健全性 |
+| 1 | `_resolve_validation_bias.py`（profile key → bias 解決ヘルパー、yaml 読取。**未知 key / yaml 欠落・破損時は normal fallback しつつ stderr に警告**＝サイレント失敗防止） | agent | low | yaml parse 健全性 |
 | 2 | apply-script: `cmd_verify`/`cmd_handoff` 冒頭で `--profile` 解決し `PLANGATE_VALIDATION_BIAS` を export（env 既設定時は尊重） | agent | **HO** | 🚩 bin/plangate 改変 |
 | 3 | `tests/extras/ta-49-bias-export.sh`（未適用SKIP / 適用後 TC-01〜05） | agent | low | — |
 | 4 | `workflow-conductor.md` に profile→bias 運用補足（補助・非強制） | agent | **HO** | 🚩 .claude/agents 改変 |
@@ -38,6 +38,11 @@ normal/lenient では従来どおり非発火（既存挙動不変）。
 - `scripts/apply-task-0147-bias-export.sh` + `_apply_task_0147_patches.py`（新規・AI 直接可）
 - `bin/plangate`（**HO** / apply-script 経由・Human 適用）
 - `.claude/agents/workflow-conductor.md`（**HO** / apply-script 経由・Human 適用）
+  - 注（PR #643 Gemini 指摘への回答）: 本リポジトリの **正本は `.claude/agents/`**
+    （repo-owned・Claude Code 実行時に読まれる定義・HO 対象）。`plugin/plangate/agents/workflow-conductor.md`
+    は **export 版**（hybrid-architecture.md 補足参照）。実行強制に関わるのは
+    `.claude/agents/` 側のため本 PBI はこちらを正とし、export 版の同期は
+    別途 plugin sync で扱う（本 PBI スコープ外・todo に follow-up 記載）。
 - `tests/extras/ta-49-bias-export.sh`（新規）
 - `docs/ai/hook-enforcement.md`（doc）
 

--- a/docs/working/TASK-0147/test-cases.md
+++ b/docs/working/TASK-0147/test-cases.md
@@ -1,0 +1,33 @@
+# TASK-0147 テストケース定義 — validation_bias conductor export（#527 follow-up）
+
+> 自動化: `tests/extras/ta-49-bias-export.sh`。未適用時 SKIP（HO apply 前は CI 非破壊）。
+
+## 受入基準 → テストケースマッピング
+
+| AC | 内容 | TC |
+|----|------|----|
+| AC-1 | `--profile <strict系key>` で `validation_bias=strict` を解決し `PLANGATE_VALIDATION_BIAS=strict` を export | TC-01 |
+| AC-2 | normal/lenient profile では strict を export しない（既定 normal＝既存挙動不変） | TC-02 |
+| AC-3 | env で `PLANGATE_VALIDATION_BIAS` が既設定なら上書きしない（明示注入尊重） | TC-03 |
+| AC-4 | 不正/未知 profile key は安全側（normal fallback またはエラー、strict にはしない） | TC-04 |
+| AC-5 | patched `bin/plangate` が構文健全（`sh -n`） | TC-05 |
+
+## テストケース一覧（適用後）
+
+| TC | 前提 | 入力 / 検査 | 期待 | 種別 |
+|----|------|------------|------|------|
+| TC-01 | apply 済み | `verify --profile gpt-5_5_pro`（strict profile）でヘルパー解決 | export=strict、EHS 有効 | 解決ロジック |
+| TC-02 | apply 済み | normal profile 指定 / 無指定 | export されない or normal | 解決ロジック |
+| TC-03 | apply 済み | `PLANGATE_VALIDATION_BIAS=normal` 環境下で strict profile 指定 | env 尊重（上書きしない） | 優先順位 |
+| TC-04 | apply 済み | 未知 profile key | strict にならない（安全側） | 異常系 |
+| TC-05 | apply 済み | `sh -n bin/plangate` | exit 0 | 構文 |
+
+## エッジケース
+
+- **未適用状態**: マーカ不在 → 全 TC SKIP（CI 非破壊）。
+- **`model-profiles.yaml` 欠落/破損**: 解決失敗時は normal fallback（strict 化しない安全側）。
+- **strict profile + env 明示 normal**: TC-03 が優先順位を担保（env > profile）。
+
+## 統合確認（sandbox）
+
+- strict profile 解決後、`verify` で EHS-1（V-3）/ EHS-3（fix-loop）、`handoff --verify` で EHS-2 が実際に block すること。

--- a/docs/working/TASK-0147/test-cases.md
+++ b/docs/working/TASK-0147/test-cases.md
@@ -9,7 +9,7 @@
 | AC-1 | `--profile <strict系key>` で `validation_bias=strict` を解決し `PLANGATE_VALIDATION_BIAS=strict` を export | TC-01 |
 | AC-2 | normal/lenient profile では strict を export しない（既定 normal＝既存挙動不変） | TC-02 |
 | AC-3 | env で `PLANGATE_VALIDATION_BIAS` が既設定なら上書きしない（明示注入尊重） | TC-03 |
-| AC-4 | 不正/未知 profile key は安全側（normal fallback またはエラー、strict にはしない） | TC-04 |
+| AC-4 | 不正/未知 profile key・yaml 欠落/破損は安全側（normal fallback、strict にしない）**かつ stderr に警告を出力**（サイレント失敗防止） | TC-04, TC-06 |
 | AC-5 | patched `bin/plangate` が構文健全（`sh -n`） | TC-05 |
 
 ## テストケース一覧（適用後）
@@ -19,13 +19,14 @@
 | TC-01 | apply 済み | `verify --profile gpt-5_5_pro`（strict profile）でヘルパー解決 | export=strict、EHS 有効 | 解決ロジック |
 | TC-02 | apply 済み | normal profile 指定 / 無指定 | export されない or normal | 解決ロジック |
 | TC-03 | apply 済み | `PLANGATE_VALIDATION_BIAS=normal` 環境下で strict profile 指定 | env 尊重（上書きしない） | 優先順位 |
-| TC-04 | apply 済み | 未知 profile key | strict にならない（安全側） | 異常系 |
+| TC-04 | apply 済み | 未知 profile key | strict にならない（安全側）+ stderr に警告 | 異常系 |
 | TC-05 | apply 済み | `sh -n bin/plangate` | exit 0 | 構文 |
+| TC-06 | apply 済み | `model-profiles.yaml` 欠落/破損 | normal fallback + stderr に警告（サイレント失敗しない） | 異常系 |
 
 ## エッジケース
 
 - **未適用状態**: マーカ不在 → 全 TC SKIP（CI 非破壊）。
-- **`model-profiles.yaml` 欠落/破損**: 解決失敗時は normal fallback（strict 化しない安全側）。
+- **`model-profiles.yaml` 欠落/破損**: 解決失敗時は normal fallback（strict 化しない安全側）+ stderr 警告（TC-06）。
 - **strict profile + env 明示 normal**: TC-03 が優先順位を担保（env > profile）。
 
 ## 統合確認（sandbox）

--- a/docs/working/TASK-0147/todo.md
+++ b/docs/working/TASK-0147/todo.md
@@ -45,3 +45,4 @@
 
 - `model-profiles.yaml` の "active profile" 自動選択（案C）
 - conductor が `--profile` を必ず渡すことの強制（プロンプト止まり＝CLI 側に強制を閉じる）
+- `plugin/plangate/agents/workflow-conductor.md`（export 版）への補足同期（plugin sync で対応・本 PBI は `.claude/agents/` 正本のみ）

--- a/docs/working/TASK-0147/todo.md
+++ b/docs/working/TASK-0147/todo.md
@@ -1,0 +1,47 @@
+# TASK-0147 EXECUTION TODO — validation_bias conductor export 配線（#527 follow-up）
+
+## 🤖 Agent タスク
+
+### 準備
+
+- [ ] `model-profiles.yaml` の profile 構造・`validation_bias` 値域確認（済: normal/strict/lenient）
+  - rollback: 不要（読取）
+- [ ] 既存 `--profile` 受理箇所（context/eval）の引数処理パターン踏襲方針確定
+  - rollback: 不要（設計）
+
+### 実装
+
+- [ ] `scripts/_resolve_validation_bias.py`（profile key → bias 解決）
+  - rollback: ファイル削除
+- [ ] `scripts/apply-task-0147-bias-export.sh` + `_apply_task_0147_patches.py`（HO apply、dry-run/--apply、文字列アンカー）
+  - rollback: ファイル削除（HO 本体未改変なら影響なし）
+- [ ] `tests/extras/ta-49-bias-export.sh`（未適用 SKIP / 適用後 TC-01〜05）
+  - rollback: ファイル削除
+
+### 検証
+
+- [ ] sandbox 適用で TC-01〜05 PASS・`sh -n` OK・strict profile で EHS 実発火確認
+- [ ] `sh tests/run-tests.sh` 0 FAIL
+
+### 完了整備
+
+- [ ] hook-enforcement.md follow-up 記述を「配線済み」へ更新（#642 マージ後に調整）
+- [ ] working-context（status/current-state/handoff）整備
+- [ ] PR 作成
+
+## 👤 Human タスク
+
+- [ ] **C-3 ゲート**: high-risk / HO 2 種 → **人間 C-3 必須**（autonomous APPROVE 不可）
+- [ ] **apply-script 適用**: `sh scripts/apply-task-0147-bias-export.sh --apply`（bin/plangate + workflow-conductor の HO 改変）
+- [ ] **新 issue 起票**: EPIC #527（CLOSED）の follow-up としてスコープ限定で起票
+- [ ] **C-4 ゲート**: PR レビュー → マージ
+
+## ⚠️ 依存関係
+
+- 本 PBI は TASK-0145/0146（EHS 配線済み・main マージ済み）を前提
+- PR #642（doc 同期）と hook-enforcement.md が競合しうる → #642 先行マージ推奨
+
+## スコープ外（別 PBI）
+
+- `model-profiles.yaml` の "active profile" 自動選択（案C）
+- conductor が `--profile` を必ず渡すことの強制（プロンプト止まり＝CLI 側に強制を閉じる）


### PR DESCRIPTION
## 概要
EPIC #527（CLOSED）の受容済み Non-goal を **follow-up PBI（TASK-0147）の plan** として正規化。

TASK-0145/0146 で EHS-1/2/3 は `bin/plangate` に配線・適用済みですが、発火条件 `PLANGATE_VALIDATION_BIAS` を**実 run で export する経路が存在しない**ため、strict profile でも EHS が発火しません。本 plan はその最後の経路を設計します。

## 設計（案A 採用）
`bin/plangate verify`/`handoff --verify` が `--profile <key>` を受理し、`model-profiles.yaml` から `validation_bias` を解決して `PLANGATE_VALIDATION_BIAS` を内部 export（既存 `--profile` と一貫）。env 既設定は尊重、normal/lenient は非発火＝既存挙動不変。conductor 文書は非強制の補足のみ。

## 本 PR の内容
- `plan.md` / `todo.md` / `test-cases.md` のみ（**実装なし**）

## Mode / ゲート
- **high-risk**（`bin/plangate` + `.claude/agents/workflow-conductor.md` = HO パス 2 種）/ `lite_eligible=false`
- **人間 C-3 必須**（autonomous APPROVE 不可、AC-10 Hardening Override）
- 実装（apply-script + HO 適用）は C-3 承認後に別 PR

## 留意
- 閉じた EPIC #527 の follow-up のため、実装着手前に**スコープ限定の新 issue 起票**を推奨
- PR #642（doc 同期）と hook-enforcement.md が競合しうる → #642 先行マージ推奨

Refs #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)