### PR TITLE
fix(skill): hypothesis-logger の壊れた相対リンク 3 件を修正（#691 チェッカーで検出）

### DIFF
--- a/.claude/skills/hypothesis-logger/SKILL.md
+++ b/.claude/skills/hypothesis-logger/SKILL.md
@@ -6,7 +6,7 @@ description: "WF-07 探索的デバッグの仮説を記録・追跡する。Use
 # Hypothesis Logger
 
 > 正本: `.claude/skills/hypothesis-logger/SKILL.md`
-> 関連: [`docs/workflows/07_exploratory_debug.md`](../../docs/workflows/07_exploratory_debug.md) Phase E-1
+> 関連: [`docs/workflows/07_exploratory_debug.md`](../../../docs/workflows/07_exploratory_debug.md) Phase E-1
 
 WF-07 探索的デバッグの仮説→検証→学習→AC 更新サイクルを構造化して記録する。
 
@@ -91,5 +91,5 @@ WF-07 探索的デバッグの仮説→検証→学習→AC 更新サイクル�
 
 ## 関連
 
-- WF-07: [`docs/workflows/07_exploratory_debug.md`](../../docs/workflows/07_exploratory_debug.md)
-- BLOCKED 状態: [`docs/ai/working-context.md`](../../docs/ai/working-context.md) §BLOCKED 状態
+- WF-07: [`docs/workflows/07_exploratory_debug.md`](../../../docs/workflows/07_exploratory_debug.md)
+- BLOCKED 状態: [`.claude/rules/working-context.md`](../../rules/working-context.md) §BLOCKED 状態


### PR DESCRIPTION
## 概要

新設した `scripts/check-stale-skill-refs.py`（#691）が検出した実バグの修正。dogfooding。

## 変更内容

`.claude/skills/hypothesis-logger/SKILL.md`（3 リンク）:
- `07_exploratory_debug.md`: `../../` → `../../../`（`.claude/docs/workflows/` を指す誤り。正しくはリポジトリルート `docs/workflows/`）
- `working-context.md`: `docs/ai/` → `.claude/rules/`（実在場所へ・表示名も是正）

パス解決を一次確認済み（両修正先とも実在）。

## Mode / C-3

- **Mode**: ultra-light（非 HO・.claude/skills/・3 行）
- **C-3: AUTONOMOUS APPROVED**（同上）

🤖 Generated with [Claude Code](https://claude.com/claude-code)