### PR TITLE
docs(ai-loop): 初回実走 — Phase 2 存在証明（W チェック → C/D 裁定 → AUTO_APPROVED + provenance 刻印）

### DIFF
--- a/docs/workflows/ai-loop/execution-runbook.md
+++ b/docs/workflows/ai-loop/execution-runbook.md
@@ -183,3 +183,5 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す:
 - [`.claude/rules/orchestrator-mode.md`](../../../.claude/rules/orchestrator-mode.md) — 検証可能性 4 条件の正本
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) §3 — PlanGate フロー共通化と C-3 置換（C-3'）・merge-ready 責務範囲の正本
 - [`docs/ai/plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md) — 強化セルフレビュー §7/§8 観点の参照元
+- [`.claude/skills/ai-loop-cycle/SKILL.md`](../../../.claude/skills/ai-loop-cycle/SKILL.md) — 本 runbook の 1 サイクルを実行する手順スキル（Model A/B/C/D 委託プロンプト定型）
+- [`.claude/skills/pr-watch/SKILL.md`](../../../.claude/skills/pr-watch/SKILL.md) — 手順 (7) の CI/AI レビュー指摘対応ループの監視・対応定型

--- a/docs/working/ai-loop-runs/20260702T212945Z-6be8dfa.json
+++ b/docs/working/ai-loop-runs/20260702T212945Z-6be8dfa.json
@@ -1,0 +1,17 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v0",
+  "target_sha": "6be8dfa",
+  "timestamp": "2026-07-02T21:29:46Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "reject",
+    "model_c": "approve",
+    "model_d": "approve",
+    "severity": "low"
+  }
+}


### PR DESCRIPTION
## 概要

**ai-loop-workflow の初回実走（Phase 2「存在証明」の完了）**。ai-loop-cycle スキルの手順どおり 1 サイクルを実際に回し、最も複雑な裁定経路を実データで通過した。

## 実走記録

| ステップ | 結果 |
|---------|------|
| 前提 | C-1 簡易（7 項目）PASS / C-2 = light モードのため N/A |
| W チェック | **Model A = approve**（形式・実在・整合を独立確認）/ **Model B = reject: documentation**（相対パス変換の明示不足を adversarial 検出） |
| 不一致処理 | documentation → **severity=low** → B の指摘を計画に反映 → Model C/D 裁定へ |
| C/D 裁定 | **C = approve**（承認境界・権限モデルに影響なし）/ **D = approve**（追記のみ・正本分担契約を保持） |
| 裁定 | `arbiter.py` **AUTO_APPROVED（exit 0・priority 5）** |
| provenance | `docs/working/ai-loop-runs/20260702T212945Z-6be8dfa.json`（C/D フィールド `w_check.severity/model_c/model_d` つき刻印・本 PR に同梱） |
| exec | runbook §5 に実行スキル 2 件の参照を追記（B の指摘どおり `../../../` の正しい相対パスで実装） |
| 強化セルフレビュー | 宣言↔実差分整合 ✓ / リンク実在 ✓ / markdownlint-cli2 0 エラー ✓ |

## 存在証明として確認できたこと

- flow → detect → escalate の全分岐が実働（boundary/lite/class 前提 → A/B 不一致 → severity 分類 → C/D 裁定 → auto-approve）
- **W チェックの独立性が機能**: Model B が Model A の見落とし（パス変換リスク）を実際に検出し、計画が改善された
- provenance が decision-table §5 スキーマどおりに刻印され、C/D 裁定の追加フィールドも記録された

## Mode 判定 / C-3'

- **Mode**: lite（1 ファイル・2 行・可逆・パターン踏襲 — lite 4 軸すべて根拠つき true）
- **C-3' Gate: AUTO_APPROVED by arbiter**（本 PR が ai-loop の C-3 置換の初適用。C-4 merge は従来どおり Human-owned）

🤖 Generated with [Claude Code](https://claude.com/claude-code)