### PR TITLE
docs(#672): Arbiter-workflow を ai-loop-workflow に改称

### DIFF
--- a/docs/ai/ai-loop/arbiter-policy.md
+++ b/docs/ai/ai-loop/arbiter-policy.md
@@ -1,6 +1,6 @@
 # Arbiter L0 policy
 
-> 適用ドメイン: Arbiter-workflow（docs/workflows/arbiter/ 配下）のみ
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
 > 上位制約の優先順: core-contract.md > responsibility-classes.md > 本 policy
 > 本 policy は「detect/escalate 判断基準」のみを追加する
@@ -53,7 +53,7 @@ escalate  : 逸脱（W チェック不一致 / boundary=touches-HO / 予算超�
 
 ### 4.1 基本判定表
 
-> 判定表の正本は [`docs/workflows/arbiter/flow-detect.md`](../../workflows/arbiter/flow-detect.md) §3.1。本表は policy 文脈での再掲であり、相違がある場合は flow-detect.md を優先する。
+> 判定表の正本は [`docs/workflows/ai-loop/flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.1。本表は policy 文脈での再掲であり、相違がある場合は flow-detect.md を優先する。
 
 | モデル A | モデル B | → 裁定 |
 | --------- | --------- | -------- |
@@ -105,7 +105,7 @@ boundary=touches-HO の場合、lite 値・W チェック結果にかかわら�
 
 > **「承認境界に触れた瞬間に全部 human に戻る」**
 
-touches-HO 判定の正本: `docs/ai/arbiter/ho-paths.md`
+touches-HO 判定の正本: `docs/ai/ai-loop/ho-paths.md`
 
 ---
 
@@ -144,7 +144,7 @@ human 昇格の洪水を防ぐため、昇格件数に上限（予算）を設�
 
 ## 9. 関連ドキュメント
 
-- `docs/ai/arbiter/ho-paths.md` — touches-HO 判定の正本
-- `docs/ai/arbiter/concept.md` — Arbiter の基本概念
+- `docs/ai/ai-loop/ho-paths.md` — touches-HO 判定の正本
+- `docs/ai/ai-loop/concept.md` — Arbiter の基本概念
 - `docs/ai/core-contract.md` — 上位制約（Iron Law）
 - `.claude/rules/responsibility-classes.md` — PlanGate 責務分類（参照のみ）

--- a/docs/ai/ai-loop/asset-inventory.md
+++ b/docs/ai/ai-loop/asset-inventory.md
@@ -1,7 +1,7 @@
 # Arbiter — PlanGate 共通資産棚卸し
 
 > **Status**: Phase 0 ドキュメント（2026-07-01）。
-> **目的**: PlanGate の既存資産について、Arbiter-workflow での利用可否を分類する。
+> **目的**: PlanGate の既存資産について、ai-loop-workflow での利用可否を分類する。
 > **原則**: 設計哲学は継承するが、in-the-loop 前提の契約・実装は再設計が必要。
 
 ---
@@ -56,6 +56,6 @@ Arbiter は以下の PlanGate 設計哲学を**実装でなく思想として**�
 
 ## 関連ドキュメント
 
-- `docs/ai/arbiter/concept.md` — Arbiter の基本概念
-- `docs/ai/arbiter/ho-paths.md` — HO パス一覧（touches-HO 判定基準）
-- `docs/ai/arbiter/related-specs.md` — 既存仕様との関係整理
+- `docs/ai/ai-loop/concept.md` — Arbiter の基本概念
+- `docs/ai/ai-loop/ho-paths.md` — HO パス一覧（touches-HO 判定基準）
+- `docs/ai/ai-loop/related-specs.md` — 既存仕様との関係整理

--- a/docs/ai/ai-loop/concept.md
+++ b/docs/ai/ai-loop/concept.md
@@ -1,7 +1,9 @@
-# Arbiter-workflow — コンセプト定義
+# ai-loop-workflow — コンセプト定義
 
 > **Status**: Phase 0 ドキュメント（2026-07-01）。PoC 段階の構想固定。確定仕様・実装方針ではない。
-> **置き場所**: docs/ai/arbiter/（PlanGate リポジトリ内 PoC 用サブディレクトリ）
+> **置き場所**: docs/ai/ai-loop/（PlanGate リポジトリ内 PoC 用サブディレクトリ）
+> **名称**: ai-loop-workflow（旧称: Arbiter-workflow、2026-07-02 改称）。
+> 「Arbiter」は本 workflow の L2 裁定エンジン（部品）の名称として存続する。
 
 ---
 
@@ -33,7 +35,7 @@ Arbiter は、PlanGate で積み重ねた統制資産 — 失敗履歴・INC 群
 を継承し、堅牢な on-the-loop モデルを構築することを目的とする。
 本 PoC を独立リポジトリではなく PlanGate リポジトリ内で行う本質的な理由は、
 これらの資産が**ここにしか存在しない**ためである。詳細な資産分類は
-[`docs/ai/arbiter/asset-inventory.md`](./asset-inventory.md) を参照。
+[`docs/ai/ai-loop/asset-inventory.md`](./asset-inventory.md) を参照。
 
 ---
 
@@ -75,8 +77,8 @@ Arbiter はその前提が異なる（人間はループの上）ため、L0 は
 ### 変更可能な範囲
 
 ```text
-docs/ai/arbiter/   配下のみ（新規作成・更新）
-docs/workflows/arbiter/  配下のみ（新規作成・更新、Phase 1 以降）
+docs/ai/ai-loop/   配下のみ（新規作成・更新）
+docs/workflows/ai-loop/  配下のみ（新規作成・更新、Phase 1 以降）
 ```
 
 ### 変更禁止（読み取り専用・参照のみ）
@@ -94,7 +96,7 @@ AGENTS.md                   同上
 .github/workflows/          CI/CD 定義。AI 直接編集不可
 ```
 
-「変更可能なのは `docs/ai/arbiter/` および `docs/workflows/arbiter/` 配下のみ。
+「変更可能なのは `docs/ai/ai-loop/` および `docs/workflows/ai-loop/` 配下のみ。
 `.claude/rules/`、`docs/ai/` 既存ファイル、`bin/plangate`、`schemas/`、`CLAUDE.md`、
 `AGENTS.md`、`.github/workflows/` は変更禁止。」
 
@@ -137,7 +139,7 @@ AGENTS.md                   同上
 > `A=approve & B=reject`（不一致）は実際には「即 human escalate」ではなく
 > **severity 分類**（critical/major → human escalate、minor/low →
 > Model C/D 裁定で auto-approve に到達し得る）へ進む。詳細分岐の正本は
-> [`docs/workflows/arbiter/flow-detect.md`](../../workflows/arbiter/flow-detect.md)
+> [`docs/workflows/ai-loop/flow-detect.md`](../../workflows/ai-loop/flow-detect.md)
 > §3.2〜3.3。
 
 ### detect フェーズの入力（L2 入力 4 軸）
@@ -230,6 +232,6 @@ L0 統制契約層        承認境界 / 責務モデル / HO / mode 判定（on
 
 ## 9. 関連ドキュメント
 
-- `docs/ai/arbiter/asset-inventory.md` — PlanGate 共通資産の uses/not-uses 分類
-- `docs/ai/arbiter/ho-paths.md` — touches-HO 判定基準リスト
-- `docs/ai/arbiter/related-specs.md` — 既存仕様との関係整理
+- `docs/ai/ai-loop/asset-inventory.md` — PlanGate 共通資産の uses/not-uses 分類
+- `docs/ai/ai-loop/ho-paths.md` — touches-HO 判定基準リスト
+- `docs/ai/ai-loop/related-specs.md` — 既存仕様との関係整理

--- a/docs/ai/ai-loop/ho-paths.md
+++ b/docs/ai/ai-loop/ho-paths.md
@@ -98,7 +98,7 @@ plugin/plangate/index.js    → HO-plugin
 
 ## Arbiter 固有の追加原則
 
-1. **docs/ai/arbiter/ 配下は Phase 0 限定の例外**: Arbiter PoC ドキュメント自体は
+1. **docs/ai/ai-loop/ 配下は Phase 0 限定の例外**: Arbiter PoC ドキュメント自体は
    AI が作成・更新できる（変更禁止リストに含まれない）。ただし、HO パスへの記述が
    HO 本体の変更を意味するわけではない（参照のみ）。
 
@@ -110,7 +110,7 @@ plugin/plangate/index.js    → HO-plugin
 
 ## 関連ドキュメント
 
-- `docs/ai/arbiter/concept.md` — Arbiter の基本概念（検証スコープ含む）
-- `docs/ai/arbiter/asset-inventory.md` — PlanGate 資産の uses/not-uses 分類
+- `docs/ai/ai-loop/concept.md` — Arbiter の基本概念（検証スコープ含む）
+- `docs/ai/ai-loop/asset-inventory.md` — PlanGate 資産の uses/not-uses 分類
 - `docs/ai/hook-enforcement.md` — HO パスの元定義（PlanGate 既存仕様）
 - `docs/ai/autonomous-degraded-gates-spec.md` — `NoHardeningOverridePath` 条件の定義元

--- a/docs/ai/ai-loop/phase3-impact-report.md
+++ b/docs/ai/ai-loop/phase3-impact-report.md
@@ -4,6 +4,9 @@
 > **位置づけ**: Phase 0〜2 + follow-up の検証結果を踏まえ、「PlanGate 内継続」vs
 > 「別リポジトリ分離」vs「中止」の判断材料を提供する。**判定は人間が行う**。
 > **出典**: [issue #659](https://github.com/s977043/plangate/issues/659)
+> **パス表記**: 本レポート §a の `docs/ai/arbiter/`・`docs/workflows/arbiter/` は
+> Phase 0〜3 当時の実パス（監査証跡のため改変しない）。2026-07-02 に
+> `docs/ai/ai-loop/`・`docs/workflows/ai-loop/` へ改称された（issue #672）。
 
 ---
 
@@ -113,8 +116,8 @@ PR #663（`docs: plan-review-readiness-gate.md にドキュメント仕様変更
 - [`docs/ai/arbiter/ho-paths.md`](./ho-paths.md) — HO パス集約リスト
 - [`docs/ai/arbiter/asset-inventory.md`](./asset-inventory.md) — PlanGate 共通資産棚卸し
 - [`docs/ai/arbiter/related-specs.md`](./related-specs.md) — 既存仕様との関係整理
-- [`docs/workflows/arbiter/00_concept.md`](../../workflows/arbiter/00_concept.md) — ワークフローコンセプト
-- [`docs/workflows/arbiter/flow-detect.md`](../../workflows/arbiter/flow-detect.md) — flow/detect フロー定義
-- [`docs/workflows/arbiter/decision-table.md`](../../workflows/arbiter/decision-table.md) — Decision table・provenance schema
-- [`docs/workflows/arbiter/review-feedback-loop.md`](../../workflows/arbiter/review-feedback-loop.md) — レビュー指摘還元閉ループ
+- [`docs/workflows/arbiter/00_concept.md`](../../workflows/ai-loop/00_concept.md) — ワークフローコンセプト
+- [`docs/workflows/arbiter/flow-detect.md`](../../workflows/ai-loop/flow-detect.md) — flow/detect フロー定義
+- [`docs/workflows/arbiter/decision-table.md`](../../workflows/ai-loop/decision-table.md) — Decision table・provenance schema
+- [`docs/workflows/arbiter/review-feedback-loop.md`](../../workflows/ai-loop/review-feedback-loop.md) — レビュー指摘還元閉ループ
 - [`.claude/rules/responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md) — 責務 4 分類正本

--- a/docs/ai/ai-loop/related-specs.md
+++ b/docs/ai/ai-loop/related-specs.md
@@ -1,7 +1,7 @@
 # Arbiter — 既存仕様との関係整理
 
 > **Status**: Phase 0 ドキュメント（2026-07-01）。
-> **目的**: Arbiter-workflow と PlanGate 既存仕様の関係を明確化し、混乱・二重定義を防ぐ。
+> **目的**: ai-loop-workflow と PlanGate 既存仕様の関係を明確化し、混乱・二重定義を防ぐ。
 
 ---
 
@@ -35,9 +35,9 @@ C4AutoApproveAllowed =
   AND NoSchemaOrBreakingOrSecurity
 ```
 
-### Arbiter-workflow との対応関係
+### ai-loop-workflow との対応関係
 
-| autonomous-degraded-gates-spec.md | Arbiter-workflow |
+| autonomous-degraded-gates-spec.md | ai-loop-workflow |
 |-----------------------------------|-----------------|
 | `NoHardeningOverridePath` | `boundary = clean`（HO に触れない限り自律継続） |
 | C-4 自律承認（例外的な自律化） | flow（自律継続が既定動作） |
@@ -51,7 +51,7 @@ C4AutoApproveAllowed =
   Arbiter の `boundary=clean` と同じ思想（HO に触れない限り自律継続）
 - Arbiter は W チェック（2 モデル非対称）と provenance 刻印を追加することで、
   この思想をより精密に実装する
-- Arbiter-workflow が成熟した段階で、`autonomous-degraded-gates-spec.md` の
+- ai-loop-workflow が成熟した段階で、`autonomous-degraded-gates-spec.md` の
   改版を検討する（**Phase 3 の判断対象**）
 
 ### 重要な違い
@@ -78,7 +78,7 @@ Arbiter は on-the-loop を前提とした制御極性の反転（flow が既定
 
 ### Arbiter での参照
 
-Arbiter-workflow でも Plan Review Readiness Gate の**考え方**は参照できる。
+ai-loop-workflow でも Plan Review Readiness Gate の**考え方**は参照できる。
 特に「判定フレームを事前定義し、条件を機械的に評価する」設計思想は
 Arbiter の boundary チェック・W チェックの設計に活用する。
 
@@ -93,13 +93,13 @@ CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された�
 
 ### Arbiter での取り扱い
 
-- `docs/ai/arbiter/` 配下のドキュメントは `responsibility-classes.md` を変更しない
+- `docs/ai/ai-loop/` 配下のドキュメントは `responsibility-classes.md` を変更しない
 - Arbiter の L0 設計（Phase 1 以降）では、**Policy-owned**（事前定義された自律許可の裁定）と
   **Sensor-owned**（逸脱検知の責務）を**追加**する設計を想定
 - Iron Law は Arbiter でも最上位制約として適用される
 
 > **注意**: ここで定義する Policy-owned / Sensor-owned の追加責務、および
-> Human-owned の役割変化は **Arbiter L0（docs/workflows/arbiter/ 配下）内のみ**に適用される。
+> Human-owned の役割変化は **Arbiter L0（docs/workflows/ai-loop/ 配下）内のみ**に適用される。
 > PlanGate 本番フロー（WF-00〜WF-07）の C-3 / C-4 / merge 責務は変更しない。
 > PlanGate 本番統制では `responsibility-classes.md` が引き続き優先する。
 
@@ -119,7 +119,7 @@ CI-owned / Workflow-owned）の正本。in-the-loop 前提に最適化された�
 ### 関係: 独立（HO パス定義を参照・継承）
 
 `hook-enforcement.md` は PlanGate の HO パスと hook 実装の正本。
-Arbiter は HO パスの定義を**参照**し、`docs/ai/arbiter/ho-paths.md` に集約する。
+Arbiter は HO パスの定義を**参照**し、`docs/ai/ai-loop/ho-paths.md` に集約する。
 `hook-enforcement.md` 自体は変更しない（`docs/ai/` 既存ファイルのため変更禁止）。
 
 ---
@@ -129,15 +129,15 @@ Arbiter は HO パスの定義を**参照**し、`docs/ai/arbiter/ho-paths.md` �
 ### 関係: 上位制約（Arbiter は Iron Law に従う）
 
 Iron Law は Arbiter でも最上位制約として適用される。
-Arbiter-workflow は Iron Law の下位に位置し、Iron Law を緩和・変更しない。
+ai-loop-workflow は Iron Law の下位に位置し、Iron Law を緩和・変更しない。
 
 ---
 
 ## 関連ドキュメント
 
-- `docs/ai/arbiter/concept.md` — Arbiter の基本概念・PlanGate との関係
-- `docs/ai/arbiter/asset-inventory.md` — 資産の uses/not-uses 分類
-- `docs/ai/arbiter/ho-paths.md` — touches-HO 判定基準リスト
+- `docs/ai/ai-loop/concept.md` — Arbiter の基本概念・PlanGate との関係
+- `docs/ai/ai-loop/asset-inventory.md` — 資産の uses/not-uses 分類
+- `docs/ai/ai-loop/ho-paths.md` — touches-HO 判定基準リスト
 - `docs/ai/autonomous-degraded-gates-spec.md` — `NoHardeningOverridePath` 定義元（読み取り専用）
 - `docs/ai/core-contract.md` — Iron Law 正本（読み取り専用）
 - `.claude/rules/responsibility-classes.md` — 責務 4 分類正本（読み取り専用）

--- a/docs/workflows/ai-loop/00_concept.md
+++ b/docs/workflows/ai-loop/00_concept.md
@@ -1,18 +1,18 @@
-# Arbiter-workflow 概念ドキュメント
+# ai-loop-workflow 概念ドキュメント
 
-> 適用ドメイン: Arbiter-workflow（docs/workflows/arbiter/ 配下）のみ
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
 
 ---
 
 ## 1. 位置づけ
 
-Arbiter-workflow は PlanGate（WF-00〜WF-07）と**並立する独立 PoC**。
+ai-loop-workflow は PlanGate（WF-00〜WF-07）と**並立する独立 PoC**。
 PlanGate を置き換えず、競合しない。
 
 ```text
 PlanGate（WF-00〜WF-07）   → in-the-loop 本番統制（並走期は継続稼働）
-Arbiter-workflow            → on-the-loop PoC（低リスク帯の flow → detect → escalate）
+ai-loop-workflow            → on-the-loop PoC（低リスク帯の flow → detect → escalate）
 ```
 
 Arbiter が存在証明を超えるまで PlanGate が本番統制を担う。
@@ -21,7 +21,7 @@ Arbiter が存在証明を超えるまで PlanGate が本番統制を担う。
 
 ## 2. WF-00〜07 との並立関係
 
-| 観点 | PlanGate（WF-00〜07） | Arbiter-workflow |
+| 観点 | PlanGate（WF-00〜07） | ai-loop-workflow |
 | ------ | ---------------------- | ----------------- |
 | ループモデル | in-the-loop（実行前承認） | on-the-loop（逸脱時昇格） |
 | 適用対象 | 全変更 | low-risk 変更のみ（boundary=clean, lite=true） |
@@ -33,7 +33,7 @@ Arbiter が存在証明を超えるまで PlanGate が本番統制を担う。
 両者は競合しない。並走期において:
 
 - PlanGate が本番統制を担当する
-- Arbiter は PoC 領域（docs/ai/arbiter/ と docs/workflows/arbiter/）で実験的に稼働する
+- Arbiter は PoC 領域（docs/ai/ai-loop/ と docs/workflows/ai-loop/）で実験的に稼働する
 
 Arbiter は WF-01〜05 相当のフェーズを持たず、置き換えもしない（判断実行は
 L1 = RiverReview 委譲、生成品質は上流責務）。
@@ -49,7 +49,7 @@ Phase 0（#655）の結論を参照:
 | ------ | ------ |
 | 拡張 | Arbiter は `docs/ai/autonomous-degraded-gates-spec.md` の degraded-gates 概念を**拡張する** |
 | 非代替 | `docs/ai/autonomous-degraded-gates-spec.md` を置き換えない。PlanGate 本番の degraded-gates はそのまま |
-| 参照元 | `NoHardeningOverridePath` 条件を `docs/ai/arbiter/ho-paths.md` の起点として参照 |
+| 参照元 | `NoHardeningOverridePath` 条件を `docs/ai/ai-loop/ho-paths.md` の起点として参照 |
 
 ---
 
@@ -59,15 +59,15 @@ intent-classifier 等の PlanGate 共通スキルは shared として参照す�
 Arbiter 側のコードから直接変更しない（参照のみ）。
 
 asset-inventory.md の uses/not-uses 分類に従う:
-`docs/ai/arbiter/asset-inventory.md`
+`docs/ai/ai-loop/asset-inventory.md`
 
 ---
 
 ## 5. 関連ドキュメント
 
-- `docs/ai/arbiter/arbiter-policy.md` — Arbiter L0 policy
-- `docs/ai/arbiter/ho-paths.md` — HO パス集約（touches-HO 判定の正本）
-- `docs/ai/arbiter/asset-inventory.md` — 共通資産 uses/not-uses 分類
-- `docs/ai/arbiter/concept.md` — Arbiter の基本概念（Phase 0）
-- `docs/ai/arbiter/related-specs.md` — 既存仕様との関係（Phase 0）
+- `docs/ai/ai-loop/arbiter-policy.md` — Arbiter L0 policy
+- `docs/ai/ai-loop/ho-paths.md` — HO パス集約（touches-HO 判定の正本）
+- `docs/ai/ai-loop/asset-inventory.md` — 共通資産 uses/not-uses 分類
+- `docs/ai/ai-loop/concept.md` — Arbiter の基本概念（Phase 0）
+- `docs/ai/ai-loop/related-specs.md` — 既存仕様との関係（Phase 0）
 - `docs/ai/autonomous-degraded-gates-spec.md` — 参照元（変更禁止）

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -1,8 +1,8 @@
 # decision-table — Arbiter 裁定 Decision table
 
-> 適用ドメイン: Arbiter-workflow（docs/workflows/arbiter/ 配下）のみ
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
-> 裁定ロジック設計: `docs/ai/arbiter/concept.md` §4 / 判定フロー: `docs/workflows/arbiter/flow-detect.md`
+> 裁定ロジック設計: `docs/ai/ai-loop/concept.md` §4 / 判定フロー: `docs/workflows/ai-loop/flow-detect.md`
 
 ---
 
@@ -17,14 +17,14 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 
 | 軸 | 値域 | 説明 |
 | ---- | ------ | ------ |
-| `boundary` | `touches-HO` / `clean` | HO パス（`docs/ai/arbiter/ho-paths.md`）への接触有無 |
+| `boundary` | `touches-HO` / `clean` | HO パス（`docs/ai/ai-loop/ho-paths.md`）への接触有無 |
 | `lite` | `true` / `false` | 低リスク要件を満たすか |
 | `verdict` | `approve-approve` / `approve-reject` / `reject-reject` / `reject-approve` | W チェック（Model A/B）の合意・不一致結果 |
 | `class` | `merge` / `no-merge` | 変更に merge（C-4）を含むか |
 
 ### 軸の補足
 
-- `boundary` の判定正本: `docs/ai/arbiter/ho-paths.md`
+- `boundary` の判定正本: `docs/ai/ai-loop/ho-paths.md`
 - `verdict=approve-reject` は W チェック不一致を意味する（`flow-detect.md §3.1` 参照）
 - `class=merge` は Human-owned 固定のため、他の軸にかかわらず human escalate となる
 - `verdict=reject-approve` は A が設計妥当性で NG のためブロック（`flow-detect.md §3.1` 参照）
@@ -67,7 +67,7 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 ## 4. approve-reject（不一致）の裁定詳細
 
 `verdict=approve-reject`（W チェック不一致: A=approve, B=reject）は priority 5 で受ける。
-詳細な分岐は `docs/workflows/arbiter/flow-detect.md` §3.2〜3.3 で定義する。
+詳細な分岐は `docs/workflows/ai-loop/flow-detect.md` §3.2〜3.3 で定義する。
 
 ```text
 approve-reject
@@ -180,8 +180,8 @@ on-the-loop 固有の「自律暴走」防止機構。
 
 ## 7. 関連ドキュメント
 
-- [`docs/ai/arbiter/arbiter-policy.md`](../../ai/arbiter/arbiter-policy.md) — W チェック・escalate 予算・第0の承認境界
-- [`docs/ai/arbiter/ho-paths.md`](../../ai/arbiter/ho-paths.md) — boundary=touches-HO 判定の正本
-- [`docs/workflows/arbiter/flow-detect.md`](./flow-detect.md) — flow→detect→escalate の動作フロー（§3.2〜3.3: approve-reject の詳細）
-- [`docs/workflows/arbiter/00_concept.md`](./00_concept.md) — WF との並立関係
-- [`docs/workflows/arbiter/review-feedback-loop.md`](./review-feedback-loop.md) — CB-1 事後 reject を L4 学習へ還元する閉ループ（§3 で本ドキュメント §6 CB-1 と接続）
+- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — W チェック・escalate 予算・第0の承認境界
+- [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
+- [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow→detect→escalate の動作フロー（§3.2〜3.3: approve-reject の詳細）
+- [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係
+- [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — CB-1 事後 reject を L4 学習へ還元する閉ループ（§3 で本ドキュメント §6 CB-1 と接続）

--- a/docs/workflows/ai-loop/flow-detect.md
+++ b/docs/workflows/ai-loop/flow-detect.md
@@ -1,6 +1,6 @@
 # flow-detect — Arbiter 動作フロー定義
 
-> 適用ドメイン: Arbiter-workflow（docs/workflows/arbiter/ 配下）のみ
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
 > W チェック定義正本: 本ドキュメント §3.1
 
@@ -32,7 +32,7 @@ auto-approve または human escalate
 
 | 条件 | 説明 |
 |------|------|
-| `boundary = clean` | 変更対象が HO パス（`docs/ai/arbiter/ho-paths.md`）のいずれにも含まれない |
+| `boundary = clean` | 変更対象が HO パス（`docs/ai/ai-loop/ho-paths.md`）のいずれにも含まれない |
 | `lite = true` | 低リスク要件を満たす（高リスク要素なし） |
 | `class = no-merge` | 変更に merge（C-4）を含まない（merge は Human-owned 固定。[`decision-table.md`](./decision-table.md) §3 priority 3） |
 
@@ -123,7 +123,7 @@ human 昇格の洪水を防ぐため:
 ## 5. provenance 刻印
 
 > **provenance スキーマの正本は
-> [`docs/workflows/arbiter/decision-table.md`](./decision-table.md) §5**。
+> [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) §5**。
 > 本セクションの責務は刻印**タイミング**の定義のみに限定し、フィールド名の
 > 独自定義は持たない（二重定義防止）。
 
@@ -142,8 +142,8 @@ human 昇格の洪水を防ぐため:
 
 ## 6. 関連ドキュメント
 
-- [`docs/ai/arbiter/arbiter-policy.md`](../../ai/arbiter/arbiter-policy.md) — W チェック拡張の policy 定義
-- [`docs/ai/arbiter/ho-paths.md`](../../ai/arbiter/ho-paths.md) — boundary=touches-HO 判定の正本
-- [`docs/ai/arbiter/concept.md`](../../ai/arbiter/concept.md) — Arbiter の基本概念
-- [`docs/workflows/arbiter/00_concept.md`](./00_concept.md) — WF との並立関係
-- [`docs/workflows/arbiter/review-feedback-loop.md`](./review-feedback-loop.md) — Model C/D 裁定結果を L4 学習へ還元する閉ループ（§3 で本ドキュメント §3.3 と接続）
+- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — W チェック拡張の policy 定義
+- [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
+- [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念
+- [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係
+- [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — Model C/D 裁定結果を L4 学習へ還元する閉ループ（§3 で本ドキュメント §3.3 と接続）

--- a/docs/workflows/ai-loop/review-feedback-loop.md
+++ b/docs/workflows/ai-loop/review-feedback-loop.md
@@ -1,8 +1,8 @@
 # review-feedback-loop — レビュー指摘の事前チェック還元閉ループ
 
-> 適用ドメイン: Arbiter-workflow（docs/workflows/arbiter/ 配下）のみ
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
-> 位置づけ: L4 学習層（[`concept.md`](../../ai/arbiter/concept.md) §7）の PoC 定義。
+> 位置づけ: L4 学習層（[`concept.md`](../../ai/ai-loop/concept.md) §7）の PoC 定義。
 > フル実装は Phase 4、本ドキュメントはフロー定義と手動運用（human-operated L4）を先行させる
 
 ---
@@ -60,7 +60,7 @@ PR レビュー指摘（外部ボット・人間レビュアー）を指摘 ID�
 | -------- | ------ | ------ |
 | skill（例: `self-review`） | 作業手順・チェックリストで捕捉できる指摘 | AI-owned（編集可） |
 | gate 観点ドキュメント（例: [`plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md)） | 計画・レビュー観点で捕捉できる指摘 | AI-owned（編集可） |
-| policy | auto-approve 条件・裁定ルールに関わる指摘 | **Human-owned 固定**（第0の承認境界 = [`arbiter-policy.md`](../../ai/arbiter/arbiter-policy.md) §6） |
+| policy | auto-approve 条件・裁定ルールに関わる指摘 | **Human-owned 固定**（第0の承認境界 = [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6） |
 | 還元不要 | 一過性・案件固有 | 記録のみ |
 
 policy への還元候補は AI が draft 提案までしか行えない。発行・適用は
@@ -115,11 +115,11 @@ Codex）で検出された指摘 7 件を issue #670 で還元しており、本
 
 ## 5. 安全制約
 
-- policy への還元は第0の承認境界（[`arbiter-policy.md`](../../ai/arbiter/arbiter-policy.md) §6）
+- policy への還元は第0の承認境界（[`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6）
   により Human-owned 固定。AI は policy draft の提案までしか行えず、発行・適用
   は人間が行う。
 - skill / gate への還元であっても、対象が HO パス
-  （[`ho-paths.md`](../../ai/arbiter/ho-paths.md)）に触れる場合は human escalate
+  （[`ho-paths.md`](../../ai/ai-loop/ho-paths.md)）に触れる場合は human escalate
   へ切り替える。
 - 学習ループ自身が承認境界を侵食してはならない（「自分の枠を自分で書き換え
   ない」の L4 版）。還元ループが policy への還元を自己承認する経路を持たない
@@ -129,8 +129,8 @@ Codex）で検出された指摘 7 件を issue #670 で還元しており、本
 
 ## 6. 関連ドキュメント
 
-- [`docs/ai/arbiter/concept.md`](../../ai/arbiter/concept.md) — Arbiter の基本概念・L4 学習層（§7）
-- [`docs/workflows/arbiter/flow-detect.md`](./flow-detect.md) — W チェック・severity 分類・Model C/D 裁定
-- [`docs/workflows/arbiter/decision-table.md`](./decision-table.md) — Decision table・provenance schema・サーキットブレーカー
-- [`docs/ai/arbiter/arbiter-policy.md`](../../ai/arbiter/arbiter-policy.md) — 第0の承認境界（§6）
+- [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念・L4 学習層（§7）
+- [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — W チェック・severity 分類・Model C/D 裁定
+- [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — Decision table・provenance schema・サーキットブレーカー
+- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — 第0の承認境界（§6）
 - [`.claude/rules/working-context.md`](../../../.claude/rules/working-context.md) — `review-external.md` R-NNN 方式（資産継承元）


### PR DESCRIPTION
## 概要

「arbiter-workflow」の認識しづらさを解消するため、workflow 名とディレクトリを **ai-loop-workflow** に改称する。「Arbiter」は L2 裁定エンジン（部品）の名称として存続（概念の連続性を維持）。

Closes #672

## 変更内容

- `docs/ai/arbiter/` → `docs/ai/ai-loop/`、`docs/workflows/arbiter/` → `docs/workflows/ai-loop/`（git mv・rename 検出 72〜96% で履歴追跡可能）
- 本文の `Arbiter-workflow` → `ai-loop-workflow`（10 ファイル）、パス参照・相対リンク追従
- concept.md に命名注記（旧称・改称日・Arbiter の位置づけ）
- **監査証跡の保全**: phase3-impact-report.md §a の当時パス・コマンド記録は改変せず、冒頭注記で改称を明示
- ファイル名は不変（`arbiter-policy.md` = Arbiter エンジンの policy として整合）
- GitHub label `arbiter` → `ai-loop` リネーム済み（過去 issue との紐付け保持）

## 検証

- `rg "Arbiter-workflow"` 残存 0 件（旧称注記を除く）
- 相対リンク到達性チェック: dead links 0
- markdownlint-cli2: 0 エラー
- 外部参照ゼロ（rg で 2 ディレクトリ + docs/working/ 履歴以外にヒットなし）

## Mode 判定 / C-3

- **Mode**: light（docs のみ・HO 非接触・外部参照なしの閉じた rename）
- **C-3 Gate: AUTONOMOUS APPROVED** — ユーザー指示（verbatim）:「コマンドは ai-loop-workflow に変更したい。これまでは arbiter-workflow だったが、認識しづらい課題があった」+ 範囲選択「名称変更 + Arbiter は部品名で残す」

🤖 Generated with [Claude Code](https://claude.com/claude-code)