### PR TITLE
docs: CHANGELOG Unreleased を 53commit で更新 + v8.16.0 release note draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,119 @@ PlanGate の主要リリース履歴。
 
 ## Unreleased
 
-- **feat(#493): exploratory intent 追加（8 分類化）・hypothesis-logger スキル実装・WF-07 接続（#651）**
+> **DRAFT 集計**: v8.15.0 タグ以降 `origin/main` 53 commit を反映（2026-07-05 時点）。
+> バージョン番号・リリース日は未確定（Human-owned）。ドラフト詳細は
+> [`docs/working/_reports/v8.16.0-release-note-draft.md`](docs/working/_reports/v8.16.0-release-note-draft.md)。
+
+### Added
+
+- **Hook Enforcement 物理配線 6/12 → 11/12（TASK-0141 / 0143〜0147）**（#625 / #627〜#639 / #642〜#643 / #645〜#647）
+  — CLI 層 5 件（EH-4 / EH-5 / EHS-1 / EHS-2 / EHS-3）の hook 物理配線を追加し **6/12 → 11/12** に到達。
+  `bin/plangate` / `scripts/hooks/*.sh` / `schemas/*.schema.json` への実適用が **コミット済みで main に
+  反映済み**（apply-script の `--apply` 実行結果を含む、仕様のみではない）。
+  - **実装は 12/12（既存）／物理配線は 11/12**。EH-7（2 段階レビューなしマージ block）は `bin/plangate doctor`
+    可視化のみ・GitHub branch protection 依存で **未配線**（#500 後続）。正本: `docs/ai/hook-enforcement.md`。
+  - 追加配線した EH-4/5/EHS-1/2/3 は **CLI 層**で `bin/plangate verify` / `handoff --verify` 実行時に発火。
+    完全手動・AI 任せ運用では休眠する（**常時強制は層 A/B の EH-1/2/3/6/8/9**）。
+  - TASK-0143: plan（#627）→ 群A hook 配線 EH-4/5/7・C-3 APPROVED（#628）→ EH-4/5/7 CLI 配線 +
+    ta-44 テスト + EHS-1〜3 設計（#625）→ bin/plangate EH-4/5 CLI 配線（#629）→ 重複成果物除去（#633）
+  - TASK-0141: EH-2 strict JSON 化 + EH-1/2 stdin fallback（#630）
+  - TASK-0144: C-3 approval mode（cli/conversation）設計（#631）→ **HO パス実適用**
+    （`apply-task-0144-c3-mode.sh --apply` 結果、#632）
+  - TASK-0145: EHS-1 strict 発火配線 増分1（#634）→ handoff.md 発行 + 配線状態更新（#636）
+  - TASK-0146: EHS-2/3 配線 増分2/3（#637）→ Gemini medium 対応・BLOCK コメント追加（#638）
+  - TASK-0145/0146 合流: EHS-1/2/3 bin/plangate 実適用（apply-script 結果、359 PASS、#639）
+  - TASK-0141/0143/0144: handoff.md 発行（WF-05 完了資産、#635）
+  - 配線実態ドキュメント同期: 6/12→11/12（#642）→ 運用モード別強制実態（CLI 依存度）追記（#647）
+  - TASK-0147: validation_bias conductor export 配線 follow-up plan（#643）→ 配線実装
+    （apply-script 方式、#645）→ bin/plangate / conductor 実適用（apply-script 結果、#646）
+
+- **ai-loop（旧 Arbiter）Phase 0〜4 + L2 裁定エンジン PoC**（#660〜#662 / #665 / #668〜#669 /
+  #671 / #673 / #675 / #678 / #680〜#682 / #696）
+  — ai-loop ワークフロー仕様の Phase 0〜4 策定と L2 裁定エンジン PoC。**現状は仕様策定・PoC
+  検証段階であり、ai-loop への本番運用切り替えや既存 plan→exec フローの置換は未実施**（既存
+  ワークフローと並存、#687 の共存ガイド参照）。
+  - Phase 0: コンセプト固定・資産棚卸し・検証スコープ定義（#660）
+  - Phase 1/2a: arbiter-policy 正本化 + W チェック拡張フロー（#661）
+  - Phase 2b: decision-table.md（二分ルール Decision table・provenance schema・CB）（#662）
+  - Phase 2 follow-up: provenance 正本一元化・安全側 severity 既定・責務範囲明記（#665）
+  - Phase 1 改訂: lite 判定基準（可逆性要件）+ severity 分類主体確定（#675）
+  - Phase 2: L2 裁定エンジン PoC `scripts/ai-loop/arbiter.py` + 59 テスト + runbook（#678）
+  - Phase 3: phase3-impact-report.md（影響評価・分岐判断基準・未解決リスク）（#669）
+  - L4 PoC: review-feedback-loop.md（レビュー指摘の事前チェック還元閉ループ）（#668）
+  - 改称: Arbiter-workflow → ai-loop-workflow（#673）
+  - 概念改定: C-2 まで PlanGate 共通化・C-3 を AI 裁定ゲート「C-3'」に置換・merge-ready 責務明記（#680）
+  - 3 系統振り返りレビュー指摘 7 件の修正（severity 別軸・class 軸・セクション番号ほか）（#671）
+  - 3 レーン監査の還元: §7 欠番解消・D-6/C-6 新設・suppression 初登録・コンフリクト対応手順（#682）
+  - 初回実走: runbook に実行スキル 2 件を追記 + provenance 刻印（#696）
+
+- **Plan Review Readiness Gate**（#653 / #663）
+  — C-1 self-review 前に `pass / needs_revision / blocked` を判定する計画実行準備ゲートを
+  追加。WF-03 完了条件・plangate-insertion-map・plan.md テンプレートを更新（#653）。ドキュメント
+  仕様変更向けのレビュー観点を追加（#663）。
+
+- **exploratory intent 追加（8 分類化）・hypothesis-logger スキル実装・WF-07 接続**（#651）
   — intent-classifier に `exploratory` を 8 番目の intent として追加。仮説採番・記録スキル
   `hypothesis-logger` を新規実装。WF-00 に exploratory 判定時の WF-07 推奨 advisory を追加。
 
-- **docs(#652): Plan Review Readiness Gate 新規追加（#653）**
-  — C-1 self-review 前に `pass / needs_revision / blocked` を判定する計画実行準備ゲートを
-  追加。WF-03 完了条件・plangate-insertion-map・plan.md テンプレートを更新。
+- **新規スキル: pr-watch / ai-loop-cycle**（#694 / #695）
+  — `pr-watch`（PR 監視・状態把握手順）、`ai-loop-cycle`（ai-loop 1 サイクル実行手順 + Model
+  A/B/C/D 委託プロンプト定型）を新設。`subagent-driven-development` に worktree 委託の安全
+  ルールを追加（#695）。
+
+- **self-review スキル拡張**（#666）
+  — シェル/ドキュメント品質観点 + 文章品質チェックを追加。
+
+- **repo-owned 整合性検出スクリプト 2 種**（#700 / #703）
+  — stale パス参照検出 `scripts/check-stale-skill-refs.py`（#700）、plugin/repo-local スキル名
+  多重定義検出 `scripts/check-skill-name-collisions.py` + 優先順位ガイド（#703）。
+
+- **gh account ドリフト検証の pre-push opt-in 拡張**（#702）
+  — 既存 #360 pre-push hook に gh アクティブアカウントのドリフト検証を opt-in 拡張。
+
+- **段階的導入ドキュメント 3 種**（#697〜#699）
+  — plugin-only 環境の動作境界と CLI 非依存の最小導入パス（#699）、既存 plan→exec ワークフロー
+  との共存・部分導入ガイド（#698）、改称移行（arbiter→ai-loop 等）の grep チェックリスト
+  正本（#697）。
+
+### Changed
+
+- **improvement-seeds スキーマの OSS 非依存化**（#650）
+  — 「1 人運用」記述を「ツール・プロセス上の摩擦点」に変更（既存エントリは append-only の
+  ため不変）。
+- **依存関係更新**（#649）
+  — dependabot による github-actions グループ更新 5 件（`codeql.yml` / `schema-validate.yml`）。
+
+### Fixed
+
+- **PR#651/#653 マージ後ドキュメント整合性修正**（#654）
+  — skill-policy-router / plan-review-readiness-gate / plangate-plugin-migration /
+  00_intent_intake の記述不整合を解消。
+- **hypothesis-logger の壊れた相対リンク 3 件を修正**（#701）
+  — #700 の stale パス検出スクリプトが検出した実バグを dogfooding 修正。
+
+### Specification（仕様 + apply-script 提供のみ・HO 実適用は Human 待ち）
+
+> 以下は「仕様策定 + Human-owned 適用スクリプト（`--dry-run` 既定）の提供」までが完了した
+> 項目。Hardening Override（HO）対象パス（`.claude/rules/*.md` 等）への実適用（`--apply`）は
+> Human-owned であり、本ドラフト時点では**未実行**。上記 Hook Enforcement 項目（実適用済み）
+> とは異なり、**enforcement は live ではない**（working-context.md「settings タスクロック」と
+> 同型のギャップ）。
+
+- **品質コマンド実行証跡の必須化 仕様**（#706）
+  — PR/handoff ゲートでプロジェクト定義の品質コマンド実行証跡（evidence-ledger EvidenceItem）
+  を必須化する仕様 `docs/ai/quality-command-evidence.md` + 適用スクリプト
+  `scripts/apply-quality-command-gate.sh`（dry-run 既定、`--apply` は Human-owned）。
+- **レビュアー沈黙時のフォールバック + 証跡必須化 仕様**（#705）
+  — `docs/ai/reviewer-silence-fallback.md` + `scripts/apply-reviewer-silence-gate.sh`
+  （dry-run 既定）。
+- **workflow-conductor の plan 再実行ガード動的フェーズ表示化 仕様**（#708）
+  — `scripts/apply-conductor-dynamic-phase.sh`（dry-run 既定、HO 実適用は未実施）。
+- **W-6 autonomous APPROVE の人間著者導入手順 + doctor 検知 仕様**（#707）
+  — `docs/ai/w6-autonomous-approve-introduction.md`（仕様のみ、導入自体は未実施）。
+- **R-NNN 監査表の C-4 拡張 仕様**（#704）
+  — `docs/ai/review-feedback-c4-extension.md` + `scripts/apply-rnnn-c4-extension.sh`
+  （dry-run 既定）。
 
 ## v8.15.0 - 2026-06-25
 

--- a/docs/working/_reports/v8.16.0-release-note-draft.md
+++ b/docs/working/_reports/v8.16.0-release-note-draft.md
@@ -1,0 +1,93 @@
+# v8.16.0 Release Note (DRAFT)
+
+> **DRAFT — tag push / GitHub Release 発行は Human-owned**
+> （[`.claude/rules/responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)
+> 「対外公開アーティファクト publish 責務分界」/ **NO RELEASE WITHOUT TAG-MAIN PARITY**
+> [`scripts/check-tag-main-parity.sh`](../../../scripts/check-tag-main-parity.sh)）。
+> 本ファイルは AI が作成した release note **草案**であり、`git tag` push・
+> `gh release create` の実行は行わない。バージョン番号 **v8.16.0 は暫定**
+> （semver 上の 8.15.0 → minor bump 想定だが、最終決定は Human）。
+> 集計基準日: 2026-07-05、対象 `v8.15.0..origin/main` 53 commit。
+
+## サマリ
+
+v8.16.0（暫定）は、hook enforcement の物理配線を **6/12 → 11/12** に前進させ
+（CLI 層 5 件 EH-4/5/EHS-1/2/3。TASK-0141・0143〜0147、`bin/plangate` /
+`scripts/hooks/*.sh` / `schemas/*.schema.json` への実適用がコミット済み。実装は
+12/12 だが EH-7 は branch protection 依存で未配線）、次世代ワークフロー
+「ai-loop」（旧 Arbiter）の Phase 0〜4 仕様策定と L2 裁定エンジン PoC
+（`scripts/ai-loop/arbiter.py` + 59 テスト）を進めた。加えて Plan Review
+Readiness Gate・exploratory intent（8 分類化）+ hypothesis-logger・段階的
+導入ドキュメント（plugin-only 環境 / 既存ワークフローとの共存 / 改称移行
+チェックリスト）・repo-owned スキル整合性検出スクリプト 2 種・gh account
+ドリフト検証の pre-push 拡張・新規スキル（pr-watch / ai-loop-cycle）・
+self-review 拡張を追加した。一方、品質コマンド証跡必須化・レビュアー
+沈黙フォールバック・W-6 autonomous APPROVE 導入・R-NNN C-4 拡張・
+workflow-conductor 動的フェーズ表示の 5 件は **仕様 + apply-script（dry-run）
+提供までで、Hardening Override 対象パスへの実適用は未実施**（Human 適用待ち）。
+
+## ハイライト
+
+- **Hook Enforcement 6/12 → 11/12 前進**（TASK-0141/0143〜0147）— CLI 層 5 件
+  EH-4/5/EHS-1/2/3 の物理配線が `bin/plangate` / `scripts/hooks/*.sh` /
+  `schemas/*.schema.json` に実適用済み（apply-script `--apply` 実行結果が main に
+  コミット済み）。TASK-0144 の C-3 approval mode（cli/conversation）も HO パスへ
+  実適用済み。**実装は 12/12・物理配線は 11/12**（EH-7 は doctor 可視化のみ・
+  branch protection 依存で未配線・#500 後続）。CLI 層 hook は `bin/plangate` 実行時
+  発火（手動運用では休眠、常時強制は EH-1/2/3/6/8/9）。
+- **ai-loop（旧 Arbiter）Phase 0〜4 + L2 裁定エンジン PoC** — コンセプト固定
+  → decision-table → lite 判定基準 → `arbiter.py` PoC（59 テスト）→ C-2 まで
+  PlanGate 共通化・C-3 を AI 裁定ゲート「C-3'」に置換する概念改定 →
+  3 レーン監査の還元 → 初回実走 provenance 刻印、まで一連の仕様策定を実施。
+  **本番運用切り替え・既存 plan→exec フローの置換は未実施**（PoC・仕様段階）。
+- **Plan Review Readiness Gate** — C-1 self-review 前に
+  `pass / needs_revision / blocked` を判定する計画実行準備ゲートを新設し、
+  ドキュメント仕様変更向けのレビュー観点を追加。
+- **exploratory intent（8 分類化）+ hypothesis-logger + WF-07 接続** —
+  intent-classifier に `exploratory` を追加し、仮説採番・記録スキルを新設。
+- **段階的導入ドキュメント 3 種** — plugin-only 環境の動作境界、既存
+  plan→exec ワークフローとの共存ガイド、改称移行（arbiter→ai-loop 等）の
+  grep チェックリスト正本を新設。
+- **repo-owned 整合性検出スクリプト 2 種** — stale パス参照検出・
+  plugin/repo-local スキル名多重定義検出。前者が実際に検出した
+  `hypothesis-logger` の壊れたリンク 3 件を dogfooding 修正。
+- **gh account ドリフト検証の pre-push opt-in 拡張** — 既存 #360 pre-push
+  hook を拡張。
+- **新規スキル・スキル拡張** — `pr-watch` / `ai-loop-cycle` 新設、
+  `subagent-driven-development`（worktree 委託安全ルール）・`self-review`
+  （シェル/ドキュメント/文章品質観点）を拡張。
+
+## 未 live の HO 適用待ち項目（enforcement ではなく仕様止まり）
+
+以下は plan/spec + apply-script（`--dry-run` 既定）の提供までが完了した項目。
+Hardening Override（HO）対象パス（`.claude/rules/*.md` / `.claude/agents/*.md`
+/ `scripts/hooks/*.sh` 等）への実適用（`--apply`）は Human-owned であり、
+本ドラフト時点で **未実行**。上記ハイライトの Hook Enforcement 項目
+（実適用済み）とは明確に区別する。
+
+| 項目                                        | 仕様ドキュメント                                | apply-script                               | 実適用状態             |
+| ------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ---------------------- |
+| 品質コマンド実行証跡の必須化（#683）        | `docs/ai/quality-command-evidence.md`           | `scripts/apply-quality-command-gate.sh`    | 未適用（dry-run のみ） |
+| レビュアー沈黙時のフォールバック（#685）    | `docs/ai/reviewer-silence-fallback.md`          | `scripts/apply-reviewer-silence-gate.sh`   | 未適用（dry-run のみ） |
+| workflow-conductor 動的フェーズ表示（#676） | —                                               | `scripts/apply-conductor-dynamic-phase.sh` | 未適用（dry-run のみ） |
+| W-6 autonomous APPROVE 導入手順（#688）     | `docs/ai/w6-autonomous-approve-introduction.md` | なし（手順書のみ）                         | 導入自体が未実施       |
+| R-NNN 監査表 C-4 拡張（#689）               | `docs/ai/review-feedback-c4-extension.md`       | `scripts/apply-rnnn-c4-extension.sh`       | 未適用（dry-run のみ） |
+
+これらを「shipped / enforcement live」として告知しないこと。次リリースで
+Human が `--apply` を実行した時点で CHANGELOG の Added に昇格させる。
+
+## リリース手順（参考・実行は Human-owned）
+
+1. 本ドラフトの内容を人間がレビューし、バージョン番号（v8.16.0 か別番号か）
+   を確定する。
+2. CHANGELOG.md の `## Unreleased` を確定版バージョン見出しに置換する。
+3. `git tag v8.16.0 <確定 SHA>` → `git push origin v8.16.0`。
+4. [`scripts/check-tag-main-parity.sh`](../../../scripts/check-tag-main-parity.sh)
+   で tag が指す commit と `origin/main` の一致を検証（NO RELEASE WITHOUT
+   TAG-MAIN PARITY）。
+5. `gh release create v8.16.0 --notes-file <確定 note>` で GitHub Release を発行。
+
+上記 3〜5 は
+[`.claude/rules/responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)
+「対外公開アーティファクト publish 責務分界」により **Human-owned**（または
+計画段階で明示承認を取得した AI 実行）。

--- a/docs/working/_reports/v8.16.0-release-note-draft.md
+++ b/docs/working/_reports/v8.16.0-release-note-draft.md
@@ -65,13 +65,13 @@ Hardening Override（HO）対象パス（`.claude/rules/*.md` / `.claude/agents/
 本ドラフト時点で **未実行**。上記ハイライトの Hook Enforcement 項目
 （実適用済み）とは明確に区別する。
 
-| 項目                                        | 仕様ドキュメント                                | apply-script                               | 実適用状態             |
-| ------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ---------------------- |
-| 品質コマンド実行証跡の必須化（#683）        | `docs/ai/quality-command-evidence.md`           | `scripts/apply-quality-command-gate.sh`    | 未適用（dry-run のみ） |
-| レビュアー沈黙時のフォールバック（#685）    | `docs/ai/reviewer-silence-fallback.md`          | `scripts/apply-reviewer-silence-gate.sh`   | 未適用（dry-run のみ） |
-| workflow-conductor 動的フェーズ表示（#676） | —                                               | `scripts/apply-conductor-dynamic-phase.sh` | 未適用（dry-run のみ） |
-| W-6 autonomous APPROVE 導入手順（#688）     | `docs/ai/w6-autonomous-approve-introduction.md` | なし（手順書のみ）                         | 導入自体が未実施       |
-| R-NNN 監査表 C-4 拡張（#689）               | `docs/ai/review-feedback-c4-extension.md`       | `scripts/apply-rnnn-c4-extension.sh`       | 未適用（dry-run のみ） |
+| 項目                                                     | 仕様ドキュメント                                | apply-script                               | 実適用状態             |
+| -------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------ | ---------------------- |
+| 品質コマンド実行証跡の必須化（#706 / issue #683）        | `docs/ai/quality-command-evidence.md`           | `scripts/apply-quality-command-gate.sh`    | 未適用（dry-run のみ） |
+| レビュアー沈黙時のフォールバック（#705 / issue #685）    | `docs/ai/reviewer-silence-fallback.md`          | `scripts/apply-reviewer-silence-gate.sh`   | 未適用（dry-run のみ） |
+| workflow-conductor 動的フェーズ表示（#708 / issue #676） | —                                               | `scripts/apply-conductor-dynamic-phase.sh` | 未適用（dry-run のみ） |
+| W-6 autonomous APPROVE 導入手順（#707 / issue #688）     | `docs/ai/w6-autonomous-approve-introduction.md` | なし（手順書のみ）                         | 導入自体が未実施       |
+| R-NNN 監査表 C-4 拡張（#704 / issue #689）               | `docs/ai/review-feedback-c4-extension.md`       | `scripts/apply-rnnn-c4-extension.sh`       | 未適用（dry-run のみ） |
 
 これらを「shipped / enforcement live」として告知しないこと。次リリースで
 Human が `--apply` を実行した時点で CHANGELOG の Added に昇格させる。


### PR DESCRIPTION
## 概要

v8.15.0 以降 **53 commit** に対し CHANGELOG の Unreleased が 2 項目しか無かった乖離を解消。全 53 PR を Added / Changed / Fixed / **Specification（未live・HO適用待ち）** の 4 分類で網羅（範囲表記含む・漏れ0/重複0検証済）。併せて `docs/working/_reports/v8.16.0-release-note-draft.md` を DRAFT 作成。

## honest 分類（最重要）

- **Specification 節に隔離**（enforcement は live ではない）: 品質コマンド証跡必須化・レビュアー沈黙フォールバック・conductor 動的フェーズ・W-6 doctor 検知・R-NNN C-4 拡張（#683/#685/#676/#688/#689）は `git show` で HO パス実変更 **0 件**を確認 → 「仕様 + apply-script 提供のみ・HO 実適用は Human 待ち」と明記。
- **Added に計上**（実 ship）: #527/#528 系（EHS-1/2/3 実適用 #639/#646、TASK-0144 HO適用 #632 等）は `bin/plangate` 等への実 diff を確認。

## 検証プロセス（別モデル委託 → レビュー）

- 実装: sonnet が 53 commit を `git show --stat` で全件精査し分類。
- レビュー: opus が敵対的検証 → **FAIL → 修正済**。指摘: 「Hook Enforcement 物理配線 6/12 → **12/12**」は過大申告（正本 `docs/ai/hook-enforcement.md` は**物理配線 11/12**・EH-7 は branch protection 依存で未配線。12/12 は**実装数**）。**実装 12/12 と物理配線 11/12 を分離**し、CLI 層 hook の休眠条件（常時強制は EH-1/2/3/6/8/9）も明記して修正。

## 境界

- draft は tag push / GitHub Release 発行が **Human-owned**（NO RELEASE WITHOUT TAG-MAIN PARITY）と明記・**DRAFT** 扱い。バージョン v8.16.0 は暫定。
- 変更は `CHANGELOG.md` と draft の 2 ファイルのみ（既存リリース節・HO 非接触）。**マージしない**（C-4 待ち）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
