### PR TITLE
fix: PR#651/#653 マージ後ドキュメント整合性修正

### DIFF
--- a/.claude/skills/skill-policy-router/SKILL.md
+++ b/.claude/skills/skill-policy-router/SKILL.md
@@ -82,7 +82,7 @@ Intent はスキルの優先度や追加推奨にのみ影響する。
 
 ```json
 {
-  "intent": "<feature|bug|refactor|research|review|docs|ops>",
+  "intent": "<feature|bug|refactor|research|review|docs|ops|exploratory>",
   "mode": "<ultra-light|light|standard|high-risk|critical>"
 }
 ```
@@ -107,6 +107,7 @@ Intent に応じて optionalSkills を追加・調整する:
 | `review` | check |
 | `docs` | — |
 | `ops` | verify（デプロイ検証のため、未追加の場合）。**PlanGate CLI 操作**（render/approve/doctor/exec）は skill でなく直接 `bin/plangate <cmd>` を実行する |
+| `exploratory` | — （WF-07 opt-in 推奨。通常フローに留まる場合は intent 相当の Skill 構成を使用）|
 
 ただし、requiredSkills に既に含まれている Skill は optionalSkills に重複追加しない。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
+- **feat(#493): exploratory intent 追加（8 分類化）・hypothesis-logger スキル実装・WF-07 接続（#651）**
+  — intent-classifier に `exploratory` を 8 番目の intent として追加。仮説採番・記録スキル
+  `hypothesis-logger` を新規実装。WF-00 に exploratory 判定時の WF-07 推奨 advisory を追加。
+
+- **docs(#652): Plan Review Readiness Gate 新規追加（#653）**
+  — C-1 self-review 前に `pass / needs_revision / blocked` を判定する計画実行準備ゲートを
+  追加。WF-03 完了条件・plangate-insertion-map・plan.md テンプレートを更新。
+
 ## v8.15.0 - 2026-06-25
 
 feat: Review Gate 機械化 + EH-3 doc-light + approve 強化 + CLI テスト完備 + OpenSSF Scorecard 対応 + Best Practices Passing 取得

--- a/docs/ai/plan-review-readiness-gate.md
+++ b/docs/ai/plan-review-readiness-gate.md
@@ -8,10 +8,12 @@
 Plan Review Readiness Gate は、`plan.md` / `todo.md` / `test-cases.md` が生成された直後、C-1 self-review の前に置く計画実行準備ゲートである。
 
 ```text
-WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
+WF-00 -> WF-01 -> WF-02 -> B[plan/todo/test-cases] -> WF-03
   -> Plan Review Readiness Gate
-  -> C-1 self-review -> C-2 external AI review -> C-3 human approval -> WF-04 -> WF-05
+  -> C-1 -> C-2 -> C-3 -> D[exec] -> WF-04 -> WF-05
 ```
+
+PlanGate 統制層フェーズ（A / B / D / L-0）との対応は [`plangate-insertion-map.md`](../workflows/plangate-insertion-map.md) を参照。
 
 このゲートの目的は、AI 実行に渡す前の計画が「レビュー可能」であり、かつ C-1 / C-2 / C-3 が見るべき境界を明示していることを確認することである。実装品質そのものを判定するゲートではなく、レビュー対象 artifact の準備状態を判定する。
 
@@ -83,7 +85,7 @@ WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
   `CLAUDE.md`, `AGENTS.md`, `docs/ai/core-contract.md`
   （詳細は EH-1 production code 定義参照）
 
-### Stop Conditions
+### Stop Condition
 - HO パス編集が必要になったら停止。
 - 新規依存や CLI 実装が必要になったら停止。
 
@@ -115,10 +117,10 @@ WF-00 -> WF-01 -> WF-02 -> WF-03 -> plan/todo/test-cases
 ### Non-goals and Scope Boundary
 - 特になし。
 
-### Stop Conditions
+### Stop Condition
 - 問題があれば止める。
 
-### Replan Conditions
+### Replan Triggers
 - 必要なら再計画する。
 
 ### Human Approval Boundary

--- a/docs/ai/plan-review-readiness-gate.md
+++ b/docs/ai/plan-review-readiness-gate.md
@@ -8,7 +8,7 @@
 Plan Review Readiness Gate は、`plan.md` / `todo.md` / `test-cases.md` が生成された直後、C-1 self-review の前に置く計画実行準備ゲートである。
 
 ```text
-WF-00 -> WF-01 -> WF-02 -> B[plan/todo/test-cases] -> WF-03
+WF-00 -> WF-01 -> WF-02 -> WF-03 -> B[plan/todo/test-cases]
   -> Plan Review Readiness Gate
   -> C-1 -> C-2 -> C-3 -> D[exec] -> WF-04 -> WF-05
 ```

--- a/docs/plangate-plugin-migration.md
+++ b/docs/plangate-plugin-migration.md
@@ -59,7 +59,7 @@ sh ~/plangate/install.sh   # .claude/ と .codex/ を自動検出
 | `systematic-debugging` | エビデンスベースの体系的デバッグ |
 | `codex-multi-agent` | Codex マルチエージェント連携 |
 | `setup-team` | タスク規模・モードに応じたマルチエージェントチーム設計 |
-| `intent-classifier` | User Request を 7 分類（feature/bug/refactor 等） |
+| `intent-classifier` | User Request を 8 分類（feature/bug/refactor/exploratory 等） |
 | `skill-policy-router` | Intent + Mode → GatePolicy（requiredSkills 等）決定 |
 | `evidence-ledger` | 証拠記録・Completion Gate 連携 |
 | `design-gate` | high-risk 以上での設計 Artifact 8 項目必須チェック |

--- a/docs/workflows/00_intent_intake.md
+++ b/docs/workflows/00_intent_intake.md
@@ -14,7 +14,7 @@
 
 ```text
 依頼文
-  → intent-classifier        （Intent 7 分類）
+  → intent-classifier        （Intent 8 分類）
   → Mode 判定                 （mode-classification.md 正本・lite_eligible 含む）
   → skill-policy-router       （確定 Mode/lite_eligible → GatePolicy 写像）
   → ai-dev-plan 前段          （plan.md 着手）


### PR DESCRIPTION
## Summary

PR#651（exploratory intent 追加）・PR#653（Plan Review Readiness Gate）マージ後の
ドキュメント整合性問題を修正。Gemini コメント指摘含む。

### 修正内容

| ファイル | 変更内容 |
|---------|---------|
| `docs/ai/plan-review-readiness-gate.md` | フロー図に PlanGate フェーズ B/D を追加・insertion-map 参照注記追記 |
| `docs/ai/plan-review-readiness-gate.md` | 例コード内 `Stop Conditions`（複数）→ `Stop Condition`（単数）統一 |
| `docs/ai/plan-review-readiness-gate.md` | 悪い例 `Replan Conditions` → `Replan Triggers`（テンプレートと統一） |
| `docs/workflows/00_intent_intake.md` | advisory フロー内 `Intent 7 分類` → `Intent 8 分類` |
| `.claude/skills/skill-policy-router/SKILL.md` | 入力スキーマ・Intent 調整テーブルに `exploratory` を追加 |
| `docs/plangate-plugin-migration.md` | User Request 分類数 `7 分類` → `8 分類` に更新 |
| `CHANGELOG.md` | Unreleased セクションに PR#651/#653 を記録 |

### 調査で更新不要と確認したファイル

- `docs/workflows/plangate-insertion-map.md` — PR#653 で正確に更新済み
- `docs/workflows/03_solution_design.md` — gate への参照が完備
- `docs/workflows/04_build_and_refine.md` / `05_verify_and_handoff.md` — 責務分離で参照不要
- `docs/workflows/execution-sequence.md` — README 経由で間接カバー済み
- `docs/ai/gate-checks.md` / `plan-quality-checks.md` — 責務分界が明記済み

## Test plan

- [ ] `docs/workflows/**/*.md` Markdown lint 通過（0 error 確認済み）
- [ ] plan-review-readiness-gate.md のフロー図・セクション名が insertion-map / plan.md テンプレートと整合していること
- [ ] skill-policy-router の intent 入力スキーマに `exploratory` が含まれていること
- [ ] CHANGELOG Unreleased に PR#651/#653 が記録されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)