### PR TITLE
feat(#731): secret 判定の policy-grounding ガード + #727 gap 分析クローズ

### DIFF
--- a/docs/ai/secret-management-policy.md
+++ b/docs/ai/secret-management-policy.md
@@ -1,0 +1,110 @@
+# secret 管理方針宣言テンプレート（正本）
+
+> #731 由来。review-gate / plan-review-gate 等のレビュー Skill が
+> secret/config のリテラル値に severity を付与する **前** に参照する
+> policy-grounding の正本。関連:
+> [`docs/ai/external-reviewer-interface.md`](./external-reviewer-interface.md)
+> （C-2/V-3 外部レビューア接続規約）/
+> [`.claude/rules/review-principles.md`](../../.claude/rules/review-principles.md)
+> §7 False-positive ガード（観点・Severity・判定基準の正本、本ドキュメントは
+> それを補完し再定義しない）。
+
+## 1. 目的と背景
+
+複数の独立レビューエージェント（security / backend / adversarial 等）が
+「Secrets Manager 注入が正規運用」という **同一の前提を共有** すると、
+adversarial のはずが合意形成で誤りを補強し、false-Critical を生む
+（#731 観測事例: `.env.production` の内部 proxy 用リテラル API キーを
+3 エージェント全員が Critical 判定 → 実際はそのキーは env 管理が
+意図的なチーム方針だった）。
+
+secret/config のリテラル値は **絶対的なアンチパターンではなく、
+プロジェクトの管理方針に依存する**。方針を未検証のまま一般論で
+Critical を付けると false-block を生む。本ドキュメントは
+「このプロジェクトでは何が正規の管理方針か」を **事前宣言** し、
+レビュー Skill が severity 判定前に参照できるようにする。
+
+## 2. 使い方
+
+1. 本ファイルをプロジェクトルート（または `docs/ai/`）にコピーし、
+   §3〜§5 をプロジェクト固有の実態に合わせて埋める。
+2. 埋めていない項目（不明・未検証）は空欄にせず **「未検証」** と明記する
+   （空欄は「検証済みで allowlist 対象なし」と誤読されるため）。
+3. review-gate 等のレビュー Skill は、secret/config のリテラル値を
+   Critical/Major と判定する前に本ファイルの有無・該当項目を確認する
+   （手順は本ファイルではなく各 Skill 側に実装する。本ファイルは
+   参照される宣言データであり、レビュー手順の正本ではない）。
+4. 本ファイルが存在しない場合、レビュー Skill は「プロジェクト固有の
+   secret 管理方針は宣言されていない」ことを前提に、
+   [`.claude/rules/review-principles.md`](../../.claude/rules/review-principles.md)
+   §7 の一般原則（推測に基づく断定禁止）に従い、finding に
+   「〜方針を仮定・要確認」と明示する。severity を下げるのは env 管理
+   慣習の傍証（§5 手順 2〜3）がある場合に限り、傍証ゼロで下げない。
+5. **本方針は「secret をコミットしてよい」という一般許可ではない**。
+   既定は禁止（リテラル secret は Critical/Major 判定の対象）であり、
+   §3 の allowlist は根拠を伴う明示的な例外宣言である。
+
+## 3. env 管理が正規運用のキー（allowlist）
+
+> 「このキーはリテラル値で `.env*` / config に置くことがチーム方針として
+> 意図されている」ものを列挙する。ここに載っていないキーのリテラル値は
+> 通常どおり Critical/Major 判定の対象とする。
+
+| キー名（またはパターン）       | 用途                                    | 根拠（決めた理由・issue/PR 等） | 最終更新       |
+| ------------------------------ | --------------------------------------- | ------------------------------- | -------------- |
+| `<例: INTERNAL_PROXY_API_KEY>` | `<例: 社内 proxy 認証用、外部公開なし>` | `<例: #123 で env 管理を決定>`  | `<YYYY-MM-DD>` |
+
+未記入の場合: 「未検証（allowlist 未整備）」と明記する。
+
+## 4. Secrets Manager 注入方針（該当する場合）
+
+- 対象: `<例: 本番環境の DB 認証情報、外部 API の顧客向けキー>`
+- 注入経路: `<例: ECS taskdef の valueFrom / Terraform の secretsmanager データソース>`
+- 検証方法（レビュー時にこれを見れば注入方針か判断できる箇所）:
+  - `<例: infra/**/*.tf の \`valueFrom\` / \`secretsmanager_secret\` 参照>`
+  - `<例: buildspec.yml の環境変数取得ステップ>`
+  - `<例: CI ワークフローの secrets コンテキスト参照>`
+
+未整備の場合: 「未検証（Secrets Manager 運用なし、または未文書化）」と明記する。
+
+## 5. 判定手順（レビュー Skill が参照する要約）
+
+secret/config のリテラル値を検出した場合の判定順序:
+
+1. **allowlist 一致確認**: §3 のキー名・パターンに一致するか確認する。
+   一致すれば方針どおりであり、Critical/Major には **しない**（info 相当）。
+2. **同ファイル内の他キーとの記法比較**: 同じファイル内の他のキーが
+   すべてプレースホルダ（`${VAR}` 等）で、対象キーだけがリテラルなら
+   逸脱の疑いが強まる（severity を上げる根拠になり得る）。逆に他キーも
+   同様にリテラルなら「このファイルは元々 env 管理」の傍証になる。
+3. **実装側の注入方針との突合**: taskdef / terraform の `valueFrom`、
+   buildspec の `.env` コピー処理、CI の secrets 取り扱いを実際に確認する
+   （§4 が整備されていればそこを見る、なければ探索する）。
+4. **検証不能な場合**: allowlist 未整備・実装側証跡が確認できない場合は
+   finding のコメントに「〜方針を仮定・要確認」と明示した上で severity を
+   確定する（黙って Critical にしない）。severity を一段階下げるのは
+   手順 2〜3 で env 管理慣習の傍証が得られた場合に限る。**例外**: 明白に
+   外部サービスのライブ認証情報と推定されるもの（cloud provider キー・
+   既知の secret scanner 検出パターン一致等）は、方針が検証できなくても
+   Critical を維持する（downgrade 禁止）。
+5. **前提の自己反証**（review-gate 側の必須ステップ）: 「Secrets Manager
+   注入が方針」という前提が逆（env 管理が方針）だった場合に severity が
+   どう変わるかを 1 行で書く。逆転させても Critical のままなら判定は
+   頑健、逆転で severity が下がるなら「前提依存の指摘」であることを
+   finding に明記する。
+
+## 6. 本ドキュメントが対象としないもの
+
+- secret を検出する手段（grep / secret scanner 等の実装）は対象外
+  （本ファイルは severity 判定の **前提となる方針データ** のみを扱う）。
+- 実際にコミットされてしまった secret のローテーション手順は対象外
+  （インシデント対応 runbook 側の責務）。
+
+## 関連
+
+- Issue: [#731](https://github.com/s977043/plangate/issues/731)
+  （review-gate/adversarial-review の calibration 改善提案）
+- Skill: `review-gate`（policy-grounding チェック / 前提の自己反証の実装先。
+  [`plugin/plangate/skills/review-gate/SKILL.md`](../../plugin/plangate/skills/review-gate/SKILL.md)）
+- Rule: [`.claude/rules/review-principles.md`](../../.claude/rules/review-principles.md)
+  §7 False-positive ガード（観点・Severity・判定基準の正本）

--- a/docs/ai/secret-management-policy.md
+++ b/docs/ai/secret-management-policy.md
@@ -61,7 +61,7 @@ Critical を付けると false-block を生む。本ドキュメントは
 - 対象: `<例: 本番環境の DB 認証情報、外部 API の顧客向けキー>`
 - 注入経路: `<例: ECS taskdef の valueFrom / Terraform の secretsmanager データソース>`
 - 検証方法（レビュー時にこれを見れば注入方針か判断できる箇所）:
-  - `<例: infra/**/*.tf の \`valueFrom\` / \`secretsmanager_secret\` 参照>`
+  - `<例: infra/**/*.tf の valueFrom / secretsmanager_secret 参照>`
   - `<例: buildspec.yml の環境変数取得ステップ>`
   - `<例: CI ワークフローの secrets コンテキスト参照>`
 

--- a/plugin/plangate/skills/review-gate/SKILL.md
+++ b/plugin/plangate/skills/review-gate/SKILL.md
@@ -15,11 +15,11 @@ severity=critical の finding がある場合、fix なしに Completion Gate �
 
 ## Common Rationalizations
 
-| こう思ったら | 現実 |
-|---|---|
-| 「テストが通ったからレビュー不要」 | テスト通過はロジック正確性の一部に過ぎない。セキュリティ・仕様準拠は別途確認が必要 |
-| 「小さな変更だから critical は出ない」 | 規模に関わらず 6 観点でチェックせよ。1 行の変更でも脆弱性は混入する |
-| 「外部レビューを受けたから大丈夫」 | review type の EvidenceItem として記録せよ。記録なき承認は存在しない |
+| こう思ったら                           | 現実                                                                               |
+| -------------------------------------- | ---------------------------------------------------------------------------------- |
+| 「テストが通ったからレビュー不要」     | テスト通過はロジック正確性の一部に過ぎない。セキュリティ・仕様準拠は別途確認が必要 |
+| 「小さな変更だから critical は出ない」 | 規模に関わらず 6 観点でチェックせよ。1 行の変更でも脆弱性は混入する                |
+| 「外部レビューを受けたから大丈夫」     | review type の EvidenceItem として記録せよ。記録なき承認は存在しない               |
 
 ## 手順
 
@@ -34,14 +34,53 @@ severity=critical の finding がある場合、fix なしに Completion Gate �
 
 `/pg-check` の Findings を以下の 6 観点に分類する:
 
-| # | 観点 | チェック内容 |
-|---|------|------------|
-| 1 | **仕様準拠** | 受入基準・設計書との一致 |
-| 2 | **コード品質** | 可読性・命名・構造の明確さ |
-| 3 | **セキュリティ** | 入力バリデーション・認証・認可・機密情報 |
-| 4 | **パフォーマンス** | N+1 クエリ・ループ内 I/O・不要データ取得 |
-| 5 | **テスト不足** | カバレッジ・エッジケース・重要パスの未テスト |
-| 6 | **破壊的変更** | 後方互換性・API 変更・スキーマ変更 |
+| #   | 観点               | チェック内容                                 |
+| --- | ------------------ | -------------------------------------------- |
+| 1   | **仕様準拠**       | 受入基準・設計書との一致                     |
+| 2   | **コード品質**     | 可読性・命名・構造の明確さ                   |
+| 3   | **セキュリティ**   | 入力バリデーション・認証・認可・機密情報     |
+| 4   | **パフォーマンス** | N+1 クエリ・ループ内 I/O・不要データ取得     |
+| 5   | **テスト不足**     | カバレッジ・エッジケース・重要パスの未テスト |
+| 6   | **破壊的変更**     | 後方互換性・API 変更・スキーマ変更           |
+
+### ステップ 2.5: secret/config finding の policy-grounding チェック（#731）
+
+> **背景**: 独立した複数レビューエージェント（security / backend / adversarial
+> 等）が「Secrets Manager 注入が正規運用」という**同一の前提を共有**すると、
+> adversarial のはずが合意形成で誤りを補強し、false-Critical を生む
+> （#731 観測: `.env.production` の内部 proxy 用リテラル API キーを 3 エージェント
+> 全員が Critical 判定 → 実際は env 管理が意図的なチーム方針だった）。
+> secret/config のリテラル値は絶対的なアンチパターンではなく**プロジェクトの
+> 管理方針に依存する**。以下は「セキュリティ」観点で secret/config のリテラル値を
+> Critical/Major と判定する**前**に必ず行う。
+
+セキュリティ観点の finding が secret/config リテラル値（API キー・トークン・
+接続文字列等）に関するものである場合:
+
+1. **policy-grounding チェック**: severity を確定する前に、以下いずれかで
+   プロジェクトの実際の管理方針を検証する。検証せずに一般論（「リテラル値は
+   常にアンチパターン」）で Critical/Major を付けない。
+   - `docs/ai/secret-management-policy.md`（存在すれば、§3 allowlist・§5 判定
+     手順を正本として参照する）
+   - 同一ファイル内の他キーの記法（他キーもリテラルか、プレースホルダ
+     `${VAR}` か）
+   - taskdef / terraform の `valueFrom`、buildspec の `.env` コピー処理、CI の
+     secrets 取り扱いなど実装側の注入方針
+   - 検証できなければ finding に「〜方針を仮定・要確認」と明示した上で
+     severity を確定する（黙って Critical にしない）。severity を一段階
+     下げるのは env 管理慣習の傍証（同ファイル内の他キーもリテラル等）が
+     ある場合に限る。傍証ゼロで下げない
+   - **例外（downgrade 禁止）**: 明白に外部サービスのライブ認証情報と
+     推定されるもの（cloud provider キー・既知の secret scanner 検出
+     パターン一致等）は、方針が検証できなくても Critical を維持する
+2. **前提の自己反証**: 「この指摘は前提（例: Secrets Manager 注入が方針）に
+   依存していないか」「前提が逆（env 管理が方針）なら severity はどう変わるか」
+   を finding に 1 行で書く。逆転させても severity が変わらないなら判定は
+   頑健、逆転で下がるなら「前提依存の指摘」であることを明記する。
+3. 手順・allowlist の詳細は
+   [`docs/ai/secret-management-policy.md`](../../../../docs/ai/secret-management-policy.md)
+   を正本とする（本 Skill は判定手順の呼び出しのみを担い、allowlist データは
+   持たない）。
 
 ### ステップ 3: critical finding の有無を判定する
 
@@ -66,14 +105,14 @@ reason: severity=critical の finding が <N> 件あります。fix 後に再レ
 
 #### Findings（6 観点）
 
-| 観点 | Finding | Severity | 対応 |
-|-----|---------|---------|------|
-| 仕様準拠 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
-| コード品質 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
-| セキュリティ | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| 観点           | Finding                    | Severity     | 対応         |
+| -------------- | -------------------------- | ------------ | ------------ |
+| 仕様準拠       | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| コード品質     | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| セキュリティ   | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
 | パフォーマンス | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
-| テスト不足 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
-| 破壊的変更 | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| テスト不足     | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
+| 破壊的変更     | \<finding または「なし」\> | \<severity\> | \<対応内容\> |
 
 #### 総合判定
 
@@ -100,6 +139,7 @@ reason: severity=critical の finding が <N> 件あります。fix 後に再レ
 > 5 観点・Severity・判定基準（`.claude/rules/review-principles.md` §2-4）は**不変**。本ブロックは Plan 正本との突合観点を補う追加レーン（観点数を増やさず C-2 設計妥当性レーン §7-bis と整合）。
 
 ### Plan Alignment
+
 - plan.md の Task 要件を満たしているか
 - design.md の設計判断から逸脱していないか（逸脱なら理由明示）
 - Target Files 外を変更していないか
@@ -107,10 +147,12 @@ reason: severity=critical の finding が <N> 件あります。fix 後に再レ
 - 余計な機能を追加していないか（scope creep）
 
 ### Evidence Alignment
+
 - test-cases.md と Evidence Ledger が対応しているか
 - TDD 必須 mode で RED/GREEN 証跡があるか（#584 の tdd_red/green phase。証跡なしは **major**）
 
 ### Production Readiness
+
 - エラー処理の具体性 / 後方互換 / セキュリティ・データ損失 / ドキュメント更新
 
 ## 関連
@@ -119,3 +161,4 @@ reason: severity=critical の finding が <N> 件あります。fix 後に再レ
 - Command: `/pg-check`（差分レビュー・finding 収集）
 - Skill: `evidence-ledger`（EvidenceItem 記録手順）
 - Rule: `review-principles.md`（レビューの姿勢・禁止事項・False-positive ガード）
+- Doc: `docs/ai/secret-management-policy.md`（secret/config policy-grounding の allowlist・判定手順正本 / #731）


### PR DESCRIPTION
## 概要

intake 第2バッチ。#731（secret 判定の false-Critical 抑制）を実装し、#727（ガードレール）は **gap 分析の結果「不足ゼロ・実装ゼロ」が正しい結論**のため issue コメントでクローズする。

Closes #731 / Refs #727（実装なし・突合表コメントでクローズ）

## #731: policy-grounding ガード

観測された failure mode:「独立した複数レビューエージェントが**同一の前提**（Secrets Manager が方針）を共有すると、adversarial のはずが同方向に倒れ、合意が誤りを補強する」。

| 成果物 | 内容 |
|---|---|
| `docs/ai/secret-management-policy.md`（新規） | secret 管理方針の宣言テンプレート正本。**既定は禁止（リテラル secret = Critical/Major 対象）・allowlist は例外宣言**を明文化 |
| `plugin/plangate/skills/review-gate/SKILL.md` | ステップ 2.5 新設: (a) policy-grounding チェック（policy → 同ファイル他キー記法 → taskdef/terraform/buildspec/CI 実慣習の順で検証） (b) 前提の自己反証（前提が逆なら severity はどう変わるか）を必須化 |

**opus レビューが major を検出・是正済み**: 初版の「検証不能なら severity 引き下げ必須」は、policy 未整備のリポジトリで**実際に漏洩したライブ認証情報まで自動降格される安全側逆転**だった → annotate（要確認明示）を既定・降格は env 管理慣習の傍証がある場合のみ・**明白なライブ外部認証情報（cloud provider キー等）は降格禁止**に修正。

## #727: gap 分析（実装ゼロの根拠）

4原則（Think Before Coding / Simplicity First / Surgical Changes / Goal-Driven）・Plan レビュー観点・実行前チェックリストを core-contract / **#735 plangate-working-discipline** / behavior-norms / AI運用4原則と1項目ずつ突合 → **全項目カバー済み**。issue の受入条件「重複がある場合は新規追加ではなく既存強化として整理する」に該当。詳細な突合表は #727 のクローズコメント参照。

## Human への申し送り（本 PR では実施しない）

1. **review-principles.md §7（HO）への追記提案**: 「secret/config リテラルの Critical/Major 判定は secret-management-policy.md の policy-grounding 検証を経ること」— HO パスのため採否は Human 判断（採用時は apply-script 化可能）
2. `plugin/plangate/skills/review-gate/SKILL.md` は `.agents/skills/` に対応ソースのない **orphan**（sync 対象外）— 構造的 drift として別 issue 起票済み

## 注記

- SKILL.md の diff にフォーマッタ hook の整形（テーブル整列等 約40行）が混入。実質変更はステップ 2.5 追加のみ
- 残存 markdownlint MD040×2 は HEAD 由来の既存（本変更で導入せず・CI globs 対象外を実測確認）
- **マージしない**（C-4 待ち・auto-merge 設定済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
