### PR TITLE
docs(#664): Arbiter Phase 2 follow-up — provenance 正本一元化・安全側 severity 既定・責務範囲明記

### DIFF
--- a/docs/ai/arbiter/concept.md
+++ b/docs/ai/arbiter/concept.md
@@ -13,7 +13,7 @@
 動作の核心は 3 ステップ:
 
 ```text
-flow      : 低リスク変更は人間承認を待たずに裁定まで流す（Arbiter の裁定は経る）
+flow      : 低リスク変更は人間承認を待たずに裁定まで流す（Arbiter の裁定を経る）
 detect    : 流れる変更を二重判定（W チェック 2 モデル）で逸脱検知
 escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だけ人間へ昇格
             合意 clean は auto-approve + provenance 刻印
@@ -30,7 +30,7 @@ escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だ�
 
 Arbiter は、PlanGate で積み重ねた統制資産 — 失敗履歴・INC 群（threat model
 初期値）、HO（Hardening Override）・承認境界・provenance・決定論の設計哲学 —
-を継承し、堅牢な on-the-loop ループモデルを構築することを目的とする。
+を継承し、堅牢な on-the-loop モデルを構築することを目的とする。
 本 PoC を独立リポジトリではなく PlanGate リポジトリ内で行う本質的な理由は、
 これらの資産が**ここにしか存在しない**ためである。詳細な資産分類は
 [`docs/ai/arbiter/asset-inventory.md`](./asset-inventory.md) を参照。

--- a/docs/ai/arbiter/concept.md
+++ b/docs/ai/arbiter/concept.md
@@ -13,7 +13,7 @@
 動作の核心は 3 ステップ:
 
 ```text
-flow      : 低リスク変更は実行前ブロックせず流す
+flow      : 低リスク変更は人間承認を待たずに裁定まで流す（Arbiter の裁定は経る）
 detect    : 流れる変更を二重判定（W チェック 2 モデル）で逸脱検知
 escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だけ人間へ昇格
             合意 clean は auto-approve + provenance 刻印
@@ -25,6 +25,15 @@ escalate  : 逸脱（2 モデル不一致 / 承認境界接触 / critical）だ�
 
 > Arbiter = AI を走らせたまま安全な枠に保ち、二重判定で逸脱だけを人間に昇格する、
 > 枠内自律 AI 開発の裁定ランタイム。
+
+### 目的（なぜ PlanGate リポジトリ内で PoC するか）
+
+Arbiter は、PlanGate で積み重ねた統制資産 — 失敗履歴・INC 群（threat model
+初期値）、HO（Hardening Override）・承認境界・provenance・決定論の設計哲学 —
+を継承し、堅牢な on-the-loop ループモデルを構築することを目的とする。
+本 PoC を独立リポジトリではなく PlanGate リポジトリ内で行う本質的な理由は、
+これらの資産が**ここにしか存在しない**ためである。詳細な資産分類は
+[`docs/ai/arbiter/asset-inventory.md`](./asset-inventory.md) を参照。
 
 ---
 
@@ -123,6 +132,13 @@ AGENTS.md                   同上
 │  • 不一致 / touches-HO / critical: human へ昇格 │
 └────────────────────────────────────────────────┘
 ```
+
+> **注（簡略版であることの明示）**: 上図は簡略版であり、
+> `A=approve & B=reject`（不一致）は実際には「即 human escalate」ではなく
+> **severity 分類**（critical/major → human escalate、minor/low →
+> Model C/D 裁定で auto-approve に到達し得る）へ進む。詳細分岐の正本は
+> [`docs/workflows/arbiter/flow-detect.md`](../../workflows/arbiter/flow-detect.md)
+> §3.2〜3.3。
 
 ### detect フェーズの入力（L2 入力 4 軸）
 

--- a/docs/workflows/arbiter/00_concept.md
+++ b/docs/workflows/arbiter/00_concept.md
@@ -27,11 +27,16 @@ Arbiter が存在証明を超えるまで PlanGate が本番統制を担う。
 | 適用対象 | 全変更 | low-risk 変更のみ（boundary=clean, lite=true） |
 | 実行ブロック | 承認前にブロック | 事前ブロックしない（flow） |
 | 競合 | なし | なし |
+| カバーする工程 | 開発プロセス全体（intent→要件→設計→実装→検証→handoff） | 裁定のみ（flow→detect→escalate） |
+| 変更の生成 | 責務内（WF-02〜04 で要件・設計・実装を導く） | 責務外（変更がどう作られたかは関知しない） |
 
 両者は競合しない。並走期において:
 
 - PlanGate が本番統制を担当する
 - Arbiter は PoC 領域（docs/ai/arbiter/ と docs/workflows/arbiter/）で実験的に稼働する
+
+Arbiter は WF-01〜05 相当のフェーズを持たず、置き換えもしない（判断実行は
+L1 = RiverReview 委譲、生成品質は上流責務）。
 
 ---
 

--- a/docs/workflows/arbiter/flow-detect.md
+++ b/docs/workflows/arbiter/flow-detect.md
@@ -118,7 +118,8 @@ human 昇格の洪水を防ぐため:
 
 ## 5. provenance 刻印
 
-> **provenance スキーマの正本は `docs/workflows/arbiter/decision-table.md` §5**。
+> **provenance スキーマの正本は
+> [`docs/workflows/arbiter/decision-table.md`](./decision-table.md) §5**。
 > 本セクションの責務は刻印**タイミング**の定義のみに限定し、フィールド名の
 > 独自定義は持たない（二重定義防止）。
 
@@ -126,11 +127,12 @@ human 昇格の洪水を防ぐため:
 
 - **A/B 合意時**（`verdict=approve-approve`）: auto-approve と同時に provenance を刻印する
 - **C/D 合意時**（severity=minor/low の不一致を Model C/D が独立裁定し合意した場合）:
-  auto-approve と同時に provenance を刻印する。この場合は decision-table.md §5 の
+  auto-approve と同時に provenance を刻印する。この場合は
+  [`decision-table.md`](./decision-table.md) §5 の
   「C/D 裁定時の追加フィールド」（`w_check.severity` / `w_check.model_c` /
   `w_check.model_d`）が併せて記録される。
 
-フィールド定義・必須項目・値域は decision-table.md §5 のみを参照すること。
+フィールド定義・必須項目・値域は [`decision-table.md`](./decision-table.md) §5 のみを参照すること。
 
 ---
 

--- a/docs/workflows/arbiter/flow-detect.md
+++ b/docs/workflows/arbiter/flow-detect.md
@@ -64,6 +64,15 @@ W チェック不一致（A=approve, B=reject）を検出した場合:
 | minor | ロジック変更・パフォーマンス影響・テスト不足 | Model C/D 裁定へ |
 | low | ドキュメント・フォーマット・命名 | Model C/D 裁定へ |
 
+**安全側既定**: 分類不能・根拠不足・判定が曖昧な場合は安全側に倒し
+**critical 扱い（human escalate）**とする（PlanGate の AC-8 安全側原則
+[`working-context.md`](../../../.claude/rules/working-context.md)
+と整合）。
+
+**Phase 1 論点（未確定）**: severity 分類の判定主体（Model B の reject
+理由から導出するのか、専用の分類器を置くのか）は本ドキュメントでは
+確定しない。Phase 1 で決定する。
+
 ### 3.3 観点特化 multi-agent 裁定（Model C/D）
 
 severity=minor/low の不一致を 2 つの観点特化モデルが独立に再判定する:
@@ -109,20 +118,19 @@ human 昇格の洪水を防ぐため:
 
 ## 5. provenance 刻印
 
-auto-approve 時（A/B 合意 または C/D 合意）に以下を記録する:
+> **provenance スキーマの正本は `docs/workflows/arbiter/decision-table.md` §5**。
+> 本セクションの責務は刻印**タイミング**の定義のみに限定し、フィールド名の
+> 独自定義は持たない（二重定義防止）。
 
-```text
-approved_by: arbiter
-model_a_verdict: approve
-model_b_verdict: approve または reject
-model_c_verdict: approve（C/D 裁定時のみ）
-model_d_verdict: approve（C/D 裁定時のみ）
-severity: low または minor（C/D 裁定時のみ）
-boundary: clean
-lite: true
-sha: <commit SHA>
-timestamp: <ISO 8601>
-```
+刻印タイミングは以下のいずれか:
+
+- **A/B 合意時**（`verdict=approve-approve`）: auto-approve と同時に provenance を刻印する
+- **C/D 合意時**（severity=minor/low の不一致を Model C/D が独立裁定し合意した場合）:
+  auto-approve と同時に provenance を刻印する。この場合は decision-table.md §5 の
+  「C/D 裁定時の追加フィールド」（`w_check.severity` / `w_check.model_c` /
+  `w_check.model_d`）が併せて記録される。
+
+フィールド定義・必須項目・値域は decision-table.md §5 のみを参照すること。
 
 ---
 


### PR DESCRIPTION
## 概要

Phase 0〜2b（#655〜#658）マージ後の全体レビュー（PR #660・#661・#662 突合）で検出した整合性指摘 3 点 + コンセプト明確化 2 点の修正。

Closes #664

## 変更内容（5 点）

| # | 修正 | 対象 |
|---|------|------|
| M-1 | provenance フィールド名の二重定義解消 — flow-detect §5 の独自フィールド定義を削除し、正本を decision-table.md §5 に一元化。§5 の責務は刻印タイミング定義のみに限定 | flow-detect.md |
| M-2 | concept §4 フロー図に「簡略版・詳細分岐は flow-detect §3.2〜3.3 が正本」注記を追加。§1 の flow 説明を「人間承認を待たずに裁定まで流す（Arbiter の裁定は経る）」に精密化 | concept.md |
| M-3 | severity 分類の安全側既定を明文化 — 分類不能・根拠不足時は critical 扱い（human escalate）。working-context.md AC-8 安全側原則と整合。分類主体は Phase 1 論点として明記 | flow-detect.md |
| 4 | 並立関係表に「カバーする工程」「変更の生成」の責務範囲 2 行を追加。Arbiter は WF-01〜05 を置き換えないことを明示 | 00_concept.md |
| 5 | 目的の明文化 — PlanGate で積み重ねた統制資産（threat model・HO・provenance 哲学・INC 群）を継承し堅牢な on-the-loop モデルを構築する、を concept §1 に追記 | concept.md |

## Mode 判定 / C-3

- **Mode**: doc-light 相当（docs のみ・`docs/ai/arbiter/` + `docs/workflows/arbiter/` 配下のみ・HO 非接触）
- **C-3 Gate: AUTONOMOUS APPROVED** — ユーザー自律実行指示（verbatim）:「対応を進めたい、実タスクは別モデルのエージェントに委託し、タスクの完了→レビューを実施して、自律的に対応を進めて欲しい」
- 実装: Sonnet エージェント（worktree 隔離）に委託 → Fable 5 がレビュー（AC-8 参照リンク 1 点を指摘・修正済み）

## 検証

- markdownlint: 変更前 90 件 → 変更後 90 件（新規エラーなし、既存エラーの行番号シフトのみ）
- 変更ファイルが対象 2 ディレクトリ配下のみであることを `git diff --stat` で確認
- 分岐元 = origin/main（c8c8fdb）を merge-base で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)