### PR TITLE
fix: check-tag-main-parity をリモート tag 実体照合に変更（偽 PASS 解消）

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -11,9 +11,12 @@ NO RELEASE WITHOUT TAG-MAIN PARITY
 
 意味:
 
-- `git rev-parse <tag>^{commit}` と `git rev-parse origin/main` が **完全一致** するまで GitHub Release を作成しない
-- 一致しない場合は `git push --force-with-lease` で貼り替え (Human オペレーション)
+- **リモート tag 実体**（`git ls-remote origin refs/tags/<tag>` の peel 先 commit）と `git rev-parse origin/main` が **完全一致** するまで GitHub Release を作成しない
+- 判定基準はローカル tag の `rev-parse` ではなく **リモート実体（ls-remote）照合**（#783 R-005。ローカル tag は貼り替え済み・リモートは旧 commit のままでも、公開されるのはリモート tag のため）
+- 一致しない場合は `git push --force-with-lease=<ref>:<期待値>` で貼り替え (Human オペレーション)
 - 検証コマンドの実行ログを `status.md` / release note に記録
+
+> **注**: 本検証はリリース時ゲート。リリース後に main が進んだ状態での再実行は MISMATCH になる（仕様）。
 
 ## 背景
 
@@ -43,10 +46,11 @@ GitHub Release 作成
 # 1. tag push
 git push origin <tag>
 
-# 2. Iron Law: tag = main 検証 (R-001: 内部で git fetch origin main 実施)
+# 2. Iron Law: tag = main 検証 (R-001: 内部で git fetch origin main 実施、
+#    R-005: git ls-remote でリモート tag 実体を照合)
 sh scripts/check-tag-main-parity.sh <tag>
-# → OK: tag '<tag>' = origin/main (<sha>)  なら次へ
-# → MISMATCH なら下記フローで貼り替え
+# → OK: tag '<tag>' (origin 実体) = origin/main (<sha>)  なら次へ
+# → MISMATCH / FAIL なら下記フローで貼り替え
 ```
 
 ## 失敗時のフロー (MISMATCH 検出時)
@@ -61,18 +65,24 @@ git rev-parse origin/main
 # 2. annotated tag を作り直し (R-004: annotated を ^{commit} で peel 可能に)
 git tag -fa <tag> origin/main -m "release <tag>"
 
-# 3. remote tag を --force-with-lease + ref 明示で上書き (R-002)
-git push --force-with-lease origin refs/tags/<tag>:refs/tags/<tag>
+# 3. リモート tag オブジェクト SHA (ls-remote の un-peeled 行) を確認
+git ls-remote origin refs/tags/<tag>
 
-# 4. 再検証 → 一致するまで GitHub Release 作成禁止
+# 4. remote tag を --force-with-lease (期待値=リモート tag オブジェクト SHA) + ref 明示で上書き (R-002)
+#    注: annotated tag では期待値に peeled commit SHA を使うと必ず stale info で拒否される。
+#    期待値なしの --force-with-lease も tag では remote-tracking 参照がなく機能しない。
+#    check-tag-main-parity.sh が MISMATCH 時にこの形式のコマンドをそのまま出力する。
+git push --force-with-lease=refs/tags/<tag>:<リモートtagオブジェクトSHA> origin refs/tags/<tag>:refs/tags/<tag>
+
+# 5. 再検証 → 一致するまで GitHub Release 作成禁止
 sh scripts/check-tag-main-parity.sh <tag>
 ```
 
 ### --force-with-lease の理由 (R-002)
 
-通常の `git push -f` ではなく `--force-with-lease` + ref 明示 (`refs/tags/<tag>:refs/tags/<tag>`) を使う:
+通常の `git push -f` ではなく `--force-with-lease=<ref>:<期待値>` + ref 明示 (`refs/tags/<tag>:refs/tags/<tag>`) を使う:
 
-- `--force-with-lease`: remote 側が想定外に進んでいた場合に上書きを拒否 (他者の変更保護)
+- `--force-with-lease=<ref>:<期待値>`: remote 側が想定外に進んでいた場合に上書きを拒否 (他者の変更保護)。期待値は **リモート tag オブジェクト SHA**（ref の格納値。annotated tag では commit でなく tag オブジェクト）
 - ref 明示: 誤って別 ref を push するリスク排除
 - Human オペレーション + 監査ログ + 対象 tag 再確認 の段階フロー
 
@@ -86,12 +96,12 @@ sh scripts/check-tag-main-parity.sh <tag>
 
 ## tag 種別 (R-004)
 
-| tag 種別 | 動作 |
+| tag 種別 | 動作 (リモート照合 / #783 R-005) |
 |---------|------|
-| annotated tag (`git tag -a`) | `<tag>^{commit}` で peel して commit SHA 取得 |
-| lightweight tag (`git tag`) | `<tag>^{commit}` で同様 (lightweight は直接 commit を指す) |
+| annotated tag (`git tag -a`) | `git ls-remote origin "refs/tags/<tag>" "refs/tags/<tag>^{}"` の **peel 行** (`refs/tags/<tag>^{}`) の SHA を commit として採用 |
+| lightweight tag (`git tag`) | peel 行が現れないため **un-peeled 行** (`refs/tags/<tag>`) の SHA を採用 (直接 commit を指す) |
 
-両者とも `^{commit}` peeling で統一的に比較。
+両者ともリモート実体の peel 先 commit を `origin/main` と比較する。
 
 ## CI 化 (V2 候補)
 

--- a/scripts/check-tag-main-parity.sh
+++ b/scripts/check-tag-main-parity.sh
@@ -4,14 +4,21 @@
 # release tag が指す commit と origin/main の最新が一致するか機械検証。
 # 不一致のまま GitHub Release を作成する事故を防ぐ Iron Law の実行 script。
 #
-# 設計原則 (C-2 R-001..R-004 反映):
+# 設計原則 (C-2 R-001..R-004 + #783 R-005 反映):
 #   R-001: 冒頭で git fetch origin main (stale 防止)、fetch 失敗時 exit + 警告
 #   R-002: 不一致時の貼り替えは --force-with-lease + ref 明示 (docs 案内)
 #   R-004: annotated / lightweight tag を ^{commit} で peel して比較
+#   R-005 (#783): 検証対象は「リモート tag 実体」を主とする。ローカル tag は
+#     git fetch では更新されないため、ローカルのみ貼り替え済み・push 未完了
+#     （リモートは旧 commit のまま）の状態でもローカル比較だけでは OK を誤返し
+#     うる（2026-07-09 v8.16.0 リリースで実害化）。公開されるのはリモート
+#     tag の実体であるため、`git ls-remote origin` でリモート実体を取得し、
+#     それを主判定に用いる。ローカル tag との不整合（貼り替え未 push）も
+#     追加検査で検出する。
 #
 # 使用例:
 #   sh scripts/check-tag-main-parity.sh v0.X.Y
-#   → tag^{commit} == origin/main なら exit 0、不一致 exit 1
+#   → リモート tag の ^{commit} == origin/main なら exit 0、不一致 exit 1
 #
 # 関連: docs/release-process.md (Iron Law + 失敗時フロー)
 
@@ -31,34 +38,86 @@ if ! git fetch origin main >/dev/null 2>&1; then
   exit 1
 fi
 
-# tag 存在確認
-if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-  echo "[tag-parity] FAIL: tag '$TAG' が存在しません" >&2
-  exit 1
-fi
-
-# R-004: annotated / lightweight tag を ^{commit} で peel
-tag_commit=$(git rev-parse "$TAG^{commit}" 2>/dev/null || true)
 main_commit=$(git rev-parse origin/main 2>/dev/null || true)
-
-if [ -z "$tag_commit" ] || [ -z "$main_commit" ]; then
-  echo "[tag-parity] FAIL: commit SHA の取得に失敗 (tag=$tag_commit main=$main_commit)" >&2
+if [ -z "$main_commit" ]; then
+  echo "[tag-parity] FAIL: origin/main の commit SHA 取得に失敗しました" >&2
   exit 1
 fi
 
-if [ "$tag_commit" = "$main_commit" ]; then
-  echo "[tag-parity] OK: tag '$TAG' = origin/main ($tag_commit)"
+# R-005: リモート tag の実体を取得 (annotated tag は ^{} で peel 要求)
+if ! remote_refs=$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}" 2>&1); then
+  echo "[tag-parity] WARN: git ls-remote origin 実行に失敗しました (offline?)。" >&2
+  echo "  リモート tag 実体を検証できません。検証を中断します (fail-closed)。" >&2
+  echo "  $remote_refs" >&2
+  exit 1
+fi
+
+if [ -z "$remote_refs" ]; then
+  echo "[tag-parity] FAIL: tag '$TAG' が origin に存在しません（push 忘れ）" >&2
+  echo "  origin へ tag を push してから再実行してください:" >&2
+  echo "    git push origin refs/tags/$TAG:refs/tags/$TAG" >&2
+  exit 1
+fi
+
+# annotated tag は peel 行 (refs/tags/$TAG^{}) の commit SHA を優先採用。
+# lightweight tag は peel 行が現れないため refs/tags/$TAG 行の SHA を採用。
+remote_tag_commit=$(printf '%s\n' "$remote_refs" | awk -v ref="refs/tags/$TAG^{}" '$2 == ref { print $1 }')
+if [ -z "$remote_tag_commit" ]; then
+  remote_tag_commit=$(printf '%s\n' "$remote_refs" | awk -v ref="refs/tags/$TAG" '$2 == ref { print $1 }')
+fi
+
+if [ -z "$remote_tag_commit" ]; then
+  echo "[tag-parity] FAIL: リモート tag '$TAG' の commit SHA 解析に失敗しました" >&2
+  echo "  $remote_refs" >&2
+  exit 1
+fi
+
+# ローカル tag が存在する場合の ^{commit}（存在しなくても検証は継続する）
+local_tag_commit=""
+if git rev-parse --verify -q "refs/tags/$TAG^{commit}" >/dev/null 2>&1; then
+  local_tag_commit=$(git rev-parse "refs/tags/$TAG^{commit}")
+fi
+
+if [ "$remote_tag_commit" = "$main_commit" ]; then
+  # 主判定 OK。ただしローカル tag が別実体を指していないか追加検査 (R-005)。
+  if [ -n "$local_tag_commit" ] && [ "$local_tag_commit" != "$remote_tag_commit" ]; then
+    echo "[tag-parity] FAIL: ローカル tag '$TAG' ($local_tag_commit) とリモート tag ($remote_tag_commit) が不一致です" >&2
+    echo "" >&2
+    echo "  ローカル tag とリモート tag が不一致（貼り替え未 push の可能性）:" >&2
+    echo "  ローカルで tag を貼り替えたが origin へ push できていない、" >&2
+    echo "  または別途 push 済みの内容がローカルへ反映されていない可能性があります。" >&2
+    echo "" >&2
+    echo "  貼り替え手順 (Human オペレーション):" >&2
+    echo "    git push --force-with-lease=refs/tags/$TAG:$remote_tag_commit origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "    sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
+    echo "" >&2
+    echo "  詳細: docs/release-process.md" >&2
+    exit 1
+  fi
+
+  echo "[tag-parity] OK: tag '$TAG' (origin 実体) = origin/main ($remote_tag_commit)"
   exit 0
 else
-  echo "[tag-parity] MISMATCH: tag '$TAG' ($tag_commit) != origin/main ($main_commit)" >&2
+  echo "[tag-parity] MISMATCH: tag '$TAG' (origin 実体: $remote_tag_commit) != origin/main ($main_commit)" >&2
   echo "" >&2
   echo "  NO RELEASE WITHOUT TAG-MAIN PARITY (Iron Law):" >&2
   echo "  一致するまで GitHub Release を作成しないでください。" >&2
   echo "" >&2
-  echo "  貼り替え手順 (Human オペレーション):" >&2
-  echo "    1. git tag -fa $TAG origin/main  # annotated tag を main に作り直し" >&2
-  echo "    2. git push --force-with-lease origin refs/tags/$TAG:refs/tags/$TAG" >&2
-  echo "    3. sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
+
+  if [ -n "$local_tag_commit" ] && [ "$local_tag_commit" = "$main_commit" ]; then
+    echo "  ローカル tag は origin/main と一致していますが、リモート tag ($TAG) は" >&2
+    echo "  古い commit のままです。貼り替え済み・push 未完了の可能性があります:" >&2
+    echo "" >&2
+    echo "  貼り替え手順 (Human オペレーション):" >&2
+    echo "    git push --force-with-lease=refs/tags/$TAG:$remote_tag_commit origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "    sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
+  else
+    echo "  貼り替え手順 (Human オペレーション):" >&2
+    echo "    1. git tag -fa $TAG origin/main  # annotated tag を main に作り直し" >&2
+    echo "    2. git push --force-with-lease origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "    3. sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
+  fi
+
   echo "" >&2
   echo "  詳細: docs/release-process.md" >&2
   exit 1

--- a/scripts/check-tag-main-parity.sh
+++ b/scripts/check-tag-main-parity.sh
@@ -79,10 +79,7 @@ if [ -z "$remote_tag_commit" ] || [ -z "$remote_tag_obj" ]; then
 fi
 
 # ローカル tag が存在する場合の ^{commit}（存在しなくても検証は継続する）
-local_tag_commit=""
-if git rev-parse --verify -q "refs/tags/$TAG^{commit}" >/dev/null 2>&1; then
-  local_tag_commit=$(git rev-parse "refs/tags/$TAG^{commit}")
-fi
+local_tag_commit=$(git rev-parse --verify -q "refs/tags/$TAG^{commit}" 2>/dev/null || true)
 
 if [ "$remote_tag_commit" = "$main_commit" ]; then
   # 主判定 OK。ただしローカル tag が別実体を指していないか追加検査 (R-005)。

--- a/scripts/check-tag-main-parity.sh
+++ b/scripts/check-tag-main-parity.sh
@@ -6,19 +6,23 @@
 #
 # 設計原則 (C-2 R-001..R-004 + #783 R-005 反映):
 #   R-001: 冒頭で git fetch origin main (stale 防止)、fetch 失敗時 exit + 警告
-#   R-002: 不一致時の貼り替えは --force-with-lease + ref 明示 (docs 案内)
-#   R-004: annotated / lightweight tag を ^{commit} で peel して比較
+#   R-002: 不一致時の貼り替えは --force-with-lease + ref 明示 (docs 案内)。
+#     lease 期待値は「リモート tag オブジェクト SHA」（ls-remote の un-peeled
+#     行）を使う。annotated tag では ref の格納値が tag オブジェクトのため、
+#     peeled commit SHA を期待値にすると必ず stale info で拒否される。
+#   R-004: annotated / lightweight tag の両対応（ls-remote の peel 行
+#     `refs/tags/<tag>^{}` があればその SHA、なければ un-peeled 行の SHA）
 #   R-005 (#783): 検証対象は「リモート tag 実体」を主とする。ローカル tag は
 #     git fetch では更新されないため、ローカルのみ貼り替え済み・push 未完了
 #     （リモートは旧 commit のまま）の状態でもローカル比較だけでは OK を誤返し
 #     うる（2026-07-09 v8.16.0 リリースで実害化）。公開されるのはリモート
 #     tag の実体であるため、`git ls-remote origin` でリモート実体を取得し、
-#     それを主判定に用いる。ローカル tag との不整合（貼り替え未 push）も
-#     追加検査で検出する。
+#     それを主判定に用いる。ローカル tag との不整合（貼り替え未 push /
+#     ローカル stale）も追加検査で検出する。
 #
 # 使用例:
 #   sh scripts/check-tag-main-parity.sh v0.X.Y
-#   → リモート tag の ^{commit} == origin/main なら exit 0、不一致 exit 1
+#   → リモート tag の peel 先 commit == origin/main なら exit 0、不一致 exit 1
 #
 # 関連: docs/release-process.md (Iron Law + 失敗時フロー)
 
@@ -45,10 +49,9 @@ if [ -z "$main_commit" ]; then
 fi
 
 # R-005: リモート tag の実体を取得 (annotated tag は ^{} で peel 要求)
-if ! remote_refs=$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}" 2>&1); then
+if ! remote_refs=$(git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}" 2>/dev/null); then
   echo "[tag-parity] WARN: git ls-remote origin 実行に失敗しました (offline?)。" >&2
   echo "  リモート tag 実体を検証できません。検証を中断します (fail-closed)。" >&2
-  echo "  $remote_refs" >&2
   exit 1
 fi
 
@@ -59,14 +62,17 @@ if [ -z "$remote_refs" ]; then
   exit 1
 fi
 
-# annotated tag は peel 行 (refs/tags/$TAG^{}) の commit SHA を優先採用。
-# lightweight tag は peel 行が現れないため refs/tags/$TAG 行の SHA を採用。
+# un-peeled 行 (refs/tags/$TAG) = リモート ref の格納値 (annotated なら tag
+# オブジェクト SHA)。--force-with-lease の期待値にはこちらを使う (R-002)。
+remote_tag_obj=$(printf '%s\n' "$remote_refs" | awk -v ref="refs/tags/$TAG" '$2 == ref { print $1 }')
+# peel 行 (refs/tags/$TAG^{}) = annotated tag の指す commit SHA。
+# lightweight tag は peel 行が現れないため un-peeled 行の SHA が commit (R-004)。
 remote_tag_commit=$(printf '%s\n' "$remote_refs" | awk -v ref="refs/tags/$TAG^{}" '$2 == ref { print $1 }')
 if [ -z "$remote_tag_commit" ]; then
-  remote_tag_commit=$(printf '%s\n' "$remote_refs" | awk -v ref="refs/tags/$TAG" '$2 == ref { print $1 }')
+  remote_tag_commit="$remote_tag_obj"
 fi
 
-if [ -z "$remote_tag_commit" ]; then
+if [ -z "$remote_tag_commit" ] || [ -z "$remote_tag_obj" ]; then
   echo "[tag-parity] FAIL: リモート tag '$TAG' の commit SHA 解析に失敗しました" >&2
   echo "  $remote_refs" >&2
   exit 1
@@ -83,12 +89,11 @@ if [ "$remote_tag_commit" = "$main_commit" ]; then
   if [ -n "$local_tag_commit" ] && [ "$local_tag_commit" != "$remote_tag_commit" ]; then
     echo "[tag-parity] FAIL: ローカル tag '$TAG' ($local_tag_commit) とリモート tag ($remote_tag_commit) が不一致です" >&2
     echo "" >&2
-    echo "  ローカル tag とリモート tag が不一致（貼り替え未 push の可能性）:" >&2
-    echo "  ローカルで tag を貼り替えたが origin へ push できていない、" >&2
-    echo "  または別途 push 済みの内容がローカルへ反映されていない可能性があります。" >&2
+    echo "  リモート tag は origin/main と一致していますが、ローカル tag が" >&2
+    echo "  別の実体を指しています（ローカルが stale）。ローカル tag を" >&2
+    echo "  リモートへ同期してください:" >&2
     echo "" >&2
-    echo "  貼り替え手順 (Human オペレーション):" >&2
-    echo "    git push --force-with-lease=refs/tags/$TAG:$remote_tag_commit origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "    git fetch --force origin \"refs/tags/$TAG:refs/tags/$TAG\"" >&2
     echo "    sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
     echo "" >&2
     echo "  詳細: docs/release-process.md" >&2
@@ -108,13 +113,13 @@ else
     echo "  ローカル tag は origin/main と一致していますが、リモート tag ($TAG) は" >&2
     echo "  古い commit のままです。貼り替え済み・push 未完了の可能性があります:" >&2
     echo "" >&2
-    echo "  貼り替え手順 (Human オペレーション):" >&2
-    echo "    git push --force-with-lease=refs/tags/$TAG:$remote_tag_commit origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "  貼り替え手順 (Human オペレーション / lease 期待値=リモート tag オブジェクト SHA):" >&2
+    echo "    git push --force-with-lease=refs/tags/$TAG:$remote_tag_obj origin refs/tags/$TAG:refs/tags/$TAG" >&2
     echo "    sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
   else
     echo "  貼り替え手順 (Human オペレーション):" >&2
     echo "    1. git tag -fa $TAG origin/main  # annotated tag を main に作り直し" >&2
-    echo "    2. git push --force-with-lease origin refs/tags/$TAG:refs/tags/$TAG" >&2
+    echo "    2. git push --force-with-lease=refs/tags/$TAG:$remote_tag_obj origin refs/tags/$TAG:refs/tags/$TAG" >&2
     echo "    3. sh scripts/check-tag-main-parity.sh $TAG  # 再検証" >&2
   fi
 

--- a/tests/extras/ta-18-tag-main-parity.sh
+++ b/tests/extras/ta-18-tag-main-parity.sh
@@ -115,14 +115,14 @@ rm -rf "$T18_TMP"
 # === #783 R-005: リモート tag 実体照合 (実行ベース TC) ===
 # 既存 TC-01〜09 はロジック部分検証のみだったため、bare リポジトリを実 origin
 # とした fixture を作り、script を実際に実行して検証する。
-
-t18b_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
-t18b_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+# ヘルパーは既存の t18_pass / t18_fail を再利用する。
 
 T18B_ROOT=$(mktemp -d)
 T18B_BARE="$T18B_ROOT/origin.git"
 T18B_WORK="$T18B_ROOT/work"
 
+# set -eu 下では subshell 直後の `RC=$?` 行に到達しない（非ゼロで即 abort）ため
+# `&& RC=0 || RC=$?` 書法で捕捉する（tests/extras/README.md 規約 4）
 (
   set -eu
   git init -q --bare "$T18B_BARE"
@@ -137,14 +137,14 @@ T18B_WORK="$T18B_ROOT/work"
   git branch -M main
   git remote add origin "$T18B_BARE"
   git push -q origin main
-) >/dev/null 2>&1
-T18B_SETUP_RC=$?
+) >/dev/null 2>&1 && T18B_SETUP_RC=0 || T18B_SETUP_RC=$?
 
 if [ "$T18B_SETUP_RC" -ne 0 ] || [ ! -d "$T18B_WORK/.git" ]; then
-  t18b_fail "TC-10/11/12 fixture セットアップ失敗 (rc=$T18B_SETUP_RC)"
+  t18_fail "TC-10〜14 fixture セットアップ失敗 (rc=$T18B_SETUP_RC)"
 else
-  # --- TC-10: リモート tag = origin/main → exit 0 (OK) ---
+  # --- TC-10: リモート tag (annotated) = origin/main → exit 0 (OK) ---
   (
+    set -eu
     cd "$T18B_WORK"
     echo "v2" >> f.txt
     git add f.txt
@@ -152,18 +152,23 @@ else
     git push -q origin main
     git tag -a v10 -m "release v10"
     git push -q origin refs/tags/v10:refs/tags/v10
-  ) >/dev/null 2>&1
+  ) >/dev/null 2>&1 && T18B_RC=0 || T18B_RC=$?
 
-  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v10 2>&1) && T18B_RC=0 || T18B_RC=$?
-  if [ "$T18B_RC" -eq 0 ] && printf '%s' "$T18B_OUT" | grep -q "OK"; then
-    t18b_pass "TC-10 リモート tag = origin/main → exit 0 (OK)"
+  if [ "$T18B_RC" -ne 0 ]; then
+    t18_fail "TC-10 fixture 準備失敗 (rc=$T18B_RC)"
   else
-    t18b_fail "TC-10 rc=$T18B_RC out=$T18B_OUT"
+    T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v10 2>&1) && T18B_RC=0 || T18B_RC=$?
+    if [ "$T18B_RC" -eq 0 ] && printf '%s' "$T18B_OUT" | grep -q "OK"; then
+      t18_pass "TC-10 リモート tag (annotated) = origin/main → exit 0 (OK)"
+    else
+      t18_fail "TC-10 rc=$T18B_RC out=$T18B_OUT"
+    fi
   fi
 
   # --- TC-11: リモート tag が古い commit・ローカル tag は新 commit
   #     (2026-07-09 v8.16.0 実害シナリオ: 貼り替え済みだが push 未完了) → exit 1 ---
   (
+    set -eu
     cd "$T18B_WORK"
     git tag -a v11 -m "old release" HEAD
     git push -q origin refs/tags/v11:refs/tags/v11
@@ -173,26 +178,80 @@ else
     git push -q origin main
     # ローカルのみ貼り替え (push しない = 実害シナリオ)
     git tag -fa v11 -m "retagged locally, not pushed" HEAD
-  ) >/dev/null 2>&1
+  ) >/dev/null 2>&1 && T18B_RC=0 || T18B_RC=$?
 
-  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v11 2>&1) && T18B_RC=0 || T18B_RC=$?
-  if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "MISMATCH|不一致"; then
-    t18b_pass "TC-11 リモート tag 古い + ローカル tag 新しい (実害シナリオ) → exit 1 + 不一致明示"
+  if [ "$T18B_RC" -ne 0 ]; then
+    t18_fail "TC-11 fixture 準備失敗 (rc=$T18B_RC)"
   else
-    t18b_fail "TC-11 rc=$T18B_RC out=$T18B_OUT"
+    T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v11 2>&1) && T18B_RC=0 || T18B_RC=$?
+    if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "MISMATCH|不一致"; then
+      t18_pass "TC-11 リモート tag 古い + ローカル tag 新しい (実害シナリオ) → exit 1 + 不一致明示"
+    else
+      t18_fail "TC-11 rc=$T18B_RC out=$T18B_OUT"
+    fi
   fi
 
   # --- TC-12: tag をローカルにのみ作成しリモート未 push → exit 1 (push 忘れ検出) ---
   (
+    set -eu
     cd "$T18B_WORK"
     git tag v12 HEAD
-  ) >/dev/null 2>&1
+  ) >/dev/null 2>&1 && T18B_RC=0 || T18B_RC=$?
 
-  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v12 2>&1) && T18B_RC=0 || T18B_RC=$?
-  if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "存在しません|push 忘れ"; then
-    t18b_pass "TC-12 ローカルのみ tag (未push) → exit 1 (push 忘れ検出)"
+  if [ "$T18B_RC" -ne 0 ]; then
+    t18_fail "TC-12 fixture 準備失敗 (rc=$T18B_RC)"
   else
-    t18b_fail "TC-12 rc=$T18B_RC out=$T18B_OUT"
+    T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v12 2>&1) && T18B_RC=0 || T18B_RC=$?
+    if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "存在しません|push 忘れ"; then
+      t18_pass "TC-12 ローカルのみ tag (未push) → exit 1 (push 忘れ検出)"
+    else
+      t18_fail "TC-12 rc=$T18B_RC out=$T18B_OUT"
+    fi
+  fi
+
+  # --- TC-13: lightweight リモート tag = origin/main → exit 0
+  #     (peel 行なし → un-peeled 行 fallback parse の実行カバー / R-004) ---
+  (
+    set -eu
+    cd "$T18B_WORK"
+    git tag v13 HEAD
+    git push -q origin refs/tags/v13:refs/tags/v13
+  ) >/dev/null 2>&1 && T18B_RC=0 || T18B_RC=$?
+
+  if [ "$T18B_RC" -ne 0 ]; then
+    t18_fail "TC-13 fixture 準備失敗 (rc=$T18B_RC)"
+  else
+    T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v13 2>&1) && T18B_RC=0 || T18B_RC=$?
+    if [ "$T18B_RC" -eq 0 ] && printf '%s' "$T18B_OUT" | grep -q "OK"; then
+      t18_pass "TC-13 lightweight リモート tag = origin/main → exit 0 (fallback parse)"
+    else
+      t18_fail "TC-13 rc=$T18B_RC out=$T18B_OUT"
+    fi
+  fi
+
+  # --- TC-14: リモート tag = origin/main だがローカル tag が古い → exit 1、
+  #     かつ「ローカル同期 (git fetch --force)」案内で「git push」案内を含まない
+  #     (逆方向 push でリモートの正しい tag を上書きさせない / #783 指摘2) ---
+  (
+    set -eu
+    cd "$T18B_WORK"
+    # ローカル tag は 1 つ前の commit を指す (古い)
+    git tag -a v14 -m "stale local" HEAD~1
+    # リモート tag は main HEAD を指す (lightweight として直接 push)
+    git push -q origin HEAD:refs/tags/v14
+  ) >/dev/null 2>&1 && T18B_RC=0 || T18B_RC=$?
+
+  if [ "$T18B_RC" -ne 0 ]; then
+    t18_fail "TC-14 fixture 準備失敗 (rc=$T18B_RC)"
+  else
+    T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v14 2>&1) && T18B_RC=0 || T18B_RC=$?
+    if [ "$T18B_RC" -eq 1 ] \
+      && printf '%s' "$T18B_OUT" | grep -q "git fetch --force" \
+      && ! printf '%s' "$T18B_OUT" | grep -q "git push"; then
+      t18_pass "TC-14 remote=main + ローカル tag 古い → exit 1 + fetch 同期案内 (push 案内なし)"
+    else
+      t18_fail "TC-14 rc=$T18B_RC out=$T18B_OUT"
+    fi
   fi
 fi
 

--- a/tests/extras/ta-18-tag-main-parity.sh
+++ b/tests/extras/ta-18-tag-main-parity.sh
@@ -111,3 +111,90 @@ fi
 
 # cleanup
 rm -rf "$T18_TMP"
+
+# === #783 R-005: リモート tag 実体照合 (実行ベース TC) ===
+# 既存 TC-01〜09 はロジック部分検証のみだったため、bare リポジトリを実 origin
+# とした fixture を作り、script を実際に実行して検証する。
+
+t18b_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t18b_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+T18B_ROOT=$(mktemp -d)
+T18B_BARE="$T18B_ROOT/origin.git"
+T18B_WORK="$T18B_ROOT/work"
+
+(
+  set -eu
+  git init -q --bare "$T18B_BARE"
+  git init -q "$T18B_WORK"
+  cd "$T18B_WORK"
+  git config user.email t@t.t
+  git config user.name t
+  git config commit.gpgsign false
+  echo "v1" > f.txt
+  git add f.txt
+  git commit -q -m "c1"
+  git branch -M main
+  git remote add origin "$T18B_BARE"
+  git push -q origin main
+) >/dev/null 2>&1
+T18B_SETUP_RC=$?
+
+if [ "$T18B_SETUP_RC" -ne 0 ] || [ ! -d "$T18B_WORK/.git" ]; then
+  t18b_fail "TC-10/11/12 fixture セットアップ失敗 (rc=$T18B_SETUP_RC)"
+else
+  # --- TC-10: リモート tag = origin/main → exit 0 (OK) ---
+  (
+    cd "$T18B_WORK"
+    echo "v2" >> f.txt
+    git add f.txt
+    git commit -q -m "c2"
+    git push -q origin main
+    git tag -a v10 -m "release v10"
+    git push -q origin refs/tags/v10:refs/tags/v10
+  ) >/dev/null 2>&1
+
+  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v10 2>&1) && T18B_RC=0 || T18B_RC=$?
+  if [ "$T18B_RC" -eq 0 ] && printf '%s' "$T18B_OUT" | grep -q "OK"; then
+    t18b_pass "TC-10 リモート tag = origin/main → exit 0 (OK)"
+  else
+    t18b_fail "TC-10 rc=$T18B_RC out=$T18B_OUT"
+  fi
+
+  # --- TC-11: リモート tag が古い commit・ローカル tag は新 commit
+  #     (2026-07-09 v8.16.0 実害シナリオ: 貼り替え済みだが push 未完了) → exit 1 ---
+  (
+    cd "$T18B_WORK"
+    git tag -a v11 -m "old release" HEAD
+    git push -q origin refs/tags/v11:refs/tags/v11
+    echo "v3" >> f.txt
+    git add f.txt
+    git commit -q -m "c3"
+    git push -q origin main
+    # ローカルのみ貼り替え (push しない = 実害シナリオ)
+    git tag -fa v11 -m "retagged locally, not pushed" HEAD
+  ) >/dev/null 2>&1
+
+  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v11 2>&1) && T18B_RC=0 || T18B_RC=$?
+  if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "MISMATCH|不一致"; then
+    t18b_pass "TC-11 リモート tag 古い + ローカル tag 新しい (実害シナリオ) → exit 1 + 不一致明示"
+  else
+    t18b_fail "TC-11 rc=$T18B_RC out=$T18B_OUT"
+  fi
+
+  # --- TC-12: tag をローカルにのみ作成しリモート未 push → exit 1 (push 忘れ検出) ---
+  (
+    cd "$T18B_WORK"
+    git tag v12 HEAD
+  ) >/dev/null 2>&1
+
+  T18B_OUT=$(cd "$T18B_WORK" && sh "$PG_T18_SCRIPT" v12 2>&1) && T18B_RC=0 || T18B_RC=$?
+  if [ "$T18B_RC" -eq 1 ] && printf '%s' "$T18B_OUT" | grep -qE "存在しません|push 忘れ"; then
+    t18b_pass "TC-12 ローカルのみ tag (未push) → exit 1 (push 忘れ検出)"
+  else
+    t18b_fail "TC-12 rc=$T18B_RC out=$T18B_OUT"
+  fi
+fi
+
+# cleanup (#783 fixture — 実 docs/working を汚染しないよう mktemp -d 配下のみ使用)
+rm -rf "$T18B_ROOT"


### PR DESCRIPTION
## 概要

**NO RELEASE WITHOUT TAG-MAIN PARITY** 検証スクリプトが**ローカル tag** を解決して判定していたため、2026-07-09 の v8.16.0 リリースで「リモート tag は旧 commit のまま（push 拒否済み）なのに OK」の**偽 PASS** が発生し、旧 commit を指す tag のまま GitHub Release が発行された実害への修正。

## 変更

1. **主判定をリモート実体に**: `git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}"` で取得した SHA（annotated は peeled 行優先・lightweight は fallback）を origin/main と照合
2. **push 忘れ検出（R-005）**: リモート tag 不在／ローカル≠リモートを個別 FAIL で明示
3. **復旧コマンドの実効性**: lease 期待値を **tag オブジェクト SHA**（un-peeled）に — peeled commit SHA だと annotated tag で必ず `stale info` 拒否される（レビューで実証）
4. **逆方向案内の是正**: remote==main でローカルだけ古いケースは `git fetch --force` によるローカル同期を案内（push 案内を削除 — 従前案は正しい公開 tag を壊す方向だった）
5. **offline / ls-remote 失敗は fail-closed**（exit 1）
6. **テスト**: bare repo を実 origin にした実行ベース TC-10〜14 追加（実害シナリオ・push 忘れ・lightweight・逆方向案内の回帰固定）。fixture は set -eu 互換書法（README 準拠）
7. **docs/release-process.md 追従**: リモート照合の意味論・復旧コマンド統一・「リリース後再実行は MISMATCH（仕様）」注記

## 実装・レビュー体制

- 実装: sonnet 委託（worktree 分離）→ **RiverReview（code/testing）+ 敵対的レビュー（opus・bare repo 再現実験つき / Codex は CLI 破損で unavailable・§7-ter 記録）** の 2 レーン
- 両レーンが独立に同一 MAJOR（lease 値問題）へ収斂 + RiverReview が逆方向案内・set -eu 非互換を検出 → 全採用し反映
- **修正版が出力する復旧コマンドをそのまま fixture で実行して成功（forced update → 再検証 OK）まで実証**。旧版では同コマンドが reject されることも実証済み
- 敵対的レーンの偽 PASS 攻撃（prefix 衝突・stderr 混入・peel 行欠落等）は全て不成立 = 検出ロジックの堅牢性を実験で確認

## 検証

- ta-18: **15/15 PASS**（TC-11 が旧スクリプトでは FAIL することを確認 = テストが差分を実証）
- フルスイート: **395 passed / 0 failed**
- markdownlint（release-process.md）: 0 error

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)