### PR TITLE
docs: define bounded adaptive production loop for ai-loop

### DIFF
--- a/docs/workflows/ai-loop/00_concept.md
+++ b/docs/workflows/ai-loop/00_concept.md
@@ -144,7 +144,50 @@ C-3 条件付き降格（F5-AD）の判定を decision table + provenance で完
 
 ---
 
-## 4. autonomous-degraded-gates-spec.md との関係
+## 4. 6 層自己改善ループとの関係
+
+ai-loop-workflow は、低リスク帯かつ承認境界に触れない範囲で、
+[`adaptive-production-loop.md`](./adaptive-production-loop.md) に定義する
+6 層自己改善ループを回す。
+
+```text
+Generate → Evaluate → Remember → Schedule → Optimize → Recurse
+```
+
+このモデルは `/goal` や `/loop` など特定ツールのコマンド仕様ではなく、
+ai-loop-workflow の上位運用 contract である。
+
+特に、`/loop` 型の schedule と、`/goal` 型の Goal / Exit Criteria を混同しない。
+PlanGate では **closed/open の違いを interval の有無で判断しない**。
+closed loop と呼べる条件は、以下が明示されていること:
+
+- Goal / Exit Criteria
+- Evaluate point
+- Stop / Escalation / Block の terminal state
+- Remember の保存先
+- Schedule の次アクション選択規則
+- Optimize の反映先
+- Human-owned 境界
+
+`/loop` の interval 省略は、PlanGate 上では Schedule の動的化にすぎない。
+Goal / Evaluate / Stop / Memory / Escalation Contract が明示されていなければ、
+closed loop とは扱わない。
+
+| 6 層 | 本ドキュメント上の対応 |
+| --- | --- |
+| Generate | WF-00〜03 / plan・todo・test-cases 生成、exec、PR 作成 |
+| Evaluate | C-1 / C-2 / C-3' / CI / AI review / DoD 判定 |
+| Remember | decision record、review-feedback-loop、suppression、provenance |
+| Schedule | CI fix、review comment handling、retry、stop、block、human escalate |
+| Optimize | self-review / gate / suppression / scheduling policy の更新 |
+| Recurse | 1 サイクルの出力を次サイクルの pre-check へ戻す |
+
+policy / HO / C-4 merge は Human-owned 固定であり、AI は自己改善ループを通じて
+承認境界そのものを自己変更しない。
+
+---
+
+## 5. autonomous-degraded-gates-spec.md との関係
 
 Phase 0（#655）の結論を参照:
 `docs/working/TASK-0655/TASK-0655-c3-review.html`
@@ -157,7 +200,7 @@ Phase 0（#655）の結論を参照:
 
 ---
 
-## 5. 共通スキル参照方法
+## 6. 共通スキル参照方法
 
 intent-classifier 等の PlanGate 共通スキルは shared として参照するが、
 Arbiter 側のコードから直接変更しない（参照のみ）。
@@ -167,7 +210,7 @@ asset-inventory.md の uses/not-uses 分類に従う:
 
 ---
 
-## 6. 関連ドキュメント
+## 7. 関連ドキュメント
 
 - `docs/ai/ai-loop/arbiter-policy.md` — Arbiter L0 policy
 - `docs/ai/ai-loop/ho-paths.md` — HO パス集約（touches-HO 判定の正本）
@@ -175,6 +218,7 @@ asset-inventory.md の uses/not-uses 分類に従う:
 - `docs/ai/ai-loop/concept.md` — Arbiter の基本概念（Phase 0）
 - `docs/ai/ai-loop/related-specs.md` — 既存仕様との関係（Phase 0）
 - `docs/ai/autonomous-degraded-gates-spec.md` — 参照元（変更禁止）
+- [`docs/workflows/ai-loop/adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 層自己改善ループと `/goal` / `/loop` 責務分離の正本
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — C-3' の flow→detect→escalate 動作フロー
 - [`docs/workflows/ai-loop/execution-runbook.md`](./execution-runbook.md) — PR 前セルフレビュー・PR 後指摘対応ループの実行手順
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — CI/AI レビュー指摘対応を L4 学習へ還元する閉ループ

--- a/docs/workflows/ai-loop/adaptive-production-loop.md
+++ b/docs/workflows/ai-loop/adaptive-production-loop.md
@@ -1,0 +1,173 @@
+# adaptive-production-loop — bounded adaptive production loop
+
+> 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
+> 非適用: PlanGate 本番フロー（WF-00〜WF-07）
+> 位置づけ: Issue #709 の正本。`Generate → Evaluate → Remember → Schedule → Optimize → Recurse` を ai-loop-workflow に取り込むための上位概念。
+
+---
+
+## 1. 目的
+
+ai-loop-workflow を、低リスク帯に限定した **bounded adaptive production loop** として定義する。
+
+```text
+Generate → Evaluate → Remember → Schedule → Optimize → Recurse
+```
+
+このループは「人間なしで完全自律する仕組み」ではない。PlanGate では、以下の境界を固定したまま、AI が自己改善できる範囲を限定する。
+
+- policy / HO / C-4 merge は Human-owned 固定
+- touches-HO は常に human escalate
+- 学習ループは承認境界そのものを自己変更しない
+- PlanGate 本番フロー（WF-00〜WF-07）は置き換えない
+
+---
+
+## 2. `/goal` と `/loop` を混同しない
+
+外部ツールの `/goal`・`/loop`・scheduled task 系の挙動は、ai-loop-workflow の設計語彙へそのまま持ち込まない。
+
+PlanGate では、以下のように責務を分離する。
+
+| 概念 | PlanGate 上の責務 | 混同してはいけない点 |
+| --- | --- | --- |
+| Goal / Exit Criteria | 何を達成すれば終わりかを定義する | `interval` の有無では決まらない |
+| Schedule | 次にいつ・何を実行するかを決める | Schedule は goal 達成判断ではない |
+| Evaluate | 継続 / 停止 / escalate / block を判定する | 再実行すること自体は評価ではない |
+| Loop | 上記を接続した運用単位 | 単なる定期実行ではない |
+
+重要な整理:
+
+- `/loop <interval> ...` 型は **cadence polling** に近い。固定間隔で再実行する schedule であり、goal 達成判断を持つとは限らない。
+- `/loop ...` のように interval を省いた self-paced 型でも、PlanGate 上は **Schedule が動的化しただけ** と扱う。Goal / Exit Criteria / Evaluate が明示されていなければ、closed loop とは呼ばない。
+- `/goal` 型は Goal / Exit Criteria を含む方向に近いが、PlanGate では外部ツールの完了判断へ委ねきらず、DoD・検証・停止条件・escalate 条件を文書側に固定する。
+
+したがって、ai-loop-workflow における closed/open の違いは **interval の有無ではなく、明示された Goal / Evaluate / Stop / Memory / Escalation Contract の有無**で決まる。
+
+---
+
+## 3. 6 層モデル
+
+| 層 | 責務 | ai-loop-workflow 上の対応 |
+| --- | --- | --- |
+| Generate | plan / todo / test-cases / diff / PR を生成する | WF-00〜03、exec、PR 作成 |
+| Evaluate | 生成物に「No」と言う | C-1、C-2、C-3' Arbiter、CI、AI review、DoD 判定 |
+| Remember | 実行結果・判断・指摘・反証を保存する | decision record、review-feedback-loop、suppression、provenance |
+| Schedule | 次アクションを選ぶ | retry、queue、CI fix、review comment handling、stop、block、human escalate |
+| Optimize | 保存した記録を次回の振る舞いへ反映する | skill / gate / suppression / self-review 観点の更新 |
+| Recurse | 1 サイクルの出力を次サイクルの入力へ戻す | 次回 pre-check、次回 C-3'、次回 PR 前 self-review |
+
+---
+
+## 4. 1 サイクルの contract
+
+ai-loop-workflow の 1 サイクルは、以下の contract を満たす場合のみ closed loop として扱う。
+
+| contract | 必須条件 |
+| --- | --- |
+| Goal | merge-ready 到達条件が明示されている |
+| Evaluate | C-1 / C-2 / C-3' / CI / AI review / DoD の判定点がある |
+| Stop | AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED / merge-ready / round limit exceeded の terminal state がある |
+| Memory | decision record、採用/不採用理由、CI/AI review 指摘、suppression を保存する |
+| Schedule | 次アクションの優先順位と retry 上限がある |
+| Boundary | policy / HO / C-4 merge を AI が自己変更しない |
+
+これを満たさない反復は、PlanGate では **scheduled repetition** または **polling** と呼び、closed loop とは呼ばない。
+
+---
+
+## 5. Scheduling 判断表
+
+PR 作成後から merge-ready までの Schedule は、以下の優先順位で決める。
+
+| 優先度 | 条件 | 次アクション | terminal state |
+| --- | --- | --- | --- |
+| 1 | boundary=touches-HO / policy 変更 / irreversible 変更 | human escalate | `HUMAN_ESCALATED` |
+| 2 | CI failed | CI failure を調査・修正し、強化セルフレビューを再実行して push | continue |
+| 3 | merge conflict | conflict 解消、三点照合、`--force-with-lease` push | continue |
+| 4 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
+| 5 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
+| 6 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
+| 7 | 対応ラウンド上限 3 超過 | human escalate | `HUMAN_ESCALATED` |
+| 8 | 同型指摘の再発 | review-feedback-loop へ還元し、Optimize 対象へ送る | recurse |
+
+Schedule は「次に動く」ための判断であり、Schedule 自身が品質評価を兼ねてはならない。品質判断は Evaluate 層に残す。
+
+---
+
+## 6. Remember と Optimize の分離
+
+`review-feedback-loop.md` は、指摘の収集から観点還元までを扱うため、Remember と Optimize が混ざりやすい。
+
+PlanGate では以下に分ける。
+
+### Remember
+
+事実を残す。
+
+- decision record
+- CI 失敗内容
+- AI review 指摘
+- 採用 / 理由付き不採用
+- suppression の機械反証
+- human reject / human override
+
+### Optimize
+
+保存された事実をもとに、次回の振る舞いを更新する。
+
+- self-review 観点を追加する
+- readiness gate の観点を更新する
+- suppression を追加する
+- scheduling policy を調整する
+- skill の手順を更新する
+
+禁止事項:
+
+- 記録なしに prompt / skill / gate を更新しない
+- policy / HO / C-4 merge 境界を AI が自己更新しない
+- false-positive 抑制を理由に critical / major 指摘を無視しない
+
+---
+
+## 7. Recurse 条件
+
+1 サイクルの出力は、次サイクルの入力へ戻す。
+
+| 出力 | 次サイクルへの戻し先 |
+| --- | --- |
+| CI failure | 強化セルフレビュー / test checklist |
+| AI review true-positive | self-review / readiness gate |
+| AI review false-positive | suppression |
+| human reject | C-3' 判定条件 / policy draft |
+| round limit exceeded | scheduling policy / escalate budget |
+| merge-ready 成功 | 成功パターンとして decision record に保存 |
+
+Recurse は無限継続ではない。次サイクルへ渡す情報を保存した時点で 1 サイクルは完了し、terminal state に従って停止または C-4 待ちへ遷移する。
+
+---
+
+## 8. 採用する表現
+
+ai-loop-workflow の説明では、以下の表現を採用する。
+
+> ai-loop-workflow は、低リスク帯かつ承認境界に触れない範囲で、Generate → Evaluate → Remember → Schedule → Optimize → Recurse の自己改善ループを回す。policy / HO / C-4 merge は Human-owned 固定であり、AI は自己改善ループを通じて承認境界そのものを自己変更しない。
+
+以下の表現は採用しない。
+
+- 人間なしで完全自律する
+- `/loop` を入れれば closed loop になる
+- interval を省けば goal 駆動になる
+- AI が policy / HO / merge 境界を自己改善できる
+- scheduled task を PlanGate の Evaluate と同一視する
+
+---
+
+## 9. 関連ドキュメント
+
+- [`00_concept.md`](./00_concept.md) — ai-loop-workflow の位置づけ、C-3'、merge-ready 責務範囲
+- [`execution-runbook.md`](./execution-runbook.md) — 1 サイクルの実行手順、PR 後の CI / AI review 対応ループ
+- [`review-feedback-loop.md`](./review-feedback-loop.md) — Remember / Optimize の実体となるレビュー指摘還元ループ
+- [`flow-detect.md`](./flow-detect.md) — C-3' の flow→detect→escalate 動作フロー
+- [`decision-table.md`](./decision-table.md) — terminal state と decision record
+- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — Human-owned 境界と escalate 予算

--- a/docs/workflows/ai-loop/adaptive-production-loop.md
+++ b/docs/workflows/ai-loop/adaptive-production-loop.md
@@ -83,13 +83,13 @@ PR 作成後から merge-ready までの Schedule は、以下の優先順位で
 | 優先度 | 条件 | 次アクション | terminal state |
 | --- | --- | --- | --- |
 | 1 | boundary=touches-HO / policy 変更 / irreversible 変更 | human escalate | `HUMAN_ESCALATED` |
-| 2 | CI failed | CI failure を調査・修正し、強化セルフレビューを再実行して push | continue |
-| 3 | merge conflict | conflict 解消、三点照合、`--force-with-lease` push | continue |
-| 4 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
-| 5 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
-| 6 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
-| 7 | 対応ラウンド上限 3 超過 | human escalate | `HUMAN_ESCALATED` |
-| 8 | 同型指摘の再発 | review-feedback-loop へ還元し、Optimize 対象へ送る | recurse |
+| 2 | 対応ラウンド上限 3 超過 | human escalate | `HUMAN_ESCALATED` |
+| 3 | 同型指摘の再発 | review-feedback-loop へ還元し、Optimize 対象へ送る | recurse |
+| 4 | CI failed | CI failure を調査・修正し、強化セルフレビューを再実行して push | continue |
+| 5 | merge conflict | conflict 解消、三点照合、`--force-with-lease` push | continue |
+| 6 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
+| 7 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
+| 8 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
 
 Schedule は「次に動く」ための判断であり、Schedule 自身が品質評価を兼ねてはならない。品質判断は Evaluate 層に残す。
 

--- a/docs/workflows/ai-loop/execution-runbook.md
+++ b/docs/workflows/ai-loop/execution-runbook.md
@@ -118,7 +118,26 @@ python3 scripts/ai-loop/arbiter.py --input /path/to/input.json \
 
 ### (7) PR 後の CI / AI レビュー指摘対応ループ（merge-ready まで）
 
-PR 作成後、以下を **merge-ready 到達まで**繰り返す:
+PR 作成後、以下を **merge-ready 到達まで**繰り返す。
+
+この手順は [`adaptive-production-loop.md`](./adaptive-production-loop.md) の
+6 層モデルにおける **Schedule** の実行点である。ただし Schedule は「次に何をするか」を
+決めるだけであり、品質評価そのものは CI / AI review / DoD などの Evaluate 層に残す。
+
+#### Scheduling 判断表
+
+| 優先度 | 条件 | 次アクション | terminal state |
+| --- | --- | --- | --- |
+| 1 | boundary=touches-HO / policy 変更 / irreversible 変更 | 停止して human escalate | `HUMAN_ESCALATED` |
+| 2 | CI failed | CI failure を調査・修正し、(6) を再実行して push | continue |
+| 3 | merge conflict | conflict 解消、三点照合、`--force-with-lease` push | continue |
+| 4 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
+| 5 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
+| 6 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
+| 7 | 対応ラウンド上限 3 超過 | 停止して human escalate | `HUMAN_ESCALATED` |
+| 8 | 同型指摘の再発 | `review-feedback-loop.md` へ還元し、Optimize 対象へ送る | recurse |
+
+#### 実行手順
 
 1. CI 実行結果を確認する。FAIL があれば修正し再度 (6) を通してから push する
 2. **コンフリクトを確認する**（`gh pr view <n> --json mergeable` が `CONFLICTING`）。
@@ -174,6 +193,7 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す:
 
 ## 5. 関連ドキュメント
 
+- [`docs/workflows/ai-loop/adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 層自己改善ループと Scheduling / Goal / Evaluate 分離の正本
 - [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — Decision table・provenance schema・CB
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow→detect→escalate 動作フロー
 - [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本

--- a/docs/workflows/ai-loop/execution-runbook.md
+++ b/docs/workflows/ai-loop/execution-runbook.md
@@ -129,13 +129,13 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
 | 優先度 | 条件 | 次アクション | terminal state |
 | --- | --- | --- | --- |
 | 1 | boundary=touches-HO / policy 変更 / irreversible 変更 | 停止して human escalate | `HUMAN_ESCALATED` |
-| 2 | CI failed | CI failure を調査・修正し、(6) を再実行して push | continue |
-| 3 | merge conflict | conflict 解消、三点照合、`--force-with-lease` push | continue |
-| 4 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
-| 5 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
-| 6 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
-| 7 | 対応ラウンド上限 3 超過 | 停止して human escalate | `HUMAN_ESCALATED` |
-| 8 | 同型指摘の再発 | `review-feedback-loop.md` へ還元し、Optimize 対象へ送る | recurse |
+| 2 | 対応ラウンド上限 3 超過 | 停止して human escalate | `HUMAN_ESCALATED` |
+| 3 | 同型指摘の再発 | `review-feedback-loop.md` へ還元し、Optimize 対象へ送る | recurse |
+| 4 | CI failed | CI failure を調査・修正し、(6) を再実行して push | continue |
+| 5 | merge conflict | conflict 解消、三点照合、lease-protected push | continue |
+| 6 | critical / major の AI review 指摘あり | 採用して修正、または理由付き不採用を記録 | continue or escalate |
+| 7 | minor / info のみ | 採用/不採用理由を記録し、DoD 判定へ進む | merge-ready candidate |
+| 8 | CI green かつ AI review 全件対応済み | C-4 待ちへ遷移 | `MERGE_READY` |
 
 #### 実行手順
 
@@ -143,7 +143,7 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
 2. **コンフリクトを確認する**（`gh pr view <n> --json mergeable` が `CONFLICTING`）。
    スタック PR の前段 squash マージ起因の場合は、固有コミットのみを
    `git rebase --onto origin/main <旧base> <branch>` で main に載せ替え、
-   三点照合（`git branch -vv`・SHA 同定）のうえ `--force-with-lease` で push する。
+   三点照合（`git branch -vv`・SHA 同定）のうえ lease-protected push で反映する。
    push 直後の mergeable は再計算中の場合があるため数十秒後に再確認する
 3. CI/PR 時の AI レビュー指摘を確認する。各指摘について
    **採用して修正**するか、**理由付きで不採用とする**かを記録する

--- a/docs/workflows/ai-loop/review-feedback-loop.md
+++ b/docs/workflows/ai-loop/review-feedback-loop.md
@@ -17,6 +17,26 @@ PR レビューで受けた指摘を観点として抽出・還元し、次の P
 を抑制する経路）の両方向が L4 の対象である。PoC 段階では誤検知抑制は
 定義のみに留め、実装は Phase 4 以降のスコープとする。
 
+本ドキュメントは [`adaptive-production-loop.md`](./adaptive-production-loop.md) の
+6 層モデルにおける **Remember** と **Optimize** の実体を扱う。
+
+---
+
+## 1.1 Remember / Optimize の責務分離
+
+本ループは「記録」と「改善」を混同しない。
+
+| 層 | 本ドキュメント上の責務 | 例 |
+| --- | --- | --- |
+| Remember | レビュー指摘・判断・反証・効果を保存する | 指摘 ID、severity、採用/不採用理由、suppression、効果測定 |
+| Optimize | 保存された事実を次回の振る舞いへ反映する | self-review 更新、readiness gate 更新、suppression 追加、scheduling policy 調整 |
+
+禁止事項:
+
+- 記録なしに skill / gate / suppression を更新しない
+- Optimize を理由に policy / HO / C-4 merge 境界を自己変更しない
+- false-positive 抑制を理由に critical / major 指摘を無視しない
+
 ---
 
 ## 2. 6 ステップフロー
@@ -27,6 +47,15 @@ PR レビューで受けた指摘を観点として抽出・還元し、次の P
                                                     再発検出 ─────────┘
                                                   （§2-1 へ戻る）
 ```
+
+| ステップ | 6 層モデル上の位置づけ |
+| --- | --- |
+| 収集 | Remember |
+| 分類 | Remember |
+| 還元先判定 | Evaluate / Schedule |
+| 反映 | Optimize |
+| 事前適用 | Recurse |
+| 効果測定 | Evaluate / Remember |
 
 ### 2-1. 収集
 
@@ -140,6 +169,7 @@ Codex）で検出された指摘 7 件を issue #670 で還元しており、本
 
 ## 7. 関連ドキュメント
 
+- [`docs/workflows/ai-loop/adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 層自己改善ループ、Remember / Optimize 分離、`/goal` / `/loop` 責務分離の正本
 - [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念・L4 学習層（§7）
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — W チェック・severity 分類・Model C/D 裁定
 - [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — Decision table・provenance schema・サーキットブレーカー


### PR DESCRIPTION
## Summary

Closes #709.

This PR incorporates the `/goal` / `/loop` distinction into `ai-loop-workflow` as a docs-only design update.

## Changes

- Add `docs/workflows/ai-loop/adaptive-production-loop.md` as the canonical definition for:
  - `Generate → Evaluate → Remember → Schedule → Optimize → Recurse`
  - `/goal` / `/loop` responsibility separation
  - closed loop contract
  - Scheduling decision table
  - Remember / Optimize separation
  - Recurse conditions
- Update `00_concept.md` to reference the new 6-layer loop model and clarify that closed/open is not determined by interval presence.
- Update `review-feedback-loop.md` to explicitly separate Remember and Optimize.
- Update `execution-runbook.md` to add the Scheduling decision table for PR-after loops.

## Design decisions

- Treat `/loop <interval>` as cadence polling / scheduling, not as goal completion logic.
- Treat interval-less `/loop` as dynamic scheduling only; it is not a closed loop unless Goal / Evaluate / Stop / Memory / Escalation Contract are explicit.
- Keep policy / HO / C-4 merge Human-owned.
- Keep this isolated to `docs/workflows/ai-loop/`; no production PlanGate workflow, CLI, schema, hook, or CI behavior is changed.

## Verification

- Docs-only change.
- Compared branch against `main`: 4 files changed.
- No runtime code paths changed.
