### PR TITLE
docs(#674): ai-loop Phase 1 — lite 判定基準（可逆性要件）+ severity 分類主体確定 + glob 修正

### DIFF
--- a/docs/ai/ai-loop/concept.md
+++ b/docs/ai/ai-loop/concept.md
@@ -85,7 +85,7 @@ docs/workflows/ai-loop/  配下のみ（新規作成・更新、Phase 1 以降�
 
 ```text
 .claude/rules/              L0 契約正本。in-the-loop 前提の契約を Arbiter が変更しない
-docs/ai/*.md                既存の PlanGate ドキュメント（arbiter/ サブディレクトリを除く）
+docs/ai/*.md                既存の PlanGate ドキュメント（ai-loop/ サブディレクトリを除く）
 docs/workflows/*.md         既存のワークフロー定義
 bin/plangate                実行エンジン。AI 直接編集不可（HO-core）
 schemas/                    バリデーション定義。AI 直接編集不可

--- a/docs/ai/ai-loop/ho-paths.md
+++ b/docs/ai/ai-loop/ho-paths.md
@@ -32,7 +32,7 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | `CLAUDE.md` | HO-contract | AI-Human 間の基本契約。AI による変更は契約の自己改ざんに相当 |
 | `AGENTS.md` | HO-contract | 同上。Codex 用基本契約 |
 | `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
-| `docs/ai/*.md`（ai-loop/ 除く） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
+| `docs/ai/*.md`（トップレベルの md のみ。`docs/ai/ai-loop/` 配下は対象外） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
 | `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
 | `**/approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
 | `.claude/commands/*.md` | HO-rules | コマンド定義。実行入口・承認境界に影響。AI 直接編集不可 |

--- a/docs/ai/ai-loop/ho-paths.md
+++ b/docs/ai/ai-loop/ho-paths.md
@@ -32,7 +32,7 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | `CLAUDE.md` | HO-contract | AI-Human 間の基本契約。AI による変更は契約の自己改ざんに相当 |
 | `AGENTS.md` | HO-contract | 同上。Codex 用基本契約 |
 | `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
-| `docs/ai/*.md`（arbiter/ 除く） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
+| `docs/ai/*.md`（ai-loop/ 除く） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
 | `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
 | `**/approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
 | `.claude/commands/*.md` | HO-rules | コマンド定義。実行入口・承認境界に影響。AI 直接編集不可 |

--- a/docs/ai/ai-loop/ho-paths.md
+++ b/docs/ai/ai-loop/ho-paths.md
@@ -34,7 +34,7 @@ Arbiter の flow → detect → escalate において、変更対象ファイル
 | `docs/ai/core-contract.md` | HO-contract | Iron Law 正本。最上位制約。Arbiter でも変更不可 |
 | `docs/ai/*.md`（arbiter/ 除く） | HO-contract | PlanGate 既存ドキュメント正本。Arbiter PoC が既存仕様を書き換えないための境界 |
 | `.github/workflows/*.yml` | HO-ci | CI/CD 定義。AI 直接編集不可。誤変更で安全装置・検証が無効化される |
-| `approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
+| `**/approvals/*.json` | HO-approval | 人間承認トークン。AI 代理作成禁止。provenance の偽造防止 |
 | `.claude/commands/*.md` | HO-rules | コマンド定義。実行入口・承認境界に影響。AI 直接編集不可 |
 | `.claude/agents/*.md` | HO-rules | Agent 行動契約。統制回避防止。AI 直接編集不可 |
 | `.claude/settings.example.json` | HO-settings | settings 契約例。自己改変・緩和防止 |
@@ -90,7 +90,7 @@ CLAUDE.md                   → HO-contract
 AGENTS.md                   → HO-contract
 docs/ai/core-contract.md    → HO-contract
 .github/workflows/ci.yml    → HO-ci
-approvals/2026-07-01.json   → HO-approval
+docs/working/TASK-0123/approvals/c3.json → HO-approval
 plugin/plangate/index.js    → HO-plugin
 ```
 

--- a/docs/ai/ai-loop/phase3-impact-report.md
+++ b/docs/ai/ai-loop/phase3-impact-report.md
@@ -101,7 +101,7 @@ PR #663（`docs: plan-review-readiness-gate.md にドキュメント仕様変更
 |---|--------|--------|-----------|------|
 | 1 | `lite` 判定の具体基準が未定義（低リスク帯の閾値が Phase 1 以降 TBD） | 中 — flow フェーズの中核条件が未確定のため、detect フェーズの実効性を評価できない | Phase 1 | 解消済み（2026-07-02、[`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)、issue #674） |
 | 2 | `lite=true` の要件に「可逆であること」を含めるかが未決 | 中 — CB-1（Circuit Breaker）の巻き戻し条件「不可逆操作を除く」との整合が取れていない | Phase 1 | 解消済み（2026-07-02、[`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md) §2 可逆性要件、issue #674） |
-| 3 | severity 分類の判定主体が未確定（Model B の reject 理由から導出するか、専用分類器を置くか） | 中 — `flow-detect.md` §3.2 に「Phase 1 論点（未確定）」として明記済み | Phase 1 | 解消済み（2026-07-02、[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.2、issue #674） |
+| 3 | severity 分類の判定主体が未確定（Model B の reject 理由から導出するか、専用分類器を置くか） | 中 — `flow-detect.md` §3.2 に「Phase 1 論点（未確定）」として明記済み | Phase 1 | 解消済み（2026-07-02、[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.2.1、issue #674） |
 | 4 | `ho-paths.md` の `approvals/*.json` glob が実際の配置 `docs/working/TASK-XXXX/approvals/*.json` にマッチしない可能性 | 高 — HO 判定の実効性に直結する。マッチしない場合、承認トークンパスへの変更が touches-HO として検出されない | Phase 2 実装移行時（現状は docs 層のみのため実害なし） | 解消済み（[`ho-paths.md`](./ho-paths.md) glob 修正、issue #674） |
 | 5 | provenance の発行元検証（`issued_by` は自己申告、署名等は別途） | 高 — PlanGate 側の未解決課題（issue #420 EH-3 発行元検証）と同型。Arbiter が実装段階に入る前に PlanGate 側の解決方針と整合させる必要がある | Phase 2 実装移行時 / PlanGate issue #420 の解決と連動 | 未解消 |
 

--- a/docs/ai/ai-loop/phase3-impact-report.md
+++ b/docs/ai/ai-loop/phase3-impact-report.md
@@ -97,13 +97,13 @@ PR #663（`docs: plan-review-readiness-gate.md にドキュメント仕様変更
 
 ## d. 未解決リスク（5 件）
 
-| # | リスク | 影響度 | 対応 Phase |
-|---|--------|--------|-----------|
-| 1 | `lite` 判定の具体基準が未定義（低リスク帯の閾値が Phase 1 以降 TBD） | 中 — flow フェーズの中核条件が未確定のため、detect フェーズの実効性を評価できない | Phase 1 |
-| 2 | `lite=true` の要件に「可逆であること」を含めるかが未決 | 中 — CB-1（Circuit Breaker）の巻き戻し条件「不可逆操作を除く」との整合が取れていない | Phase 1 |
-| 3 | severity 分類の判定主体が未確定（Model B の reject 理由から導出するか、専用分類器を置くか） | 中 — `flow-detect.md` §3.2 に「Phase 1 論点（未確定）」として明記済み | Phase 1 |
-| 4 | `ho-paths.md` の `approvals/*.json` glob が実際の配置 `docs/working/TASK-XXXX/approvals/*.json` にマッチしない可能性 | 高 — HO 判定の実効性に直結する。マッチしない場合、承認トークンパスへの変更が touches-HO として検出されない | Phase 2 実装移行時（現状は docs 層のみのため実害なし） |
-| 5 | provenance の発行元検証（`issued_by` は自己申告、署名等は別途） | 高 — PlanGate 側の未解決課題（issue #420 EH-3 発行元検証）と同型。Arbiter が実装段階に入る前に PlanGate 側の解決方針と整合させる必要がある | Phase 2 実装移行時 / PlanGate issue #420 の解決と連動 |
+| # | リスク | 影響度 | 対応 Phase | 状況 |
+|---|--------|--------|-----------|------|
+| 1 | `lite` 判定の具体基準が未定義（低リスク帯の閾値が Phase 1 以降 TBD） | 中 — flow フェーズの中核条件が未確定のため、detect フェーズの実効性を評価できない | Phase 1 | 解消済み（2026-07-02、[`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)、issue #674） |
+| 2 | `lite=true` の要件に「可逆であること」を含めるかが未決 | 中 — CB-1（Circuit Breaker）の巻き戻し条件「不可逆操作を除く」との整合が取れていない | Phase 1 | 解消済み（2026-07-02、[`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md) §2 可逆性要件、issue #674） |
+| 3 | severity 分類の判定主体が未確定（Model B の reject 理由から導出するか、専用分類器を置くか） | 中 — `flow-detect.md` §3.2 に「Phase 1 論点（未確定）」として明記済み | Phase 1 | 解消済み（2026-07-02、[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.2、issue #674） |
+| 4 | `ho-paths.md` の `approvals/*.json` glob が実際の配置 `docs/working/TASK-XXXX/approvals/*.json` にマッチしない可能性 | 高 — HO 判定の実効性に直結する。マッチしない場合、承認トークンパスへの変更が touches-HO として検出されない | Phase 2 実装移行時（現状は docs 層のみのため実害なし） | 解消済み（[`ho-paths.md`](./ho-paths.md) glob 修正、issue #674） |
+| 5 | provenance の発行元検証（`issued_by` は自己申告、署名等は別途） | 高 — PlanGate 側の未解決課題（issue #420 EH-3 発行元検証）と同型。Arbiter が実装段階に入る前に PlanGate 側の解決方針と整合させる必要がある | Phase 2 実装移行時 / PlanGate issue #420 の解決と連動 | 未解消 |
 
 **件数**: 5 件（0 件ではない）。
 

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -183,5 +183,6 @@ on-the-loop 固有の「自律暴走」防止機構。
 - [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — W チェック・escalate 予算・第0の承認境界
 - [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow→detect→escalate の動作フロー（§3.2〜3.3: approve-reject の詳細）
+- [`docs/workflows/ai-loop/lite-criteria.md`](./lite-criteria.md) — `lite` 軸の判定基準（可逆性要件含む）
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — CB-1 事後 reject を L4 学習へ還元する閉ループ（§3 で本ドキュメント §6 CB-1 と接続）

--- a/docs/workflows/ai-loop/flow-detect.md
+++ b/docs/workflows/ai-loop/flow-detect.md
@@ -72,9 +72,27 @@ W チェック不一致（A=approve, B=reject）を検出した場合:
 [`working-context.md`](../../../.claude/rules/working-context.md)
 と整合）。
 
-**Phase 1 論点（未確定）**: severity 分類の判定主体（Model B の reject
-理由から導出するのか、専用の分類器を置くのか）は本ドキュメントでは
-確定しない。Phase 1 で決定する。
+### 3.2.1 severity 分類主体（Phase 1 確定）
+
+severity 分類の判定主体は **決定論 rule ベースの分類器**とする。Model B
+の reject 理由テキストを、以下のカテゴリマッピング表に機械的に照合して
+severity を導出する。**Model B 自身に severity を自己申告させない**
+（自己申告は self-serving 判定の温床になるため、判定は Model B の入力から
+独立した分類器が行う）。
+
+**カテゴリマッピング表**（policy 扱い・改版は Human-owned 固定。第0の
+承認境界 = [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6）:
+
+| severity | reject 理由カテゴリ例 |
+| ---------- | ------------------------ |
+| critical | HO パス接触 / 権限変更 / 不可逆操作 / セキュリティ破壊 |
+| major | 公開 API 変更 / データ整合性 / マイグレーション / 認証変更 |
+| minor | ロジック変更 / パフォーマンス影響 / テスト不足 |
+| low | ドキュメント変更 / フォーマット / 命名 |
+
+分類器がいずれのカテゴリにも一致しない reject 理由を検出した場合（分類
+不能）は、本節冒頭の安全側既定に従い **critical 扱い（human escalate）**
+とする。この既定はマッピング表の改版によっても緩和しない。
 
 ### 3.3 観点特化 multi-agent 裁定（Model C/D）
 
@@ -146,4 +164,5 @@ human 昇格の洪水を防ぐため:
 - [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
 - [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係
+- [`docs/workflows/ai-loop/lite-criteria.md`](./lite-criteria.md) — `lite` 判定基準（§2 flow フェーズで使用）
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — Model C/D 裁定結果を L4 学習へ還元する閉ループ（§3 で本ドキュメント §3.3 と接続）

--- a/docs/workflows/ai-loop/flow-detect.md
+++ b/docs/workflows/ai-loop/flow-detect.md
@@ -72,7 +72,7 @@ W チェック不一致（A=approve, B=reject）を検出した場合:
 [`working-context.md`](../../../.claude/rules/working-context.md)
 と整合）。
 
-### 3.2.1 severity 分類主体（Phase 1 確定）
+#### 3.2.1 severity 分類主体（Phase 1 確定）
 
 severity 分類の判定主体は **決定論 rule ベースの分類器**とする。Model B
 の reject 理由テキストを、以下のカテゴリマッピング表に機械的に照合して

--- a/docs/workflows/ai-loop/lite-criteria.md
+++ b/docs/workflows/ai-loop/lite-criteria.md
@@ -1,0 +1,117 @@
+# lite-criteria — lite 判定基準
+
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
+> 非適用: PlanGate 本番フロー（WF-00〜WF-07）
+> lite 基準の制定・改版は policy 扱い（第0の承認境界 =
+> [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6、Human-owned 固定）。
+> AI は基準改定の draft 提案までしか行えず、発行・適用は人間が行う
+
+---
+
+## 1. 目的
+
+Arbiter flow フェーズの `lite` 軸（[`decision-table.md`](./decision-table.md)
+§2）の判定基準を具体化する。[`mode-classification.md`](../../../.claude/rules/mode-classification.md)
+の `lite_eligible` 判定軸（PlanGate 本番向け）を継承しつつ、PoC 用に単純化し、
+**可逆性要件**を追加する。
+
+`docs/ai/ai-loop/phase3-impact-report.md` §d リスク 1・2 を解消する成果物。
+
+---
+
+## 2. 判定軸
+
+`lite=true` の候補となるには、以下 4 軸を**すべて**満たす必要がある。
+
+| 軸 | lite=true 候補条件 | 継承元 |
+| ---- | -------------------- | -------- |
+| 変更規模 | `mode-classification.md` の light 相当以下（変更ファイル数 1〜2 目安） | `mode-classification.md` 定量基準 |
+| 新規設計の有無 | なし（既存構造の枠内） | `mode-classification.md` lite_eligible 判定軸 |
+| 既存パターン踏襲 | あり（新規設計ゼロ・ミラー実装） | `mode-classification.md` lite_eligible 判定軸 |
+| **可逆性** | 変更が可逆である（巻き戻し手順が機械的に実行可能。例: `git revert` 一発、ファイル単位の差し戻しで完全復元できる） | 本ドキュメントで新規追加（PoC 固有） |
+
+### 可逆性要件の根拠
+
+[`decision-table.md`](./decision-table.md) §6 CB-1（事後 reject）の巻き戻しは
+「**可能な範囲で巻き戻し実行（不可逆操作を除く）**」と定義されている。
+
+lite=true と判定された変更は flow フェーズを通過し、事前ブロックなしで
+detect フェーズへ進む（[`00_concept.md`](./00_concept.md) の on-the-loop
+モデル）。もし不可逆な変更が flow に流れ、後から人間が事後 reject した場合、
+CB-1 の巻き戻しが「不可逆操作を除く」制約により**巻き戻せない**という
+構造的な穴が生じる。
+
+可逆性を lite=true の必須要件とすることで、この穴を構造的に排除する。
+不可逆な変更は lite=false（human escalate）へ落ち、実行前承認（in-the-loop
+相当）を経由するため、事後 reject 時の巻き戻し不能リスクを負わない。
+
+**不可逆操作の例**（該当すれば可逆性要件を満たさない）:
+
+- 外部公開操作（tag push・release publish・対外通知）
+- データ削除・破壊的マイグレーション
+- 課金・決済など外部システムへの副作用を伴う操作
+- 一度公開すると取り消せない性質のもの（社外送信済みメール等）
+
+---
+
+## 3. AC-8 安全側（判定不能時の既定）
+
+`mode-classification.md` の `lite_eligible` AC-8 安全側不変条件を継承する。
+
+**いずれかの軸が判定不能・根拠不足・曖昧な場合は、必ず `lite=false`
+（human escalate）とする。**
+
+対象:
+
+- 変更規模が light 相当か判定できない
+- 新規設計の有無が曖昧
+- 既存パターン踏襲の有無が判定できない
+- **可逆性が判定できない、または巻き戻し手順が明示されていない**
+
+lite は「証明可能なときだけの例外」であり既定ではない。判定不能を lite=true
+側に倒すことは決して行わない。
+
+---
+
+## 4. 判定アルゴリズム
+
+```pseudocode
+入力: 変更内容（対象ファイルリスト・変更種別・巻き戻し手順の有無）
+出力: lite = true | false
+
+lite = true
+
+// 軸1: 変更規模
+if not (変更規模 <= light相当):
+    lite = false
+
+// 軸2: 新規設計の有無
+if 新規設計あり or 新規設計の有無が判定不能:
+    lite = false
+
+// 軸3: 既存パターン踏襲
+if not 既存パターン踏襲 or 判定不能:
+    lite = false
+
+// 軸4: 可逆性（本ドキュメントで追加）
+if not 可逆 or 巻き戻し手順が機械的に実行可能でない or 判定不能:
+    lite = false
+
+// AC-8 安全側: いずれかの軸が判定不能なら安全側(false)へ倒す
+// （上記各分岐で既に判定不能ケースを false 側に含めている）
+
+if lite == false:
+    → human escalate（decision-table.md priority 2）
+else:
+    → class 判定へ進む（decision-table.md priority 3 以降）
+```
+
+---
+
+## 5. 関連ドキュメント
+
+- [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — `lite` 軸を使う Decision table 本体
+- [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow フェーズでの `lite` 判定の位置づけ
+- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — §6 第0の承認境界（本基準の改版が Human-owned 固定である根拠）
+- [`docs/ai/ai-loop/phase3-impact-report.md`](../../ai/ai-loop/phase3-impact-report.md) — §d リスク 1・2（本ドキュメントで解消）
+- [`.claude/rules/mode-classification.md`](../../../.claude/rules/mode-classification.md) — `lite_eligible` 判定軸・AC-8 安全側・AC-11 の継承元

--- a/docs/workflows/ai-loop/lite-criteria.md
+++ b/docs/workflows/ai-loop/lite-criteria.md
@@ -10,7 +10,7 @@
 
 ## 1. 目的
 
-Arbiter flow フェーズの `lite` 軸（[`decision-table.md`](./decision-table.md)
+ai-loop-workflow の flow フェーズにおける `lite` 軸（[`decision-table.md`](./decision-table.md)
 §2）の判定基準を具体化する。[`mode-classification.md`](../../../.claude/rules/mode-classification.md)
 の `lite_eligible` 判定軸（PlanGate 本番向け）を継承しつつ、PoC 用に単純化し、
 **可逆性要件**を追加する。


### PR DESCRIPTION
## 概要

Human-owned 判定「**継続**」（2026-07-02・phase3-impact-report §c の 3 択）を受けた Phase 1 最初の実タスク。§d 未解決リスク 1〜4 を docs 層の仕様策定で解消する。

Closes #674

## 変更内容

| 成果物 | 内容 | 解消リスク |
|--------|------|-----------|
| **lite-criteria.md**（新規・117 行） | lite 判定の 4 軸（変更規模 / 新規設計なし / 既存パターン踏襲 / **可逆性**）+ AC-8 安全側 + 判定 pseudocode。基準の制定・改版は policy 扱い（第0の承認境界・Human-owned 固定） | リスク 1・2 |
| **flow-detect.md §3.2.1**（新設） | severity 分類主体 = **決定論 rule ベースの分類器**（Model B の自己申告禁止・self-serving 防止）。カテゴリマッピング表は policy 扱い。分類不能→critical は改版でも緩和不可 | リスク 3 |
| **ho-paths.md** | `approvals/*.json` → `**/approvals/*.json`（実配置にマッチ）。例示パスも実在確認済みのものに更新 | リスク 4 |
| **phase3-impact-report.md §d** | リスク 1〜4 に「解消済み」の状況列を追記（元記述は監査記録として保持）。リスク 5 は #420 連動のため未解消のまま | — |
| 付随 | decision-table.md 関連ドキュメント節にリンク 1 行 / #673 改称の取り残し（「arbiter/ 除く」表記 2 箇所）修正 | — |

### 可逆性要件の設計判断

CB-1 の巻き戻しは「不可逆操作を除く」ため、不可逆変更が flow を通過すると事後 reject 時に巻き戻せない構造的な穴があった。可逆性を lite=true の必須要件とすることでこの穴を排除（不可逆変更は human escalate = 実行前承認へ）。

## Mode 判定 / C-3

- **Mode**: standard 相当（新規仕様 1 + 既存 4 ファイル・docs のみ・HO 非接触）
- **C-3 Gate: AUTONOMOUS APPROVED** — ユーザー自律実行指示（verbatim）:「対応を進めたい、実タスクは別モデルのエージェントに委託し、タスクの完了→レビューを実施して、自律的に対応を進めて欲しい」+ PoC 継続の Human-owned 判定を明示取得済み
- 実装: Sonnet エージェント（worktree 隔離）→ Fable 5 統合検証（エージェントは指示中の非実在パス例を実在確認で自主差し替え・文字化け 1 件を自己検出修正。私は #673 改称の取り残し 2 箇所を追加検出・修正）

## 検証

- markdownlint-cli2: 0 エラー / 文字化け残存 0 / 例示パス実在確認済み
- 分岐元 = origin/main（e6060f0）、変更は 2 ディレクトリ配下のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)