### PR TITLE
docs(#640): improvement-seeds スキーマ OSS 非依存化（「1 人運用」→「ツール・プロセス上の摩擦点」）

### DIFF
--- a/docs/ai/retro-phase.md
+++ b/docs/ai/retro-phase.md
@@ -31,7 +31,7 @@ WF-06 は発火しない＝既存 run 挙動は完全に不変（純追加・後
 - 失敗・手戻り: <text>
 - 次回再利用すべき判断: <text>
 - 効いた skill / gate / artifact: <text>
-- 1 人運用で負荷が高かった箇所: <text>
+- ツール・プロセス上の摩擦点: <text>
 - confirmed_by: <human>
 ```
 

--- a/docs/workflows/06_retro.md
+++ b/docs/workflows/06_retro.md
@@ -26,7 +26,7 @@ run（PBI/TASK）完了時に振り返りドラフトを生成し、改善ネタ
 
 - #228 固定 5 項目のドラフトが生成されている
   （目的達成可否 / 失敗・手戻り / 次回再利用すべき判断 /
-  効いた skill・gate・artifact / 1 人運用で負荷が高かった箇所）
+  効いた skill・gate・artifact / ツール・プロセス上の摩擦点）
 - ドラフトは **スコアリング（良し悪し判定）を含まない**（#231 judge と責務非重複）
 - 人間が 1 行で confirm / skip している
 - confirm 時、`docs/working/improvement-seeds.md` に append-only で 1 エントリ追記されている

--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -22,3 +22,5 @@
 {"ts":"2026-06-25T03:36:28Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/hook-enforcement.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-06-25T03:43:45Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0143/status.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-06-25T05:54:51Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/hook-enforcement.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-06-29T00:09:09Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/retro-phase.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-06-29T00:09:36Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/workflows/06_retro.md","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
## Summary

- `docs/ai/retro-phase.md` §2 スキーマの「1 人運用で負荷が高かった箇所」を「ツール・プロセス上の摩擦点」に変更
- `docs/workflows/06_retro.md` 完了条件の同項目名を同期更新
- 既存エントリ（v8.12.0 / TASK-0143）は append-only ルールで変更なし

closes #640

## Test plan

- [ ] `docs/ai/retro-phase.md` §2 に「1 人運用」の文字列が残っていないこと（説明文中の例示は対象外）
- [ ] `docs/workflows/06_retro.md` 完了条件が新項目名を参照していること
- [ ] `improvement-seeds.md` の既存エントリが変更されていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)