### PR TITLE
feat(#527): TASK-0147 validation_bias conductor export 配線（apply-script 方式）

### DIFF
--- a/docs/working/TASK-0147/approvals/c3.json
+++ b/docs/working/TASK-0147/approvals/c3.json
@@ -1,10 +1,10 @@
 {
   "task_id": "TASK-0147",
+  "phase": "C-3",
   "c3_status": "APPROVED",
-  "decision": "APPROVED",
-  "approved_by": "human (masatake.komine@proni.co.jp)",
-  "approved_at": "2026-06-27",
-  "mode": "high-risk",
+  "approved_by": "masatake.komine@proni.co.jp",
+  "approved_at": "2026-06-27T00:00:00Z",
   "plan_hash": "sha256:0a3bb2744f8ef0b8b20ddbf55df988f24b9299fd077ec1a845e689274fc39de9",
-  "note": "ユーザー明示承認: 「TASK-0147 を C-3 承認して実装を進めて」。HO 2種 (bin/plangate + .claude/agents/workflow-conductor.md) を含む high-risk。実装は AI-owned 成果物 (helper/apply-script/test) のみ、HO 本体適用は Human-owned。"
+  "source": "conversation",
+  "conditions": "ユーザー明示承認: 「TASK-0147 を C-3 承認して実装を進めて」。high-risk / HO 2種 (bin/plangate + .claude/agents/workflow-conductor.md)。実装は AI-owned 成果物 (helper/apply-script/test) のみ、HO 本体適用は Human-owned (apply-script)。"
 }

--- a/docs/working/TASK-0147/approvals/c3.json
+++ b/docs/working/TASK-0147/approvals/c3.json
@@ -1,0 +1,10 @@
+{
+  "task_id": "TASK-0147",
+  "c3_status": "APPROVED",
+  "decision": "APPROVED",
+  "approved_by": "human (masatake.komine@proni.co.jp)",
+  "approved_at": "2026-06-27",
+  "mode": "high-risk",
+  "plan_hash": "sha256:0a3bb2744f8ef0b8b20ddbf55df988f24b9299fd077ec1a845e689274fc39de9",
+  "note": "ユーザー明示承認: 「TASK-0147 を C-3 承認して実装を進めて」。HO 2種 (bin/plangate + .claude/agents/workflow-conductor.md) を含む high-risk。実装は AI-owned 成果物 (helper/apply-script/test) のみ、HO 本体適用は Human-owned。"
+}

--- a/docs/working/TASK-0147/current-state.md
+++ b/docs/working/TASK-0147/current-state.md
@@ -1,0 +1,8 @@
+# TASK-0147 現在状態スナップショット
+
+- **フェーズ**: C-3 APPROVED（人間）→ 実装完了 → sandbox 検証 PASS → **PR 作成直前**
+- **ブランチ**: `feat/task-0147-validation-bias-export`（origin/main 起点）
+- **成果**: helper（`_resolve_validation_bias.py`）+ apply-script（3 patch）+ ta-49
+- **検証**: sandbox 適用で ta-49 TC-01〜06 全 PASS / suite 363 passed・0 failed
+- **次アクション**: PR 作成 → 👤 apply（`--apply`、マージ後）→ hook-enforcement.md 更新
+- **ブロッカー**: なし（HO 適用は Human-owned＝設計どおり）

--- a/docs/working/TASK-0147/handoff.md
+++ b/docs/working/TASK-0147/handoff.md
@@ -1,0 +1,40 @@
+# TASK-0147 Handoff — validation_bias conductor export 配線（#527 follow-up）
+
+> WF-05 完了資産（Rule 5）。issue #644 / plan PR #643（マージ済み）の実装フェーズ。
+
+## 1. 要件適合確認結果（AC ごと）
+
+| AC | 内容 | 判定 | 根拠 |
+|----|------|------|------|
+| AC-1 | `--profile <strict系>` で `PLANGATE_VALIDATION_BIAS=strict` を export | PASS（sandbox）| ta-49 TC-01 / 統合解決 gpt-5_5_pro→strict |
+| AC-2 | normal/lenient・無指定では strict を export しない | PASS | ta-49 TC-02 |
+| AC-3 | env 既設定なら上書きしない | PASS（sandbox）| ta-49 TC-03（`[ -z "${PLANGATE_VALIDATION_BIAS:-}" ]` ガード） |
+| AC-4 | 不正/未知 key・yaml 破損は安全側 normal + stderr 警告 | PASS | ta-49 TC-04 / TC-06 |
+| AC-5 | patched `bin/plangate` 構文健全 | PASS（sandbox）| ta-49 TC-05（`sh -n`） |
+
+## 2. 既知課題一覧
+
+- `bin/plangate` / `workflow-conductor.md`（HO）は PR 時点で未パッチ（apply-script のみ同梱）。適用は Human が PR マージ後に `--apply`。
+- `model-profiles.yaml` の「active profile」自動選択は本 PBI 対象外（明示 `--profile` のみ）。
+- conductor が `--profile` を必ず渡すことの強制はしない（強制は CLI 側に閉じる・補足は非強制）。
+
+## 3. V2 候補
+
+- `model-profiles.yaml` の active profile 自動選択（案C）。
+- `plugin/plangate/agents/workflow-conductor.md`（export 版）への補足同期（plugin sync）。
+- hook-enforcement.md の follow-up 記述を「配線済み（実 run 発火）」へ更新。
+
+## 4. 妥協点（採用しなかった選択肢と理由）
+
+- **conductor 手順で env export を強制（案B）**: プロンプト依存で強制力なし → CLI 側 export（案A）を主、conductor は非強制の補足に限定。
+- **`--validation-bias` 直フラグ**: profile と二重管理になる → 既存 `--profile` に一本化し profile から解決。
+- **active profile 自動解決（案C）**: active 概念が未定義 → スコープ外。
+
+## 5. 引き継ぎ文書（サマリ）
+
+EHS-1/2/3 は配線・適用済みだったが発火条件 `PLANGATE_VALIDATION_BIAS` を実 run で供給する経路が欠けていた（TASK-0146 Non-goals / issue #644）。本 PBI で `bin/plangate verify`/`handoff --verify` が `--profile <key>` を受理し `model-profiles.yaml` の `validation_bias` を解決して内部 export する経路を配線。strict profile で EHS が実発火し、normal/lenient・env 明示時は従来挙動。HO のため実ツリー本体は未改変、Human が `sh scripts/apply-task-0147-bias-export.sh --apply` で適用する。
+
+## 6. テスト結果サマリ
+
+- `tests/extras/ta-49-bias-export.sh`: 未適用ツリーで層A 4 PASS / 層B SKIP、sandbox 適用で TC-01〜06 全 PASS
+- `sh tests/run-tests.sh`: 363 passed / 0 failed

--- a/docs/working/TASK-0147/status.md
+++ b/docs/working/TASK-0147/status.md
@@ -1,0 +1,51 @@
+# TASK-0147 作業ステータス — validation_bias conductor export（#527 follow-up）
+
+## モード判定
+
+**high-risk**（`bin/plangate` + `.claude/agents/workflow-conductor.md` = HO パス 2 種）/ `lite_eligible=false`
+
+## C-3 Gate: APPROVED
+
+- ユーザー明示承認（2026-06-27）: 「TASK-0147 を C-3 承認して実装を進めて」
+- 記録: `approvals/c3.json`（`c3_status=APPROVED`, plan_hash 記載）
+- HO のため autonomous APPROVE 不可 → **人間 C-3 として成立**
+
+## 全体構成（PR 一覧）
+
+| ブランチ | 状態 | 内容 |
+|---------|------|------|
+| `feat/task-0147-validation-bias-export` | PR 作成予定 | helper + apply-script + test（HO 本体は Human 適用） |
+
+## 実装内容（AI-owned）
+
+- `scripts/_resolve_validation_bias.py`: profile key → `validation_bias` 解決。未知 key / yaml 欠落・破損 / pyyaml 未導入は **normal fallback + stderr 警告**（サイレント失敗防止）。
+- `scripts/apply-task-0147-bias-export.sh` + `_apply_task_0147_patches.py`: HO apply（文字列アンカー・dry-run/--apply）。3 patch:
+  1. `cmd_verify` に `--profile` 解析 + bias export（env 既設定尊重）
+  2. `cmd_handoff` に `--profile` 解析 + bias export
+  3. `workflow-conductor.md` に profile→bias 運用の**非強制の補足**追記
+- `tests/extras/ta-49-bias-export.sh`: 層A（helper 機能・常時実行）+ 層B（bin/plangate 配線・未適用 SKIP）
+
+## 検証結果
+
+- helper 単体: strict profile (`gpt-5_5_pro`)→strict / normal→normal / 未知 key・yaml 欠落→normal+stderr 警告
+- ta-49 未適用ツリー: 層A 4 PASS / 層B SKIP
+- **sandbox 適用**: 3 patch 命中・`sh -n` OK・ta-49 TC-01〜06 **全 PASS**・conductor 非強制明記・統合解決 OK（実ツリー HO 非改変）
+- `sh tests/run-tests.sh`: **363 passed / 0 failed**
+
+## 残タスク
+
+- [x] helper / apply-script / test 実装
+- [x] sandbox 適用検証（全 PASS）
+- [x] C-3 承認記録
+- [ ] PR 作成（C-4 ゲート）
+- [ ] 👤 apply-script 適用（`--apply`、PR マージ後）
+- [ ] hook-enforcement.md の follow-up 記述を「配線済み」へ更新（適用後・別 PR 可）
+
+## フェーズ履歴
+
+- 2026-06-27 C-3 APPROVED（人間）→ 実装 → sandbox 検証 → PR 作成
+
+## 参照ファイル
+
+- `docs/working/TASK-0147/plan.md` / `todo.md` / `test-cases.md` / `handoff.md`
+- `scripts/_resolve_validation_bias.py` / `scripts/apply-task-0147-bias-export.sh`

--- a/scripts/_apply_task_0147_patches.py
+++ b/scripts/_apply_task_0147_patches.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# scripts/_apply_task_0147_patches.py
+# TASK-0147 / #527 follow-up: validation_bias の conductor export 配線
+#   bin/plangate verify / handoff --verify が --profile <key> を受理し、
+#   model-profiles.yaml の validation_bias を解決して PLANGATE_VALIDATION_BIAS
+#   を内部 export する（EHS-1/2/3 の発火条件を実 run で供給）。
+#   env で既に明示注入済みなら尊重（上書きしない）。normal/lenient は非発火。
+#   workflow-conductor.md には profile→bias 運用の非強制の補足を追記する。
+import sys, os, difflib
+
+if len(sys.argv) < 3:
+    print(f"Usage: {sys.argv[0]} <repo_root> <dry_run_flag>", file=sys.stderr)
+    sys.exit(1)
+
+repo_root = sys.argv[1]
+dry_run = sys.argv[2] == "1"
+errors = 0
+
+
+def patch_file(rel_path, old, new, label=""):
+    global errors
+    path = os.path.join(repo_root, rel_path)
+    try:
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        print(f"[ERROR] {label or rel_path}: cannot read file: {e}", file=sys.stderr)
+        errors += 1
+        return
+    if new in content:
+        print(f"[SKIP] {label or rel_path}: already applied")
+        return
+    if old not in content:
+        print(f"[ERROR] {label or rel_path}: target string not found", file=sys.stderr)
+        errors += 1
+        return
+    new_content = content.replace(old, new, 1)
+    if dry_run:
+        diff = difflib.unified_diff(
+            content.splitlines(keepends=True),
+            new_content.splitlines(keepends=True),
+            fromfile=rel_path, tofile=rel_path + " (patched)")
+        lines = list(diff)
+        sys.stdout.writelines(lines)
+        if not lines:
+            print(f"[NO DIFF] {rel_path}")
+    else:
+        try:
+            with open(path + ".bak", "w", encoding="utf-8") as f:
+                f.write(content)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+        except OSError as e:
+            print(f"[ERROR] {label or rel_path}: cannot write file: {e}", file=sys.stderr)
+            errors += 1
+            return
+        print(f"[PATCHED] {rel_path}  (backup: {os.path.basename(path)}.bak)")
+
+
+# shared: --profile から bias を解決し PLANGATE_VALIDATION_BIAS を export する block
+def _export_block(profile_var):
+    return (
+        "  # validation_bias export (TASK-0147 / #527): --profile 指定時に解決し export。\n"
+        "  # env で既に明示注入済みなら尊重（上書きしない）。normal/lenient は非発火。\n"
+        f"  if [ -z \"${{PLANGATE_VALIDATION_BIAS:-}}\" ] && [ -n \"${profile_var}\" ]; then\n"
+        f"    PLANGATE_VALIDATION_BIAS=$(python3 \"$plangate_root/scripts/_resolve_validation_bias.py\" \"${profile_var}\" \"$plangate_root/docs/ai/model-profiles.yaml\")\n"
+        "    export PLANGATE_VALIDATION_BIAS\n"
+        "  fi\n"
+    )
+
+
+# ======================================================================
+# Patch 1: cmd_verify の --mode ループに --profile を追加し、直後で bias export
+# ======================================================================
+V_OLD = (
+    "  mode_flag=\"\"\n"
+    "  for arg in \"$@\"; do\n"
+    "    case \"$arg\" in\n"
+    "      --mode=*) mode_flag=\"${arg#--mode=}\" ;;\n"
+    "    esac\n"
+    "  done\n"
+)
+V_NEW = (
+    "  mode_flag=\"\"\n"
+    "  profile_flag=\"\"\n"
+    "  for arg in \"$@\"; do\n"
+    "    case \"$arg\" in\n"
+    "      --mode=*) mode_flag=\"${arg#--mode=}\" ;;\n"
+    "      --profile=*) profile_flag=\"${arg#--profile=}\" ;;\n"
+    "    esac\n"
+    "  done\n"
+    + _export_block("profile_flag")
+)
+patch_file("bin/plangate", V_OLD, V_NEW, label="TASK-0147 cmd_verify --profile bias export")
+
+# ======================================================================
+# Patch 2: cmd_handoff の --verify ループに --profile を追加し、直後で bias export
+# ======================================================================
+H_OLD = (
+    "  _handoff_verify=0\n"
+    "  for _harg in \"$@\"; do\n"
+    "    case \"$_harg\" in --verify) _handoff_verify=1 ;; esac\n"
+    "  done\n"
+)
+H_NEW = (
+    "  _handoff_verify=0\n"
+    "  _handoff_profile=\"\"\n"
+    "  for _harg in \"$@\"; do\n"
+    "    case \"$_harg\" in\n"
+    "      --verify) _handoff_verify=1 ;;\n"
+    "      --profile=*) _handoff_profile=\"${_harg#--profile=}\" ;;\n"
+    "    esac\n"
+    "  done\n"
+    + _export_block("_handoff_profile")
+)
+patch_file("bin/plangate", H_OLD, H_NEW, label="TASK-0147 cmd_handoff --profile bias export")
+
+# ======================================================================
+# Patch 3: workflow-conductor.md に profile→bias 運用の非強制の補足を追記
+# ======================================================================
+C_OLD = (
+    "- **working-context.md** — ディレクトリ構造・ファイル定義\n"
+)
+C_NEW = (
+    "- **working-context.md** — ディレクトリ構造・ファイル定義\n"
+    "\n"
+    "---\n"
+    "\n"
+    "## validation_bias の供給（TASK-0147 / #527・非強制の補足）\n"
+    "\n"
+    "strict profile（`model-profiles.yaml` の `validation_bias: strict`）で EHS-1/2/3 を\n"
+    "実 run 発火させたい場合、conductor は V フェーズの CLI 呼び出しに `--profile <key>` を\n"
+    "渡す（例: `bin/plangate verify <TASK> --mode <m> --profile gpt-5_5_pro`）。CLI が\n"
+    "`model-profiles.yaml` から `validation_bias` を解決し `PLANGATE_VALIDATION_BIAS` を\n"
+    "内部 export する。env で明示注入済みならそれを尊重する。normal/lenient profile では\n"
+    "従来どおり非発火（既存挙動不変）。**強制は CLI 側（`bin/plangate`）に閉じており、\n"
+    "本補足は運用ガイドであって強制力を持たない**。\n"
+)
+patch_file(".claude/agents/workflow-conductor.md", C_OLD, C_NEW,
+           label="TASK-0147 workflow-conductor profile->bias note (non-enforcing)")
+
+sys.exit(1 if errors else 0)

--- a/scripts/_resolve_validation_bias.py
+++ b/scripts/_resolve_validation_bias.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""_resolve_validation_bias.py — TASK-0147 / #527 follow-up
+
+model-profiles.yaml の指定 profile key から validation_bias を解決して stdout に出力する。
+
+Usage:
+    python3 scripts/_resolve_validation_bias.py <profile_key> [model-profiles.yaml path]
+
+出力:
+    stdout に解決した bias（normal|strict|lenient のいずれか）を 1 行で出力。
+    解決できない場合（未知 key / yaml 欠落・破損 / pyyaml 未導入）は安全側で
+    "normal" を stdout に出力し、理由を stderr に警告出力する（サイレント失敗防止）。
+
+終了コード:
+    0  正常解決（strict/normal/lenient を出力）
+    0  fallback（normal を出力 + stderr 警告）— 呼び出し側を止めない安全側
+    2  引数不足（profile_key 未指定）
+"""
+import sys
+
+VALID_BIASES = ("normal", "strict", "lenient")
+
+
+def _warn(msg):
+    sys.stderr.write("[validation-bias] WARN: %s (fallback=normal)\n" % msg)
+
+
+def main(argv):
+    if len(argv) < 2 or not argv[1].strip():
+        sys.stderr.write("Usage: _resolve_validation_bias.py <profile_key> [yaml_path]\n")
+        return 2
+
+    profile_key = argv[1].strip()
+    yaml_path = argv[2] if len(argv) >= 3 else "docs/ai/model-profiles.yaml"
+
+    try:
+        import yaml
+    except Exception:
+        _warn("pyyaml not available")
+        print("normal")
+        return 0
+
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        _warn("model-profiles.yaml not found: %s" % yaml_path)
+        print("normal")
+        return 0
+    except Exception as e:
+        _warn("failed to parse %s: %s" % (yaml_path, e))
+        print("normal")
+        return 0
+
+    if not isinstance(data, dict):
+        _warn("model-profiles.yaml is not a mapping")
+        print("normal")
+        return 0
+
+    models = data.get("models")
+    if not isinstance(models, dict):
+        _warn("no 'models' mapping in %s" % yaml_path)
+        print("normal")
+        return 0
+
+    profile = models.get(profile_key)
+    if not isinstance(profile, dict):
+        _warn("unknown profile key: %s" % profile_key)
+        print("normal")
+        return 0
+
+    bias = profile.get("validation_bias")
+    if bias not in VALID_BIASES:
+        _warn("profile '%s' has no valid validation_bias (got: %r)" % (profile_key, bias))
+        print("normal")
+        return 0
+
+    print(bias)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/apply-task-0147-bias-export.sh
+++ b/scripts/apply-task-0147-bias-export.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# scripts/apply-task-0147-bias-export.sh
+# TASK-0147 / EPIC #527 follow-up — validation_bias の conductor export 配線
+#
+#   bin/plangate verify / handoff --verify が --profile <key> を受理し、
+#   model-profiles.yaml の validation_bias を解決して PLANGATE_VALIDATION_BIAS
+#   を内部 export する。これにより strict profile で EHS-1/2/3 が実 run 発火する。
+#   env で既に明示注入済みなら尊重（上書きしない）。normal/lenient は非発火＝
+#   既存挙動不変。workflow-conductor.md には非強制の運用補足を追記。
+#
+# Human が実行する（HO パス bin/plangate / .claude/agents を変更するため）。
+#
+# 使い方:
+#   sh scripts/apply-task-0147-bias-export.sh --dry-run  # 差分確認のみ
+#   sh scripts/apply-task-0147-bias-export.sh --apply    # 実際に適用
+
+set -eu
+
+REPO_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+DRY_RUN=1
+for _arg in "$@"; do
+  case "$_arg" in
+    --apply)   DRY_RUN=0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    *) printf 'Usage: %s [--dry-run|--apply]\n' "$0" >&2; exit 2 ;;
+  esac
+done
+
+printf '=== apply-task-0147-bias-export.sh (dry_run=%s) — validation_bias export ===\n' "$DRY_RUN"
+exec python3 "$REPO_ROOT/scripts/_apply_task_0147_patches.py" "$REPO_ROOT" "$DRY_RUN"

--- a/tests/extras/ta-49-bias-export.sh
+++ b/tests/extras/ta-49-bias-export.sh
@@ -1,0 +1,85 @@
+# tests/extras/ta-49-bias-export.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# TASK-0147 (#527 follow-up): validation_bias の conductor export 配線
+#
+# 2 層:
+#   A. _resolve_validation_bias.py の機能テスト（常時実行・AI-owned ヘルパー）
+#   B. bin/plangate 配線テスト（HO 未適用時は SKIP）
+#      前提: scripts/apply-task-0147-bias-export.sh --apply で適用済み。
+
+printf '\n=== TA-49: validation_bias conductor export (#527 TASK-0147) ===\n'
+
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T49_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T49_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+_T49_PG="$_T49_ROOT/bin/plangate"
+_T49_RESOLVE="$_T49_ROOT/scripts/_resolve_validation_bias.py"
+_T49_YAML="$_T49_ROOT/docs/ai/model-profiles.yaml"
+
+# ---- 層 A: resolver helper（常時実行）-------------------------------------
+
+# strict profile key を yaml から取得（存在すれば）
+_T49_STRICT_KEY=$(python3 -c "
+import yaml,sys
+try:
+    d=yaml.safe_load(open('$_T49_YAML'))
+    ks=[k for k,v in (d.get('models') or {}).items() if isinstance(v,dict) and v.get('validation_bias')=='strict']
+    print(ks[0] if ks else '')
+except Exception:
+    print('')
+" 2>/dev/null)
+
+# TC-01: strict profile → strict
+if [ -n "$_T49_STRICT_KEY" ] && [ "$(python3 "$_T49_RESOLVE" "$_T49_STRICT_KEY" "$_T49_YAML" 2>/dev/null)" = "strict" ]; then
+  printf '  [PASS] TC-01 strict profile (%s) → strict\n' "$_T49_STRICT_KEY"; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-01 strict profile 解決失敗\n'; fail=$((fail + 1))
+fi
+
+# TC-02: normal profile / 既定 → strict にならない
+if [ "$(python3 "$_T49_RESOLVE" gpt-5_5 "$_T49_YAML" 2>/dev/null)" = "normal" ]; then
+  printf '  [PASS] TC-02 normal profile は strict にならない\n'; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-02 normal profile 解決異常\n'; fail=$((fail + 1))
+fi
+
+# TC-04: 未知 key → normal fallback + stderr 警告
+_t49_out=$(python3 "$_T49_RESOLVE" __nope__ "$_T49_YAML" 2>/tmp/ta49_err); _t49_err=$(cat /tmp/ta49_err 2>/dev/null)
+if [ "$_t49_out" = "normal" ] && printf '%s' "$_t49_err" | grep -q "WARN"; then
+  printf '  [PASS] TC-04 未知 key は normal fallback + stderr 警告\n'; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-04 未知 key の安全側 fallback/警告 欠落\n'; fail=$((fail + 1))
+fi
+
+# TC-06: yaml 欠落 → normal fallback + stderr 警告
+_t49_out2=$(python3 "$_T49_RESOLVE" gpt-5_5 /no/such/file.yaml 2>/tmp/ta49_err2); _t49_err2=$(cat /tmp/ta49_err2 2>/dev/null)
+if [ "$_t49_out2" = "normal" ] && printf '%s' "$_t49_err2" | grep -q "WARN"; then
+  printf '  [PASS] TC-06 yaml 欠落は normal fallback + stderr 警告\n'; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-06 yaml 欠落の安全側 fallback/警告 欠落\n'; fail=$((fail + 1))
+fi
+rm -f /tmp/ta49_err /tmp/ta49_err2 2>/dev/null
+
+# ---- 層 B: bin/plangate 配線（未適用なら SKIP）---------------------------
+
+if ! grep -q "TASK-0147" "$_T49_PG" 2>/dev/null; then
+  printf '  [SKIP] TC-03/TC-05 bin/plangate 未適用（sh scripts/apply-task-0147-bias-export.sh --apply で適用後に PASS）\n'
+  return 0 2>/dev/null || true
+fi
+
+# TC-03: env 既設定を上書きしない（明示注入尊重）— 配線コードに既定尊重ガードが存在
+if grep -q 'PLANGATE_VALIDATION_BIAS:-}" ] && \[ -n' "$_T49_PG" 2>/dev/null \
+   || grep -q '\[ -z "${PLANGATE_VALIDATION_BIAS:-}" \]' "$_T49_PG" 2>/dev/null; then
+  printf '  [PASS] TC-03 env 既設定尊重ガード（上書きしない）配線\n'; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-03 env 尊重ガードの配線欠落\n'; fail=$((fail + 1))
+fi
+
+# TC-05: patched bin/plangate 構文健全
+if sh -n "$_T49_PG" 2>/dev/null; then
+  printf '  [PASS] TC-05 patched bin/plangate 構文健全\n'; pass=$((pass + 1))
+else
+  printf '  [FAIL] TC-05 構文エラー\n'; fail=$((fail + 1))
+fi


### PR DESCRIPTION
## 概要
EPIC #527 follow-up（**closes #644**）。EHS-1/2/3 は配線・適用済みだが、発火条件 `PLANGATE_VALIDATION_BIAS` を**実 run で供給する経路が欠けていた**（TASK-0146 Non-goals）。本 PR でその最後の経路を配線する。

`bin/plangate verify` / `handoff --verify` が `--profile <key>` を受理し、`model-profiles.yaml` の `validation_bias` を解決して `PLANGATE_VALIDATION_BIAS` を内部 export。strict profile（例 `gpt-5_5_pro`）で EHS-1/2/3 が実 run 発火し、normal/lenient・env 明示注入時は従来挙動（既存挙動不変）。

## 実装
- `scripts/_resolve_validation_bias.py`: profile→bias 解決。**未知 key / yaml 欠落・破損 / pyyaml 未導入は normal fallback + stderr 警告**（サイレント失敗防止、PR #643 Gemini 指摘反映）
- `scripts/apply-task-0147-bias-export.sh` + `_apply_task_0147_patches.py`: HO apply（文字列アンカー・dry-run/--apply）。3 patch = cmd_verify / cmd_handoff の `--profile` export（env 既設定尊重）+ `workflow-conductor.md` の**非強制**補足
- `tests/extras/ta-49-bias-export.sh`: 層A（helper 常時実行）+ 層B（bin/plangate 配線・未適用 SKIP）

## 方式（HO 対応）
`bin/plangate` + `.claude/agents/workflow-conductor.md` は HO パスで AI 直接編集不可。**apply-script のみ同梱**し、本体適用はマージ後に Human が `sh scripts/apply-task-0147-bias-export.sh --apply`。

## テスト
- helper 単体: gpt-5_5_pro→strict / gpt-5_5→normal / 未知 key・yaml 欠落→normal+stderr 警告
- **sandbox 適用**: 3 patch 命中・`sh -n` OK・ta-49 **TC-01〜06 全 PASS**（実ツリー HO 非改変）
- `sh tests/run-tests.sh`: **363 passed / 0 failed**

## ゲート
- **Mode**: high-risk / `lite_eligible=false`
- **C-3**: 人間 APPROVED（`docs/working/TASK-0147/approvals/c3.json`）
- マージ後 Human 操作: apply-script 適用 + hook-enforcement.md follow-up 更新

Refs #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)