### PR TITLE
feat(#720,#721,#722): doctor に W-6 検知 / skill 名衝突 / pre-push ガード検査を追加

### DIFF
--- a/scripts/doctor_check.py
+++ b/scripts/doctor_check.py
@@ -293,7 +293,7 @@ def check_skill_collisions() -> dict:
     except (OSError, subprocess.TimeoutExpired) as exc:
         return {
             "name": name,
-            "ok": True,
+            "ok": False,
             "level": "warn",
             "detail": f"could not run collision check: {exc}",
         }
@@ -301,9 +301,9 @@ def check_skill_collisions() -> dict:
     if proc.returncode not in (0, 1):
         return {
             "name": name,
-            "ok": True,
+            "ok": False,
             "level": "warn",
-            "detail": f"collision check exited with unexpected code {proc.returncode} (skip)",
+            "detail": f"collision check exited with unexpected code {proc.returncode}",
         }
 
     collision = proc.returncode == 1
@@ -325,6 +325,19 @@ def check_prepush_guard() -> dict:
     乖離を防ぐため、hook ファイルの存在・実行可能性を検査する。
     """
     hook = REPO / ".git" / "hooks" / "pre-push"
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(REPO), "rev-parse", "--git-path", "hooks/pre-push"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            resolved = Path(proc.stdout.strip())
+            hook = resolved if resolved.is_absolute() else REPO / resolved
+    except (OSError, subprocess.TimeoutExpired):
+        pass  # 非 git 環境 (テスト sandbox 等) はハードコードパスにフォールバック
     installed = hook.is_file() and os.access(hook, os.X_OK)
     return {
         "name": "pre-push guard installed (#722)",

--- a/scripts/doctor_check.py
+++ b/scripts/doctor_check.py
@@ -216,6 +216,130 @@ def run_hooks_checks() -> dict:
     }
 
 
+def check_w6_introduction() -> dict:
+    """#720 follow-up: W-6 (C-3 Autonomous APPROVE 判定マトリクス) が未導入の
+
+    まま autonomous APPROVE 記録が存在する場合に WARN する (doc 仕様:
+    docs/ai/w6-autonomous-approve-introduction.md 5).
+
+    W6NotIntroduced: working-context.md (または相当ファイル) に見出し文字列
+    "C-3 Autonomous APPROVE" が存在しない。
+    AutonomousApproveRecordExists: docs/working/TASK-*/status.md のいずれかに
+    "C-3 Gate: AUTONOMOUS APPROVED" 文字列が存在する。
+    """
+    wc = REPO / ".claude" / "rules" / "working-context.md"
+    heading_marker = "C-3 Autonomous APPROVE"
+    introduced = False
+    if wc.is_file():
+        try:
+            introduced = heading_marker in wc.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            introduced = False
+
+    record_tasks: list[str] = []
+    working_dir = REPO / "docs" / "working"
+    if working_dir.is_dir():
+        for task_dir in sorted(working_dir.glob("TASK-*")):
+            status = task_dir / "status.md"
+            if not status.is_file():
+                continue
+            try:
+                text = status.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if "C-3 Gate: AUTONOMOUS APPROVED" in text:
+                record_tasks.append(task_dir.name)
+
+    gap = (not introduced) and bool(record_tasks)
+    return {
+        "name": "W-6 autonomous APPROVE introduction gap (#720)",
+        "ok": not gap,
+        "level": "warn",
+        "detail": None
+        if not gap
+        else (
+            f"W-6 未導入だが AUTONOMOUS APPROVED 記録が {len(record_tasks)} 件検出 "
+            f"({', '.join(record_tasks)}). "
+            "導入手順: docs/ai/w6-autonomous-approve-introduction.md"
+        ),
+    }
+
+
+def check_skill_collisions() -> dict:
+    """#721 follow-up: skill/command/agent の name 多重定義を検出し WARN する。
+
+    scripts/check-skill-name-collisions.py (#692) をサブプロセスで実行し、
+    exit code 1 (衝突あり) を WARN として報告する。優先順位規約は
+    docs/ai/skill-collision-detection.md を参照 (repo-local 優先)。
+    """
+    script = REPO / "scripts" / "check-skill-name-collisions.py"
+    name = "skill/command/agent name collisions (#721)"
+    if not script.is_file():
+        return {
+            "name": name,
+            "ok": True,
+            "level": "warn",
+            "detail": "check-skill-name-collisions.py not found (skip)",
+        }
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "name": name,
+            "ok": True,
+            "level": "warn",
+            "detail": f"could not run collision check: {exc}",
+        }
+
+    if proc.returncode not in (0, 1):
+        return {
+            "name": name,
+            "ok": True,
+            "level": "warn",
+            "detail": f"collision check exited with unexpected code {proc.returncode} (skip)",
+        }
+
+    collision = proc.returncode == 1
+    first_line = (proc.stdout.splitlines() or [""])[0]
+    return {
+        "name": name,
+        "ok": not collision,
+        "level": "warn",
+        "detail": None
+        if not collision
+        else f"{first_line} (repo-local 優先。詳細: docs/ai/skill-collision-detection.md)",
+    }
+
+
+def check_prepush_guard() -> dict:
+    """#722 follow-up: pre-push gh account ドリフトガード hook の導入検証。
+
+    宣言 (docs/ai/repo-guard.md) と実装 (.git/hooks/pre-push の実体) の
+    乖離を防ぐため、hook ファイルの存在・実行可能性を検査する。
+    """
+    hook = REPO / ".git" / "hooks" / "pre-push"
+    installed = hook.is_file() and os.access(hook, os.X_OK)
+    return {
+        "name": "pre-push guard installed (#722)",
+        "ok": installed,
+        "level": "warn",
+        "detail": None
+        if installed
+        else (
+            "pre-push guard 未導入 (protected branch / gh account drift 検証なし)。"
+            " 導入: sh scripts/install-pre-push.sh --dry-run -> "
+            "sh scripts/install-pre-push.sh (docs/ai/repo-guard.md)"
+        ),
+    }
+
+
 def run_v860_checks() -> dict:
     checks: list[dict] = []
     for path_rel, level in V860_FILE_CHECKS:
@@ -224,6 +348,9 @@ def run_v860_checks() -> dict:
     checks.append(check_events_gitignored())
     checks.append(check_events_actually_ignored())
     checks.append(check_events_not_tracked())
+    checks.append(check_w6_introduction())
+    checks.append(check_skill_collisions())
+    checks.append(check_prepush_guard())
 
     failures = sum(1 for c in checks if not c["ok"] and c["level"] == "fail")
     warnings = sum(1 for c in checks if not c["ok"] and c["level"] == "warn")

--- a/tests/extras/ta-51-doctor-w6.sh
+++ b/tests/extras/ta-51-doctor-w6.sh
@@ -1,0 +1,113 @@
+# tests/extras/ta-51-doctor-w6.sh
+# Sourced by tests/run-tests.sh -- uses $pass / $fail counters
+# Issue #720: doctor W-6 (C-3 Autonomous APPROVE) introduction gap detection
+#
+# Sandbox: copy scripts/doctor_check.py + scripts/_paths.py into a tmp dir
+# mimicking <tmp>/scripts + <tmp>/.claude/rules + <tmp>/docs/working so that
+# doctor_check.py's own REPO_ROOT resolution (Path(__file__).resolve().parents[1])
+# points into the sandbox (ta-39/ta-50 pattern) -- avoids touching the real repo.
+
+printf '\n=== TA-51: doctor W-6 introduction gap detection (#720) ===\n'
+
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T51_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T51_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+
+_T51_TMP=$(mktemp -d)
+if command -v register_cleanup >/dev/null 2>&1; then
+  register_cleanup "$_T51_TMP"
+fi
+
+mkdir -p "$_T51_TMP/scripts"
+mkdir -p "$_T51_TMP/.claude/rules"
+mkdir -p "$_T51_TMP/docs/working"
+cp "$_T51_ROOT/scripts/doctor_check.py" "$_T51_TMP/scripts/doctor_check.py"
+cp "$_T51_ROOT/scripts/_paths.py" "$_T51_TMP/scripts/_paths.py"
+# skill collision + pre-push checks also run as part of --scope v8.6.0; keep
+# them harmless/no-op in this sandbox (script absent -> "skip" warn, not a crash).
+
+t51_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t51_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+_t51_run() {
+  ( cd "$_T51_TMP" && python3 scripts/doctor_check.py --scope v8.6.0 2>&1 )
+}
+
+_t51_w6_ok() {
+  # $1 = json blob; prints "true"/"false" for the W-6 check's ok field
+  printf '%s' "$1" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for c in d["checks"]:
+    if c["name"].startswith("W-6"):
+        print("true" if c["ok"] else "false")
+        sys.exit(0)
+print("MISSING")
+'
+}
+
+# --- TC-01: not introduced + no record -> ok (no WARN) ---
+rm -f "$_T51_TMP/.claude/rules/working-context.md"
+rm -rf "$_T51_TMP/docs/working"/TASK-*
+_t51_out=$(_t51_run) || true
+_t51_ok=$(_t51_w6_ok "$_t51_out")
+if [ "$_t51_ok" = "true" ]; then
+  t51_pass "TC-01: not introduced + no record -> ok=true (no WARN)"
+else
+  t51_fail "TC-01: expected ok=true, got $_t51_ok"
+fi
+
+# --- TC-02: not introduced + record exists -> WARN (ok=false) ---
+printf '# rules\n(no W-6 heading here)\n' > "$_T51_TMP/.claude/rules/working-context.md"
+mkdir -p "$_T51_TMP/docs/working/TASK-9001"
+printf '## C-3 Gate: AUTONOMOUS APPROVED\n\n- w6_status: not_introduced\n' \
+  > "$_T51_TMP/docs/working/TASK-9001/status.md"
+_t51_out=$(_t51_run) || true
+_t51_ok=$(_t51_w6_ok "$_t51_out")
+if [ "$_t51_ok" = "false" ] && printf '%s' "$_t51_out" | grep -q 'TASK-9001'; then
+  t51_pass "TC-02: not introduced + record exists -> WARN (ok=false, task listed)"
+else
+  t51_fail "TC-02: expected ok=false + TASK-9001 in detail, got ok=$_t51_ok"
+fi
+
+# --- TC-03: introduced (heading present) + record exists -> ok (no WARN) ---
+printf '#### C-3 Autonomous APPROVE (autonomous exec delegation)\n\nmatrix here\n' \
+  > "$_T51_TMP/.claude/rules/working-context.md"
+_t51_out=$(_t51_run) || true
+_t51_ok=$(_t51_w6_ok "$_t51_out")
+if [ "$_t51_ok" = "true" ]; then
+  t51_pass "TC-03: introduced + record exists -> ok=true (no WARN)"
+else
+  t51_fail "TC-03: expected ok=true, got $_t51_ok"
+fi
+
+# --- TC-04: introduced + no record -> ok (no WARN) ---
+rm -rf "$_T51_TMP/docs/working"/TASK-*
+_t51_out=$(_t51_run) || true
+_t51_ok=$(_t51_w6_ok "$_t51_out")
+if [ "$_t51_ok" = "true" ]; then
+  t51_pass "TC-04: introduced + no record -> ok=true (no WARN)"
+else
+  t51_fail "TC-04: expected ok=true, got $_t51_ok"
+fi
+
+# --- TC-05: WARN never fails the overall scope (level is warn, not fail) ---
+printf '# rules\n(no W-6 heading here)\n' > "$_T51_TMP/.claude/rules/working-context.md"
+mkdir -p "$_T51_TMP/docs/working/TASK-9002"
+printf '## C-3 Gate: AUTONOMOUS APPROVED\n' > "$_T51_TMP/docs/working/TASK-9002/status.md"
+_t51_out=$(_t51_run) || true
+if printf '%s' "$_t51_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+w6 = [c for c in d["checks"] if c["name"].startswith("W-6")][0]
+assert w6["level"] == "warn"
+assert w6["ok"] is False
+' 2>/dev/null; then
+  t51_pass "TC-05: W-6 gap is level=warn (never blocks passed via failures)"
+else
+  t51_fail "TC-05: expected level=warn for W-6 gap check"
+fi
+
+rm -rf "$_T51_TMP" 2>/dev/null || true

--- a/tests/extras/ta-52-doctor-skill-collision.sh
+++ b/tests/extras/ta-52-doctor-skill-collision.sh
@@ -1,0 +1,101 @@
+# tests/extras/ta-52-doctor-skill-collision.sh
+# Sourced by tests/run-tests.sh -- uses $pass / $fail counters
+# Issue #721: doctor skill/command/agent name collision detection integration
+#
+# Sandbox: copy scripts/doctor_check.py + scripts/_paths.py +
+# scripts/check-skill-name-collisions.py into a tmp dir so doctor_check.py's
+# own REPO_ROOT resolution points into the sandbox (ta-39/ta-50 pattern).
+
+printf '\n=== TA-52: doctor skill name collision integration (#721) ===\n'
+
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T52_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T52_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+
+_T52_TMP=$(mktemp -d)
+if command -v register_cleanup >/dev/null 2>&1; then
+  register_cleanup "$_T52_TMP"
+fi
+
+mkdir -p "$_T52_TMP/scripts"
+cp "$_T52_ROOT/scripts/doctor_check.py" "$_T52_TMP/scripts/doctor_check.py"
+cp "$_T52_ROOT/scripts/_paths.py" "$_T52_TMP/scripts/_paths.py"
+cp "$_T52_ROOT/scripts/check-skill-name-collisions.py" "$_T52_TMP/scripts/check-skill-name-collisions.py"
+
+t52_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t52_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+_t52_run() {
+  ( cd "$_T52_TMP" && python3 scripts/doctor_check.py --scope v8.6.0 2>&1 )
+}
+
+_t52_collision_ok() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for c in d["checks"]:
+    if c["name"].startswith("skill/command/agent"):
+        print("true" if c["ok"] else "false")
+        sys.exit(0)
+print("MISSING")
+'
+}
+
+# --- TC-01: no .claude / plugin dirs at all -> no collision -> ok=true ---
+_t52_out=$(_t52_run) || true
+_t52_ok=$(_t52_collision_ok "$_t52_out")
+if [ "$_t52_ok" = "true" ]; then
+  t52_pass "TC-01: no skill roots -> ok=true (no collision)"
+else
+  t52_fail "TC-01: expected ok=true, got $_t52_ok"
+fi
+
+# --- TC-02: single repo-local skill (no plugin mirror) -> no collision ---
+mkdir -p "$_T52_TMP/.claude/skills/only-here"
+printf -- '---\nname: only-here\ndescription: solo\n---\n# only-here\n' \
+  > "$_T52_TMP/.claude/skills/only-here/SKILL.md"
+_t52_out=$(_t52_run) || true
+_t52_ok=$(_t52_collision_ok "$_t52_out")
+if [ "$_t52_ok" = "true" ]; then
+  t52_pass "TC-02: repo-local only skill -> ok=true (no collision)"
+else
+  t52_fail "TC-02: expected ok=true, got $_t52_ok"
+fi
+
+# --- TC-03: repo-local + plugin same name -> collision -> ok=false + WARN ---
+mkdir -p "$_T52_TMP/plugin/plugin-a/skills/only-here"
+printf -- '---\nname: only-here\ndescription: mirrored\n---\n# only-here\n' \
+  > "$_T52_TMP/plugin/plugin-a/skills/only-here/SKILL.md"
+_t52_out=$(_t52_run) || true
+_t52_ok=$(_t52_collision_ok "$_t52_out")
+if [ "$_t52_ok" = "false" ] && printf '%s' "$_t52_out" | grep -q '多重定義'; then
+  t52_pass "TC-03: repo-local + plugin collision -> ok=false (WARN with detail)"
+else
+  t52_fail "TC-03: expected ok=false + detail, got ok=$_t52_ok"
+fi
+
+# --- TC-04: WARN level is warn, not fail (never blocks passed) ---
+if printf '%s' "$_t52_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+c = [x for x in d["checks"] if x["name"].startswith("skill/command/agent")][0]
+assert c["level"] == "warn"
+' 2>/dev/null; then
+  t52_pass "TC-04: collision check is level=warn (does not count toward failures)"
+else
+  t52_fail "TC-04: expected level=warn for collision check"
+fi
+
+# --- TC-05: script missing -> ok=true (skip, not a crash) ---
+rm -f "$_T52_TMP/scripts/check-skill-name-collisions.py"
+_t52_out=$(_t52_run) || true
+_t52_ok=$(_t52_collision_ok "$_t52_out")
+if [ "$_t52_ok" = "true" ] && printf '%s' "$_t52_out" | grep -q 'not found'; then
+  t52_pass "TC-05: collision script missing -> ok=true skip (no crash)"
+else
+  t52_fail "TC-05: expected ok=true skip on missing script, got ok=$_t52_ok"
+fi
+
+rm -rf "$_T52_TMP" 2>/dev/null || true

--- a/tests/extras/ta-53-doctor-prepush.sh
+++ b/tests/extras/ta-53-doctor-prepush.sh
@@ -1,0 +1,91 @@
+# tests/extras/ta-53-doctor-prepush.sh
+# Sourced by tests/run-tests.sh -- uses $pass / $fail counters
+# Issue #722: doctor pre-push gh account drift guard installation verification
+#
+# Sandbox: copy scripts/doctor_check.py + scripts/_paths.py into a tmp dir
+# with a fake .git/hooks/pre-push so doctor_check.py's own REPO_ROOT
+# resolution points into the sandbox (ta-39/ta-50 pattern).
+
+printf '\n=== TA-53: doctor pre-push guard installation verification (#722) ===\n'
+
+if [ -n "${FIXTURES_DIR:-}" ]; then
+  _T53_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+else
+  _T53_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+fi
+
+_T53_TMP=$(mktemp -d)
+if command -v register_cleanup >/dev/null 2>&1; then
+  register_cleanup "$_T53_TMP"
+fi
+
+mkdir -p "$_T53_TMP/scripts"
+mkdir -p "$_T53_TMP/.git/hooks"
+cp "$_T53_ROOT/scripts/doctor_check.py" "$_T53_TMP/scripts/doctor_check.py"
+cp "$_T53_ROOT/scripts/_paths.py" "$_T53_TMP/scripts/_paths.py"
+
+t53_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t53_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+_t53_run() {
+  ( cd "$_T53_TMP" && python3 scripts/doctor_check.py --scope v8.6.0 2>&1 )
+}
+
+_t53_prepush_ok() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for c in d["checks"]:
+    if c["name"].startswith("pre-push guard"):
+        print("true" if c["ok"] else "false")
+        sys.exit(0)
+print("MISSING")
+'
+}
+
+# --- TC-01: no pre-push hook at all -> WARN (ok=false) ---
+rm -f "$_T53_TMP/.git/hooks/pre-push"
+_t53_out=$(_t53_run) || true
+_t53_ok=$(_t53_prepush_ok "$_t53_out")
+if [ "$_t53_ok" = "false" ] && printf '%s' "$_t53_out" | grep -q '未導入'; then
+  t53_pass "TC-01: pre-push hook absent -> WARN (ok=false, detail present)"
+else
+  t53_fail "TC-01: expected ok=false + detail, got ok=$_t53_ok"
+fi
+
+# --- TC-02: pre-push hook present but not executable -> WARN (ok=false) ---
+printf '#!/bin/sh\nexit 0\n' > "$_T53_TMP/.git/hooks/pre-push"
+chmod -x "$_T53_TMP/.git/hooks/pre-push"
+_t53_out=$(_t53_run) || true
+_t53_ok=$(_t53_prepush_ok "$_t53_out")
+if [ "$_t53_ok" = "false" ]; then
+  t53_pass "TC-02: pre-push hook present but not executable -> WARN (ok=false)"
+else
+  t53_fail "TC-02: expected ok=false, got ok=$_t53_ok"
+fi
+
+# --- TC-03: pre-push hook present and executable -> ok (no WARN) ---
+chmod +x "$_T53_TMP/.git/hooks/pre-push"
+_t53_out=$(_t53_run) || true
+_t53_ok=$(_t53_prepush_ok "$_t53_out")
+if [ "$_t53_ok" = "true" ]; then
+  t53_pass "TC-03: pre-push hook installed + executable -> ok=true (no WARN)"
+else
+  t53_fail "TC-03: expected ok=true, got ok=$_t53_ok"
+fi
+
+# --- TC-04: WARN level is warn, not fail (never blocks passed) ---
+rm -f "$_T53_TMP/.git/hooks/pre-push"
+_t53_out=$(_t53_run) || true
+if printf '%s' "$_t53_out" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+c = [x for x in d["checks"] if x["name"].startswith("pre-push guard")][0]
+assert c["level"] == "warn"
+' 2>/dev/null; then
+  t53_pass "TC-04: prepush guard gap is level=warn (does not count toward failures)"
+else
+  t53_fail "TC-04: expected level=warn for prepush guard check"
+fi
+
+rm -rf "$_T53_TMP" 2>/dev/null || true


### PR DESCRIPTION
## Summary

doctor の 3 つの follow-up issue（#720 / #721 / #722）をまとめて実装する。

各 issue は「doctor 実装は bin/plangate（HO）のため follow-up」と宣言されていたが、接地の結果 **bin/plangate は \`--json --scope\` を scripts/doctor_check.py（非 HO）へ無条件透過転送**しており、doctor_check.py への直接実装のみで 3 件とも到達可能だった（**HO 非接触・apply-script 不要**）。

| issue | チェック | 判定 |
|---|---|---|
| #720 | W-6 autonomous APPROVE の人間著者手順**未導入** + autonomous APPROVE **記録あり** の組合せのみ WARN（w6-autonomous-approve-introduction.md §5 仕様準拠） | 本リポジトリは導入済みのため WARN なし |
| #721 | 既存 scripts/check-skill-name-collisions.py をサブプロセス実行し衝突を WARN 転記（移植せず既存資産呼び出しで二重管理回避） | 既知 41 件により WARN 常時（issue の意図どおり棚卸しを促す） |
| #722 | .git/hooks/pre-push の存在 + 実行ビットを検査、未導入なら WARN（宣言↔実装乖離の是正） | 未 install 環境では WARN（想定内） |

全チェック \`level=warn\`（既存の failures ベース \`passed\` 判定を崩さない安全設計）。

## Verification

- ta-51/52/53 新設（計 14 TC・sandbox 方式）全 PASS — opus レビュアーも独立再実行で確認
- \`sh bin/plangate doctor --json\` / テキストモードとも無改変で新チェック到達・従来 PASS 維持
- フルスイート 387 passed / 1 failed（既存 FAIL: status 異常系 ta-42 系。bin/plangate 無変更 + status 経路の doctor_check.py 非依存を直接確認済みで本変更と無関係）
- HO 非接触を git diff で実測（変更は doctor_check.py + tests/extras のみ）

## 申し送り（V2 候補・opus レビュー minor 3 件）

1. 3 チェックが v8.6.0 scope に意味的混在 → 専用 scope 分割は V2
2. #721 の恒常 WARN はノイズ源になり得る → acknowledge 機構（許容リスト）は V2
3. #722 は存在/実行ビットのみでテンプレート内容一致まで未検証 → マーカー grep は V2

Closes #720
Refs: #721 #722（Closes は先頭のみ・残 2 件は本 PR マージ後に手動 close）

🤖 Generated with [Claude Code](https://claude.com/claude-code)