### PR TITLE
feat: /ai-loop-workflow コマンド新設（/ai-dev-workflow と対・HO apply 提示）

### DIFF
--- a/docs/working/_prompts/ai-loop-workflow-command.md
+++ b/docs/working/_prompts/ai-loop-workflow-command.md
@@ -1,0 +1,47 @@
+# /ai-loop-workflow
+
+ai-loop-workflow（human-on-the-loop 裁定ループ）を明示起動する。
+`/ai-dev-workflow`（PlanGate 本番フロー WF-00〜07）と**対をなす入口**であり、
+本番フローの置き換えではない（低リスク帯限定・PoC。本番承認フローには適用しない）。
+
+実行手順の正本: skill `ai-loop-cycle`（1 サイクル = LoopSpec → W チェック →
+arbiter 裁定 → exec → rubric grader）。本コマンドは前提確認と起動のみを担う。
+
+## 引数
+
+$ARGUMENTS に以下の形式で渡される:
+
+- `run <対象の説明>` — 新しい run を開始（LoopSpec 作成から）
+- `status` — 直近 run の状態・decision record・摩擦台帳の要約を表示
+- （引数なし） — 前提チェックのみ実施して結果を報告
+
+## 実行前チェック（必須・満たさない場合は開始せず報告）
+
+1. **HO 境界の解決**: ho-paths（導入先確定済み）が arbiter から解決できるか
+   — `python3 <arbiter.py の実パス> --input /dev/null` 相当の疎通でなく、
+   ho-paths 解決元の stderr 表示を確認する。未確定なら「全件 human escalate になる」旨を伝え、確定を促す
+2. **保存先の定義**: run 記録（LoopSpec・decision record）と摩擦台帳の置き場が
+   プロジェクトで定義済みか（未定義なら既定案を提示して合意を取る）
+3. **適用ドメイン**: 対象変更が低リスク帯（docs 等・可逆）か。承認境界・本番
+   承認フローに触れる場合は本コマンドを使わず通常フローへ
+
+## 実行
+
+前提 3 点を満たしたら、skill `ai-loop-cycle` の手順に従って 1 サイクルを実行する。
+停止規則（round 上限・escalate 条件・touches-HO 無条件 escalate）は skill と
+同梱 docs（decision-table / execution-runbook / loop-safety-gates）が正本。
+
+## Iron Law（ai-loop 版・違反したら即停止）
+
+| ルール | 意味 |
+|-------|------|
+| `NO LOOP WITHOUT STOPPING RULE` | 停止できないループを回すな |
+| `NO AUTO-APPROVE ON HO CONTACT` | HO 接触は無条件で人間へ |
+| `NO OPTIMIZE WITHOUT RECORD` | 記録なき最適化をするな |
+| `NO MERGE BY AI` | マージは常に Human |
+
+## 関連
+
+- skill: `ai-loop-cycle`（実行単位の正本）
+- docs: 同梱 ai-loop ドキュメント（design-philosophy / decision-table / execution-runbook）
+- 対: `/ai-dev-workflow`（PlanGate 本番フロー入口）

--- a/scripts/apply-ai-loop-workflow-command.sh
+++ b/scripts/apply-ai-loop-workflow-command.sh
@@ -19,13 +19,18 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 DST="$ROOT/.claude/commands/ai-loop-workflow.md"
 SRC="$ROOT/docs/working/_prompts/ai-loop-workflow-command.md"
 [ $# -eq 1 ] || { echo "usage: $0 --dry-run|--apply" >&2; exit 1; }
+[ "$1" = "--dry-run" ] || [ "$1" = "--apply" ] || { echo "usage: $0 --dry-run|--apply" >&2; exit 1; }
 [ -f "$SRC" ] || { echo "error: source not found: $SRC" >&2; exit 2; }
 if [ -f "$DST" ] && cmp -s "$SRC" "$DST"; then
   echo "[apply] SKIP: 適用済み（差分なし）"; exit 0
 fi
 if [ "$1" = "--dry-run" ]; then
   echo "[dry-run] COPY 予定: $SRC -> $DST"
-  [ -f "$DST" ] && diff -u "$DST" "$SRC" | head -40 || echo "[dry-run] 新規作成"
+  if [ -f "$DST" ]; then
+    diff -u "$DST" "$SRC" | head -40 || true
+  else
+    echo "[dry-run] 新規作成"
+  fi
   exit 0
 elif [ "$1" = "--apply" ]; then
   [ -d "$(dirname "$DST")" ] || { echo "error: .claude/commands/ 不在" >&2; exit 2; }

--- a/scripts/apply-ai-loop-workflow-command.sh
+++ b/scripts/apply-ai-loop-workflow-command.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# apply-ai-loop-workflow-command.sh -- /ai-loop-workflow コマンド新設
+#
+# .claude/commands/ は Hardening Override (HO) 対象（self-mod guard）。
+# AI は --dry-run のみ実行可。--apply の実行は Human-owned
+# （.claude/rules/responsibility-classes.md）。
+#
+# 背景: /ai-dev-workflow（PlanGate 本番フロー入口）と対をなす ai-loop の
+# 明示起動入口。skill `ai-loop-cycle`（1 サイクル実行単位・モデル起動）は
+# 改名せず、コマンド層で対称性を取る（Human 設計決定 2026-07-08）。
+# 適用後は scripts/sync-plugin-plangate.sh で plugin/plangate/commands/ へ同期
+# され、導入先では /plangate:ai-loop-workflow として起動できる。
+#
+# Usage:
+#   sh scripts/apply-ai-loop-workflow-command.sh --dry-run
+#   sh scripts/apply-ai-loop-workflow-command.sh --apply   # Human 実行のみ
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DST="$ROOT/.claude/commands/ai-loop-workflow.md"
+SRC="$ROOT/docs/working/_prompts/ai-loop-workflow-command.md"
+[ $# -eq 1 ] || { echo "usage: $0 --dry-run|--apply" >&2; exit 1; }
+[ -f "$SRC" ] || { echo "error: source not found: $SRC" >&2; exit 2; }
+if [ -f "$DST" ] && cmp -s "$SRC" "$DST"; then
+  echo "[apply] SKIP: 適用済み（差分なし）"; exit 0
+fi
+if [ "$1" = "--dry-run" ]; then
+  echo "[dry-run] COPY 予定: $SRC -> $DST"
+  [ -f "$DST" ] && diff -u "$DST" "$SRC" | head -40 || echo "[dry-run] 新規作成"
+  exit 0
+elif [ "$1" = "--apply" ]; then
+  [ -d "$(dirname "$DST")" ] || { echo "error: .claude/commands/ 不在" >&2; exit 2; }
+  cp "$SRC" "$DST"
+  echo "[apply] 作成: $DST"
+  echo "[apply] 次に: sh scripts/sync-plugin-plangate.sh で plugin へ同期"
+  exit 0
+fi
+echo "usage: $0 --dry-run|--apply" >&2; exit 1


### PR DESCRIPTION
## Summary

Human 設計決定（2026-07-08）: **`/ai-dev-workflow` と対をなす ai-loop の明示起動コマンド `/ai-loop-workflow` を新設**する。skill `ai-loop-cycle`（1 サイクル実行単位・モデル起動）は改名せず、**コマンド層で対称性を取る**（ai-dev-workflow も同名 skill を持たないコマンドであり構成が揃う）。

| 成果物 | 内容 |
|---|---|
| `docs/working/_prompts/ai-loop-workflow-command.md` | コマンド本文（正本ソース）: 引数（run/status/前提チェック）/ **実行前チェック 3 点**（ho-paths 解決・保存先定義・適用ドメイン）/ ai-loop 版 Iron Law 4 条 / ai-dev-workflow の文体踏襲 |
| `scripts/apply-ai-loop-workflow-command.sh` | `.claude/commands/`（**HO**）への配置スクリプト。dry-run 実施済み・冪等。**適用は Human** |

## マージ後の Human 手順

```sh
sh scripts/apply-ai-loop-workflow-command.sh --apply
sh scripts/sync-plugin-plangate.sh        # plugin へ同期（導入先では /plangate:ai-loop-workflow）
# 変更を PR で main へ（.claude/commands + plugin/plangate/commands）
```

Refs: #772（配布フロー整備 — 本コマンドの plugin 同期は commands/ の既存 sync 対象で自動カバー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)