### PR TITLE
docs(#652): Plan Review Readiness Gate — C-1前の計画実行準備ゲート追加

### DIFF
--- a/docs/ai/gate-checks.md
+++ b/docs/ai/gate-checks.md
@@ -9,6 +9,10 @@
 `gate_checks` は C-3 承認時に人間が任意で記録する計画ゲートチェックリスト。
 Goal / Scope / Risk の 3 項目を boolean で記録し、審査の透明性を高める。
 
+C-1 前に `pass / needs_revision / blocked` を判定する実行準備ゲートは、本仕様ではなく
+[`plan-review-readiness-gate.md`](./plan-review-readiness-gate.md) が扱う。`gate_checks`
+は C-3 承認記録の optional フィールドであり、Plan Review Readiness Gate を代替しない。
+
 | フィールド | 型 | 必須 | 説明 |
 |----------|---|------|------|
 | `gate_checks.goal` | boolean | 任意 | plan.md に Goal と成功条件が明確に定義されているか |

--- a/docs/ai/plan-quality-checks.md
+++ b/docs/ai/plan-quality-checks.md
@@ -23,6 +23,11 @@ orchestration / PR review / QA automation / browser daemon）を直接移植
 > の承認境界・[responsibility-classes.md](../../.claude/rules/responsibility-classes.md)
 > の Human-owned 境界は不変）。
 
+C-1 前の `pass / needs_revision / blocked` 判定は
+[`plan-review-readiness-gate.md`](./plan-review-readiness-gate.md) を正本とする。
+本 Check は score と助言を返す補助層であり、Plan Review Readiness Gate の通過判定を
+代替しない。
+
 ## 2. Check 種別と責務
 
 | Check | 責務（何を確認するか） | 主出力フィールド |

--- a/docs/ai/plan-review-readiness-gate.md
+++ b/docs/ai/plan-review-readiness-gate.md
@@ -1,0 +1,129 @@
+# Plan Review Readiness Gate
+
+> Issue: [#652](https://github.com/s977043/plangate/issues/652)
+> Related upstream: [s977043/river-review#1325](https://github.com/s977043/river-review/issues/1325)
+
+## 1. 目的と位置づけ
+
+Plan Review Readiness Gate は、`plan.md` / `todo.md` / `test-cases.md` が生成された直後、C-1 self-review の前に置く計画実行準備ゲートである。
+
+```text
+WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
+  -> Plan Review Readiness Gate
+  -> C-1 self-review -> C-2 external AI review -> C-3 human approval -> WF-04 -> WF-05
+```
+
+このゲートの目的は、AI 実行に渡す前の計画が「レビュー可能」であり、かつ C-1 / C-2 / C-3 が見るべき境界を明示していることを確認することである。実装品質そのものを判定するゲートではなく、レビュー対象 artifact の準備状態を判定する。
+
+> Design decision: 新規 standalone gate として定義する。`docs/ai/plan-quality-checks.md` は advisory な計画品質チェック、`docs/ai/gate-checks.md` は C-3 承認記録の optional 拡張であり、本ゲートのように C-1 前で `pass / needs_revision / blocked` を返す実行前判定とは責務と時点が異なるため、既存文書への混在を避ける。
+
+## 2. 判定値
+
+| Verdict | 意味 | 次アクション |
+|---------|------|--------------|
+| `pass` | 7 項目がすべて記入され、C-1 で妥当性レビューできる状態 | C-1 self-review へ進む |
+| `needs_revision` | 計画の不足はあるが、危険操作や承認境界違反ではない | `plan.md` / `todo.md` / `test-cases.md` を修正して再判定 |
+| `blocked` | 矛盾、未承認の危険操作、Human-owned 境界、破壊的操作、依存追加など、AI が自己判断で進めてはいけない要素がある | 人間判断または PBI 再整理まで停止 |
+
+判定不能な場合は安全側に倒し、少なくとも `needs_revision` とする。危険操作・承認境界・破壊的変更に関わる判定不能は `blocked` とする。
+
+## 3. チェック項目
+
+すべての項目は `plan.md` に明示し、必要に応じて `todo.md` / `test-cases.md` と対応させる。
+
+| # | 項目 | `pass` | `needs_revision` | `blocked` |
+|---|------|--------|------------------|-----------|
+| 1 | Success criteria | AC、完了境界、Done 判定が具体的で、`test-cases.md` と対応している | AC と作業の対応が一部曖昧、検証方法が不足 | 成功条件が矛盾、または完了境界が定義不能 |
+| 2 | Review criteria | 設計整合、テスト期待値、セキュリティ、保守性、後方互換、運用リスクの観点が揃っている | 一部観点が N/A 理由なしで欠落 | 重要リスクをレビュー対象から外している |
+| 3 | Required context | 参照 Issue / ADR / docs / 既存実装 / 関連テスト / 制約が列挙されている | 参照先が不足、または確認済み/未確認の区別が弱い | 必須前提が未確認で、誤実装や破壊的変更につながる |
+| 4 | Non-goals and scope boundary | Out of scope、変更禁止領域、禁止依存が明示されている | 禁止領域や依存追加方針が曖昧 | HO パスや禁止領域を編集対象に含めている |
+| 5 | Stop conditions | 競合要件、認証/課金/破壊的操作、新規依存、大規模な想定外変更の停止条件がある | 停止条件が一般論で、実行者が判断しにくい | 停止すべき条件を通常作業として扱っている |
+| 6 | Replan conditions | hidden dependency、public API 変更、test contract mismatch、scope bloat、security impact の再計画条件がある | 再計画条件が一部未記入、または閾値が曖昧 | 再計画が必要な変更を exec 中に吸収する計画になっている |
+| 7 | Human approval boundary | security、auth、billing、permissions、prod ops、data deletion、migration、irreversible changes の人間承認境界が明示されている | 一部境界が N/A 理由なしで欠落 | Human-owned 操作を AI 判断で実行する計画になっている |
+
+## 4. Decision table
+
+| 条件 | Verdict |
+|------|---------|
+| 7 項目すべてが具体的に記入され、未解決の危険境界がない | `pass` |
+| 1 つ以上の項目に記入不足があるが、修正すれば C-1 に進める | `needs_revision` |
+| `TBD` / `TODO` / `必要に応じて` などが重要項目に残っている | `needs_revision` |
+| AC と `test-cases.md` の対応が欠落している | `needs_revision` |
+| 禁止ファイル、HO パス、Out of scope が変更対象に含まれている | `blocked` |
+| 認証、課金、権限、本番運用、データ削除、migration、不可逆変更を AI 判断で実行する | `blocked` |
+| 新規依存や public API 変更が必要だが、承認境界と再計画条件が未定義 | `blocked` |
+| 要件が互いに矛盾し、AI が一意に解釈できない | `blocked` |
+
+## 5. 良い AI 実行計画の例
+
+```markdown
+## Plan Review Readiness
+
+### Success Criteria
+- AC-1 は `test-cases.md` T1/T2 で確認する。
+- Done は docs 更新、リンク整合、`rg` による旧名称なし確認まで。
+
+### Review Criteria
+- Design alignment: 既存の `docs/workflows/` 命名と対応表に合わせる。
+- Security: executable code と hook は変更しないため N/A。
+- Backward compatibility: 既存フェーズ名を削除せず追記のみ。
+
+### Required Context
+- Issue: #652
+- Existing docs: `docs/ai/gate-checks.md`, `docs/ai/plan-quality-checks.md`
+- Constraints: HO paths は編集しない。
+
+### Non-goals and Scope Boundary
+- Out of scope: schema 変更、hook 実装、CLI 実装。
+- Forbidden zones: `bin/plangate`, `schemas/*.schema.json`, `.github/workflows/*.yml`
+
+### Stop Conditions
+- HO パス編集が必要になったら停止。
+- 新規依存や CLI 実装が必要になったら停止。
+
+### Replan Conditions
+- C-1 前でなく C-3 側に置くべき既存正本が見つかった場合は再計画。
+- public API / schema 変更が必要になった場合は再計画。
+
+### Human Approval Boundary
+- schema、hook、CI、権限、本番運用、データ削除、migration は人間承認なしに実行しない。
+```
+
+この例は、レビュー観点と停止境界が具体的で、実行者が「どこまで進めてよいか」を判断できる。
+
+## 6. 悪い AI 実行計画の例
+
+```markdown
+## Plan Review Readiness
+
+### Success Criteria
+- いい感じに動くこと。
+
+### Review Criteria
+- 必要に応じて確認する。
+
+### Required Context
+- たぶん既存 docs を見る。
+
+### Non-goals and Scope Boundary
+- 特になし。
+
+### Stop Conditions
+- 問題があれば止める。
+
+### Replan Conditions
+- 必要なら再計画する。
+
+### Human Approval Boundary
+- AI が判断する。
+```
+
+この例は、AC、レビュー観点、停止条件、再計画条件、人間承認境界が実行可能な粒度ではないため `needs_revision` になる。加えて、Human-owned 操作を AI 判断に委ねている場合は `blocked` とする。
+
+## 7. 関連
+
+- [`plan-quality-checks.md`](./plan-quality-checks.md) — advisory な計画品質チェック
+- [`gate-checks.md`](./gate-checks.md) — C-3 承認時の optional 記録拡張
+- [`review-gate-decision-mapping.md`](./review-gate-decision-mapping.md) — C-2 / C-3 判定接続
+- [`../workflows/03_solution_design.md`](../workflows/03_solution_design.md) — WF-03 の完了条件
+- [`../working/templates/plan.md`](../working/templates/plan.md) — 本ゲートが確認する plan fields

--- a/docs/ai/plan-review-readiness-gate.md
+++ b/docs/ai/plan-review-readiness-gate.md
@@ -34,23 +34,26 @@ WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
 | # | 項目 | `pass` | `needs_revision` | `blocked` |
 |---|------|--------|------------------|-----------|
 | 1 | Success criteria | AC、完了境界、Done 判定が具体的で、`test-cases.md` と対応している | AC と作業の対応が一部曖昧、検証方法が不足 | 成功条件が矛盾、または完了境界が定義不能 |
-| 2 | Review criteria | 設計整合、テスト期待値、セキュリティ、保守性、後方互換、運用リスクの観点が揃っている | 一部観点が N/A 理由なしで欠落 | 重要リスクをレビュー対象から外している |
+| 2 | Review criteria | 設計整合、テスト期待値、セキュリティ、保守性、後方互換、運用リスクの観点が揃っている | 一部観点が N/A 理由なし（N/A の根拠が未記載）または空欄で欠落 | 重要リスクをレビュー対象から外している |
 | 3 | Required context | 参照 Issue / ADR / docs / 既存実装 / 関連テスト / 制約が列挙されている | 参照先が不足、または確認済み/未確認の区別が弱い | 必須前提が未確認で、誤実装や破壊的変更につながる |
-| 4 | Non-goals and scope boundary | Out of scope、変更禁止領域、禁止依存が明示されている | 禁止領域や依存追加方針が曖昧 | HO パスや禁止領域を編集対象に含めている |
+| 4 | Non-goals and scope boundary | Out of scope、変更禁止領域、禁止依存が明示されている | 禁止領域や依存追加方針が曖昧 | HO パス（`bin/plangate`・`schemas/`・`.claude/`・`CLAUDE.md` 等、[EH-1 正本](./hook-enforcement.md) 参照）や禁止領域を編集対象に含めている |
 | 5 | Stop conditions | 競合要件、認証/課金/破壊的操作、新規依存、大規模な想定外変更の停止条件がある | 停止条件が一般論で、実行者が判断しにくい | 停止すべき条件を通常作業として扱っている |
-| 6 | Replan conditions | hidden dependency、public API 変更、test contract mismatch、scope bloat、security impact の再計画条件がある | 再計画条件が一部未記入、または閾値が曖昧 | 再計画が必要な変更を exec 中に吸収する計画になっている |
-| 7 | Human approval boundary | security、auth、billing、permissions、prod ops、data deletion、migration、irreversible changes の人間承認境界が明示されている | 一部境界が N/A 理由なしで欠落 | Human-owned 操作を AI 判断で実行する計画になっている |
+| 6 | Replan Triggers | hidden dependency、public API 変更、test contract mismatch、scope bloat、security impact の再計画トリガーが列挙されている | 再計画トリガーが一部未記入、または閾値が曖昧 | 再計画が必要な変更を exec 中に吸収する計画になっている |
+| 7 | Human approval boundary | security、auth、billing、permissions、prod ops、data deletion、migration、irreversible changes、merge（C-4）の人間承認境界が明示されている | 一部境界が N/A 理由なし（N/A の根拠が未記載）または空欄で欠落 | Human-owned 操作を AI 判断で実行する計画になっている |
 
 ## 4. Decision table
+
+複数条件が同時に成立した場合は、より厳しい verdict を採用する（`blocked` > `needs_revision` > `pass`）。
 
 | 条件 | Verdict |
 |------|---------|
 | 7 項目すべてが具体的に記入され、未解決の危険境界がない | `pass` |
 | 1 つ以上の項目に記入不足があるが、修正すれば C-1 に進める | `needs_revision` |
-| `TBD` / `TODO` / `必要に応じて` などが重要項目に残っている | `needs_revision` |
+| `TBD` / `TODO` / `必要に応じて` / プレースホルダ未置換 / 空欄 が重要項目に残っている | `needs_revision` |
 | AC と `test-cases.md` の対応が欠落している | `needs_revision` |
-| 禁止ファイル、HO パス、Out of scope が変更対象に含まれている | `blocked` |
-| 認証、課金、権限、本番運用、データ削除、migration、不可逆変更を AI 判断で実行する | `blocked` |
+| 禁止ファイル、HO パス（EH-1 正本参照）、Out of scope が変更対象に含まれている | `blocked` |
+| 認証、課金、権限、本番運用、データ削除、migration、不可逆変更、merge（C-4）を AI 判断で実行する | `blocked` |
+| 承認トークンファイル（`approvals/c3.json`・`maintenance.json` 等）を AI が直接編集する計画がある | `blocked` |
 | 新規依存や public API 変更が必要だが、承認境界と再計画条件が未定義 | `blocked` |
 | 要件が互いに矛盾し、AI が一意に解釈できない | `blocked` |
 
@@ -75,18 +78,22 @@ WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
 
 ### Non-goals and Scope Boundary
 - Out of scope: schema 変更、hook 実装、CLI 実装。
-- Forbidden zones: `bin/plangate`, `schemas/*.schema.json`, `.github/workflows/*.yml`
+- Forbidden zones: `bin/plangate`, `schemas/*.schema.json`, `.github/workflows/*.yml`,
+  `.claude/settings*.json`, `.claude/rules/**`, `plugin/plangate/**`,
+  `CLAUDE.md`, `AGENTS.md`, `docs/ai/core-contract.md`
+  （詳細は EH-1 production code 定義参照）
 
 ### Stop Conditions
 - HO パス編集が必要になったら停止。
 - 新規依存や CLI 実装が必要になったら停止。
 
-### Replan Conditions
+### Replan Triggers
 - C-1 前でなく C-3 側に置くべき既存正本が見つかった場合は再計画。
 - public API / schema 変更が必要になった場合は再計画。
 
 ### Human Approval Boundary
-- schema、hook、CI、権限、本番運用、データ削除、migration は人間承認なしに実行しない。
+- schema、hook、CI、権限、本番運用、データ削除、migration、merge（C-4）は人間承認なしに実行しない。
+- 承認トークンファイル（`approvals/c3.json` 等）の AI 直接編集は禁止。
 ```
 
 この例は、レビュー観点と停止境界が具体的で、実行者が「どこまで進めてよいか」を判断できる。
@@ -118,7 +125,7 @@ WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
 - AI が判断する。
 ```
 
-この例は、AC、レビュー観点、停止条件、再計画条件、人間承認境界が実行可能な粒度ではないため `needs_revision` になる。加えて、Human-owned 操作を AI 判断に委ねている場合は `blocked` とする。
+この例は、AC・レビュー観点・停止条件・再計画条件が実行可能な粒度ではないため `needs_revision` の要素を含む。さらに Human Approval Boundary に「AI が判断する」と記入されている箇所は Section 4 の `blocked` 条件に直接該当する。`needs_revision` と `blocked` は独立した判定軸であり、`blocked` 条件が 1 つでも成立すれば最終判定は `blocked`（優先順: `blocked` > `needs_revision` > `pass`）。
 
 ## 7. 関連
 

--- a/docs/workflows/03_solution_design.md
+++ b/docs/workflows/03_solution_design.md
@@ -20,6 +20,7 @@
 - 失敗時の扱い（エラーパス / リトライ / フォールバック）が決定されている
 - テスト観点（Unit / Integration / E2E の分担）が決定されている
 - 依存ライブラリ制約・技術的妥協点が一覧化されている
+- `plan.md` / `todo.md` / `test-cases.md` 生成後、C-1 前に [`Plan Review Readiness Gate`](../ai/plan-review-readiness-gate.md) の 7 項目が確認可能な状態になっている
 
 ## 呼び出す Skill
 
@@ -50,4 +51,6 @@ WF-03 で生成する `design.md` は、PlanGate 既存の `plan.md` と併存�
 | 変化頻度 | チケット毎 | チケット毎 + アーキ変更時 |
 | 対象読者 | 実装者・レビュアー・PM | 実装者・アーキテクト |
 
-PlanGate 既存フロー（A → B → C-1 〜 C-3 → D）における WF-03 の挿入位置は [`docs/workflows/plangate-insertion-map.md`](./plangate-insertion-map.md) を参照。
+PlanGate 既存フロー（A → B → Plan Review Readiness Gate → C-1 〜 C-3 → D）における WF-03 の挿入位置は [`docs/workflows/plangate-insertion-map.md`](./plangate-insertion-map.md) を参照。
+
+WF-03 完了後、AI 実行計画は C-1 self-review に入る前に [`Plan Review Readiness Gate`](../ai/plan-review-readiness-gate.md) を通す。これは C-1 / C-2 / C-3 の代替ではなく、レビュー対象 artifact が実行可能な粒度で揃っているかを判定する前段ゲートである。

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -67,6 +67,7 @@ PlanGate（統制の外殻）の内側で動作する **実行層（Execution Ar
 | --- | --- | --- | --- |
 | **A**: PBI INPUT PACKAGE 作成 | 統制 / 人間 | 人間 | WF-01 / WF-02 への入力提供 |
 | **B**: Plan + ToDo + TestCases 生成 | 統制 / AI | `workflow-conductor` 経由（内部で `spec-writer` が生成） | WF-01〜WF-03 を横断する計画策定 |
+| **Plan Review Readiness Gate** | 統制 / AI | 主エージェント | C-1 前の計画実行準備判定（[`plan-review-readiness-gate.md`](../ai/plan-review-readiness-gate.md)） |
 | **C-1**: セルフレビュー（17項目） | 統制 / AI | 主エージェント | 計画品質ゲート（WF 外） |
 | **C-2**: 外部AIレビュー | 統制 / AI | 外部 AI（Codex 等） | 計画独立検証ゲート（WF 外） |
 | **C-3**: 人間レビュー（三値） | 統制 / 人間 | 人間 | 計画承認ゲート（WF 外） |
@@ -81,7 +82,7 @@ PlanGate（統制の外殻）の内側で動作する **実行層（Execution Ar
 
 **読み方**:
 
-- **統制層**（PlanGate）: A / B / C-1 / C-2 / C-3 / PR作成 / C-4 — 「止める・承認する・状態を保存する」役割
+- **統制層**（PlanGate）: A / B / Plan Review Readiness Gate / C-1 / C-2 / C-3 / PR作成 / C-4 — 「止める・承認する・状態を保存する」役割
 - **実行層**（Workflow）: D / L-0 / V-1 / V-2 / V-3 / V-4 — 「柔軟で拡張可能な実行基盤」の中身を WF-01〜WF-05 で構造化
 
 ## Rule 1 の適用

--- a/docs/workflows/plangate-insertion-map.md
+++ b/docs/workflows/plangate-insertion-map.md
@@ -15,6 +15,7 @@ graph TB
     subgraph "統制層（PlanGate）"
         A[A: PBI INPUT PACKAGE]
         B[B: Plan + ToDo + Test Cases]
+        PRR[Plan Review Readiness Gate]
         C1[C-1: セルフレビュー]
         C2[C-2: 外部AIレビュー]
         C3[C-3: 人間レビュー<br>三値ゲート]
@@ -40,7 +41,8 @@ graph TB
     WF01 --> WF02
     WF02 --> B
     B --> WF03
-    WF03 --> C1
+    WF03 --> PRR
+    PRR --> C1
     C1 --> C2
     C2 --> C3
     C3 -->|APPROVE| D
@@ -57,21 +59,21 @@ graph TB
 
 ## WF-03 Solution Design の挿入位置（詳細）
 
-WF-03 は **B（Plan）と C-1（セルフレビュー）の間** に挿入される。
+WF-03 は **B（Plan）と Plan Review Readiness Gate の間** に挿入される。Plan Review Readiness Gate は `plan.md` / `todo.md` / `test-cases.md` 生成後、C-1（セルフレビュー）の直前に置く。
 
 ```text
-A → WF-01 → WF-02 → B → [ WF-03 ] → C-1 → C-2 → C-3 → D
-                        ↑
-                        ここに挿入
+A → WF-01 → WF-02 → B → [ WF-03 ] → Plan Review Readiness Gate → C-1 → C-2 → C-3 → D
+                        ↑           ↑
+                        WF-03       C-1前のreadiness判定
 ```
 
 ### 挿入の意義
 
 | 挿入前（v5/v6） | 挿入後（v7 ハイブリッド） |
 | ---------------- | ---------------------- |
-| B（plan.md 生成）→ 直接 C-1 | B → **WF-03（design.md 生成）** → C-1 |
+| B（plan.md 生成）→ 直接 C-1 | B → **WF-03（design.md 生成）** → **Plan Review Readiness Gate** → C-1 |
 | plan.md に設計要素が混在 | plan.md = 計画、design.md = 設計（分離） |
-| 実装前の設計抜けが発生しやすい | 設計 artifact で抜けを防ぐ |
+| 実装前の設計抜けが発生しやすい | 設計 artifact と readiness 判定で抜けを防ぐ |
 
 ## WF-05 Verify & Handoff の挿入位置（詳細）
 

--- a/docs/working/templates/plan.md
+++ b/docs/working/templates/plan.md
@@ -151,6 +151,38 @@ created_by: orchestrator
 
 > **検証が実行不能な場合**（環境制約・依存未整備等）は、その**理由**と**代替確認方法**を明記する（「Done = 検証完了」を満たせない検証を黙って省略しない / #578）。
 
+## Plan Review Readiness
+
+> C-1 self-review の前に [`docs/ai/plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md) で確認する。各項目は `pass / needs_revision / blocked` 判定に使われるため、`TBD` / `TODO` / `必要に応じて` / `適切に` のまま残さない。
+
+### Success Criteria
+
+- AC: {受入基準と対応する `test-cases.md` のケースID}
+- Completion boundary: {どこまで終わればDoneか、どこから先は別PBIか}
+
+### Review Criteria
+
+- Design alignment: {既存設計・ADR・UI/UX・workflowとの整合観点}
+- Test expectations: {C-1/C-2/C-3で確認すべきテスト期待値}
+- Security: {セキュリティ観点。N/Aの場合は理由}
+- Maintainability: {保守性・命名・責務境界の観点}
+- Backward compatibility: {後方互換性。N/Aの場合は理由}
+- Operational risk: {運用リスク。N/Aの場合は理由}
+
+### Required Context
+
+- Referenced issues: {Issue URL / 番号}
+- ADR / docs: {参照したADR・設計doc・運用doc}
+- Existing implementation: {既存実装・関連ファイル}
+- Related tests: {関連テスト・fixture}
+- Constraints: {HO paths / forbidden files / 環境制約 / 権限制約}
+
+### Non-goals and Scope Boundary
+
+- Out of scope: {今回やらないこと}
+- Change-prohibited zones: {触らないファイル・ディレクトリ・設定}
+- Forbidden new dependencies: {追加禁止の依存。許可する場合は承認条件}
+
 ## Replan Triggers
 
 以下に該当した場合はexecを止め、planを更新してC-1を再実行する。
@@ -160,18 +192,37 @@ created_by: orchestrator
 - 受入基準と実装方針に矛盾が見つかった
 - Task間のインターフェースが成立しない
 - セキュリティ・データ損失・後方互換性リスクが見つかった
+- hidden dependency が見つかり、Work Breakdown または Files / Interfaces が変わる
+- public API / schema / hook / workflow 契約の変更が必要になった
+- `test-cases.md` と実装可能なテスト契約が一致しない
+- scope bloat（計画外ファイルが大幅に増える、または目的外改善が混入する）が発生した
+- security impact が新たに見つかった
 
 ## Stop Condition
 
 以下に該当した場合は人間判断まで停止する。
 
 - C-3承認前にexecが必要になった
+- 要件間の矛盾、または AC と実装方針の矛盾が見つかった
 - rollback不能な変更が必要になった
-- 外部API / 認証情報 / 本番データに触る必要が出た
+- 外部API / 認証情報 / 課金 / 権限 / 本番データに触る必要が出た
+- 破壊的操作、データ削除、migration、不可逆変更が必要になった
+- 新規依存追加、または大規模な想定外変更が必要になった
 - high-risk / criticalでTDD証跡を残せない
+
+## Human Approval Boundary
+
+以下は AI が自己判断で実行せず、人間承認または別PBI化まで停止する。
+
+- Security-sensitive changes: {暗号化・認証・認可・秘密情報・監査ログなど}
+- Auth / billing / permissions: {認証、課金、権限、アカウント操作}
+- Production operations: {本番操作、デプロイ、外部公開、運用設定}
+- Data deletion / migration: {削除、移行、不可逆なデータ変換}
+- Irreversible changes: {戻せない変更、公開 API 契約変更、広範な互換性破壊}
 
 ## C-1 Self Review Checklist
 
+- [ ] Plan Review Readiness Gate が `pass` 相当（7 項目がすべて具体化済み）
 - [ ] 受入基準がWork Breakdownにマッピングされている
 - [ ] TaskごとのFiles / Interfaces / Steps / Completion Criteriaが具体的
 - [ ] `TBD` / `TODO` / `後で実装` / `必要に応じて` / `適切に` / `いい感じに` が残っていない


### PR DESCRIPTION
## Summary

- `docs/ai/plan-review-readiness-gate.md` を新規作成（standalone gate、129行）
- plan.md テンプレートに Plan Review Readiness の7チェック項目の必須フィールドを追加
- WF-03 / plangate-insertion-map / docs/workflows/README をゲート位置反映で更新
- `gate-checks.md` / `plan-quality-checks.md` に参照追加

## ゲートの位置

```text
WF-03 → plan.md/todo.md/test-cases.md 生成
  → Plan Review Readiness Gate  ← 本 PR で追加
  → C-1 self-review → C-2 external AI review → C-3 human approval → WF-04
```

## 設計判断

既存の `gate-checks.md`（C-3 記録拡張）/ `plan-quality-checks.md`（advisory）と責務・タイミングが異なるため、**standalone gate** として新規定義。

## 判定値

| Verdict | 意味 |
|---------|------|
| `pass` | 7 項目すべて記入済み、C-1 へ進める |
| `needs_revision` | 不足あり、plan.md を修正して再判定 |
| `blocked` | 危険操作・承認境界・HO パス侵害、人間判断まで停止 |

## AC カバレッジ

- [x] 新規 vs 既存拡張の判断（standalone gate として決定）
- [x] `Plan Review Readiness Gate` を docs に追加
- [x] 実行可能 plan の必須フィールド定義（7項目）
- [x] `pass` / `needs_revision` / `blocked` のセマンティクス定義
- [x] stop/replan 条件を plan review フローに追加
- [x] human approval boundary ガイダンス追加
- [x] 良い・悪い AI 実行 plan のサンプル追加
- [x] River Review issue #1325 との相互参照

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)