### PR TITLE
feat(ai-loop): Run-006 — deterministic 構造化（F-18・human承認A・escalate第2型の初通過）

### DIFF
--- a/docs/workflows/ai-loop/loopspec.md
+++ b/docs/workflows/ai-loop/loopspec.md
@@ -51,8 +51,10 @@ loop:
     maker: string # 必須。生成側の識別子（例: implementation_agent）
     checker: string # 必須。maker と異なる主体でなければならない（I-2）
   verification:
-    deterministic: # 必須（最低1件）。機械検証コマンド
-      - string
+    deterministic: # 必須（最低1件）。機械検証コマンド（構造化 — F-18/Run-006）
+      - cmd: string # 純粋なシェルコマンド（注記・期待値を混ぜない。そのまま実行可能）
+        expect_exit: int # 任意。期待 exit code（既定 0）
+        note: string # 任意。人間可読の注記（期待値の要点・AC 対応。実行には使わない）
     review: # 必須（最低1件）。裁定・レビュー観点
       - string # 例: requirements_fit / architecture_consistency / security_risk
   stopping_rule:
@@ -77,25 +79,28 @@ loop:
 
 ## 3. フィールド定義（必須 / 任意 / 既定値）
 
-| フィールド                              | 必須/任意                 | 既定値（未指定時）                                                   | 説明                                                                                                       |
-| --------------------------------------- | ------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `loop.name`                             | 必須                      | なし（欠落は起票拒否）                                               | ループの一意識別子                                                                                         |
-| `loop.trigger.type`                     | 必須                      | なし                                                                 | `manual` / `issue_created` / `pr_opened` / `scheduled` の4値                                               |
-| `loop.trigger.detail`                   | 任意                      | 空                                                                   | scheduled 時の実行条件補足                                                                                 |
-| `loop.goal.description`                 | 必須                      | なし                                                                 | 自然文での目的記述                                                                                         |
-| `loop.goal.exit_criteria_ref`           | 必須                      | なし（**安全側**: 未指定は closed loop 扱い不可＝polling 扱い、I-4） | merge-ready 到達条件の参照先                                                                               |
-| `loop.context.include`                  | 必須（1件以上）           | なし                                                                 | 持ち込む情報の種類の列挙                                                                                   |
-| `loop.context.exclude`                  | 必須（0件可だが明示必須） | 空配列でも明示要                                                     | stale 情報の除外を宣言的に強制する（黙示の「見せない」を許さない）                                         |
-| `loop.actors.maker`                     | 必須                      | なし                                                                 | 生成側識別子                                                                                               |
-| `loop.actors.checker`                   | 必須                      | なし（**maker と同一値は不可**。I-2 違反として拒否）                 | 検証側識別子                                                                                               |
-| `loop.verification.deterministic`       | 必須（1件以上）           | なし                                                                 | 機械検証コマンド列挙                                                                                       |
-| `loop.verification.review`              | 必須（1件以上）           | なし                                                                 | レビュー観点列挙                                                                                           |
-| `loop.stopping_rule.terminal_state_ref` | 必須                      | なし                                                                 | decision-table.md への参照固定                                                                             |
-| `loop.stopping_rule.round_limit_ref`    | 必須                      | なし                                                                 | execution-runbook.md §2-(7) への参照固定（数値の再定義禁止）                                               |
-| `loop.memory.write`                     | 必須（1件以上）           | なし                                                                 | 保存する記録種別                                                                                           |
-| `loop.memory.ref`                       | 必須                      | なし                                                                 | execution-runbook.md §2-(4)（decision record 保存の正本）への参照固定。L4 学習側は review-feedback-loop.md |
-| `loop.escalation.touches_ho`            | 固定値 `unconditional`    | `unconditional`（変更不可）                                          | I-1/I-8 に基づく絶対条件。LoopSpec が上書きすることは許容しない                                            |
-| `loop.escalation.budget_ref`            | 必須                      | なし                                                                 | arbiter-policy.md §7 への参照固定                                                                          |
+| フィールド                                      | 必須/任意                 | 既定値（未指定時）                                                   | 説明                                                                                                                                                                   |
+| ----------------------------------------------- | ------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `loop.name`                                     | 必須                      | なし（欠落は起票拒否）                                               | ループの一意識別子                                                                                                                                                     |
+| `loop.trigger.type`                             | 必須                      | なし                                                                 | `manual` / `issue_created` / `pr_opened` / `scheduled` の4値                                                                                                           |
+| `loop.trigger.detail`                           | 任意                      | 空                                                                   | scheduled 時の実行条件補足                                                                                                                                             |
+| `loop.goal.description`                         | 必須                      | なし                                                                 | 自然文での目的記述                                                                                                                                                     |
+| `loop.goal.exit_criteria_ref`                   | 必須                      | なし（**安全側**: 未指定は closed loop 扱い不可＝polling 扱い、I-4） | merge-ready 到達条件の参照先                                                                                                                                           |
+| `loop.context.include`                          | 必須（1件以上）           | なし                                                                 | 持ち込む情報の種類の列挙                                                                                                                                               |
+| `loop.context.exclude`                          | 必須（0件可だが明示必須） | 空配列でも明示要                                                     | stale 情報の除外を宣言的に強制する（黙示の「見せない」を許さない）                                                                                                     |
+| `loop.actors.maker`                             | 必須                      | なし                                                                 | 生成側識別子                                                                                                                                                           |
+| `loop.actors.checker`                           | 必須                      | なし（**maker と同一値は不可**。I-2 違反として拒否）                 | 検証側識別子                                                                                                                                                           |
+| `loop.verification.deterministic`               | 必須（1件以上）           | なし                                                                 | 構造化された機械検証コマンドの列挙（下記 3 サブフィールド）                                                                                                            |
+| `loop.verification.deterministic[].cmd`         | 必須                      | なし                                                                 | 純粋なシェルコマンド。そのまま実行可能・注記や期待値を混ぜない。F-12/F-14 規律（実機事前検証・証跡）は本フィールドに適用                                               |
+| `loop.verification.deterministic[].expect_exit` | 任意                      | 0                                                                    | 期待 exit code。**count ≥ N 型の判定は cmd 内で exit code に畳み込む**（例: `test "$(grep -cF x f)" -ge 2`。`grep -c` 単体は件数 1 でも exit 0 になる footgun に注意） |
+| `loop.verification.deterministic[].note`        | 任意                      | 空                                                                   | 人間可読注記（AC 対応の説明）。実行には使わない                                                                                                                        |
+| `loop.verification.review`                      | 必須（1件以上）           | なし                                                                 | レビュー観点列挙                                                                                                                                                       |
+| `loop.stopping_rule.terminal_state_ref`         | 必須                      | なし                                                                 | decision-table.md への参照固定                                                                                                                                         |
+| `loop.stopping_rule.round_limit_ref`            | 必須                      | なし                                                                 | execution-runbook.md §2-(7) への参照固定（数値の再定義禁止）                                                                                                           |
+| `loop.memory.write`                             | 必須（1件以上）           | なし                                                                 | 保存する記録種別                                                                                                                                                       |
+| `loop.memory.ref`                               | 必須                      | なし                                                                 | execution-runbook.md §2-(4)（decision record 保存の正本）への参照固定。L4 学習側は review-feedback-loop.md                                                             |
+| `loop.escalation.touches_ho`                    | 固定値 `unconditional`    | `unconditional`（変更不可）                                          | I-1/I-8 に基づく絶対条件。LoopSpec が上書きすることは許容しない                                                                                                        |
+| `loop.escalation.budget_ref`                    | 必須                      | なし                                                                 | arbiter-policy.md §7 への参照固定                                                                                                                                      |
 
 **安全側デフォルト（I-4 の適用）**: 上記「必須」フィールドが欠落・空・判定不能な LoopSpec は
 **closed loop として受理せず、Arbiter 統治外での実行も許可しない**（human へ差し戻す）。
@@ -105,6 +110,8 @@ loop:
 deterministic の各コマンドは、計画時に**実機で PASS/FAIL 両方向**（PASS する入力と FAIL する入力の双方）の挙動を確認してから AC に採用する。環境差 — BSD/GNU 等 — でサイレントに空を返す・ハードエラーになるコマンドの混入を防ぐ（実例: Run-003 R1/R2・Run-004 R1）。
 
 また、『実機で確認した』という申告には**実行出力（コマンドと結果）の貼付**を必須とする。証跡のない事前検証申告は未検証として扱う（実例: Run-004 R1 — 申告のみで未検証だった AC が W チェックで exit 2 を実機再現され虚偽と判明）。
+
+本規律は構造化後の `cmd` フィールドに適用される（`note` は実行対象外）。
 
 ---
 
@@ -133,8 +140,12 @@ loop:
     checker: review_agent
   verification:
     deterministic:
-      - "markdownlint docs/**/*.md"
-      - "scripts/check-links.sh docs/"
+      - cmd: "markdownlint docs/**/*.md"
+        expect_exit: 0
+        note: "全 docs 配下の markdownlint エラー 0 件"
+      - cmd: 'test "$(scripts/check-links.sh docs/ | grep -cF ''BROKEN'')" -eq 0'
+        expect_exit: 0
+        note: "リンク切れ 0 件（count 型は cmd 内 test で exit code に畳み込み）"
     review:
       - requirements_fit
       - architecture_consistency

--- a/docs/working/ai-loop-runs/20260707T050311Z-7703b50-run006.json
+++ b/docs/working/ai-loop-runs/20260707T050311Z-7703b50-run006.json
@@ -1,0 +1,14 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "HUMAN_ESCALATED",
+  "issued_by": "arbiter-v0.1",
+  "lite_check": false,
+  "policy_ref": "auto-approve-lite-clean@v0",
+  "target_sha": "7703b50",
+  "timestamp": "2026-07-07T05:03:11Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}

--- a/docs/working/ai-loop-runs/20260707T055726Z-7703b50-run006-final.json
+++ b/docs/working/ai-loop-runs/20260707T055726Z-7703b50-run006-final.json
@@ -1,0 +1,14 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v0",
+  "target_sha": "7703b50",
+  "timestamp": "2026-07-07T05:57:27Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}

--- a/docs/working/ai-loop-runs/run-001-frictions.md
+++ b/docs/working/ai-loop-runs/run-001-frictions.md
@@ -107,3 +107,21 @@
 | F-16 | （成功）教訓の事前適用でラウンド数が 3→1 に短縮。**「前 run の reject 理由を次 run の計画チェックリストに変換する」**が最も効率の高い Optimize であることの実測 | 成功シグナル |
 | F-17 | B 指摘の残課題（実害化前）: 証跡の「貼付」水準が要約で満たされ得る曖昧さ・貼付内容の改竄（実行していない出力の捏造）には無力。多層防御（deterministic 再実行 + adversarial 再検証）が前提であることを規律の限界として明記すべき | 証跡の限界 |
 | F-18 | LoopSpec の deterministic 欄が「コマンド+日本語注記」混在で、そのままシェル実行できない（C-4 Gemini 指摘・Run-005）。**「純粋コマンド + 期待 exit code」の分離フィールド形式**（例: cmd / expect_exit / expect_stdout）へ loopspec.md テンプレートを改善する — 将来の自動実行（L3）への布石にもなる | テンプレート形式 |
+
+---
+
+## Run-006 追記
+
+### 結果サマリ（Run-006）
+
+- 経過: **誠実 lite 申告（no_new_design=false）→ flow 段階で HUMAN_ESCALATED（W チェック前の
+  設計判断事前検出 — Run-001 とは別の escalate 経路の初通過）** → 人間判断「A」（構造体
+  cmd/expect_exit/note）→ no_new_design=true へ更新 → R1 A✓/B✓ ワンラウンド合意（3連続）→
+  AUTO_APPROVED → exec 全 AC PASS（maker が記入例の -ge 0 常真バグを自己検出し -eq 0 へ修正）
+
+### 摩擦点（Remember）
+
+| #    | 観測事実 | 種別 |
+| ---- | -------- | ---- |
+| F-19 | B 検出の footgun（実害前）: 構造体 A は expect_stdout を持たず、count ≥ N 型判定は exit code 単体で表現できない（grep -c は件数 1 でも exit 0）。対策として「cmd 内で test 畳み込み」を §3 に明記済み。将来 L3 自動実行の設計時に expect_stdout 追加を再検討 | スキーマ表現力 |
+| F-20 | （成功）「設計判断を含む run は lite を誠実に false 申告 → W チェック前に human へ」の経路が機能。escalate の 2 型（Run-001: W チェックが検出 / Run-006: 申告段階で自己検出）が出揃い、後者はレビューコスト（W 2体分）を節約 | escalate 経路 |

--- a/docs/working/ai-loop-runs/run-006-loopspec.md
+++ b/docs/working/ai-loop-runs/run-006-loopspec.md
@@ -1,0 +1,61 @@
+# ai-loop Run-006 — LoopSpec + 計画（F-18: deterministic 欄の構造化・設計判断あり）
+
+> **本 run は lite 自己判定を誠実に no_new_design=false とする**: deterministic の
+> スキーマ変更（文字列リスト → 構造体）には複数の設計選択肢があり、Run-001 の教訓
+> （スキーマ拡張 = new design）に照らし I-4 安全側に倒す。よって flow 段階で
+> **human escalate が正しい挙動**であり、W チェックは実施せず設計選択肢を人間へ提示する。
+
+## LoopSpec（骨子）
+
+```yaml
+loop:
+  name: run-006-deterministic-schema
+  trigger: {type: manual, detail: "F-18（#745 C-4 Gemini 指摘由来）の Optimize"}
+  goal:
+    description: "loopspec.md の verification.deterministic を『純粋コマンド + 期待値』の分離形式へ改定"
+  actors: {maker: implementation_agent(sonnet), checker: w-check(A/B)}
+  escalation: {touches_ho: unconditional, budget_ref: "arbiter-policy.md §7"}
+```
+
+- **boundary**: clean（docs/workflows/ai-loop/）
+- **lite**: size_ok=true / **no_new_design=false（スキーマ設計の選択肢あり — 下記）** /
+  follows_pattern=true / reversible=true
+- **class**: no-merge
+
+## Human への設計選択肢（escalate 事項）
+
+| 案 | 形式 | 利点 | 欠点 |
+|---|---|---|---|
+| **A（推奨）** | 構造体: `- cmd: <純粋シェルコマンド>` / `expect_exit: <int・既定0>` / `note: <任意・人間可読>` | 機械実行可能（L3 自動実行への布石）・期待値が明示・注記の混入を構造で排除 | 既存 run 記録と形式が異なる（時点記録ゆえ移行不要） |
+| B | 文字列リスト維持 + 規約「コマンドのみ・注記は別欄 notes に」 | 変更最小 | 規約頼み（Run-005 と同型の混入が再発しうる） |
+| C | 並行リスト（commands / expects） | 単純 | 対応関係がインデックス頼みで壊れやすい |
+
+推奨 **A**: F-18 の趣旨（そのままシェル実行可能）を構造で保証し、Run-004/005 で確立した
+「AC 固定句・実機事前検証・証跡」の規律とも `note` 欄で両立する。
+
+---
+
+## Human 判断の記録（escalate 解消）
+
+**2026-07-07 ユーザー回答: 「A」** — 構造体形式（`cmd` / `expect_exit` / `note`）を採用。
+設計判断は human 承認済みとなったため、以降の実装は **no_new_design=true**（Run-002 の
+先例: 方向性の human 決定後、run は実装のみを担う）。
+
+## 確定計画（W チェック対象）
+
+- **対象**: `docs/workflows/ai-loop/loopspec.md` 1 ファイルのみ
+  1. §2 YAML の `deterministic` を構造体定義に置換:
+     `- cmd: string`（純粋シェルコマンド・そのまま実行可能・注記や期待値を混ぜない）/
+     `expect_exit: int`（任意・既定 0）/ `note: string`（任意・人間可読、実行に使わない）
+  2. §3 フィールド定義表の `loop.verification.deterministic` 行を構造体仕様に更新し、
+     `cmd` / `expect_exit` / `note` の 3 行を追加（既存表記規約 `loop.verification.deterministic[].cmd` 形式）
+  3. §4 記入例の deterministic を新形式へ書き換え（例自体は living なテンプレート例であり
+     run の時点記録ではない — 原則 11 の対象外）
+  4. F-12/F-14 規律文（実機事前検証・証跡）は `cmd` に対して適用される旨を 1 文で接続
+- **AC（実機事前検証済み・証跡は上記実行ログ）**:
+  1. `grep -cF 'expect_exit' docs/workflows/ai-loop/loopspec.md` → **2 以上**（スキーマ+記入例。現状 0/exit1 実測・サンプル 1 実測）
+  2. `grep -cF -- '- cmd:' docs/workflows/ai-loop/loopspec.md` → **2 以上**（現状 0/exit1 実測・サンプル 1 実測）
+  3. markdownlint（repo 設定）→ 0 error
+  4. `git diff --name-only origin/main` が loopspec.md + run 記録に収まる
+- **lite（更新）**: size_ok=true / **no_new_design=true（human 承認済み設計の実装）** /
+  follows_pattern=true / reversible=true


### PR DESCRIPTION
## 概要
**ai-loop Run-006**: LoopSpec の `verification.deterministic` を構造体（`cmd`/`expect_exit`/`note`）へ改定（F-18・#745 C-4 指摘由来）。**L3 自動実行への布石**。

## ハイライト
- **escalate 第 2 型の初通過**: スキーマ設計の選択肢を理由に **lite を誠実に false 申告 → W チェック前に HUMAN_ESCALATED**（Run-001 の「W チェックが検出」型と対をなす「申告段階の自己検出」型・レビューコスト節約 = F-20）→ 人間判断「A」→ ワンラウンド合意 → AUTO_APPROVED
- B 検出の footgun（count≥N は exit code 単体で表現不能）を **test 畳み込み注記**として §3 に反映（F-19）
- maker が記入例の `-ge 0` 常真バグを自己検出し `-eq 0` へ修正

boundary=clean・1 ファイル・**マージしない**（C-4 待ち・auto-merge 設定済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)