### PR TITLE
feat(#760): PostToolUse/Stop 軽量品質 hook（EH-10/EH-11 候補）を配線

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -82,6 +82,29 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "_comment_": "Hook (Issue #760 提案 / EH-10 候補): Edit/Write/MultiEdit 直後の軽量品質チェック。git diff --check のみで whitespace error / leftover conflict marker を検出。PostToolUse はツール実行後発火のため取り消し不可 — default は warning、PLANGATE_HOOK_STRICT=1 で exit 2、PLANGATE_BYPASS_HOOK=1 で常時 pass。非 git 環境では no-op。",
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ${CLAUDE_PROJECT_DIR}/scripts/hooks/check-post-edit-diff.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "_comment_": "Hook (Issue #760 提案 / EH-11 候補): セッション停止時の軽量 verify。git status --short + git diff --check のみ。意図的に non-blocking 固定（exit 0 常時）— Stop hook の block は停止阻止＝会話継続でループリスクがあるため STRICT モードは提供しない。完了担保は doctor タスクロックが別途担う。非 git 環境では no-op。",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ${CLAUDE_PROJECT_DIR}/scripts/hooks/check-stop-diff-status.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/hooks/check-post-edit-diff.sh
+++ b/scripts/hooks/check-post-edit-diff.sh
@@ -88,7 +88,13 @@ if [ -n "$target_file" ]; then
     /*) rel_target=${target_file#"$REPO_ROOT"/} ;;
     *)  rel_target=$target_file ;;
   esac
-  diff_output=$(git -C "$REPO_ROOT" diff --check -- "$rel_target" 2>/dev/null) || diff_rc=$?
+  if git -C "$REPO_ROOT" ls-files --error-unmatch "$rel_target" >/dev/null 2>&1; then
+    diff_output=$(git -C "$REPO_ROOT" diff --check -- "$rel_target" 2>/dev/null) || diff_rc=$?
+  elif [ -f "$REPO_ROOT/$rel_target" ]; then
+    # 新規作成された未追跡ファイル（untracked）は git diff --check の対象外のため、
+    # /dev/null と比較してファイル全体をチェックする（PR #762 gemini high 指摘）
+    diff_output=$(git -C "$REPO_ROOT" diff --no-index --check /dev/null "$rel_target" 2>/dev/null) || diff_rc=$?
+  fi
 else
   diff_output=$(git -C "$REPO_ROOT" diff --check 2>/dev/null) || diff_rc=$?
 fi
@@ -101,7 +107,7 @@ if [ "$diff_rc" -eq 0 ] || [ -z "$diff_output" ]; then
   exit 0
 fi
 
-reason="git diff --check flagged issue(s) in ${target_file:-<worktree>}: $(printf '%s' "$diff_output" | tr '\n' ' | ')"
+reason="git diff --check flagged issue(s) in ${target_file:-<worktree>}: $(printf '%s' "$diff_output" | awk 'NR>1{printf " | "} {printf "%s", $0}')"
 log_event "VIOLATION" "$reason"
 
 if [ "${PLANGATE_HOOK_STRICT:-0}" = "1" ]; then

--- a/scripts/hooks/check-post-edit-diff.sh
+++ b/scripts/hooks/check-post-edit-diff.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# check-post-edit-diff.sh — Hook (proposed EH-10 候補): PostToolUse 軽量品質チェック
+#
+# Edit / Write / MultiEdit 直後に `git diff --check` のみを実行し、
+# whitespace error（trailing whitespace 等）/ leftover conflict marker
+# (<<<<<<< / ======= / >>>>>>>) を検出する。lint やテストは実行しない
+# （重い処理は Stop / CI に委ねる。issue #760 スコープ）。
+#
+# Claude Code PostToolUse hook 仕様の注意点（重要）:
+#   - PostToolUse は「ツール実行後」に発火するため、この hook 自体は
+#     直前の Edit/Write を取り消せない（exit 2 でも "tool already ran"）。
+#     本 hook の役割は「次のターンで Claude が気づいて直せるように
+#     stderr へフィードバックする」ことに限定される。
+#   - stdin には Claude Code から JSON（tool_name / tool_input.file_path 等）
+#     が渡される想定（check-plan-hash.sh / check-forbidden-files.sh と同じ
+#     env-first・stdin-fallback の流儀を踏襲）。
+#
+# 入力（優先順）:
+#   PLANGATE_HOOK_FILE   編集対象ファイルの相対 path（明示があれば最優先）
+#   stdin JSON           tool_input.file_path（jq があれば優先、無ければ grep）
+#   (未解決)             リポジトリ全体の working tree 差分を対象にする
+#
+# Modes:
+#   default                       warning（exit 0、stdout に警告のみ）
+#   PLANGATE_HOOK_STRICT=1        違反検出時 exit 2（stderr で Claude にフィードバック。
+#                                 ツール実行そのものは取り消せない点に注意）
+#   PLANGATE_BYPASS_HOOK=1        常時 exit 0
+#
+# 非 git 環境（.git 不在）では静かに exit 0（no-op）。
+#
+# 監査: docs/working/_audit/hook-events.log
+#
+# Issue #760（HO 制約により本ファイルは提示のみ。適用は Human-owned）
+
+set -eu
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+WORKING_DIR="$REPO_ROOT/docs/working"
+AUDIT_LOG="$WORKING_DIR/_audit/hook-events.log"
+
+log_event() {
+  level=$1
+  msg=$2
+  mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || return 0
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  printf '%s\t%s\tcheck-post-edit-diff\t-\t%s\n' "$ts" "$level" "$msg" >>"$AUDIT_LOG" 2>/dev/null || true
+}
+
+# bypass
+if [ "${PLANGATE_BYPASS_HOOK:-0}" = "1" ]; then
+  log_event "BYPASS" "PLANGATE_BYPASS_HOOK=1 set"
+  printf '[Hook check-post-edit-diff] BYPASS\n'
+  exit 0
+fi
+
+# 非 git 環境では no-op（false-positive 防止。plangate 以外のプロジェクトへ
+# コピーされた場合や、git 未初期化のワークスペースでも安全に動く）
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+# ---- 対象ファイルの解決（env → stdin JSON → 未解決） ----
+target_file=${PLANGATE_HOOK_FILE:-}
+
+if [ -z "$target_file" ] && [ ! -t 0 ]; then
+  _stdin=$(cat 2>/dev/null || true)
+  if [ -n "$_stdin" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      target_file=$(printf '%s' "$_stdin" \
+        | jq -r '.tool_input.file_path // empty' 2>/dev/null \
+        | head -1)
+    fi
+    if [ -z "$target_file" ]; then
+      target_file=$(printf '%s' "$_stdin" \
+        | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -1 \
+        | sed 's/.*"\([^"]*\)"$/\1/')
+    fi
+  fi
+fi
+
+# ---- git diff --check 実行（scope: target_file があればそれのみ、無ければ全体）----
+diff_output=""
+diff_rc=0
+if [ -n "$target_file" ]; then
+  # リポジトリルート相対 / 絶対どちらの表記でも受け付ける
+  case "$target_file" in
+    /*) rel_target=${target_file#"$REPO_ROOT"/} ;;
+    *)  rel_target=$target_file ;;
+  esac
+  diff_output=$(git -C "$REPO_ROOT" diff --check -- "$rel_target" 2>/dev/null) || diff_rc=$?
+else
+  diff_output=$(git -C "$REPO_ROOT" diff --check 2>/dev/null) || diff_rc=$?
+fi
+
+# git diff --check は問題を検出すると非 0 を返す（"trailing whitespace" /
+# "leftover conflict marker" 等）。diff 対象が無い場合も非 0 だが出力は空。
+if [ "$diff_rc" -eq 0 ] || [ -z "$diff_output" ]; then
+  log_event "PASS" "no whitespace error / conflict marker (target=${target_file:-<worktree>})"
+  printf '[Hook check-post-edit-diff PASS] no whitespace error / conflict marker detected\n'
+  exit 0
+fi
+
+reason="git diff --check flagged issue(s) in ${target_file:-<worktree>}: $(printf '%s' "$diff_output" | tr '\n' ' | ')"
+log_event "VIOLATION" "$reason"
+
+if [ "${PLANGATE_HOOK_STRICT:-0}" = "1" ]; then
+  printf '[Hook check-post-edit-diff BLOCK] whitespace error / conflict marker detected (tool already ran; fix before continuing)\n' >&2
+  printf '%s\n' "$diff_output" >&2
+  exit 2
+fi
+
+printf '[Hook check-post-edit-diff WARNING] whitespace error / conflict marker detected\n' >&2
+printf '%s\n' "$diff_output" >&2
+exit 0

--- a/scripts/hooks/check-stop-diff-status.sh
+++ b/scripts/hooks/check-stop-diff-status.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# check-stop-diff-status.sh — Hook (proposed EH-11 候補): Stop 軽量 verify
+#
+# セッション停止時に `git status --short` + `git diff --check` のみを実行し、
+# 未コミット差分の一覧と whitespace error / conflict marker の有無を
+# 情報提示する。テスト・lint 等の重い処理は一切実行しない（issue #760 スコープ、
+# 重い検証は bin/plangate verify / CI に委ねる）。
+#
+# 【重要】本 hook は常に non-blocking（exit 0 固定）とする。理由:
+#   1. Claude Code の Stop hook は `decision:"block"`（または exit code 2）を
+#      返すと「Claude の停止を阻止し会話を継続させる」（PostToolUse の
+#      block=ツール実行後の警告のみ、とは挙動が異なる）。ドキュメント上
+#      ループガード（回数上限等）が明記されておらず、条件判定を誤ると
+#      Stop hook が繰り返し発火し続けるリスクがある。
+#   2. 完了担保は既に doctor タスクロック（working-context.md 「settings
+#      タスクロック」節、Workflow-owned）と V-1/handoff プロセスが担っている。
+#      Stop hook で重複して block すると、責務 4 分類（Workflow-owned の
+#      完了ゲート）と二重化し、かつ (1) のループリスクを追加で背負うだけで
+#      増分の安全性が乏しい。
+#   → 本 hook は「情報提示のみ・exit 0 固定」を推奨とし、PLANGATE_HOOK_STRICT
+#     によるブロックモードは意図的に提供しない（他の EH hook との非対称は
+#     上記 2 点の理由による意図的な設計判断）。
+#
+# 入力: なし（対象は常にリポジトリ全体の working tree）
+#
+# 出力: stdout に `git status --short` と `git diff --check` の結果を提示。
+#        差分・警告が無い場合も PASS として明示する。
+#
+# 非 git 環境（.git 不在）では静かに exit 0（no-op）。
+#
+# 監査: docs/working/_audit/hook-events.log
+#
+# Issue #760（HO 制約により本ファイルは提示のみ。適用は Human-owned）
+
+set -eu
+
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+WORKING_DIR="$REPO_ROOT/docs/working"
+AUDIT_LOG="$WORKING_DIR/_audit/hook-events.log"
+
+log_event() {
+  level=$1
+  msg=$2
+  mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || return 0
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  printf '%s\t%s\tcheck-stop-diff-status\t-\t%s\n' "$ts" "$level" "$msg" >>"$AUDIT_LOG" 2>/dev/null || true
+}
+
+# bypass（他 hook との一貫性のため用意するが、本 hook は non-blocking 固定
+# なので実質的には audit ログを出すか出さないかの差のみ）
+if [ "${PLANGATE_BYPASS_HOOK:-0}" = "1" ]; then
+  log_event "BYPASS" "PLANGATE_BYPASS_HOOK=1 set"
+  printf '[Hook check-stop-diff-status] BYPASS\n'
+  exit 0
+fi
+
+# 非 git 環境では no-op
+if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+status_output=$(git -C "$REPO_ROOT" status --short 2>/dev/null || true)
+diff_output=$(git -C "$REPO_ROOT" diff --check 2>/dev/null || true)
+
+printf '[Hook check-stop-diff-status] session stop — lightweight repo status\n'
+
+if [ -z "$status_output" ]; then
+  printf '  git status --short: (clean, no uncommitted changes)\n'
+else
+  printf '  git status --short:\n'
+  printf '%s\n' "$status_output" | sed 's/^/    /'
+fi
+
+if [ -z "$diff_output" ]; then
+  printf '  git diff --check  : PASS (no whitespace error / conflict marker)\n'
+  log_event "PASS" "clean status, no diff --check issues"
+else
+  printf '  git diff --check  : WARNING (whitespace error / conflict marker detected)\n'
+  printf '%s\n' "$diff_output" | sed 's/^/    /'
+  log_event "WARNING" "diff --check flagged issue(s): $(printf '%s' "$diff_output" | tr '\n' ' | ')"
+fi
+
+# non-blocking 固定（設計上の意図的判断。上記コメント参照）
+exit 0

--- a/scripts/hooks/check-stop-diff-status.sh
+++ b/scripts/hooks/check-stop-diff-status.sh
@@ -77,7 +77,7 @@ if [ -z "$diff_output" ]; then
 else
   printf '  git diff --check  : WARNING (whitespace error / conflict marker detected)\n'
   printf '%s\n' "$diff_output" | sed 's/^/    /'
-  log_event "WARNING" "diff --check flagged issue(s): $(printf '%s' "$diff_output" | tr '\n' ' | ')"
+  log_event "WARNING" "diff --check flagged issue(s): $(printf '%s' "$diff_output" | awk 'NR>1{printf " | "} {printf "%s", $0}')"
 fi
 
 # non-blocking 固定（設計上の意図的判断。上記コメント参照）


### PR DESCRIPTION
## 概要

Closes #760

外部知見（Claude Code bounded loop 運用記事）との比較監査（2026-07-07）で特定した未配線 hook イベント 2 種を配線する。Refs #760（提示物・設計判断の全文は issue コメント参照）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `scripts/hooks/check-post-edit-diff.sh`（新規・EH-10 候補） | Edit/Write/MultiEdit 直後の `git diff --check` のみ（whitespace error / conflict marker 検出）。default=warning、`PLANGATE_HOOK_STRICT=1` で exit 2 |
| `scripts/hooks/check-stop-diff-status.sh`（新規・EH-11 候補） | Stop 時の `git status --short` + `git diff --check` のみ。**non-blocking（exit 0）固定**（Stop hook の block は停止阻止＝会話継続でループリスクがあるため STRICT モードを意図的に非提供） |
| `.claude/settings.example.json` | `PostToolUse` / `Stop` ブロック追加 |

## 検証

- `sh -n` / `bash -n` 構文検査 PASS（両スクリプト）
- 一時 git repo で実挙動テスト: trailing whitespace 検出（warn/strict）、conflict marker 検出、クリーン時 PASS、`PLANGATE_HOOK_FILE` スコープ限定、Stop の exit 0 固定を実測
- **doctor: `PlanGate hooks wired (10/10 hook blocks present)` PASS 実測**（既存の汎用イベント走査が新イベントを自動カバー、doctor コード変更不要 — #760 §4 判断）
- 既存 hook 流儀（`set -eu`・env-first/stdin-fallback・hook-events.log 監査・BYPASS/STRICT）を踏襲

## HO / 責務

- `.claude/settings*.json` / `scripts/hooks/*.sh` は HO 対象。**実適用（settings.json 反映・スクリプト配置）はユーザーが `apply-issue-760.sh` で実行済み**。本 PR のコミットもユーザーの名指し承認（settings.example.json を明示）に基づく
- Hardening Override 対象パスにつき Mode=high・人間 C-3/C-4 必須（autonomous APPROVE 不可）
- merge は Human-owned

## 既知の follow-up（本 PR スコープ外）

- `apply-claude-settings.sh` は EH-3/EH-9 専用ハードコードマージのため PostToolUse/Stop を汎用マージしない（恒久対応は別 issue 候補、#760 §3 参照）
- `tests/hooks/run-tests.sh` への 2 スクリプトのテストケース追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
