### PR TITLE
feat(#655): Arbiter Phase 0 — コンセプト固定・資産棚卸し・検証スコープ定義

### DIFF
--- a/docs/ai/arbiter/asset-inventory.md
+++ b/docs/ai/arbiter/asset-inventory.md
@@ -1,0 +1,61 @@
+# Arbiter — PlanGate 共通資産棚卸し
+
+> **Status**: Phase 0 ドキュメント（2026-07-01）。
+> **目的**: PlanGate の既存資産について、Arbiter-workflow での利用可否を分類する。
+> **原則**: 設計哲学は継承するが、in-the-loop 前提の契約・実装は再設計が必要。
+
+---
+
+## 分類基準
+
+| 分類 | 意味 |
+|------|------|
+| **uses（共通利用可能）** | Arbiter でもそのまま参照・活用できる資産 |
+| **not-uses（再設計が必要）** | in-the-loop 前提に最適化されており、on-the-loop 用に再設計が必要な資産 |
+
+---
+
+## uses — 共通利用可能な資産
+
+| 資産 | 場所 | 共通利用の理由 |
+|------|------|--------------|
+| スキル群（intent-classifier, hypothesis-logger 等） | `.claude/skills/` | ワークフロー非依存。判断実行スキルは Arbiter の L1 でも活用可能 |
+| HO パス定義の哲学 | `docs/ai/hook-enforcement.md` | Arbiter でも変更禁止ファイルは同じ。HO の思想を継承 |
+| provenance の設計哲学 | `docs/ai/plan-review-readiness-gate.md` 等 | 証跡担保の思想は継承。Arbiter の auto-approve + provenance 刻印に活用 |
+| Plan Review Readiness Gate | `docs/ai/plan-review-readiness-gate.md` | 判定フレームとして参照可。detect フェーズの設計に活用 |
+| Iron Law（core-contract.md） | `docs/ai/core-contract.md` | Arbiter でも最上位制約。Iron Law は on-the-loop でも不変 |
+| 責務 4 分類の設計哲学 | `.claude/rules/responsibility-classes.md` | Human-owned / AI-owned の区別の思想は Arbiter でも継承 |
+| PlanGate の失敗履歴・INC 群 | `docs/working/` 各チケット | Arbiter の threat model 初期値として最大の遺産 |
+| 承認境界・決定論・HO の設計思想 | `docs/ai/hook-enforcement.md` 等 | 設計哲学レベルで参照（契約・実装は継承しない） |
+
+---
+
+## not-uses — on-the-loop 用に再設計が必要な資産
+
+| 資産 | 場所 | 再設計が必要な理由 |
+|------|------|------------------|
+| L0 契約（責務分類本体） | `.claude/rules/responsibility-classes.md` | in-the-loop 前提に最適化されている。on-the-loop では責務モデルが異なる（Policy-owned / Sensor-owned が新設） |
+| bin/plangate exec（実行エンジン） | `bin/plangate` | "block until approved" 前提で設計されており、flow → detect と制御の極性が逆。HO-core のため AI 直接編集不可 |
+| C-3 承認ロジック | `.claude/rules/working-context.md` 等 | 実行前承認が前提。on-the-loop では承認の時制が「逸脱検知時」に移るため再設計が必要 |
+| mode-classification | `.claude/rules/mode-classification.md` | in-the-loop の mode 判定に特化。on-the-loop では boundary（touches-HO / clean）と lite が主軸 |
+| C-4 自律承認拡張（autonomous-degraded-gates） | `docs/ai/autonomous-degraded-gates-spec.md` | in-the-loop 内の例外的自律化仕様。Arbiter では flow が既定動作のため極性が異なる（関係は related-specs.md 参照） |
+| HO パス（scripts, schemas, settings 等）の実装 | `scripts/hooks/*.sh`, `schemas/`, `.claude/settings*.json` | HO-core のため AI 直接変更不可。Arbiter 側で独自定義を持つ（ho-paths.md 参照） |
+
+---
+
+## 継承する設計哲学（要約）
+
+Arbiter は以下の PlanGate 設計哲学を**実装でなく思想として**継承する:
+
+1. **承認境界の死守**: HO パスに触れた瞬間は常に人間へ。緩和なし。
+2. **provenance の強制**: 誰が・どの policy で・何を自律許可したかを刻印。
+3. **決定論・明示的失敗・トレース可能**: 判断は機械的・明示的・追跡可能。
+4. **policy 制定は永久 in-the-loop**: 自分の枠を自分で書き換えない（第0の承認境界）。
+
+---
+
+## 関連ドキュメント
+
+- `docs/ai/arbiter/concept.md` — Arbiter の基本概念
+- `docs/ai/arbiter/ho-paths.md` — HO パス一覧（touches-HO 判定基準）
+- `docs/ai/arbiter/related-specs.md` — 既存仕様との関係整理

--- a/docs/ai/arbiter/concept.md
+++ b/docs/ai/arbiter/concept.md
@@ -13,7 +13,7 @@
 
 動作の核心は 3 ステップ:
 
-```
+```text
 flow      : 低リスク変更は実行前ブロックせず流す
 detect    : 流れる変更を二重判定（W チェック 2 モデル）で逸脱検知
 escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だけ人間へ昇格
@@ -56,14 +56,14 @@ PlanGate 本番は**並走期全体で in-the-loop を維持**する。PoC の�
 
 ### 変更可能な範囲
 
-```
+```text
 docs/ai/arbiter/   配下のみ（新規作成・更新）
 docs/workflows/arbiter/  配下のみ（新規作成・更新、Phase 1 以降）
 ```
 
 ### 変更禁止（読み取り専用・参照のみ）
 
-```
+```text
 .claude/rules/              L0 契約正本。in-the-loop 前提の契約を Arbiter が変更しない
 docs/ai/*.md                既存の PlanGate ドキュメント（arbiter/ サブディレクトリを除く）
 docs/workflows/*.md         既存のワークフロー定義
@@ -84,7 +84,7 @@ AGENTS.md                   同上
 
 ## 4. flow → detect → escalate の基本フロー
 
-```
+```text
 ┌────────────────────────────────────────────────┐
 │ AI が変更を生成                                  │
 └──────────────────┬─────────────────────────────┘
@@ -115,6 +115,18 @@ AGENTS.md                   同上
 └────────────────────────────────────────────────┘
 ```
 
+### detect フェーズの入力（L2 入力 4 軸）
+
+W チェックは以下の 4 軸を入力として評価する（Phase 1/2 で Decision table に展開）：
+
+- `boundary`: touches-HO / clean（HO パスに触れるか）
+- `lite`: true / false（低リスク要件を満たすか）
+- `verdict`: W チェック合意結果（approve-approve / approve-reject / reject-reject）
+- `class`: merge を含む / 含まない
+
+`boundary=touches-HO` の場合は残りの 3 軸を無視して即 human escalate。
+`boundary=clean` かつ `lite=false`、`critical` verdict、merge class 変更の場合も human escalate とする。
+
 ---
 
 ## 5. human-in-the-loop との違い
@@ -137,7 +149,7 @@ touches-HO は常に同期ブロック固定（Arbiter でも緩和しない）�
 
 ## 6. Phase 0 の位置づけ
 
-```
+```text
 Phase 0  哲学抽出  ← 現在地
   PlanGate threat model 移植 / L0 設計哲学の明文化 / 勝利条件定義
   成果物: concept.md / asset-inventory.md / ho-paths.md / related-specs.md

--- a/docs/ai/arbiter/concept.md
+++ b/docs/ai/arbiter/concept.md
@@ -125,7 +125,7 @@ W チェックは以下の 4 軸を入力として評価する（Phase 1/2 で D
 - `class`: merge を含む / 含まない
 
 `boundary=touches-HO` の場合は残りの 3 軸を無視して即 human escalate。
-`boundary=clean` かつ `lite=false`、`critical` verdict、merge class 変更の場合も human escalate とする。
+`boundary=clean` かつ `lite=false`、W チェック不一致（approve-reject）、または merge class を含む変更の場合も human escalate とする。
 
 ---
 

--- a/docs/ai/arbiter/concept.md
+++ b/docs/ai/arbiter/concept.md
@@ -1,0 +1,171 @@
+# Arbiter-workflow — コンセプト定義
+
+> **Status**: Phase 0 ドキュメント（2026-07-01）。PoC 段階の構想固定。確定仕様・実装方針ではない。
+> **置き場所**: docs/ai/arbiter/（PlanGate リポジトリ内 PoC 用サブディレクトリ）
+> **出典**: `docs/working/discussions/2026-06-11-arbiter-vision.md`
+
+---
+
+## 1. Arbiter とは何か
+
+**Arbiter** は、**AI を走らせたまま安全な枠に保ち、逸脱だけを人間に昇格する**、
+枠内自律（governed autonomy）AI 開発の**裁定ランタイム**。
+
+動作の核心は 3 ステップ:
+
+```
+flow      : 低リスク変更は実行前ブロックせず流す
+detect    : 流れる変更を二重判定（W チェック 2 モデル）で逸脱検知
+escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だけ人間へ昇格
+            合意 clean は auto-approve + provenance 刻印
+```
+
+人間は「各実行の承認者」をやめ、「**枠（policy）の制定者・例外の裁定者・事後の監督者**」になる。
+
+### 一行サマリ
+
+> Arbiter = AI を走らせたまま安全な枠に保ち、二重判定で逸脱だけを人間に昇格する、
+> 枠内自律 AI 開発の裁定ランタイム。
+
+---
+
+## 2. PlanGate との関係
+
+Arbiter は PlanGate の延長（v9 / 2.0）ではなく、**次世代検証プロジェクト**として位置づける。
+
+| 項目 | PlanGate | Arbiter |
+|------|----------|---------|
+| 人間の役割 | ループの中（in-the-loop）= 実行前承認者 | ループの上（on-the-loop）= 枠の制定者・例外裁定者 |
+| 承認の時制 | 実行前 | 逸脱検知時 |
+| 制御の基本姿勢 | block until approved | flow → detect → escalate |
+| 現在の位置づけ | 本番統制を担う（並走期全体） | PoC 段階の独立プロジェクト |
+
+### 配置方針（Phase 0 判断）
+
+構想（`arbiter-vision.md` §8）では「別リポジトリ」を推奨している（同一リポジトリに同居すると
+in/on の契約が混在し承認境界が二重定義になるため）。
+
+ただし、CLI 非依存設計への移行方針により、**まず docs/ 層で PoC を進める**。
+PlanGate 本番は**並走期全体で in-the-loop を維持**する。PoC の結果に応じて独立リポジトリへの移行を判断する。
+
+---
+
+## 3. 検証スコープ（変更可否の境界）
+
+> **この制約は Phase 0 全体に適用される不変条件。**
+
+### 変更可能な範囲
+
+```
+docs/ai/arbiter/   配下のみ（新規作成・更新）
+docs/workflows/arbiter/  配下のみ（新規作成・更新、Phase 1 以降）
+```
+
+### 変更禁止（読み取り専用・参照のみ）
+
+```
+.claude/rules/              L0 契約正本。in-the-loop 前提の契約を Arbiter が変更しない
+docs/ai/*.md                既存の PlanGate ドキュメント（arbiter/ サブディレクトリを除く）
+docs/workflows/*.md         既存のワークフロー定義
+bin/plangate                実行エンジン。AI 直接編集不可（HO-core）
+schemas/                    バリデーション定義。AI 直接編集不可
+.claude/settings*.json      Human-owned 設定
+.claude/settings.local.json 同上
+CLAUDE.md                   AI-Human 間の基本契約
+AGENTS.md                   同上
+.github/workflows/          CI/CD 定義。AI 直接編集不可
+```
+
+「変更可能なのは `docs/ai/arbiter/` および `docs/workflows/arbiter/` 配下のみ。
+`.claude/rules/`、`docs/ai/` 既存ファイル、`bin/plangate`、`schemas/`、`CLAUDE.md`、
+`AGENTS.md`、`.github/workflows/` は変更禁止。」
+
+---
+
+## 4. flow → detect → escalate の基本フロー
+
+```
+┌────────────────────────────────────────────────┐
+│ AI が変更を生成                                  │
+└──────────────────┬─────────────────────────────┘
+                   │
+                   ▼
+┌────────────────────────────────────────────────┐
+│ [FLOW] boundary チェック                         │
+│  • touches-HO? → YES: 即 human escalate         │
+│  • touches-HO? → NO: detect フェーズへ           │
+└──────────────────┬─────────────────────────────┘
+                   │
+                   ▼
+┌────────────────────────────────────────────────┐
+│ [DETECT] W チェック（2 モデル非対称）              │
+│  Model A: 順方向（設計妥当性「正しく作られているか」）│
+│  Model B: 逆方向（adversarial「どう壊れるか」）    │
+│                                                 │
+│  A=approve & B=approve → 合意 clean             │
+│  A=approve & B=reject  → 不一致 → human escalate│
+│  A=reject  & B=reject  → 合意 → block           │
+└──────────────────┬─────────────────────────────┘
+                   │
+                   ▼
+┌────────────────────────────────────────────────┐
+│ [ESCALATE / AUTO-APPROVE]                       │
+│  • 合意 clean: auto-approve + provenance 刻印   │
+│  • 不一致 / touches-HO / critical: human へ昇格 │
+└────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. human-in-the-loop との違い
+
+| 観点 | human-in-the-loop（PlanGate） | human-on-the-loop（Arbiter） |
+|------|-------------------------------|------------------------------|
+| 承認の時制 | 実行前（block until approved） | 逸脱検知時（flow → detect → escalate） |
+| 人間の関与 | 各実行を1件ずつ承認 | 枠の制定・例外の裁定・事後監督 |
+| AI の動作 | 承認を待ってから実行 | 枠内では自律実行、逸脱時に停止 |
+| ボトルネック | 人的レビューがリニアにしか伸びない | 低リスク帯はボトルネックを回避 |
+| 安全装置 | 実行前ゲート | provenance 刻印・逸脱検知・サーキットブレーカー |
+| policy 制定 | 都度人間判断 | **policy 制定は永久 in-the-loop**（第0の承認境界） |
+
+### 不変の原則
+
+「**承認境界に触れた瞬間に全部 human に戻る**」。
+touches-HO は常に同期ブロック固定（Arbiter でも緩和しない）。
+
+---
+
+## 6. Phase 0 の位置づけ
+
+```
+Phase 0  哲学抽出  ← 現在地
+  PlanGate threat model 移植 / L0 設計哲学の明文化 / 勝利条件定義
+  成果物: concept.md / asset-inventory.md / ho-paths.md / related-specs.md
+
+Phase 1  心臓
+  L2 裁定層を薄く実装（二分ルール + policy + provenance 発行）
+
+Phase 2  PoC
+  1 領域（最低リスク帯）で flow→detect→escalate の存在証明
+
+Phase 3  L1 接続
+  RiverReview 成熟に合わせ判断実行を委譲
+
+Phase 4  拡張
+  L3 自律オーケストレーション / L4 学習閉ループ
+
+Phase 5  解禁判定
+  policy maturity で領域ごと on-the-loop 委譲を拡大（人間が判定）
+
+並走期（全期間）
+  Arbiter が存在証明を超えるまで PlanGate が本番統制を担う
+```
+
+---
+
+## 7. 関連ドキュメント
+
+- `docs/ai/arbiter/asset-inventory.md` — PlanGate 共通資産の uses/not-uses 分類
+- `docs/ai/arbiter/ho-paths.md` — touches-HO 判定基準リスト
+- `docs/ai/arbiter/related-specs.md` — 既存仕様との関係整理
+- `docs/working/discussions/2026-06-11-arbiter-vision.md` — 構想まとめ（出典）

--- a/docs/ai/arbiter/ho-paths.md
+++ b/docs/ai/arbiter/ho-paths.md
@@ -11,6 +11,7 @@
 ## touches-HO 判定ルール
 
 > **「上記パスのいずれか一つでも変更対象に含む場合、boundary=touches-HO とし、必ず human escalate とする」**
+> **優先順位**: `ho-paths.md` の HO パス一覧が machine-readable 正本。`concept.md §3` の「変更禁止」リストは人間向け概説。両者が異なる場合は `ho-paths.md` を優先する。
 
 Arbiter の flow → detect → escalate において、変更対象ファイルパスが以下の HO パス一覧に
 一致するものを含む場合は、W チェック（detect フェーズ）をスキップして即座に human escalate とする。
@@ -31,6 +32,7 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | `CLAUDE.md` | HO-contract | AI-Human 間の基本契約。AI による変更は契約の自己改ざんに相当 |
 | `AGENTS.md` | HO-contract | 同上。Codex 用基本契約 |
 | `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
+| `docs/ai/*.md`（arbiter/ 除く） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
 | `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
 | `approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
 | `.claude/commands/*.md` | HO-rules | コマンド定義。実行入口・承認境界に影響。AI 直接編集不可 |

--- a/docs/ai/arbiter/ho-paths.md
+++ b/docs/ai/arbiter/ho-paths.md
@@ -33,6 +33,10 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
 | `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
 | `approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
+| `.claude/commands/*.md` | HO-rules | コマンド定義。実行入口・承認境界に影響。AI 直接編集不可 |
+| `.claude/agents/*.md` | HO-rules | Agent 行動契約。統制回避防止。AI 直接編集不可 |
+| `.claude/settings.example.json` | HO-settings | settings 契約例。自己改変・緩和防止 |
+| `.github/workflows/*.yaml` | HO-ci | CI/CD 定義（yaml 拡張子）。AI 直接編集不可 |
 | `plugin/plangate/**` | HO-plugin | プラグイン本体。AI 直接編集不可 |
 
 ---
@@ -55,7 +59,7 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 
 ## 判定アルゴリズム（Phase 2 Decision table 向け）
 
-```
+```pseudocode
 入力: 変更対象ファイルパスのリスト
 出力: boundary = "touches-HO" | "clean"
 
@@ -73,7 +77,7 @@ else:
 
 ### パターンマッチの例
 
-```
+```text
 bin/plangate                → HO-core
 scripts/hooks/check-*.sh    → HO-hook
 schemas/plan.schema.json    → HO-schema

--- a/docs/ai/arbiter/ho-paths.md
+++ b/docs/ai/arbiter/ho-paths.md
@@ -24,8 +24,8 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | パス | 分類 | 変更禁止理由 |
 |------|------|------------|
 | `bin/plangate` | HO-core | 実行エンジン。AI 直接編集不可。制御極性（block until approved）が Arbiter と逆 |
-| `scripts/hooks/*.sh` | HO-hook | フック本体。AI 直接編集不可。誤変更で安全装置が無効化される |
-| `schemas/*.schema.json` | HO-schema | バリデーション定義。AI 直接編集不可。スキーマ改ざんで不変条件が崩壊する |
+| `scripts/hooks/**` | HO-hook | フック本体（全ファイル）。AI 直接編集不可。誤変更で安全装置が無効化される |
+| `schemas/**` | HO-schema | バリデーション定義（全ファイル）。AI 直接編集不可。スキーマ改ざんで不変条件が崩壊する |
 | `.claude/rules/*.md` | HO-rules | L0 契約正本。AI 直接編集不可。in-the-loop 前提の契約を Arbiter が変更しない |
 | `.claude/settings*.json` | HO-settings | Human-owned 設定。AI 自己改変禁止（self-mod guard） |
 | `.claude/settings.local.json` | HO-settings | 同上。ローカル設定も Human-owned |
@@ -81,8 +81,8 @@ else:
 
 ```text
 bin/plangate                → HO-core
-scripts/hooks/check-*.sh    → HO-hook
-schemas/plan.schema.json    → HO-schema
+scripts/hooks/check-hook.sh → HO-hook
+schemas/plan.schema.json   → HO-schema
 .claude/rules/mode-classification.md → HO-rules
 .claude/settings.json       → HO-settings
 .claude/settings.local.json → HO-settings

--- a/docs/ai/arbiter/ho-paths.md
+++ b/docs/ai/arbiter/ho-paths.md
@@ -1,0 +1,110 @@
+# Arbiter — HO（Hardening Override）パス集約リスト
+
+> **Status**: Phase 0 ドキュメント（2026-07-01）。
+> **目的**: "touches-HO" 判定の基準となるパスを machine-readable な形式で列挙する。
+> Phase 2 の Decision table から参照される。
+> **出典**: `docs/ai/hook-enforcement.md`、`docs/ai/autonomous-degraded-gates-spec.md` の
+> `NoHardeningOverridePath` 条件、および `docs/working/discussions/2026-06-11-arbiter-vision.md` §5.3
+
+---
+
+## touches-HO 判定ルール
+
+> **「上記パスのいずれか一つでも変更対象に含む場合、boundary=touches-HO とし、必ず human escalate とする」**
+
+Arbiter の flow → detect → escalate において、変更対象ファイルパスが以下の HO パス一覧に
+一致するものを含む場合は、W チェック（detect フェーズ）をスキップして即座に human escalate とする。
+これは Arbiter でも緩和しない**絶対条件**（iron law 相当）。
+
+---
+
+## HO パス一覧
+
+| パス | 分類 | 変更禁止理由 |
+|------|------|------------|
+| `bin/plangate` | HO-core | 実行エンジン。AI 直接編集不可。制御極性（block until approved）が Arbiter と逆 |
+| `scripts/hooks/*.sh` | HO-hook | フック本体。AI 直接編集不可。誤変更で安全装置が無効化される |
+| `schemas/*.schema.json` | HO-schema | バリデーション定義。AI 直接編集不可。スキーマ改ざんで不変条件が崩壊する |
+| `.claude/rules/*.md` | HO-rules | L0 契約正本。AI 直接編集不可。in-the-loop 前提の契約を Arbiter が変更しない |
+| `.claude/settings*.json` | HO-settings | Human-owned 設定。AI 自己改変禁止（self-mod guard） |
+| `.claude/settings.local.json` | HO-settings | 同上。ローカル設定も Human-owned |
+| `CLAUDE.md` | HO-contract | AI-Human 間の基本契約。AI による変更は契約の自己改ざんに相当 |
+| `AGENTS.md` | HO-contract | 同上。Codex 用基本契約 |
+| `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
+| `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
+| `approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
+| `plugin/plangate/**` | HO-plugin | プラグイン本体。AI 直接編集不可 |
+
+---
+
+## 分類定義
+
+| 分類 | 説明 |
+|------|------|
+| HO-core | 実行エンジン・制御中枢。AI 直接変更不可 |
+| HO-hook | フックスクリプト本体。安全装置の物理実装 |
+| HO-schema | バリデーション・スキーマ定義 |
+| HO-rules | L0 契約正本（in-the-loop 統制の根拠） |
+| HO-settings | Human-owned 設定ファイル（self-mod guard 対象） |
+| HO-contract | AI-Human 間の基本契約・Iron Law |
+| HO-ci | CI/CD 定義・自動検証の物理配線 |
+| HO-approval | 人間承認トークン・provenance 証跡 |
+| HO-plugin | CLI プラグイン本体 |
+
+---
+
+## 判定アルゴリズム（Phase 2 Decision table 向け）
+
+```
+入力: 変更対象ファイルパスのリスト
+出力: boundary = "touches-HO" | "clean"
+
+boundary = "clean"
+for each path in changed_files:
+    if matches_any_ho_pattern(path):
+        boundary = "touches-HO"
+        break  # 1 つでも該当すれば即確定
+
+if boundary == "touches-HO":
+    → human escalate（W チェックをスキップ）
+else:
+    → detect フェーズ（W チェック）へ進む
+```
+
+### パターンマッチの例
+
+```
+bin/plangate                → HO-core
+scripts/hooks/check-*.sh    → HO-hook
+schemas/plan.schema.json    → HO-schema
+.claude/rules/mode-classification.md → HO-rules
+.claude/settings.json       → HO-settings
+.claude/settings.local.json → HO-settings
+CLAUDE.md                   → HO-contract
+AGENTS.md                   → HO-contract
+docs/ai/core-contract.md    → HO-contract
+.github/workflows/ci.yml    → HO-ci
+approvals/2026-07-01.json   → HO-approval
+plugin/plangate/index.js    → HO-plugin
+```
+
+---
+
+## Arbiter 固有の追加原則
+
+1. **docs/ai/arbiter/ 配下は Phase 0 限定の例外**: Arbiter PoC ドキュメント自体は
+   AI が作成・更新できる（変更禁止リストに含まれない）。ただし、HO パスへの記述が
+   HO 本体の変更を意味するわけではない（参照のみ）。
+
+2. **policy ファイル（将来定義）は HO-policy として追加予定**: Arbiter の
+   `auto-approve-lite-clean@v1` 等の policy ファイルは制定・改版が Human-owned のため、
+   Phase 1 以降に HO-policy として追加する。
+
+---
+
+## 関連ドキュメント
+
+- `docs/ai/arbiter/concept.md` — Arbiter の基本概念（検証スコープ含む）
+- `docs/ai/arbiter/asset-inventory.md` — PlanGate 資産の uses/not-uses 分類
+- `docs/ai/hook-enforcement.md` — HO パスの元定義（PlanGate 既存仕様）
+- `docs/ai/autonomous-degraded-gates-spec.md` — `NoHardeningOverridePath` 条件の定義元

--- a/docs/ai/arbiter/related-specs.md
+++ b/docs/ai/arbiter/related-specs.md
@@ -17,7 +17,7 @@
 
 ## autonomous-degraded-gates-spec.md との関係
 
-**関係: 拡張**
+### 関係: 拡張
 
 ### autonomous-degraded-gates-spec.md の思想
 
@@ -64,7 +64,7 @@ Arbiter は on-the-loop を前提とした制御極性の反転（flow が既定
 
 ## plan-review-readiness-gate.md との関係
 
-**関係: 独立**
+### 関係: 独立
 
 `plan-review-readiness-gate.md` は Arbiter の detect フェーズとは**異なる時点**で動作する
 既存ゲート。C-1 前（plan 提出前）の readiness 検証を担う。
@@ -86,7 +86,7 @@ Arbiter の boundary チェック・W チェックの設計に活用する。
 
 ## responsibility-classes.md との関係
 
-**関係: 上位制約（Arbiter は「追加」するが「変更」しない）**
+### 関係: 上位制約（Arbiter は「追加」するが「変更」しない）
 
 `responsibility-classes.md` は PlanGate の責務 4 分類（AI-owned / Human-owned /
 CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された分類。
@@ -97,6 +97,11 @@ CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された�
 - Arbiter の L0 設計（Phase 1 以降）では、**Policy-owned**（事前定義された自律許可の裁定）と
   **Sensor-owned**（逸脱検知の責務）を**追加**する設計を想定
 - Iron Law は Arbiter でも最上位制約として適用される
+
+> **注意**: ここで定義する Policy-owned / Sensor-owned の追加責務、および
+> Human-owned の役割変化は **Arbiter L0（docs/workflows/arbiter/ 配下）内のみ**に適用される。
+> PlanGate 本番フロー（WF-00〜WF-07）の C-3 / C-4 / merge 責務は変更しない。
+> PlanGate 本番統制では `responsibility-classes.md` が引き続き優先する。
 
 | 責務クラス | PlanGate 既存 | Arbiter 追加予定（Phase 1+） |
 |-----------|--------------|----------------------------|
@@ -111,7 +116,7 @@ CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された�
 
 ## hook-enforcement.md との関係
 
-**関係: 独立（HO パス定義を参照・継承）**
+### 関係: 独立（HO パス定義を参照・継承）
 
 `hook-enforcement.md` は PlanGate の HO パスと hook 実装の正本。
 Arbiter は HO パスの定義を**参照**し、`docs/ai/arbiter/ho-paths.md` に集約する。
@@ -121,7 +126,7 @@ Arbiter は HO パスの定義を**参照**し、`docs/ai/arbiter/ho-paths.md` �
 
 ## core-contract.md（Iron Law）との関係
 
-**関係: 上位制約（Arbiter は Iron Law に従う）**
+### 関係: 上位制約（Arbiter は Iron Law に従う）
 
 Iron Law は Arbiter でも最上位制約として適用される。
 Arbiter-workflow は Iron Law の下位に位置し、Iron Law を緩和・変更しない。

--- a/docs/ai/arbiter/related-specs.md
+++ b/docs/ai/arbiter/related-specs.md
@@ -1,0 +1,138 @@
+# Arbiter — 既存仕様との関係整理
+
+> **Status**: Phase 0 ドキュメント（2026-07-01）。
+> **目的**: Arbiter-workflow と PlanGate 既存仕様の関係を明確化し、混乱・二重定義を防ぐ。
+
+---
+
+## 関係の種類（3 択）
+
+| 関係 | 意味 |
+|------|------|
+| **代替** | Arbiter が既存仕様を置き換える（既存仕様は非推奨化） |
+| **拡張** | Arbiter が既存仕様の思想を継承し、より精密に実装する |
+| **独立** | 異なる時点・目的で動作し、干渉しない |
+
+---
+
+## autonomous-degraded-gates-spec.md との関係
+
+**関係: 拡張**
+
+### autonomous-degraded-gates-spec.md の思想
+
+`autonomous-degraded-gates-spec.md` は「証明可能なときだけ自律、それ以外は安全側（人間）」という
+思想を持ち、`C4AutoApproveAllowed` 条件として `NoHardeningOverridePath`
+（HO 対象パスを含まない）を定義している。
+
+```text
+C4AutoApproveAllowed =
+  mode == ultra-light
+  AND (C3AutonomousApproved OR C3Skipped)
+  AND RiskTierIntegrityPassed
+  AND CiAllGreen
+  AND NoHardeningOverridePath       ← HO 対象パスを 1 つも含まない
+  AND NoSchemaOrBreakingOrSecurity
+```
+
+### Arbiter-workflow との対応関係
+
+| autonomous-degraded-gates-spec.md | Arbiter-workflow |
+|-----------------------------------|-----------------|
+| `NoHardeningOverridePath` | `boundary = clean`（HO に触れない限り自律継続） |
+| C-4 自律承認（例外的な自律化） | flow（自律継続が既定動作） |
+| in-the-loop 内の例外として設計 | on-the-loop が前提（極性が逆） |
+| ultra-light mode 限定 | lite 条件で low-risk 帯を定義（Phase 1 以降） |
+| CI green が必須条件 | W チェック 2 モデル合意が主軸（CI は補完） |
+
+### 拡張の内容
+
+- `autonomous-degraded-gates-spec.md` の "NoHardeningOverridePath" 条件は
+  Arbiter の `boundary=clean` と同じ思想（HO に触れない限り自律継続）
+- Arbiter は W チェック（2 モデル非対称）と provenance 刻印を追加することで、
+  この思想をより精密に実装する
+- Arbiter-workflow が成熟した段階で、`autonomous-degraded-gates-spec.md` の
+  改版を検討する（**Phase 3 の判断対象**）
+
+### 重要な違い
+
+`autonomous-degraded-gates-spec.md` は in-the-loop の例外的自律化（承認前ゲートを1箇所狭める）。
+Arbiter は on-the-loop を前提とした制御極性の反転（flow が既定動作）。
+**思想は同じだが、実装の極性が逆**。Phase 0 では干渉しない（Arbiter は PoC 段階）。
+
+---
+
+## plan-review-readiness-gate.md との関係
+
+**関係: 独立**
+
+`plan-review-readiness-gate.md` は Arbiter の detect フェーズとは**異なる時点**で動作する
+既存ゲート。C-1 前（plan 提出前）の readiness 検証を担う。
+
+| 観点 | plan-review-readiness-gate.md | Arbiter detect フェーズ |
+|------|-------------------------------|------------------------|
+| 動作タイミング | C-1 前（plan 提出前） | 変更生成後（flow 中） |
+| 目的 | plan が review に耐えられる状態か確認 | 変更が承認境界・逸脱条件に抵触するか判定 |
+| 判定対象 | plan artifact | 変更ファイルセット |
+| 位置づけ | in-the-loop の前処理ゲート | on-the-loop の逸脱検知エンジン |
+
+### Arbiter での参照
+
+Arbiter-workflow でも Plan Review Readiness Gate の**考え方**は参照できる。
+特に「判定フレームを事前定義し、条件を機械的に評価する」設計思想は
+Arbiter の boundary チェック・W チェックの設計に活用する。
+
+---
+
+## responsibility-classes.md との関係
+
+**関係: 上位制約（Arbiter は「追加」するが「変更」しない）**
+
+`responsibility-classes.md` は PlanGate の責務 4 分類（AI-owned / Human-owned /
+CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された分類。
+
+### Arbiter での取り扱い
+
+- `docs/ai/arbiter/` 配下のドキュメントは `responsibility-classes.md` を変更しない
+- Arbiter の L0 設計（Phase 1 以降）では、**Policy-owned**（事前定義された自律許可の裁定）と
+  **Sensor-owned**（逸脱検知の責務）を**追加**する設計を想定
+- Iron Law は Arbiter でも最上位制約として適用される
+
+| 責務クラス | PlanGate 既存 | Arbiter 追加予定（Phase 1+） |
+|-----------|--------------|----------------------------|
+| AI-owned | 実装・テスト・PR 準備 等 | + 自律実行・auto-approve 発行 |
+| Human-owned | 実行前承認・merge | → **policy 制定・例外裁定・事後監督**（実行前承認から退却） |
+| CI-owned | drift 検出・必須検証 | + drift 検出・逸脱検知・サーキットブレーカー発火 |
+| Workflow-owned | DoD・handoff 追跡 | + 学習ループ・昇格予算管理 |
+| **Policy-owned** | - | 事前定義された自律許可の裁定（Human でも AI でもない第三主体） |
+| **Sensor-owned** | - | 逸脱検知の責務 |
+
+---
+
+## hook-enforcement.md との関係
+
+**関係: 独立（HO パス定義を参照・継承）**
+
+`hook-enforcement.md` は PlanGate の HO パスと hook 実装の正本。
+Arbiter は HO パスの定義を**参照**し、`docs/ai/arbiter/ho-paths.md` に集約する。
+`hook-enforcement.md` 自体は変更しない（`docs/ai/` 既存ファイルのため変更禁止）。
+
+---
+
+## core-contract.md（Iron Law）との関係
+
+**関係: 上位制約（Arbiter は Iron Law に従う）**
+
+Iron Law は Arbiter でも最上位制約として適用される。
+Arbiter-workflow は Iron Law の下位に位置し、Iron Law を緩和・変更しない。
+
+---
+
+## 関連ドキュメント
+
+- `docs/ai/arbiter/concept.md` — Arbiter の基本概念・PlanGate との関係
+- `docs/ai/arbiter/asset-inventory.md` — 資産の uses/not-uses 分類
+- `docs/ai/arbiter/ho-paths.md` — touches-HO 判定基準リスト
+- `docs/ai/autonomous-degraded-gates-spec.md` — `NoHardeningOverridePath` 定義元（読み取り専用）
+- `docs/ai/core-contract.md` — Iron Law 正本（読み取り専用）
+- `.claude/rules/responsibility-classes.md` — 責務 4 分類正本（読み取り専用）

--- a/docs/working/TASK-0655/TASK-0655-c3-review.html
+++ b/docs/working/TASK-0655/TASK-0655-c3-review.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="ja"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>TASK-0655 (PR #660) — C-3 Review</title>
+<style>
+:root{--fg:#1f2328;--muted:#656d76;--bd:#d0d7de;--bg:#fff;--accent:#0969da;--code:#f6f8fa;
+--pass:#1a7f37;--pass-bg:#dafbe1;--warn:#9a6700;--warn-bg:#fff8c5;
+--fail:#cf222e;--fail-bg:#ffebe9;--ap:#0969da;--ap-bg:#ddf4ff}
+*{box-sizing:border-box}
+body{margin:0;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;color:var(--fg);background:#fafbfc}
+.wrap{max-width:980px;margin:0 auto;padding:24px}
+header h1{margin:0 0 4px}
+.meta{color:var(--muted);font-size:14px;margin-bottom:16px}
+nav.toc{position:sticky;top:0;background:var(--bg);border:1px solid var(--bd);border-radius:8px;padding:12px 16px;margin-bottom:24px;z-index:10}
+nav.toc strong{display:block;margin-bottom:6px}
+nav.toc a{display:inline-block;margin:2px 10px 2px 0;color:var(--accent);text-decoration:none;font-size:14px}
+nav.toc a:hover{text-decoration:underline}
+section.block{background:var(--bg);border:1px solid var(--bd);border-radius:8px;padding:8px 24px 24px;margin-bottom:28px}
+section.block>h2{border-bottom:2px solid var(--bd);padding-bottom:8px}
+h1,h2,h3,h4{line-height:1.3}
+table{border-collapse:collapse;width:100%;margin:12px 0;font-size:14px}
+th,td{border:1px solid var(--bd);padding:6px 10px;text-align:left;vertical-align:top}
+th{background:var(--code)}
+code{background:var(--code);padding:.15em .35em;border-radius:4px;font-size:85%}
+pre{background:var(--code);padding:12px;border-radius:8px;overflow:auto;font-size:13px}
+pre code{background:none;padding:0}
+blockquote{margin:8px 0;padding:0 12px;color:var(--muted);border-left:3px solid var(--bd)}
+a{color:var(--accent)}
+.badge{display:inline-block;padding:2px 10px;border-radius:20px;font-size:13px;font-weight:600}
+.badge-pass{background:var(--pass-bg);color:var(--pass)}
+.badge-warn{background:var(--warn-bg);color:var(--warn)}
+.badge-fail{background:var(--fail-bg);color:var(--fail)}
+.badge-approve{background:var(--ap-bg);color:var(--ap)}
+.badge-request{background:var(--fail-bg);color:var(--fail)}
+.verdict-bar{background:var(--pass-bg);border:1px solid #1a7f37;border-radius:8px;padding:12px 20px;margin:16px 0;font-size:15px}
+.verdict-bar.warn{background:var(--warn-bg);border-color:var(--warn)}
+.reviewer-card{border:1px solid var(--bd);border-radius:8px;padding:12px 16px;margin:12px 0}
+.reviewer-card h4{margin:0 0 8px;font-size:15px}
+hr{border:none;border-top:1px solid var(--bd);margin:16px 0}
+ul{margin:4px 0;padding-left:20px}
+li{margin:2px 0}
+.section-note{font-size:13px;color:var(--muted);margin-top:-8px;margin-bottom:12px}
+</style></head>
+<body><div class="wrap">
+
+<header>
+  <h1>TASK-0655 / PR #660</h1>
+  <div class="meta">C-3 レビュー集約ビュー &nbsp;|&nbsp; 2026-07-01 &nbsp;|&nbsp; feat/arbiter-phase0 &nbsp;|&nbsp; <a href="https://github.com/s977043/PlanGate/issues/655">#655</a> &nbsp;|&nbsp; <a href="https://github.com/s977043/PlanGate/pull/660">PR #660</a></div>
+</header>
+
+<nav class="toc">
+  <strong>目次</strong>
+  <a href="#overview">変更概要</a>
+  <a href="#c2-review">C-2 外部レビュー（3 エージェント）</a>
+  <a href="#c3-review">C-3 観点別レビュー（2 エージェント）</a>
+  <a href="#known-issues">既知課題</a>
+  <a href="#final-verdict">最終判定</a>
+</nav>
+
+<section class="block" id="overview">
+<h2>変更概要</h2>
+<table>
+  <tr><th>ブランチ</th><td><code>feat/arbiter-phase0</code></td></tr>
+  <tr><th>対象 issue</th><td><a href="https://github.com/s977043/PlanGate/issues/655">#655</a> feat(Arbiter): Phase 0 — コンセプト固定・資産棚卸し・検証スコープ定義</td></tr>
+  <tr><th>PR</th><td><a href="https://github.com/s977043/PlanGate/pull/660">#660</a></td></tr>
+  <tr><th>最終コミット</th><td><code>9ee7030</code> — fix: ho-paths.md に docs/ai/*.md 追加・優先順位明記</td></tr>
+</table>
+
+<h3>変更ファイル一覧</h3>
+<table>
+  <tr><th>ファイル</th><th>種別</th><th>内容</th></tr>
+  <tr><td><code>docs/ai/arbiter/concept.md</code></td><td>新規</td><td>Arbiter の定義・flow→detect→escalate・L2 入力 4 軸・検証スコープ</td></tr>
+  <tr><td><code>docs/ai/arbiter/asset-inventory.md</code></td><td>新規</td><td>PlanGate 共通資産の uses/not-uses 分類</td></tr>
+  <tr><td><code>docs/ai/arbiter/ho-paths.md</code></td><td>新規</td><td>touches-HO 判定基準リスト（17 パス、machine-readable）</td></tr>
+  <tr><td><code>docs/ai/arbiter/related-specs.md</code></td><td>新規</td><td>既存仕様との関係整理（autonomous-degraded-gates-spec.md = 拡張 等）</td></tr>
+  <tr><td><code>docs/working/_audit/skip-decision-log.jsonl</code></td><td>自動記録</td><td>EH-3 doc-light スキップの hook 自動追記（4 行）</td></tr>
+</table>
+
+<h3>HO パスへの変更確認</h3>
+<pre><code>.claude/rules/         — 変更なし
+bin/plangate           — 変更なし
+schemas/               — 変更なし
+.claude/settings*.json — 変更なし
+CLAUDE.md / AGENTS.md  — 変更なし
+.github/workflows/     — 変更なし
+docs/ai/*.md（既存）   — 変更なし</code></pre>
+</section>
+
+<section class="block" id="c2-review">
+<h2>C-2 外部レビュー（実装後・3 エージェント並列）</h2>
+<p class="section-note">初回実装コミット（14e31a8）後に実施。指摘はすべて修正対応済み。</p>
+
+<div class="reviewer-card">
+  <h4>plangate:acceptance-tester<span style="float:right"><span class="badge badge-fail">初回 FAIL</span> → <span class="badge badge-pass">修正後 PASS</span></span></h4>
+  <p><strong>検出:</strong> markdownlint 12 エラー（MD040×7 コードブロック言語指定なし、MD036×5 太字見出し）</p>
+  <p><strong>修正:</strong> コードブロックに <code>text</code>/<code>pseudocode</code> 指定追加。太字見出しを <code>###</code> に統一。最終 0 エラー。</p>
+</div>
+
+<div class="reviewer-card">
+  <h4>plangate:qa-reviewer<span style="float:right"><span class="badge badge-request">初回 REQUEST_CHANGES</span> → <span class="badge badge-approve">修正後 APPROVE</span></span></h4>
+  <p><strong>検出:</strong> <code>ho-paths.md</code> に <code>.claude/commands/*.md</code> と <code>.claude/agents/*.md</code> が欠落（正本 HO 9 カテゴリとの差分）</p>
+  <p><strong>修正:</strong> 4 パスを HO パス一覧に追加（commands、agents、workflows/*.yaml、settings.example.json）</p>
+</div>
+
+<div class="reviewer-card">
+  <h4>codex:codex-rescue<span style="float:right"><span class="badge badge-warn">MINOR_CHANGES → 対応済み</span></span></h4>
+  <p><strong>検出:</strong> ①同上 HO パス漏れ ②concept.md に L2 入力 4 軸の記述不足 ③responsibility-classes.md の責務 namespace 不明確</p>
+  <p><strong>修正:</strong> concept.md §4 に L2 入力 4 軸を追記。related-specs.md に「Arbiter L0 内のみ適用」の namespace 注記を追加。</p>
+</div>
+</section>
+
+<section class="block" id="c3-review">
+<h2>C-3 観点別レビュー（2 エージェント）</h2>
+<p class="section-note">修正後コミット（27ee064）を対象に実施。</p>
+
+<h3>plangate:qa-reviewer</h3>
+<table>
+  <tr><th>#</th><th>観点</th><th>判定</th><th>所見</th></tr>
+  <tr><td>1</td><td>Design alignment</td><td><span class="badge badge-pass">PASS</span></td><td>WF-00〜07 は変更対象外。concept.md §2 に「PlanGate 本番は in-the-loop 維持」明記。</td></tr>
+  <tr><td>2</td><td>Security</td><td><span class="badge badge-pass">PASS</span></td><td>HO パスへの変更ゼロ。settings*.json が self-mod guard 対象として明示。権限昇格リスクなし。</td></tr>
+  <tr><td>3</td><td>Backward compatibility</td><td><span class="badge badge-pass">PASS</span></td><td>「PlanGate 本番統制では responsibility-classes.md が優先」と明記。Policy-owned 追加は arbiter/ 内のみ。</td></tr>
+  <tr><td>4</td><td>Maintainability</td><td><span class="badge badge-warn">PASS/WARN</span></td><td>ロードマップが concept.md §6 に明記。<br><strong>WARN:</strong> ho-paths.md と hook-enforcement.md の同期手順未定義。→ KI-01</td></tr>
+  <tr><td>5</td><td>Operational risk</td><td><span class="badge badge-pass">PASS</span></td><td>新規ドキュメント 4 件 + append-only 自動記録のみ。markdownlint 0 エラー。</td></tr>
+  <tr><td>6</td><td>Scope boundary</td><td><span class="badge badge-pass">PASS</span></td><td>issue #655 完了条件 6 項目すべて充足。スコープ外変更なし。</td></tr>
+</table>
+<div class="verdict-bar">
+  <strong>qa-reviewer 総合:</strong> <span class="badge badge-approve">APPROVE</span> — HO パス影響ゼロ、#655 完了条件を全て充足。
+</div>
+
+<h3>plangate:solution-architect</h3>
+<table>
+  <tr><th>観点</th><th>判定</th><th>所見</th></tr>
+  <tr>
+    <td>A. Arbiter 構想との整合</td>
+    <td><span class="badge badge-pass">PASS</span></td>
+    <td>concept.md の flow→detect→escalate が vision §3 と一致。ho-paths.md の「即 human escalate」が vision §5.3 の要石を正確に実装。asset-inventory.md の uses/not-uses が vision §8「機構でなく哲学のみ継承」と整合。</td>
+  </tr>
+  <tr>
+    <td>B. Phase 1〜3 への接続性</td>
+    <td><span class="badge badge-warn">PASS/WARN</span></td>
+    <td>L2 入力 4 軸が concept.md §4 に明記され Phase 1 の基盤として十分。ho-paths.md は Phase 2 Decision table から参照可能な構造。<br><strong>WARN:</strong> <code>lite</code> 条件の定量定義が Phase 1 以降に先送り → KI-02</td>
+  </tr>
+  <tr>
+    <td>C. PlanGate 正本との境界</td>
+    <td><span class="badge badge-pass">PASS</span></td>
+    <td>related-specs.md が適用ドメインを明確分離。ho-paths.md が machine-readable 正本として concept.md §3 との優先順位を明記（C-3 対応コミット 9ee7030 で解消済み）。</td>
+  </tr>
+</table>
+<div class="verdict-bar warn">
+  <strong>solution-architect 総合:</strong> <span class="badge badge-approve">APPROVE_WITH_NOTE</span> — 設計骨格承認。必須対処（docs/ai/*.md エントリ欠落）は修正済み。残 WARN は Phase 1 入口で対応推奨。
+</div>
+</section>
+
+<section class="block" id="known-issues">
+<h2>既知課題 / Phase 1 申し送り事項</h2>
+<table>
+  <tr><th>ID</th><th>重大度</th><th>内容</th><th>推奨タイミング</th></tr>
+  <tr>
+    <td>KI-01</td>
+    <td><span class="badge badge-warn">WARN</span></td>
+    <td><code>ho-paths.md</code> と <code>hook-enforcement.md</code> の同期手順が未定義。Phase 1 以降で追従漏れリスク。</td>
+    <td>Phase 1 着手前に <code>ho-paths.md</code> 末尾に更新トリガーを追記</td>
+  </tr>
+  <tr>
+    <td>KI-02</td>
+    <td><span class="badge badge-warn">WARN</span></td>
+    <td><code>lite</code> 条件（低リスク要件の定量定義）が未定義。Phase 1 の arbiter-policy.md 作成時に auto-approve 候補の範囲が曖昧になる。</td>
+    <td>issue <a href="https://github.com/s977043/PlanGate/issues/656">#656</a>（Phase 1）着手前に TODO 明記</td>
+  </tr>
+  <tr>
+    <td>KI-03</td>
+    <td><span class="badge badge-warn">WARN</span></td>
+    <td>Policy-owned / Sensor-owned の責務骨格が Phase 1 以降に全量先送り。L2 裁定層の実装境界が曖昧になるリスク。</td>
+    <td>Phase 1 の arbiter-policy.md で定義</td>
+  </tr>
+  <tr>
+    <td>KI-04</td>
+    <td>INFO</td>
+    <td><code>skip-decision-log.jsonl</code> の 4 エントリが <code>acknowledged_by: null</code>（doc-light 経路の正式追認ステータス）。</td>
+    <td>本 C-3 承認時または doc-light 省略の明文化</td>
+  </tr>
+</table>
+</section>
+
+<section class="block" id="final-verdict">
+<h2>最終判定</h2>
+<div class="verdict-bar">
+  <strong>C-3 総合判定: <span class="badge badge-approve">APPROVE</span></strong><br><br>
+  <ul>
+    <li>HO パスへの変更ゼロ — PlanGate 本番への悪影響なし</li>
+    <li>issue #655 完了条件 6 項目すべて充足</li>
+    <li>markdownlint 0 エラー（最終）</li>
+    <li>5 エージェント独立レビューで Arbiter 構想との整合を確認</li>
+    <li>C-3 指摘（docs/ai/*.md エントリ欠落）は修正コミット（9ee7030）で解消済み</li>
+  </ul>
+  <br>
+  <strong>次ステップ:</strong> マージ後、Phase 1（<a href="https://github.com/s977043/PlanGate/issues/656">#656</a>）着手前に KI-01 / KI-02 を issue に反映。
+</div>
+
+<h3>レビュー参加エージェント</h3>
+<table>
+  <tr><th>エージェント</th><th>フェーズ</th><th>判定</th></tr>
+  <tr><td>plangate:acceptance-tester</td><td>C-2（初回）</td><td>FAIL → 修正後 PASS</td></tr>
+  <tr><td>plangate:qa-reviewer</td><td>C-2（初回）</td><td>REQUEST_CHANGES → 修正後 APPROVE</td></tr>
+  <tr><td>codex:codex-rescue</td><td>C-2（初回）</td><td>MINOR_CHANGES → 対応済み</td></tr>
+  <tr><td>plangate:qa-reviewer</td><td>C-3</td><td>APPROVE</td></tr>
+  <tr><td>plangate:solution-architect</td><td>C-3</td><td>APPROVE_WITH_NOTE</td></tr>
+</table>
+</section>
+
+</div></body></html>

--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -34,3 +34,7 @@
 {"ts":"2026-06-29T02:03:56Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/skills/hypothesis-logger/SKILL.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-06-29T02:04:07Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/workflows/00_intent_intake.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-06-29T02:06:15Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/workflows/00_intent_intake.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-01T04:18:18Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/arbiter/concept.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-01T04:18:50Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/arbiter/asset-inventory.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-01T04:19:25Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/arbiter/ho-paths.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-01T04:20:09Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/ai/arbiter/related-specs.md","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
## Summary

- Closes #655
- Arbiter-workflow 検証フェーズ Phase 0 の成果物を `docs/ai/arbiter/` 配下に新規作成
- **PlanGate 本番フロー（.claude/rules/ / bin/plangate 等 HO パス）への変更はゼロ**

### 作成ファイル

| ファイル | 内容 |
|---------|------|
| `docs/ai/arbiter/concept.md` | Arbiter の定義・flow→detect→escalate・検証スコープ・L2 入力 4 軸 |
| `docs/ai/arbiter/asset-inventory.md` | PlanGate 共通資産の uses/not-uses 分類（表形式） |
| `docs/ai/arbiter/ho-paths.md` | touches-HO 判定基準リスト（16 パス、機械可読） |
| `docs/ai/arbiter/related-specs.md` | 既存仕様との関係整理（autonomous-degraded-gates-spec.md = 拡張） |

### レビュー対応（3 エージェント並列レビュー後）

- `ho-paths.md` に `.claude/commands/*.md`、`.claude/agents/*.md`、`.github/workflows/*.yaml`、`.claude/settings.example.json` を追加（正本 HO 9 カテゴリとの差分を解消）
- `concept.md` に L2 入力 4 軸（boundary/lite/verdict/class）を明記
- `related-specs.md` に Arbiter L0 の適用 namespace を明示（PlanGate 本番 C-3/C-4 は変更しない）
- markdownlint エラー 12 件 → 0 件に解消

## Test plan

- [x] `git diff --name-only` で変更ファイルが `docs/ai/arbiter/` 配下のみ（HO パスへの変更ゼロ）
- [x] `npx markdownlint-cli2 "docs/ai/arbiter/*.md"` — 0 エラー
- [x] `docs/ai/arbiter/ho-paths.md` の HO パス数 ≥ 10（16 パス）
- [x] `concept.md` に検証スコープ制約の記述あり
- [x] `related-specs.md` に autonomous-degraded-gates-spec.md との関係「拡張」が明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)