### PR TITLE
chore: CLAUDE.md v8.16.0 更新の apply 提示 + version 同期マップ正本化

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -121,5 +121,5 @@ v8.16.0 の README_en 漏れ（レビューで水際検出）が実害・ヒヤ�
 | 7 | **`CLAUDE.md`「最新リリース」節** | **HO パスのため AI は apply スクリプト提示まで・適用は Human**（`sh scripts/apply-claude-md-*.sh --apply`。v8.14〜8.16 で 3 世代 stale になった構造原因への対策として本表に常設） |
 | 8 | `docs/changelog.md` | 更新**不要**（release published 後に `release-docs-sync` が自動 PR） |
 
-検証: `tests/extras/ta-28-plugin-version.sh`（1〜4/6 を機械検査。5・7 は未カバー —
-リリース準備 PR のレビュー観点として本表で担保する）。
+検証: `tests/extras/ta-28-plugin-version.sh`（2〜4 を機械検査。1・5・6・7 は未カバー —
+リリース準備 PR のレビュー観点として本表で担保する。ta-28 の 1/6 カバー拡張は V2 候補）。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -103,3 +103,23 @@ sh scripts/check-tag-main-parity.sh <tag>
 - 検証 script: [`scripts/check-tag-main-parity.sh`](../scripts/check-tag-main-parity.sh)
 - 責務分界: [`.claude/rules/responsibility-classes.md`](../.claude/rules/responsibility-classes.md) §対外公開アーティファクト publish 責務分界
 - 参考: PocketEitan `.claude/commands/release.md` Phase 5 / memory `feedback_release_tag_collision_verify.md`
+
+## version 同期マップ（リリース準備 PR で更新する箇所の正本）
+
+リリース準備 PR（AI-owned）で以下を**全箇所同時に**対象 version へ更新する。
+1 箇所でも漏れると「Latest 表記の drift」となる（v8.13.0 の README 漏れ・
+v8.16.0 の README_en 漏れ（レビューで水際検出）が実害・ヒヤリの実例）:
+
+| # | ファイル | 箇所 |
+|---|---|---|
+| 1 | `CHANGELOG.md` | `## vX.Y.Z (date)` 節の確定（Unreleased を残す） |
+| 2 | `plugin/plangate/.claude-plugin/plugin.json` | `version` |
+| 3 | `.claude-plugin/marketplace.json` | `plugins[].version` と `metadata.version` の両方 |
+| 4 | `README.md` | 「最新リリース」表の行 + 冒頭散文 + 「リリース済」行 |
+| 5 | `README_en.md` | 同上（英語） |
+| 6 | `plugin/plangate/README.md` | `**Version**:` 行 |
+| 7 | **`CLAUDE.md`「最新リリース」節** | **HO パスのため AI は apply スクリプト提示まで・適用は Human**（`sh scripts/apply-claude-md-*.sh --apply`。v8.14〜8.16 で 3 世代 stale になった構造原因への対策として本表に常設） |
+| 8 | `docs/changelog.md` | 更新**不要**（release published 後に `release-docs-sync` が自動 PR） |
+
+検証: `tests/extras/ta-28-plugin-version.sh`（1〜4/6 を機械検査。5・7 は未カバー —
+リリース準備 PR のレビュー観点として本表で担保する）。

--- a/scripts/apply-claude-md-v8160.sh
+++ b/scripts/apply-claude-md-v8160.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# apply-claude-md-v8160.sh -- CLAUDE.md「最新リリース」節を v8.16.0 へ更新
+#
+# CLAUDE.md は Hardening Override (HO) 対象（self-mod guard）。AI は --dry-run
+# のみ実行可。--apply の実行は Human-owned（.claude/rules/responsibility-classes.md）。
+#
+# 背景: CLAUDE.md の「最新リリース」節は v8.13.0 のまま v8.14/8.15/8.16 の
+# 3 リリースで未更新（version 同期マップの対象外だったことが構造原因。
+# 本 PR で docs/release-process.md 側にも同期対象として追記済み）。
+#
+# Usage:
+#   sh scripts/apply-claude-md-v8160.sh --dry-run   # 差分プレビュー（書込なし）
+#   sh scripts/apply-claude-md-v8160.sh --apply     # 適用（Human 実行のみ）
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+F="$ROOT/CLAUDE.md"
+[ $# -eq 1 ] || { echo "usage: $0 --dry-run|--apply" >&2; exit 1; }
+
+OLD_HEAD='## v8.13.0 全体健全化・エージェント model tier（最新リリース機能）'
+NEW_HEAD='## v8.16.0 ai-loop 実運用（dogfooding）・Plugin 同梱配布（最新リリース機能）'
+NEW_BODY='> 最新リリース: **v8.16.0**（2026-07-08）ai-loop（旧 Arbiter）を自身の開発プロセスへの dogfooding として初実運用（Run-001〜021 の摩擦是正閉ループ・auto-merge 廃止 + merge-ready 運用・rubric grader・HO 境界の実行時 parse 化。**PlanGate 本番フロー WF-00〜07 は不変・ai-loop は PoC**）+ `ai-loop-cycle` スキルの plangate プラグイン同梱（bundled resources・導入前に ho-paths の導入先確定が必須）+ Hook Enforcement 物理配線 11/12 + サブエージェント委譲プロトコル正本。v8.15.0 で Review Gate 機械化・approve ハードニング、v8.14.0 で C-3 HTML 出力 + ワンアクション承認、v8.13.0 で全体健全化 + model tier。リリース履歴の正本は [`CHANGELOG.md`](CHANGELOG.md)。'
+
+grep -qF "$OLD_HEAD" "$F" || { echo "[apply] SKIP: 対象節が見つからない（適用済み or 構造変更）"; exit 0; }
+
+if [ "$1" = "--dry-run" ]; then
+  echo "[dry-run] 置換予定:"
+  echo "  - 見出し: $OLD_HEAD"
+  echo "  +        : $NEW_HEAD"
+  echo "  - 本文  : 「> 最新リリース: **v8.13.0**…」の段落 1 つを v8.16.0 版に置換"
+  exit 0
+elif [ "$1" = "--apply" ]; then
+  python3 - "$F" "$NEW_HEAD" "$NEW_BODY" <<'PY'
+import sys, re
+f, new_head, new_body = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(f, encoding="utf-8").read()
+old_head = "## v8.13.0 全体健全化・エージェント model tier（最新リリース機能）"
+i = s.index(old_head)
+j = s.index("\n\n", s.index("> 最新リリース", i))
+s = s[:i] + new_head + "\n\n" + new_body + s[j:]
+open(f, "w", encoding="utf-8").write(s)
+print("[apply] CLAUDE.md 最新リリース節を v8.16.0 に更新")
+PY
+  exit 0
+fi
+echo "usage: $0 --dry-run|--apply" >&2; exit 1

--- a/scripts/apply-claude-md-v8160.sh
+++ b/scripts/apply-claude-md-v8160.sh
@@ -30,14 +30,14 @@ if [ "$1" = "--dry-run" ]; then
   exit 0
 elif [ "$1" = "--apply" ]; then
   python3 - "$F" "$NEW_HEAD" "$NEW_BODY" <<'PY'
-import sys, re
+import sys
 f, new_head, new_body = sys.argv[1], sys.argv[2], sys.argv[3]
 s = open(f, encoding="utf-8").read()
 old_head = "## v8.13.0 全体健全化・エージェント model tier（最新リリース機能）"
 i = s.index(old_head)
 j = s.index("\n\n", s.index("> 最新リリース", i))
 s = s[:i] + new_head + "\n\n" + new_body + s[j:]
-open(f, "w", encoding="utf-8").write(s)
+open(f, "w", encoding="utf-8", newline="\n").write(s)
 print("[apply] CLAUDE.md 最新リリース節を v8.16.0 に更新")
 PY
   exit 0


### PR DESCRIPTION
## Summary

リリース後ドキュメント鮮度の実測で検出した **CLAUDE.md の 3 世代 stale**（v8.13.0 表記のまま）への対応。CLAUDE.md は HO パスのため #721/#742 と同型の「仕様 + apply 提示」パターン。

1. **`scripts/apply-claude-md-v8160.sh`**: 「最新リリース」節を v8.16.0（dogfooding・PoC 限定表現は README/release note と統一）へ置換する Human 実行スクリプト。dry-run 実施済み・冪等（適用済みなら SKIP）
2. **`docs/release-process.md` に version 同期マップ 8 項目表を常設** — README_en 漏れ（今回レビューで水際検出）・CLAUDE.md 恒常 stale の**構造原因（マップの不在）**への再発防止。ta-28 のカバー範囲と残余（README_en / CLAUDE.md はレビュー観点で担保）も明記

## マージ後の Human 1 アクション

```sh
sh scripts/apply-claude-md-v8160.sh --apply && git add CLAUDE.md && git commit -m "docs: CLAUDE.md 最新リリース節を v8.16.0 に更新（apply-claude-md-v8160.sh 実行結果）"
```
（main 直接 commit 禁止のためブランチ上で実行 → PR。または次の任意 PR に同乗）

🤖 Generated with [Claude Code](https://claude.com/claude-code)