### PR TITLE
chore: /ai-loop-workflow コマンドへ docs 参照先の環境別明記を追加

### DIFF
--- a/.claude/commands/ai-loop-workflow.md
+++ b/.claude/commands/ai-loop-workflow.md
@@ -7,6 +7,11 @@ ai-loop-workflow（human-on-the-loop 裁定ループ）を明示起動する。
 実行手順の正本: skill `ai-loop-cycle`（1 サイクル = LoopSpec → W チェック →
 arbiter 裁定 → exec → rubric grader）。本コマンドは前提確認と起動のみを担う。
 
+> **docs の参照先**: plugin 導入先では ai-loop ドキュメントは skill 内の
+> `references/` 配下（`skills/ai-loop-cycle/references/`）に同梱される。
+> 本リポジトリ（正本側）では `docs/workflows/ai-loop/` 配下。以下の参照は
+> 環境に応じてどちらかで解決すること。
+
 ## 引数
 
 $ARGUMENTS に以下の形式で渡される:
@@ -43,5 +48,6 @@ $ARGUMENTS に以下の形式で渡される:
 ## 関連
 
 - skill: `ai-loop-cycle`（実行単位の正本）
-- docs: 同梱 ai-loop ドキュメント（design-philosophy / decision-table / execution-runbook）
+- docs: 同梱 ai-loop ドキュメント（design-philosophy / decision-table / execution-runbook —
+  plugin 導入先は skill 内 `references/`、本リポジトリは `docs/workflows/ai-loop/` 配下）
 - 対: `/ai-dev-workflow`（PlanGate 本番フロー入口）

--- a/plugin/plangate/commands/ai-loop-workflow.md
+++ b/plugin/plangate/commands/ai-loop-workflow.md
@@ -7,6 +7,11 @@ ai-loop-workflow（human-on-the-loop 裁定ループ）を明示起動する。
 実行手順の正本: skill `ai-loop-cycle`（1 サイクル = LoopSpec → W チェック →
 arbiter 裁定 → exec → rubric grader）。本コマンドは前提確認と起動のみを担う。
 
+> **docs の参照先**: plugin 導入先では ai-loop ドキュメントは skill 内の
+> `references/` 配下（`skills/ai-loop-cycle/references/`）に同梱される。
+> 本リポジトリ（正本側）では `docs/workflows/ai-loop/` 配下。以下の参照は
+> 環境に応じてどちらかで解決すること。
+
 ## 引数
 
 $ARGUMENTS に以下の形式で渡される:
@@ -43,5 +48,6 @@ $ARGUMENTS に以下の形式で渡される:
 ## 関連
 
 - skill: `ai-loop-cycle`（実行単位の正本）
-- docs: 同梱 ai-loop ドキュメント（design-philosophy / decision-table / execution-runbook）
+- docs: 同梱 ai-loop ドキュメント（design-philosophy / decision-table / execution-runbook —
+  plugin 導入先は skill 内 `references/`、本リポジトリは `docs/workflows/ai-loop/` 配下）
 - 対: `/ai-dev-workflow`（PlanGate 本番フロー入口）


### PR DESCRIPTION
## 概要

`scripts/apply-ai-loop-workflow-command.sh --apply`（**Human 実行**）+ `sh scripts/sync-plugin-plangate.sh` の結果を PR 化。

`/ai-loop-workflow` コマンド定義に、ai-loop ドキュメントの**参照先が環境で異なる**旨を明記:
- plugin 導入先: skill 内 `references/`（`skills/ai-loop-cycle/references/`）配下に bundled
- 本リポジトリ（正本側）: `docs/workflows/ai-loop/` 配下

これにより導入先ユーザーが docs 参照を正しく解決できる（#778 でソース更新済み → 再適用分）。

## 変更（2 ファイル・各 +7 行）

- `.claude/commands/ai-loop-workflow.md`（正本）
- `plugin/plangate/commands/ai-loop-workflow.md`（sync 生成コピー）

無関係な既存 plugin sync ドリフト（workflow-conductor.md / review-gate SKILL.md）は本 PR から除外済み（別途対応）。

## 備考

`.claude/commands/*.md` は Hardening Override 対象。**適用=Human（apply 実行済み）→ PR 化=AI**（責務分界どおり）。C-4 マージは Human。markdownlint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)