### PR TITLE
feat(#691): repo-owned skill/command/agent の stale パス参照検出スクリプト

### DIFF
--- a/docs/ai/stale-ref-detection.md
+++ b/docs/ai/stale-ref-detection.md
@@ -1,0 +1,110 @@
+# repo-owned skill/command/agent の stale パス参照検出
+
+> Issue [#691](https://github.com/s977043/plangate/issues/691) 実装。
+> false-positive canary ガイドライン: [`docs/plangate.md`](../plangate.md) #499 節。
+> 関連: [#684](https://github.com/s977043/plangate/issues/684)（doctor の repo guard 標準提供）
+
+## 目的
+
+repo-owned の `.claude/skills/` / `.claude/commands/` / `.claude/agents/` は
+特定のファイルパスやシンボルを参照して書かれるが、コードベースのリファクタ
+リング後に誰も更新せず陳腐化することがある。参照先が barrel 化・分割・改名
+されても skill/command/agent 自体は「動く」ため、静かにレビュー精度が落ち
+続け、棚卸しするまで発覚しない。
+
+### 実例（interactive-ocean リポジトリ）
+
+2026-07-03 に資産棚卸しを実施したところ、2026-04-09 作成のレビューコマンド
+7 件が、Phase 1-3 再設計（2026-06-27 の PR #185-#194）で barrel 化・分割済み
+の旧パス（`JellyfishSwarm.tsx` / `simulation.ts` 直参照）を約 2 ヶ月間指した
+ままだった。うち 1 件（dev-lead-review）は「JellyfishSwarm.tsx の肥大化」と
+いうレビューの中心課題自体が解消済みで、前提ごと崩れていた。発見は
+improvement-architect による手動棚卸しで、機械的検出があれば即日気付けた
+（修正: interactive-ocean PR #200）。
+
+## 使い方
+
+```sh
+# デフォルト（.claude/skills, .claude/commands, .claude/agents 配下の *.md）を検査
+python3 scripts/check-stale-skill-refs.py
+
+# 対象を明示指定する場合
+python3 scripts/check-stale-skill-refs.py ".claude/skills/**/*.md"
+
+# 内蔵の false-positive ガード自己テスト
+python3 scripts/check-stale-skill-refs.py --selftest
+```
+
+### 出力例
+
+```text
+WARN .claude/skills/hypothesis-logger/SKILL.md:9 → 非実在パス: ../../docs/workflows/07_exploratory_debug.md
+合計 1 件の stale パス参照を検出
+```
+
+### exit code
+
+| code | 意味 |
+|------|------|
+| 0 | stale パス参照なし |
+| 1 | stale パス参照あり（WARN を標準出力に列挙） |
+| 2 | 引数エラー・実行時エラー |
+
+## 検出方法
+
+対象 Markdown を 1 行ずつ走査し、以下 2 パターンからパス候補を抽出する:
+
+- Markdown リンク `](path)` の `path` 部分
+- インラインコード `` `path` `` の中身
+
+候補が `src/` / `docs/` / `scripts/` / `.claude/` / `schemas/` / `bin/` /
+`app/` / `lib/` / `tests/` / `test/` のいずれかで始まる、または `./` /
+`../` の相対パス表記であればリポジトリ内パス参照とみなし、リポジトリルート
+基準（相対パスは参照元ファイル基準）で実在確認する。実在しなければ WARN。
+
+## false-positive ガード（#499 準拠）
+
+以下は非実在でも WARN 対象から除外する。理由をコメントで明示している
+（`scripts/check-stale-skill-refs.py` の `is_excluded` 関数）:
+
+| 除外種別 | 例 | 理由 |
+|---------|----|------|
+| glob 表記 | `config/*.ts`, `docs/**/*.md` | ワイルドカードは実在確認の対象外（`*`/`?` を含む） |
+| プレースホルダ・例示 | `<repo-root>/src/index.ts`, `path/to/file.ts`, `{{TASK_ID}}/plan.md` | 説明用の仮パスであり実パスではない（`<` `>` `{` `}` `...` や `path/to` / `example` / `foo` / `bar` / `xxxx` を含む文字列） |
+| URL | `https://github.com/...` | ファイルシステムパスではない |
+| アンカーのみ | `#section` | ファイルパスを伴わない見出しアンカー |
+
+これに加えて、空白を含む文字列（自然文の一部と誤認しうる）や、拡張子も
+スラッシュも持たない単語はそもそもパス候補として扱わない
+（`looks_like_repo_path` 関数）。
+
+### 既知の限界（本 PR のスコープ外・将来課題）
+
+実行時にリポジトリへ実走した結果、以下の非 stale なパターンが誤検出され
+うることを確認した（本 PR では既存の stale 参照を修正しないため、これらは
+スコープ外の参考情報として記録するのみ）:
+
+- `.gitignore` 対象ファイル（例: `.claude/settings.json`）は「テンプレート
+  上は実在すべきだがローカル checkout には無い」ケースがあり、単純な
+  ファイルシステム実在確認では stale と区別できない
+- 地の文（説明文）中の例示パス（例: 「`app/admin` 配下で〜」のような自然な
+  日本語文中のバッククォート引用）は、プレースホルダキーワードを含まない
+  限りパス候補として拾われる
+
+これらは doctor / L-0 配線時に精度を高める余地として次項に記録する。
+
+## doctor / L-0 / CI への配線について
+
+本スクリプトはスタンドアロンの静的解析ツールとして提供する。
+`bin/plangate doctor` への組み込みや CI ワークフローでの定期実行は
+Hardening Override 対象パス（`bin/plangate` / `.github/workflows/*.yml`）
+に触れるため、承認境界周辺の変更として **別 PBI の follow-up** とする
+（[`.claude/rules/mode-classification.md`](../../.claude/rules/mode-classification.md)
+の Hardening Override 対象パス、[`.claude/rules/responsibility-classes.md`](../../.claude/rules/responsibility-classes.md)
+の責務 4 分類を参照）。
+
+## 関連
+
+- Issue [#691](https://github.com/s977043/plangate/issues/691)
+- Issue [#499](https://github.com/s977043/plangate/issues/499)（L-0 カスタム静的解析の canary 必須化）
+- Issue [#684](https://github.com/s977043/plangate/issues/684)（doctor の repo guard 標準提供）

--- a/scripts/check-stale-skill-refs.py
+++ b/scripts/check-stale-skill-refs.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""
+check-stale-skill-refs.py — repo-owned skill/command/agent の stale パス参照検出
+
+Issue #691.
+
+repo-owned の `.claude/skills/**/*.md` / `.claude/commands/**/*.md` /
+`.claude/agents/**/*.md` はコード内のファイルパスを参照して書かれるが、
+リファクタリング後に誰も更新せず陳腐化しやすい（interactive-ocean 実例:
+2026-04-09 作成のレビューコマンド 7 件が 2026-06-27 の barrel 化 PR 後も
+約 2 ヶ月間旧パスを指したまま気づかれなかった）。
+
+本スクリプトは対象 Markdown 内のファイルパス参照を抽出し、リポジトリ内に
+実在しないものを WARN として列挙する。false-positive canary（#499 の
+ガイドライン準拠）として glob 表記・プレースホルダ・URL・アンカーのみの
+参照を除外する。
+
+配線について: 本スクリプトはスタンドアロンの静的解析であり、
+doctor / L-0 / CI への配線は Hardening Override 対象（bin/plangate,
+.github/workflows/）に触れるため別 PBI の follow-up とする
+（docs/ai/stale-ref-detection.md 参照）。
+
+Usage:
+    python3 scripts/check-stale-skill-refs.py [ROOT ...]
+    python3 scripts/check-stale-skill-refs.py --selftest
+
+Exit codes:
+    0 — stale 参照なし
+    1 — stale 参照あり（WARN 列挙）
+    2 — 引数エラー
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_TARGET_GLOBS = (
+    ".claude/skills/**/*.md",
+    ".claude/commands/**/*.md",
+    ".claude/agents/**/*.md",
+)
+
+# Markdown リンク `](path)` からパスらしき文字列を取り出す
+MD_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+
+# インラインコード ` `...` ` の中身
+INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+
+# コード起点として扱うプレフィックス（リポジトリ内パスらしさの判定）
+CODE_PATH_PREFIXES = (
+    "src/",
+    "docs/",
+    "scripts/",
+    ".claude/",
+    "schemas/",
+    "bin/",
+    "app/",
+    "lib/",
+    "tests/",
+    "test/",
+)
+
+# 除外対象: URL
+URL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
+
+# 除外対象: アンカーのみ（#section）
+ANCHOR_ONLY_RE = re.compile(r"^#[^/]*$")
+
+# 除外対象: プレースホルダ・例示（<...>, {...}, path/to, TASK-XXXX の XXXX 部等）
+PLACEHOLDER_TOKENS = (
+    "path/to",
+    "example",
+    "foo",
+    "bar",
+    "xxxx",
+    "<",
+    ">",
+    "{",
+    "}",
+    "...",
+)
+
+# glob 表記
+GLOB_CHARS = ("*", "?")
+
+
+def _strip_anchor_and_query(path: str) -> str:
+    """`#anchor` や `?query` をパス判定用に取り除く。"""
+    for sep in ("#", "?"):
+        idx = path.find(sep)
+        if idx != -1:
+            path = path[:idx]
+    return path
+
+
+def is_excluded(raw: str) -> tuple[bool, str]:
+    """False-positive ガード。除外すべきなら (True, 理由) を返す。"""
+    candidate = raw.strip()
+    if not candidate:
+        return True, "empty"
+
+    if URL_RE.match(candidate):
+        return True, "url"
+
+    if ANCHOR_ONLY_RE.match(candidate):
+        return True, "anchor-only"
+
+    lowered = candidate.lower()
+    for token in PLACEHOLDER_TOKENS:
+        if token in lowered:
+            return True, "placeholder"
+
+    for ch in GLOB_CHARS:
+        if ch in candidate:
+            return True, "glob"
+
+    return False, ""
+
+
+def looks_like_repo_path(raw: str) -> bool:
+    """コード内パス参照らしいかを判定する（誤検出を減らすための緩い正規化）。"""
+    candidate = _strip_anchor_and_query(raw.strip())
+    if not candidate:
+        return False
+
+    # コードブロック言語指定や単なる単語（拡張子なし・スラッシュなし）は除外
+    if "/" not in candidate and "." not in candidate:
+        return False
+
+    # 明らかに自然文の一部（空白を含む）は除外
+    if " " in candidate:
+        return False
+
+    if candidate.startswith(CODE_PATH_PREFIXES):
+        return True
+
+    # 相対パス表記（./ や ../）も対象
+    if candidate.startswith("./") or candidate.startswith("../"):
+        return True
+
+    return False
+
+
+def extract_candidates(text: str) -> list[str]:
+    """Markdown リンクとインラインコードからパス候補を抽出する。"""
+    candidates: list[str] = []
+    for match in MD_LINK_RE.finditer(text):
+        candidates.append(match.group(1))
+    for match in INLINE_CODE_RE.finditer(text):
+        candidates.append(match.group(1))
+    return candidates
+
+
+def resolve_repo_relative(path_str: str, source_file: Path) -> Path:
+    """相対パスをリポジトリルート基準に解決する。"""
+    cleaned = _strip_anchor_and_query(path_str.strip())
+    if cleaned.startswith("./") or cleaned.startswith("../"):
+        base = source_file.parent
+        return (base / cleaned).resolve()
+    return (REPO_ROOT / cleaned).resolve()
+
+
+def check_file(path: Path) -> list[tuple[int, str, str]]:
+    """1 ファイルを検査し、(行番号, 参照文字列, 除外理由 or '') の WARN リストを返す。"""
+    warnings: list[tuple[int, str, str]] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return warnings
+
+    for lineno, line in enumerate(lines, start=1):
+        for raw in extract_candidates(line):
+            excluded, _reason = is_excluded(raw)
+            if excluded:
+                continue
+            if not looks_like_repo_path(raw):
+                continue
+
+            cleaned = _strip_anchor_and_query(raw.strip())
+            if not cleaned:
+                continue
+
+            resolved = resolve_repo_relative(raw, path)
+            try:
+                resolved.relative_to(REPO_ROOT)
+            except ValueError:
+                # リポジトリ外へ逸脱するパス（../ の辿りすぎ等）はスコープ外として無視
+                continue
+
+            if not resolved.exists():
+                warnings.append((lineno, cleaned, ""))
+
+    return warnings
+
+
+def iter_target_files(roots: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        for path in sorted(REPO_ROOT.glob(root)):
+            if path.is_file() and path.suffix == ".md":
+                files.append(path)
+    return files
+
+
+def run_scan(roots: list[str]) -> int:
+    files = iter_target_files(roots)
+    total_warnings = 0
+
+    for path in files:
+        rel = path.relative_to(REPO_ROOT)
+        file_warnings = check_file(path)
+        for lineno, ref, _reason in file_warnings:
+            print(f"WARN {rel}:{lineno} → 非実在パス: {ref}")
+            total_warnings += 1
+
+    if total_warnings == 0:
+        print(f"OK: {len(files)} ファイルを検査し stale パス参照なし")
+        return 0
+
+    print(f"合計 {total_warnings} 件の stale パス参照を検出")
+    return 1
+
+
+# =========================================================
+# selftest
+# =========================================================
+
+
+def run_selftest() -> int:
+    """内蔵ケースで false-positive ガードと実在/非実在判定を検証する。"""
+    failures: list[str] = []
+
+    def check(name: str, condition: bool) -> None:
+        if not condition:
+            failures.append(name)
+
+    # 1. 実在パス → 除外されず、実在するので WARN にならない
+    real_path = "scripts/check-stale-skill-refs.py"
+    excluded, _ = is_excluded(real_path)
+    check("real-path not excluded", not excluded)
+    check("real-path looks_like_repo_path", looks_like_repo_path(real_path))
+    resolved = resolve_repo_relative(real_path, REPO_ROOT / ".claude/skills/dummy/SKILL.md")
+    check("real-path resolves and exists", resolved.exists())
+
+    # 2. 非実在パス → WARN 対象
+    fake_path = "scripts/definitely-not-a-real-file-691.py"
+    excluded, _ = is_excluded(fake_path)
+    check("fake-path not excluded", not excluded)
+    resolved_fake = resolve_repo_relative(fake_path, REPO_ROOT / ".claude/skills/dummy/SKILL.md")
+    check("fake-path does not exist", not resolved_fake.exists())
+
+    # 3. glob 表記 → 除外
+    glob_path = "config/*.ts"
+    excluded, reason = is_excluded(glob_path)
+    check("glob excluded", excluded and reason == "glob")
+
+    glob_path2 = "docs/**/*.md"
+    excluded2, reason2 = is_excluded(glob_path2)
+    check("double-glob excluded", excluded2 and reason2 == "glob")
+
+    # 4. プレースホルダ → 除外
+    placeholder_cases = [
+        "<repo-root>/src/index.ts",
+        "path/to/file.ts",
+        "docs/example/foo.md",
+        "{{TASK_ID}}/plan.md",
+    ]
+    for case in placeholder_cases:
+        excluded, reason = is_excluded(case)
+        check(f"placeholder excluded: {case}", excluded and reason == "placeholder")
+
+    # 5. URL → 除外
+    url_cases = ["https://github.com/s977043/plangate", "http://example.com/docs"]
+    for case in url_cases:
+        excluded, reason = is_excluded(case)
+        check(f"url excluded: {case}", excluded and reason == "url")
+
+    # 6. アンカーのみ → 除外
+    anchor_cases = ["#section", "#見出し"]
+    for case in anchor_cases:
+        excluded, reason = is_excluded(case)
+        check(f"anchor excluded: {case}", excluded and reason == "anchor-only")
+
+    # 7. 自然文（スペースを含む）は looks_like_repo_path で false
+    check(
+        "natural language not path",
+        not looks_like_repo_path("this is not a path at all"),
+    )
+
+    # 8. check_file 統合テスト
+    sample_text = (
+        "See [real](scripts/check-stale-skill-refs.py) and "
+        "[fake](scripts/does-not-exist-691.py) and `config/*.ts` glob and "
+        "`path/to/example.md` placeholder.\n"
+    )
+    tmp_candidates = extract_candidates(sample_text)
+    check(
+        "extract_candidates finds all 4 refs",
+        len(tmp_candidates) == 4,
+    )
+
+    if failures:
+        print("SELFTEST FAIL:")
+        for name in failures:
+            print(f"  - {name}")
+        return 1
+
+    total_checks = 8 + len(placeholder_cases) + len(url_cases) + len(anchor_cases)
+    print(f"SELFTEST PASS ({total_checks} checks)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=list(DEFAULT_TARGET_GLOBS),
+        help="検査対象の glob パターン（デフォルト: skills/commands/agents 配下の *.md）",
+    )
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="内蔵の false-positive ガード自己テストを実行する",
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return run_selftest()
+
+    try:
+        return run_scan(args.roots)
+    except Exception as exc:  # noqa: BLE001 - CLI 境界での明示的エラー化
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要

skill / command / agent 定義内のファイルパス参照が、リファクタ後に陳腐化する問題を検出するスタンドアロンチェッカー。

Closes #691（チェッカー本体）。doctor/L-0/CI 配線は HO（bin/plangate・.github/workflows）のため follow-up 別 PBI。

## 変更内容（非 HO・scripts 直下）

- `scripts/check-stale-skill-refs.py`（344 行）: `.claude/skills|commands|agents` の md からファイルパス参照を抽出し非実在を WARN。`--selftest`（16 checks PASS）。false-positive ガード（glob / プレースホルダ / URL / アンカー）を #499 canary 準拠で実装
- `docs/ai/stale-ref-detection.md`（110 行）: 仕様・使い方・限界・HO follow-up 方針

## 実リポジトリでの有効性実証

デフォルト走査で 8 件検出。うち **4 件は本物のリンク切れ**（`hypothesis-logger/SKILL.md` の `../../docs/...` が `.claude/docs/` を指す誤り・working-context.md の場所誤り）で、別 PR で修正した（下記）。残り 4 件は文書化済みの既知 false-positive（`.claude/settings.json` は gitignore・地の文の例示パス）。**新設ツールが即座に実バグを発見**した dogfooding 事例。

## 既知の限界（v1・doc 記載）

- gitignore 対象ファイル参照を stale と誤検出（settings.json 等）
- 地の文中の例示パス（プレースホルダキーワードを含まないもの）の誤検出
- 位置引数でのディレクトリ指定時の走査挙動は今後精緻化（#691 の「barrel 警告レベルは別途検討」に沿う）

## Mode / C-3

- **Mode**: light（非 HO・新規 script + doc）
- **C-3: AUTONOMOUS APPROVED**（ユーザー自律委任）
- Sonnet エージェント（worktree・cd ガード遵守で自 worktree 完結）→ Fable 5 統合検証（selftest 再現・実バグ 4 件を一次確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)