### PR TITLE
fix(TASK-0123): 偽 DONE を実態へ是正（Part A deployed / Part B HMAC 未適用・要Human判断）

### DIFF
--- a/docs/working/TASK-0123/current-state.md
+++ b/docs/working/TASK-0123/current-state.md
@@ -7,14 +7,14 @@
 
 - **C-3: APPROVED** — `approvals/c3.json` 実在（approved_by: human-s977043、#427 で ship）。旧記載「C-3 待ち / c3.json 未発行」は stale。
 - **Part A（承認トークン書込ガード / AC-1〜4）: 稼働済み** — `scripts/check-approval-token-write.sh` 実在 + `.claude/settings.json` L65/74 の PreToolUse に配線済。exec は #427（c70563b）でマージ済。
-- **Part B（HMAC 署名 / AC-5）: 未適用** — `schemas/maintenance.schema.json` に `hmac_signature` フィールド不在（grep 実測 0 件）。`scripts/apply-task-0123-patches.sh` は生成済だが `--apply` 未実行（HO パス / Human-owned）。
+- **Part B（HMAC 署名 / AC-5）: 未適用** — `schemas/maintenance.schema.json` に `hmac_signature` フィールド不在（grep 実測 0 件）。`scripts/apply-task-0123-patches.sh` は生成済だが未実行（引数なし実行で適用・`--dry-run` で事前確認。HO パス / Human-owned）。
 - 親 issue **#420 は #427 で CLOSED COMPLETED**（コミット本文が "Closes #420 (partial — HO patches pending human application)" と明記）。
 
 ## 次のアクション（要 Human 判断・承認境界 / security）
 
 HMAC 署名層（Part B）を、以下のいずれかに決定する:
 
-- **(a) 適用**: Human が `sh scripts/apply-task-0123-patches.sh --apply` を実行 → HMAC による多層防御を完成。
+- **(a) 適用**: Human が `sh scripts/apply-task-0123-patches.sh`（`--dry-run` 確認後、引数なしで適用）を実行 → HMAC による多層防御を完成。
 - **(b) Deferred / Superseded クローズ**: Part A ガードで #420 の実害は解消済みとして HMAC 層を見送る。
 
 AI は本判断を行わない（`.claude/rules/responsibility-classes.md`）。詳細は `handoff.md` の「状態訂正（bookkeeping 2026-07-05）」節を参照。

--- a/docs/working/TASK-0123/current-state.md
+++ b/docs/working/TASK-0123/current-state.md
@@ -1,28 +1,27 @@
 # TASK-0123 current-state
 
-更新日時: 2026-06-02
+> 更新日時: 2026-07-05（bookkeeping 是正 / stale 状態を実態へ修正）
+> フェーズ: 部分完了（Part A ガード deployed / Part B HMAC 未適用・要 Human 判断）
 
-## 現在フェーズ
+## 実態（2026-07-05 実測）
 
-**C-1 セルフレビュー完了 → C-3 人間レビュー待ち**
+- **C-3: APPROVED** — `approvals/c3.json` 実在（approved_by: human-s977043、#427 で ship）。旧記載「C-3 待ち / c3.json 未発行」は stale。
+- **Part A（承認トークン書込ガード / AC-1〜4）: 稼働済み** — `scripts/check-approval-token-write.sh` 実在 + `.claude/settings.json` L65/74 の PreToolUse に配線済。exec は #427（c70563b）でマージ済。
+- **Part B（HMAC 署名 / AC-5）: 未適用** — `schemas/maintenance.schema.json` に `hmac_signature` フィールド不在（grep 実測 0 件）。`scripts/apply-task-0123-patches.sh` は生成済だが `--apply` 未実行（HO パス / Human-owned）。
+- 親 issue **#420 は #427 で CLOSED COMPLETED**（コミット本文が "Closes #420 (partial — HO patches pending human application)" と明記）。
 
-## 完了済み
+## 次のアクション（要 Human 判断・承認境界 / security）
 
-- pbi-input.md 生成
-- plan.md 生成（Mode=critical / lite_eligible=false / HO 制約・AI/Human 責務分界明記）
-- todo.md 生成
-- test-cases.md 生成
-- review-self.md（C-1）生成 → **PASS**
-- INDEX.md 生成
+HMAC 署名層（Part B）を、以下のいずれかに決定する:
 
-## 次のアクション
+- **(a) 適用**: Human が `sh scripts/apply-task-0123-patches.sh --apply` を実行 → HMAC による多層防御を完成。
+- **(b) Deferred / Superseded クローズ**: Part A ガードで #420 の実害は解消済みとして HMAC 層を見送る。
 
-1. Human: plan.md / pbi-input.md / test-cases.md / review-self.md をレビューし `approvals/c3.json` を発行（C-3 Gate）
-2. AI（C-3 APPROVED 後）: Phase 1〜2（patch 生成・テストスクリプト実装）
+AI は本判断を行わない（`.claude/rules/responsibility-classes.md`）。詳細は `handoff.md` の「状態訂正（bookkeeping 2026-07-05）」節を参照。
 
 ## ブロッカー
 
-**C-3 Human 承認待ち**（`docs/working/TASK-0123/approvals/c3.json` 未発行）
+Part B のみ: HO 実適用（Human-owned）の要否が未決。Part A（ガード稼働・C-3 承認）は解消済み。
 
 ## 重要な設計決定
 

--- a/docs/working/TASK-0123/handoff.md
+++ b/docs/working/TASK-0123/handoff.md
@@ -1,29 +1,40 @@
 # TASK-0123 Handoff
 
-## ステータス: DONE
+## ステータス: 部分完了（承認トークン書込ガードは deployed / HMAC 署名層は未適用・要 Human 判断）
+
+> **状態訂正（bookkeeping 2026-07-05）**: 旧記載「ステータス: DONE」は不正確だったため訂正した。実測で以下を確認:
+>
+> - ✅ **Part A（承認トークン書込ガード / AC-1〜4）は稼働済み**: `scripts/check-approval-token-write.sh` が存在し、`.claude/settings.json`（L65 / L74 の PreToolUse）に配線済み。C-3 も APPROVED（`approvals/c3.json` 実在）。
+> - ❌ **Part B（HMAC 署名 / AC-5）は未適用**: `schemas/maintenance.schema.json` に `hmac_signature` フィールドが**存在しない**（grep 実測 0 件）。`apply-task-0123-patches.sh` は生成済みだが **--apply が一度も実行されていない**（HO パスのため Human-owned）。したがって旧 AC-5「PASS（patch 適用後）」・TC-06「hmac_signature field present」は **現 main を反映しない偽 PASS**。
+> - 親 issue **#420 は #427（本 TASK の PR）で CLOSED COMPLETED**。#427 コミット本文自身が "Closes #420 (partial — HO patches pending human application)" と明記しており、HMAC 層は当初から Human 適用待ち。
+>
+> **⚠️ 要 Human 判断（承認境界・security）**: HMAC 署名層（Part B）を
+> (a) 今から適用する（`sh scripts/apply-task-0123-patches.sh --apply` を Human が実行 = 多層防御を完成）か、
+> (b) 適用せず「Part A ガードで #420 の実害は解消済み」として **Deferred/Superseded でクローズ**するか、
+> を人間が決定する。AI は本判断を行わない（`.claude/rules/responsibility-classes.md`）。
 
 ---
 
 ## 1. 要件適合確認結果（AC ごとの PASS / FAIL / WARN）
 
-| AC | 内容 | 結果 | 備考 |
-|----|------|------|------|
-| AC-1 | `check-approval-token-write.sh` が存在・実行可能 | PASS | patch 適用後 TC-01/02 PASS |
-| AC-2 | maintenance.json パスへの書き込みを block | PASS | TC-03 PASS (exit 1) |
-| AC-3 | approvals/*.json パスへの書き込みを block | PASS | TC-04 PASS (exit 1) |
-| AC-4 | 通常ファイルは通過 | PASS | TC-05 PASS (exit 0) |
-| AC-5 | schemas/maintenance.schema.json に hmac_signature フィールド | PASS | TC-06 PASS（patch 適用後） |
-| AC-6 | apply-task-0123-patches.sh が存在・syntax OK | PASS | TC-07 PASS |
+| AC   | 内容                                                         | 結果      | 備考                                                                                                   |
+| ---- | ------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------ |
+| AC-1 | `check-approval-token-write.sh` が存在・実行可能             | PASS      | deployed: script 実在 + `.claude/settings.json` L65/74 配線済（2026-07-05 実測）。TC-01/02 PASS        |
+| AC-2 | maintenance.json パスへの書き込みを block                    | PASS      | TC-03 PASS (exit 1)                                                                                    |
+| AC-3 | approvals/*.json パスへの書き込みを block                    | PASS      | TC-04 PASS (exit 1)                                                                                    |
+| AC-4 | 通常ファイルは通過                                           | PASS      | TC-05 PASS (exit 0)                                                                                    |
+| AC-5 | schemas/maintenance.schema.json に hmac_signature フィールド | ❌ 未適用 | `hmac_signature` は schema に不在（2026-07-05 grep 実測 0 件）。旧「適用後 PASS」は未実現条件＝偽 PASS |
+| AC-6 | apply-task-0123-patches.sh が存在・syntax OK                 | PASS      | TC-07 PASS                                                                                             |
 
 ---
 
 ## 2. 既知課題一覧
 
-| ID | 内容 | 優先度 |
-|----|------|--------|
-| KI-1 | `.claude/settings.json` への hook wiring は Human が手動で実施する必要がある（self-mod ガードのため AI 不可） | 中 |
-| KI-2 | `PLANGATE_MAINTENANCE_KEY` の鍵ローテーション手順が未整備 | 低 |
-| KI-3 | CI の `check-maintenance-provenance.yml` は `PLANGATE_MAINTENANCE_KEY_CI` GitHub Secret の登録が Human 操作必須 | 中 |
+| ID   | 内容                                                                                                                                                | 優先度 |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| KI-1 | `.claude/settings.json` への hook wiring は **完了済み**（L65/74 PreToolUse に配線・2026-07-05 実測）。旧「Human 手動必要」は当時の未配線状態の記載 | 中     |
+| KI-2 | `PLANGATE_MAINTENANCE_KEY` の鍵ローテーション手順が未整備                                                                                           | 低     |
+| KI-3 | CI の `check-maintenance-provenance.yml` は `PLANGATE_MAINTENANCE_KEY_CI` GitHub Secret の登録が Human 操作必須                                     | 中     |
 
 ---
 
@@ -37,11 +48,11 @@
 
 ## 4. 妥協点（採用しなかった選択肢と理由）
 
-| 選択肢 | 不採用理由 |
-|--------|-----------|
-| plan.md のフィールド名 `hmac_sha256` を使用 | コンダクター指示が `hmac_signature` だったため合わせた |
-| `openssl dgst -hmac` を使った署名 | Python `hmac` モジュールの方が macOS/Linux 互換性が高いため |
-| `required` 配列に `hmac_signature` を追加 | 後方互換のため省略（新規 start 時は bin/plangate が自動付与） |
+| 選択肢                                      | 不採用理由                                                    |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| plan.md のフィールド名 `hmac_sha256` を使用 | コンダクター指示が `hmac_signature` だったため合わせた        |
+| `openssl dgst -hmac` を使った署名           | Python `hmac` モジュールの方が macOS/Linux 互換性が高いため   |
+| `required` 配列に `hmac_signature` を追加   | 後方互換のため省略（新規 start 時は bin/plangate が自動付与） |
 
 ---
 
@@ -52,32 +63,35 @@
 TASK-0123 では承認境界の核心的な迂回経路を二重に閉じる防御を実装した。
 
 **EH-token-guard**:
+
 - `scripts/hooks/check-approval-token-write.sh`（新規）
 - AI が `maintenance.json` や `approvals/*.json` に直接書き込もうとすると exit 1 でブロック
 - `.claude/settings.json` への PreToolUse hook wiring は Human が手動実施（Human 向け手順: `docs/ai/approval-token-guard.md`）
 
 **HMAC 署名検証**:
+
 - `schemas/maintenance.schema.json` に `hmac_signature` フィールドを追加
 - `bin/plangate maintenance start` が `PLANGATE_MAINTENANCE_KEY` 設定時に自動付与
 - EH-3 (`check-plan-hash.sh`) が署名検証を実施（署名あり・鍵設定済み → 一致必須、鍵未設定 → 通過（後方互換））
 
 **Human が次に実施すべき操作**:
+
 1. `.claude/settings.json` に `check-approval-token-write.sh` を PreToolUse hook として追加
 2. `export PLANGATE_MAINTENANCE_KEY=$(openssl rand -hex 32)` でローカル鍵を設定
 3. GitHub Secret `PLANGATE_MAINTENANCE_KEY_CI` を登録
 
 ### ファイル一覧
 
-| ファイル | 種別 | 備考 |
-|---------|------|------|
-| `scripts/apply-task-0123-patches.sh` | 新規（非 HO） | HO ファイルへの変更を Human が適用するスクリプト |
-| `scripts/hooks/check-approval-token-write.sh` | 新規（HO/patch 適用後） | EH-token-guard 本体 |
-| `schemas/maintenance.schema.json` | 変更（HO/patch 適用後） | hmac_signature フィールド追加 |
-| `scripts/hooks/check-plan-hash.sh` | 変更（HO/patch 適用後） | HMAC 署名検証ブロック追加 |
-| `bin/plangate` | 変更（HO/patch 適用後） | maintenance start に署名生成追加 |
-| `.github/workflows/check-maintenance-provenance.yml` | 新規（HO/patch 適用後） | CI 署名検証 workflow |
-| `tests/extras/ta-25-approval-token-guard.sh` | 新規（非 HO） | TC-01〜TC-07 テストスクリプト |
-| `docs/ai/approval-token-guard.md` | 新規（非 HO） | Human 向け運用ガイド |
+| ファイル                                             | 種別                    | 備考                                             |
+| ---------------------------------------------------- | ----------------------- | ------------------------------------------------ |
+| `scripts/apply-task-0123-patches.sh`                 | 新規（非 HO）           | HO ファイルへの変更を Human が適用するスクリプト |
+| `scripts/hooks/check-approval-token-write.sh`        | 新規（HO/patch 適用後） | EH-token-guard 本体                              |
+| `schemas/maintenance.schema.json`                    | 変更（HO/patch 適用後） | hmac_signature フィールド追加                    |
+| `scripts/hooks/check-plan-hash.sh`                   | 変更（HO/patch 適用後） | HMAC 署名検証ブロック追加                        |
+| `bin/plangate`                                       | 変更（HO/patch 適用後） | maintenance start に署名生成追加                 |
+| `.github/workflows/check-maintenance-provenance.yml` | 新規（HO/patch 適用後） | CI 署名検証 workflow                             |
+| `tests/extras/ta-25-approval-token-guard.sh`         | 新規（非 HO）           | TC-01〜TC-07 テストスクリプト                    |
+| `docs/ai/approval-token-guard.md`                    | 新規（非 HO）           | Human 向け運用ガイド                             |
 
 ---
 
@@ -89,12 +103,13 @@ Results: 228 passed, 0 failed
 ```
 
 **ta-25 詳細:**
+
 - TC-01: PASS — check-approval-token-write.sh exists and is executable
 - TC-02: PASS — check-approval-token-write.sh syntax ok
 - TC-03: PASS — maintenance.json path blocked (exit 1)
 - TC-04: PASS — approvals/c3.json path blocked (exit 1)
 - TC-05: PASS — normal file passes (exit 0)
-- TC-06: PASS — hmac_signature field present in maintenance.schema.json
+- TC-06: ⚠️ 現 main 不一致 — 上記ログはローカルで patch を一時適用した際の記録。現 main では `hmac_signature` フィールドは schema に不在（未適用）
 - TC-07: PASS — apply-task-0123-patches.sh exists and syntax ok
 
 既存テスト（ta-12 maintenance 等）への回帰なし確認済み。

--- a/docs/working/TASK-0123/handoff.md
+++ b/docs/working/TASK-0123/handoff.md
@@ -5,13 +5,15 @@
 > **状態訂正（bookkeeping 2026-07-05）**: 旧記載「ステータス: DONE」は不正確だったため訂正した。実測で以下を確認:
 >
 > - ✅ **Part A（承認トークン書込ガード / AC-1〜4）は稼働済み**: `scripts/check-approval-token-write.sh` が存在し、`.claude/settings.json`（L65 / L74 の PreToolUse）に配線済み。C-3 も APPROVED（`approvals/c3.json` 実在）。
-> - ❌ **Part B（HMAC 署名 / AC-5）は未適用**: `schemas/maintenance.schema.json` に `hmac_signature` フィールドが**存在しない**（grep 実測 0 件）。`apply-task-0123-patches.sh` は生成済みだが **--apply が一度も実行されていない**（HO パスのため Human-owned）。したがって旧 AC-5「PASS（patch 適用後）」・TC-06「hmac_signature field present」は **現 main を反映しない偽 PASS**。
+> - ❌ **Part B（HMAC 署名 / AC-5）は未適用**: `schemas/maintenance.schema.json` に `hmac_signature` フィールドが**存在しない**（grep 実測 0 件）。`apply-task-0123-patches.sh` は生成済みだが **一度も実行されていない**（引数なし実行で適用・`--dry-run` で事前確認。HO パスのため Human-owned）。したがって旧 AC-5「PASS（patch 適用後）」・TC-06「hmac_signature field present」は **現 main を反映しない偽 PASS**。
 > - 親 issue **#420 は #427（本 TASK の PR）で CLOSED COMPLETED**。#427 コミット本文自身が "Closes #420 (partial — HO patches pending human application)" と明記しており、HMAC 層は当初から Human 適用待ち。
 >
 > **⚠️ 要 Human 判断（承認境界・security）**: HMAC 署名層（Part B）を
-> (a) 今から適用する（`sh scripts/apply-task-0123-patches.sh --apply` を Human が実行 = 多層防御を完成）か、
+> (a) 今から適用する（Human が `sh scripts/apply-task-0123-patches.sh` を実行 = 多層防御を完成。`--dry-run` で事前確認後、引数なしで適用）か、
 > (b) 適用せず「Part A ガードで #420 の実害は解消済み」として **Deferred/Superseded でクローズ**するか、
 > を人間が決定する。AI は本判断を行わない（`.claude/rules/responsibility-classes.md`）。
+>
+> **残る防御課題（C-2 Gemini 指摘 / security-medium）**: Part A ガード本体 `scripts/check-approval-token-write.sh` は HO 保護対象外（`scripts/hooks/` でも `.claude/` でもない）ため、AI が当該スクリプトを改変すればガードをバイパスしうる。Part B（HMAC 署名）の適用、またはガードスクリプト自体の HO 化（`scripts/hooks/` への移設 + settings 参照更新）が、この迂回を塞ぐ残存対策。上記 (a)/(b) の判断材料。
 
 ---
 


### PR DESCRIPTION
## 概要

TASK-0123 の `handoff.md` が「ステータス: DONE / AC-5 PASS（patch適用後）」と**過大申告**する一方、`current-state.md` は「C-3待ち / c3.json 未発行」と**過小申告**しており、両方が実態と不一致だった（承認境界の「適用済み誤認」= Shadow Config 類似）。2026-07-05 実測で確定し是正する。

## 実測で確定した実態

| レイヤ                                       | 実態             | 証跡                                                                                                     |
| -------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
| **Part A**（承認トークン書込ガード AC-1〜4） | ✅ 稼働済み      | `scripts/check-approval-token-write.sh` 実在 + `.claude/settings.json` L65/74 PreToolUse 配線済          |
| **C-3**                                      | ✅ APPROVED      | `approvals/c3.json` 実在（approved_by: human-s977043・#427 で ship）                                     |
| **Part B**（HMAC 署名 AC-5）                 | ❌ 未適用        | `schemas/maintenance.schema.json` に `hmac_signature` 不在（grep 0件）・apply-script は `--apply` 未実行 |
| 親 #420                                      | CLOSED COMPLETED | #427 で close。コミット本文自身 "Closes #420 (partial — HO patches pending human application)"           |

→ 旧 AC-5/TC-06「PASS」は現 main を反映しない**偽 PASS**。

## 是正内容

- `handoff.md`: DONE → 「部分完了」。AC-5 を「未適用」に、KI-1（settings 配線）を「完了済み」に、TC-06 を「現 main 不一致」に訂正。冒頭に状態訂正バナー。
- `current-state.md`: 実態（C-3 APPROVED・Part A deployed・Part B のみ未適用）へ書き換え。

## 要 Human 判断（本 PR では決定しない）

HMAC 署名層（Part B）を **(a) 適用**（Human が `apply-task-0123-patches.sh --apply`）か **(b) Superseded クローズ**（Part A ガードで #420 実害は解消済み）か。承認境界の判断のため AI は決定しない。

- HO パス非接触（変更は `docs/working/TASK-0123/` の 2 ファイルのみ）。**マージしない**（C-4 待ち）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
