### PR TITLE
fix: plugin bundle を dead link ゼロで自己完結化（#790）

### DIFF
--- a/plugin/plangate/skills/ai-loop-cycle/references/00_concept.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/00_concept.md
@@ -37,7 +37,7 @@ Arbiter が存在証明を超えるまで PlanGate が本番統制を担う。
 
 Arbiter は plan 生成・要件展開・設計（WF-01〜03）の**工程の実体**を再実装せず、
 PlanGate 既存フローをそのまま利用する。置き換えの対象は **C-3 のみ**であり、
-C-2（2 レーン契約、[`review-principles.md`](../../../.claude/rules/review-principles.md)
+C-2（2 レーン契約、`review-principles.md`
 §7-bis）は不変のまま踏襲する。判断実行は L1 = RiverReview 委譲、C-4・merge
 は引き続き Human-owned 固定（詳細は次節）。ただし ai-loop-workflow は
 **ai-dev-workflow（AI 工程は PR 作成まで、C-4 は人間）より広い責務**を持ち、
@@ -56,7 +56,7 @@ PR 作成後の CI・AI レビュー指摘対応が完了し merge-ready に到�
 >
 > 「そのために、PR作成前のセルフレビューの強化も整える」
 
-追加判断（AskUserQuestion）: 既存 C-2（2 レーン・[`review-principles.md`](../../../.claude/rules/review-principles.md)
+追加判断（AskUserQuestion）: 既存 C-2（2 レーン・`review-principles.md`
 §7-bis）は**不変**のまま、**後段に W チェック（C-3'）を追加**する方式を選択。
 
 ### 3.2 確定パイプライン
@@ -108,7 +108,7 @@ detect である。CI/PR 時の AI レビュー（ボットレビュー）を**�
 **収束ルール（指摘対応ループの打ち切り基準）**: 対応ラウンド（push →
 新規指摘確認）の上限は **3 ラウンド**とし、超過した場合は human escalate
 とする（escalate 予算 =
-[`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §7 と接続）。
+[`arbiter-policy.md`](./arbiter-policy.md) §7 と接続）。
 また新規指摘が minor / info のみとなった時点で、採用 / 理由付き不採用の
 記録を条件に merge-ready 判定へ進んでよい（収束保証）。
 
@@ -125,7 +125,7 @@ merge-ready 責務を担保するため、exec / V 系完了後・PR 作成前�
   として実装予定）。宣言外の変更を検出した場合は exec へ差し戻すか、
   再裁定（C-3' 再実行）を行う
 - **内容**: self-review スキル（Phase 1〜13 全観点）+
-  [`plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md)
+  `plan-review-readiness-gate.md`
   §7/§8 観点 + review-feedback-loop（L4）で還元済みの観点を必ず通す
 - **狙い**: PR 作成後の CI 失敗・AI レビュー指摘を事前に潰し、「PR 作成後に
   指摘を受けない状態」に近づける。指摘が出た場合は L4 ループ
@@ -136,11 +136,11 @@ merge-ready 責務を担保するため、exec / V 系完了後・PR 作成前�
 ### 3.5 位置づけの整理
 
 本節は PlanGate 既存の C-3 Autonomous APPROVE
-（[`working-context.md`](../../../.claude/rules/working-context.md) #353）・
+（`working-context.md` #353）・
 C-3 条件付き降格（F5-AD）の判定を decision table + provenance で完全機械化
 した位置づけである。escalate は従来の人間 C-3 への降格であり、**承認境界の
 撤廃ではない**。touches-HO は W チェック結果にかかわらず常に人間へ固定
-（[`concept.md`](../../ai/ai-loop/concept.md) §5「不変の原則」参照）。
+（[`concept.md`](./concept.md) §5「不変の原則」参照）。
 
 ---
 
@@ -222,6 +222,6 @@ asset-inventory.md の uses/not-uses 分類に従う:
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — C-3' の flow→detect→escalate 動作フロー
 - [`docs/workflows/ai-loop/execution-runbook.md`](./execution-runbook.md) — PR 前セルフレビュー・PR 後指摘対応ループの実行手順
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — CI/AI レビュー指摘対応を L4 学習へ還元する閉ループ
-- [`docs/ai/plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md) — 強化セルフレビュー §7/§8 観点の参照元
-- [`.claude/rules/review-principles.md`](../../../.claude/rules/review-principles.md) §7-bis — C-2 の 2 レーン契約（不変）
-- [`.claude/rules/working-context.md`](../../../.claude/rules/working-context.md) — C-3 Autonomous APPROVE（#353）・C-3 条件付き降格（F5-AD）の正本
+- `plan-review-readiness-gate.md` — 強化セルフレビュー §7/§8 観点の参照元
+- `review-principles.md` §7-bis — C-2 の 2 レーン契約（不変）
+- `working-context.md` — C-3 Autonomous APPROVE（#353）・C-3 条件付き降格（F5-AD）の正本

--- a/plugin/plangate/skills/ai-loop-cycle/references/README.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/README.md
@@ -12,13 +12,13 @@
 
 ## 時点固定のスナップショットについて（改変しない）
 
-[`asset-inventory.md`](./asset-inventory.md) / [`related-specs.md`](./related-specs.md) /
+`asset-inventory.md` / [`related-specs.md`](./related-specs.md) /
 [`ho-paths.md`](./ho-paths.md) の Phase 0 記述、および
-[`phase3-impact-report.md`](./phase3-impact-report.md) は**時点固定の監査証跡**であり、
+`phase3-impact-report.md` は**時点固定の監査証跡**であり、
 最新化のために書き換えない。最新の役割定義は常に `design-philosophy.md` §7 を参照する。
 
 ## 実行系正本
 
 ワークフロー手順（flow-detect / decision-table / execution-runbook 等）の正本は
-[`docs/workflows/ai-loop/`](../../workflows/ai-loop/) 配下（`00_concept.md` ほか）に
+`ai-loop` 配下（`00_concept.md` ほか）に
 ある。詳細は `design-philosophy.md` §7 を参照。

--- a/plugin/plangate/skills/ai-loop-cycle/references/adaptive-production-loop.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/adaptive-production-loop.md
@@ -170,4 +170,4 @@ ai-loop-workflow の説明では、以下の表現を採用する。
 - [`review-feedback-loop.md`](./review-feedback-loop.md) — Remember / Optimize の実体となるレビュー指摘還元ループ
 - [`flow-detect.md`](./flow-detect.md) — C-3' の flow→detect→escalate 動作フロー
 - [`decision-table.md`](./decision-table.md) — terminal state と decision record
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — Human-owned 境界と escalate 予算
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — Human-owned 境界と escalate 予算

--- a/plugin/plangate/skills/ai-loop-cycle/references/arbiter-policy.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/arbiter-policy.md
@@ -53,7 +53,7 @@ escalate  : 逸脱（W チェック不一致 / boundary=touches-HO / 予算超�
 
 ### 4.1 基本判定表
 
-> 判定表の正本は [`docs/workflows/ai-loop/flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.1。本表は policy 文脈での再掲であり、相違がある場合は flow-detect.md を優先する。
+> 判定表の正本は [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) §3.1。本表は policy 文脈での再掲であり、相違がある場合は flow-detect.md を優先する。
 
 | モデル A | モデル B | → 裁定 |
 | --------- | --------- | -------- |

--- a/plugin/plangate/skills/ai-loop-cycle/references/concept.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/concept.md
@@ -14,7 +14,7 @@
 全体では PlanGate の WF-00〜03・C-1・C-2 を共通利用し、**Arbiter は C-3
 （人間の計画承認）を置換する C-3' として動作する**
 （位置づけの詳細は
-[`docs/workflows/ai-loop/00_concept.md`](../../workflows/ai-loop/00_concept.md) §3）。
+[`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) §3）。
 
 動作の核心は 3 ステップ:
 
@@ -39,7 +39,7 @@ Arbiter は、PlanGate で積み重ねた統制資産 — 失敗履歴・INC 群
 を継承し、堅牢な on-the-loop モデルを構築することを目的とする。
 本 PoC を独立リポジトリではなく PlanGate リポジトリ内で行う本質的な理由は、
 これらの資産が**ここにしか存在しない**ためである。詳細な資産分類は
-[`docs/ai/ai-loop/asset-inventory.md`](./asset-inventory.md) を参照。
+`asset-inventory.md` を参照。
 
 ---
 
@@ -53,7 +53,7 @@ Arbiter は PlanGate の延長（v9 / 2.0）ではなく、**次世代検証プ�
 | 承認の時制 | 実行前 | 逸脱検知時 |
 | 制御の基本姿勢 | block until approved | flow → detect → escalate |
 | 現在の位置づけ | 本番統制を担う（並走期全体） | PoC 段階の独立プロジェクト |
-| AI 責務の終点 | PR 作成まで（C-4 は人間） | **merge-ready**（CI green + AI レビュー指摘対応完了）まで一気通貫（[`00_concept.md`](../../workflows/ai-loop/00_concept.md) §3.3） |
+| AI 責務の終点 | PR 作成まで（C-4 は人間） | **merge-ready**（CI green + AI レビュー指摘対応完了）まで一気通貫（[`00_concept.md`](./00_concept.md) §3.3） |
 
 ### 配置方針（Phase 0 判断）
 
@@ -110,7 +110,7 @@ AGENTS.md                   同上
 ## 4. flow → detect → escalate の基本フロー
 
 本フローは C-1 PASS・C-2 完了後の **C-3' ゲート**として発火する
-（[`00_concept.md`](../../workflows/ai-loop/00_concept.md) §3.2 パイプライン参照）。
+（[`00_concept.md`](./00_concept.md) §3.2 パイプライン参照）。
 W チェックの対象は C-2 通過済みの plan アーティファクト（plan.md /
 todo.md / test-cases.md）である。実差分（実装コード）に対する独立判定は
 第 2 段の detect（CI/PR 時の AI レビュー。00_concept.md §3.3）が担う。
@@ -150,7 +150,7 @@ todo.md / test-cases.md）である。実差分（実装コード）に対する
 > `A=approve & B=reject`（不一致）は実際には「即 human escalate」ではなく
 > **severity 分類**（critical/major → human escalate、minor/low →
 > Model C/D 裁定で auto-approve に到達し得る）へ進む。詳細分岐の正本は
-> [`docs/workflows/ai-loop/flow-detect.md`](../../workflows/ai-loop/flow-detect.md)
+> [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md)
 > §3.2〜3.3。
 
 ### detect フェーズの入力（L2 入力 4 軸）
@@ -246,4 +246,4 @@ L0 統制契約層        承認境界 / 責務モデル / HO / mode 判定（on
 - `docs/ai/ai-loop/asset-inventory.md` — PlanGate 共通資産の uses/not-uses 分類
 - `docs/ai/ai-loop/ho-paths.md` — touches-HO 判定基準リスト
 - `docs/ai/ai-loop/related-specs.md` — 既存仕様との関係整理
-- [`docs/workflows/ai-loop/00_concept.md`](../../workflows/ai-loop/00_concept.md) §3 — PlanGate フロー共通化と C-3 置換（C-3'）の確定パイプライン・責務範囲
+- [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) §3 — PlanGate フロー共通化と C-3 置換（C-3'）の確定パイプライン・責務範囲

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -194,8 +194,8 @@ on-the-loop 固有の「自律暴走」防止機構。
 
 ## 7. 関連ドキュメント
 
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — W チェック・escalate 予算・第0の承認境界
-- [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — W チェック・escalate 予算・第0の承認境界
+- [`docs/ai/ai-loop/ho-paths.md`](./ho-paths.md) — boundary=touches-HO 判定の正本
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow→detect→escalate の動作フロー（§3.2〜3.3: approve-reject の詳細）
 - [`docs/workflows/ai-loop/lite-criteria.md`](./lite-criteria.md) — `lite` 軸の判定基準（可逆性要件含む）
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係

--- a/plugin/plangate/skills/ai-loop-cycle/references/design-philosophy.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/design-philosophy.md
@@ -364,7 +364,7 @@ ai-loop ドキュメント全体で同じ意味に使う。
 - [`concept.md`](./concept.md) — ai-loop コンセプト定義（L0-L5・Phase 計画）
 - [`adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 ステップサイクル・1 サイクル contract 正本
 - [`arbiter-policy.md`](./arbiter-policy.md) — Human-owned 境界・escalate 予算
-- [`docs/ai/subagent-delegation/README.md`](./README.md) — 委譲プロトコル（Harness 層の隣接正本）
+- `subagent-delegation/README.md` — 委譲プロトコル（Harness 層の隣接正本）
 - issue [#726](https://github.com/s977043/plangate/issues/726) / [#727](https://github.com/s977043/plangate/issues/727) / [#728](https://github.com/s977043/plangate/issues/728) / [#729](https://github.com/s977043/plangate/issues/729) — intake 待ち知見
 
 ---

--- a/plugin/plangate/skills/ai-loop-cycle/references/design-philosophy.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/design-philosophy.md
@@ -86,7 +86,7 @@ policy 制定は永久に Human-owned（第0の承認境界。[`arbiter-policy.m
 
 生成者に自己評価させない。Evaluate は生成と独立した主体・独立した極性
 （Model A=順方向「正しく作られているか」/ Model B=adversarial「どう壊れるか」）で行う
-（W チェック。[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3）。
+（W チェック。[`flow-detect.md`](./flow-detect.md) §3）。
 この分離は成果物の評価に限らない: **思想・仕様の取り込み判断（§6 intake loop）にも適用する**。
 
 **なぜ**: 自己評価の甘さは、プロンプトの工夫では消えない。生成と同一のコンテキスト・
@@ -96,7 +96,7 @@ policy 制定は永久に Human-owned（第0の承認境界。[`arbiter-policy.m
 
 裁定（L2 / Arbiter）は決定論ロジックで行い、LLM の判断に委ねない。
 severity 分類は rule ベース分類器が行い、Model B の自己申告を採用しない
-（[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.2.1）。
+（[`flow-detect.md`](./flow-detect.md) §3.2.1）。
 auto-approve には provenance を刻印し、「誰が・何を根拠に・何を承認したか」を追跡可能に残す。
 
 **なぜ**: 同じ入力に同じ裁定が返らないシステムは監査できない。冪等性・明示的失敗・
@@ -104,7 +104,7 @@ auto-approve には provenance を刻印し、「誰が・何を根拠に・何�
 
 > **既知の限界（honest 注記）**: 現行 PoC の provenance は「刻印されている」ことを保証するが、
 > `issued_by` の**発行元真正性は未検証**（署名等が別途必要。
-> [`decision-table.md`](../../workflows/ai-loop/decision-table.md) §5 / PlanGate #420 と同型の
+> [`decision-table.md`](./decision-table.md) §5 / PlanGate #420 と同型の
 > 未解決課題）。I-3 は「決定論で裁定し記録を残す」原理であり、偽装不可能性まで主張しない。
 
 ### I-4. 安全側デフォルト — 判定不能は昇格側に倒す
@@ -120,7 +120,7 @@ boundary 判定不能・severity 分類不能・lite 判定の根拠不足は、
 Optimize（gate / skill / suppression / scheduling policy の更新）は、
 Remember（decision record・指摘・反証・効果の保存）に**記録された事実のみ**を根拠とする。
 逆に、記録するだけで次回の振る舞いに反映されない Remember も失敗として扱う
-（[`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md) §6）。
+（[`adaptive-production-loop.md`](./adaptive-production-loop.md) §6）。
 
 **なぜ**: 根拠なきプロンプト・ゲート書き換えは再現不能な劣化を生み、
 記録だけの蓄積は「学習している感」だけを生む。両者を分離し一方向依存にすることで、
@@ -129,7 +129,7 @@ Remember（decision record・指摘・反証・効果の保存）に**記録さ�
 ### I-6. 停止できないループはループではない
 
 closed loop は 1 サイクルの contract
-（[`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md) §4 を正本とする
+（[`adaptive-production-loop.md`](./adaptive-production-loop.md) §4 を正本とする
 Goal / Evaluate / Stop / Memory / Schedule / Boundary の 6 要素）を満たす反復のみを指す。
 これを満たさない反復は **scheduled repetition（polling）** と呼び、区別する。
 Budget（対応ラウンド上限・escalate 予算）は Stop / Schedule に内包される停止資源である。
@@ -138,7 +138,7 @@ Budget（対応ラウンド上限・escalate 予算）は Stop / Schedule に内
 
 停止機構は 2 層ある: **反復の停止**（terminal state への到達）と、
 **自律そのものの一時停止**（サーキットブレーカー CB。
-[`decision-table.md`](../../workflows/ai-loop/decision-table.md) §6 — 誤って学習した policy や
+[`decision-table.md`](./decision-table.md) §6 — 誤って学習した policy や
 昇格の洪水を止める）。両方を持たないループは片肺である。
 
 **なぜ**: 非停止は安全性の問題である以前に経済性の問題（推論コスト・トークン・時間）であり、
@@ -157,8 +157,8 @@ escalate が無制限なら人間はまた全件レビューに戻り、ゼロ�
 ### I-8. 枠内自律は低リスク帯に限定する — 可逆性の担保
 
 flow に乗せてよいのは `boundary=clean` **かつ** `lite=true` の変更のみ
-（[`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §2 /
-[`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)）。
+（[`flow-detect.md`](./flow-detect.md) §2 /
+[`lite-criteria.md`](./lite-criteria.md)）。
 lite 判定の必須軸には**可逆性**が含まれる: **不可逆な変更は flow に流さない**。
 
 **なぜ**: on-the-loop の安全装置（サーキットブレーカー・事後 reject・巻き戻し）は、
@@ -170,8 +170,8 @@ lite 判定の必須軸には**可逆性**が含まれる: **不可逆な変更�
 
 C-3'（Arbiter）が裁定するのは **plan 宣言**（第 1 段 detect）であり、
 実装後の**実差分**は PR 前の宣言↔実差分整合検証 + CI / AI レビュー（第 2 段 detect）で
-独立に再検証される（[`00_concept.md`](../../workflows/ai-loop/00_concept.md) §3.3 /
-[`execution-runbook.md`](../../workflows/ai-loop/execution-runbook.md) §2-(6)）。
+独立に再検証される（[`00_concept.md`](./00_concept.md) §3.3 /
+[`execution-runbook.md`](./execution-runbook.md) §2-(6)）。
 宣言外の変更は exec 差し戻しまたは C-3' 再裁定であり、承認の使い回しを認めない。
 
 **なぜ**: 「plan は承認された」ことと「実装が plan の通りである」ことは別の命題である。
@@ -206,7 +206,7 @@ ai-loop は 2 つの直交する軸で記述される。混同しない。
   （[`concept.md`](./concept.md) §7）。L0 統制契約が全層を拘束し、L2 裁定が心臓。
 - **Generate → Evaluate → Remember → Schedule → Optimize → Recurse（動的な 1 サイクル）**:
   時間軸上で何が起きるか
-  （[`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md) §3 の
+  （[`adaptive-production-loop.md`](./adaptive-production-loop.md) §3 の
   6 ステップ表。各ステップの ai-loop 上の対応は同表右列）。
 
 両軸の突き合わせ（どのステップがどの層で実行されるか）は、各正本の該当節を参照して行う。
@@ -227,13 +227,13 @@ ai-loop ドキュメント全体で同じ意味に使う。
 | **governed autonomy（枠内自律）**    | 承認境界の内側での AI 自律実行。境界外は常に人間                                                                                                                                                                                                                                                                                   | 完全自律（人間なし）                                                                                    |
 | **bounded adaptive production loop** | 低リスク帯に限定され、1 サイクル contract（下記 closed loop）を満たす自己改善ループ                                                                                                                                                                                                                                                | 無制限の自己改善                                                                                        |
 | **human-on-the-loop**                | 人間＝枠の制定者・例外の裁定者・事後の監督者。一般分類（EU HLEG / DoD 3000.09）では **HIC + HOTL + HITL（例外・境界）のハイブリッド**であり、定常運転時の位置を指す運用呼称（§1.1）                                                                                                                                                | human-in-the-loop（実行前承認者）／ human-out-of-the-loop ／ 一般 HOTL 単独（監視のみ）としての弱い読み |
-| **closed loop**                      | 1 サイクル contract（**Goal / Evaluate / Stop / Memory / Schedule / Boundary** — 正本: [`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md) §4）を満たす反復。Budget は Stop / Schedule に内包                                                                                                     | scheduled repetition / polling（interval 駆動の再実行）                                                 |
+| **closed loop**                      | 1 サイクル contract（**Goal / Evaluate / Stop / Memory / Schedule / Boundary** — 正本: [`adaptive-production-loop.md`](./adaptive-production-loop.md) §4）を満たす反復。Budget は Stop / Schedule に内包                                                                                                     | scheduled repetition / polling（interval 駆動の再実行）                                                 |
 | **escalate**                         | 逸脱を人間へ昇格すること。2 文脈を区別する: **C-3' escalate**（plan 裁定の人間 C-3 への降格。承認境界の撤廃ではない）と **Schedule escalate**（PR 後ループでのラウンド上限超過・critical 指摘等による人間介入要求）                                                                                                                | エラー・失敗（escalate は正常系の一部）                                                                 |
 | **W チェック**                       | 順方向（A）と adversarial（B）の 2 モデル非対称二重判定                                                                                                                                                                                                                                                                            | 単一モデルの自己レビュー                                                                                |
-| **severity（二軸）**                 | ①W チェック不一致の severity（critical/major/minor/**low** — [`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §3.2）と ②レビュー指摘の severity（critical/major/minor/**info** — review-principles §3）は**別軸**。混同しない                                                                                            | 単一の severity 軸として扱うこと                                                                        |
+| **severity（二軸）**                 | ①W チェック不一致の severity（critical/major/minor/**low** — [`flow-detect.md`](./flow-detect.md) §3.2）と ②レビュー指摘の severity（critical/major/minor/**info** — review-principles §3）は**別軸**。混同しない                                                                                            | 単一の severity 軸として扱うこと                                                                        |
 | **L2 入力 4 軸**                     | `boundary`（touches-HO / clean）・`lite`（true / false）・`verdict`（W チェック合意結果）・`class`（merge 含む / 含まない）。裁定の全入力（[`concept.md`](./concept.md) §4）                                                                                                                                                       | —                                                                                                       |
 | **provenance**                       | auto-approve の根拠刻印。誰が・何を・何を根拠に承認したかの追跡記録（発行元真正性の検証は未実装 — I-3 注記）                                                                                                                                                                                                                       | 単なる実行ログ                                                                                          |
-| **terminal state**                   | 裁定の終端 3 値（`AUTO_APPROVED` / `HUMAN_ESCALATED` / `BLOCKED` — [`decision-table.md`](../../workflows/ai-loop/decision-table.md)）。**merge-ready は裁定でなく DoD 状態**（[`00_concept.md`](../../workflows/ai-loop/00_concept.md) §3.3）、**round limit exceeded は HUMAN_ESCALATED への遷移理由**であり独立の state ではない | 中間状態・無限継続                                                                                      |
+| **terminal state**                   | 裁定の終端 3 値（`AUTO_APPROVED` / `HUMAN_ESCALATED` / `BLOCKED` — [`decision-table.md`](./decision-table.md)）。**merge-ready は裁定でなく DoD 状態**（[`00_concept.md`](./00_concept.md) §3.3）、**round limit exceeded は HUMAN_ESCALATED への遷移理由**であり独立の state ではない | 中間状態・無限継続                                                                                      |
 | **suppression**                      | 機械反証を伴う誤検知抑制の登録                                                                                                                                                                                                                                                                                                     | 根拠なき指摘の無視                                                                                      |
 | **Turn/Goal/Time/Proactive（外部語彙）** | Claude Code 系の loop 4 型分類（issue #746）。PlanGate では **型として採用しない**: Turn≒`trigger:manual`・Time≒`trigger:scheduled`・Proactive≒`trigger:scheduled/issue_created` は **trigger の値**であり、Goal は型ではなく **contract の一要素**（adaptive-production-loop §2 の分離を維持） | 4 型を独立の分類軸として輸入すること（trigger/contract 混同の逆流） |
 | **memory trust boundary（ro/rw 分離）** | memory 層の信頼区分（issue #751 intake）: 正本（read-only 参照・無条件信頼）/ 生成 memory（decision record・plan-memory 等 read-write・生成物としての信頼度）/ **外部入力由来**（issue 本文・PR コメント等 — **memory へ直接転記しない隔離対象**。poisoning 対策）。機構化は follow-up（設計判断・Human escalate 経由） | 外部入力を「信頼された記憶」として次回セッションに読ませること |
@@ -300,17 +300,17 @@ ai-loop ドキュメント全体で同じ意味に使う。
 |          | [`ho-paths.md`](./ho-paths.md)                                                                                                                   | touches-HO の機械判定                                              |
 |          | [`hotl-merge-entry-criteria.md`](./hotl-merge-entry-criteria.md)                                                                                 | HOTL merge 解禁の入口基準（C-4 merge 解禁判定は Human-owned 不変） |
 | **概念** | [`concept.md`](./concept.md)                                                                                                                     | ai-loop とは何か（L0-L5・in/on 対比・Phase 計画）                  |
-|          | [`00_concept.md`](../../workflows/ai-loop/00_concept.md)                                                                                         | PlanGate フローとの接続（C-3'・merge-ready 責務）                  |
-|          | [`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md)                                                             | 6 ステップサイクルと 1 サイクル contract（closed loop の正本）     |
-| **機構** | [`flow-detect.md`](../../workflows/ai-loop/flow-detect.md)                                                                                       | flow→detect→escalate の判定分岐                                    |
-|          | [`decision-table.md`](../../workflows/ai-loop/decision-table.md)                                                                                 | 裁定の決定表・provenance schema・terminal state・CB                |
-|          | [`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)                                                                                   | lite（低リスク・可逆性）判定基準                                   |
-|          | [`loopspec.md`](../../workflows/ai-loop/loopspec.md)                                                                                             | ループ実行境界の宣言構造                                           |
-|          | [`loop-safety-gates.md`](../../workflows/ai-loop/loop-safety-gates.md)                                                                           | 非停止プロンプトの事前拒否・再形成                                 |
-| **運用** | [`execution-runbook.md`](../../workflows/ai-loop/execution-runbook.md)                                                                           | 1 サイクルの実行手順・Scheduling 判断表                            |
-|          | [`review-feedback-loop.md`](../../workflows/ai-loop/review-feedback-loop.md)                                                                     | L4 学習閉ループ（Remember/Optimize の実体）                        |
-|          | [`unknown-discovery.md`](../../workflows/ai-loop/unknown-discovery.md)                                                                           | unknowns 4 分類と 3 ゲート                                         |
-| **記録** | [`asset-inventory.md`](./asset-inventory.md) / [`related-specs.md`](./related-specs.md) / [`phase3-impact-report.md`](./phase3-impact-report.md) | 資産分類・関連仕様・Phase 判断記録                                 |
+|          | [`00_concept.md`](./00_concept.md)                                                                                         | PlanGate フローとの接続（C-3'・merge-ready 責務）                  |
+|          | [`adaptive-production-loop.md`](./adaptive-production-loop.md)                                                             | 6 ステップサイクルと 1 サイクル contract（closed loop の正本）     |
+| **機構** | [`flow-detect.md`](./flow-detect.md)                                                                                       | flow→detect→escalate の判定分岐                                    |
+|          | [`decision-table.md`](./decision-table.md)                                                                                 | 裁定の決定表・provenance schema・terminal state・CB                |
+|          | [`lite-criteria.md`](./lite-criteria.md)                                                                                   | lite（低リスク・可逆性）判定基準                                   |
+|          | [`loopspec.md`](./loopspec.md)                                                                                             | ループ実行境界の宣言構造                                           |
+|          | [`loop-safety-gates.md`](./loop-safety-gates.md)                                                                           | 非停止プロンプトの事前拒否・再形成                                 |
+| **運用** | [`execution-runbook.md`](./execution-runbook.md)                                                                           | 1 サイクルの実行手順・Scheduling 判断表                            |
+|          | [`review-feedback-loop.md`](./review-feedback-loop.md)                                                                     | L4 学習閉ループ（Remember/Optimize の実体）                        |
+|          | [`unknown-discovery.md`](./unknown-discovery.md)                                                                           | unknowns 4 分類と 3 ゲート                                         |
+| **記録** | `asset-inventory.md` / [`related-specs.md`](./related-specs.md) / `phase3-impact-report.md` | 資産分類・関連仕様・Phase 判断記録                                 |
 |          | `agentic-six-stage-loop.md`                                                                 | 6段階ループ（Triage/Conductor/Worker/Verifier/Gate/Trust Ledger）対応表 + Trust Ledger 索引（#780） |
 
 ### 7.1 既知の構造的課題（次期リファクタリング候補）
@@ -362,9 +362,9 @@ ai-loop ドキュメント全体で同じ意味に使う。
 ## 10. 関連ドキュメント
 
 - [`concept.md`](./concept.md) — ai-loop コンセプト定義（L0-L5・Phase 計画）
-- [`adaptive-production-loop.md`](../../workflows/ai-loop/adaptive-production-loop.md) — 6 ステップサイクル・1 サイクル contract 正本
+- [`adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 ステップサイクル・1 サイクル contract 正本
 - [`arbiter-policy.md`](./arbiter-policy.md) — Human-owned 境界・escalate 予算
-- [`docs/ai/subagent-delegation/README.md`](../subagent-delegation/README.md) — 委譲プロトコル（Harness 層の隣接正本）
+- [`docs/ai/subagent-delegation/README.md`](./README.md) — 委譲プロトコル（Harness 層の隣接正本）
 - issue [#726](https://github.com/s977043/plangate/issues/726) / [#727](https://github.com/s977043/plangate/issues/727) / [#728](https://github.com/s977043/plangate/issues/728) / [#729](https://github.com/s977043/plangate/issues/729) — intake 待ち知見
 
 ---

--- a/plugin/plangate/skills/ai-loop-cycle/references/execution-runbook.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/execution-runbook.md
@@ -2,8 +2,8 @@
 
 > 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
-> 実装本体: [`scripts/ai-loop/arbiter.py`](../../../scripts/ai-loop/arbiter.py)
-> テスト: [`scripts/ai-loop/test_arbiter.py`](../../../scripts/ai-loop/test_arbiter.py)
+> 実装本体: `arbiter.py`
+> テスト: `test_arbiter.py`
 
 ---
 
@@ -89,7 +89,7 @@ python3 scripts/ai-loop/arbiter.py --input /path/to/input.json
 echo '{...}' | python3 scripts/ai-loop/arbiter.py
 ```
 
-入力 JSON のフィールド仕様は [`arbiter.py`](../../../scripts/ai-loop/arbiter.py)
+入力 JSON のフィールド仕様は `arbiter.py`
 モジュール docstring および [`decision-table.md`](./decision-table.md) §2・§5 を
 正本とする。
 
@@ -115,7 +115,7 @@ python3 scripts/ai-loop/arbiter.py --input /path/to/input.json \
 保存した decision record は次回以降の監査・L4 学習（[`review-feedback-loop.md`](./review-feedback-loop.md)）
 の入力となる。
 
-摩擦 ID は台帳（[`run-001-frictions.md`](../../working/ai-loop-runs/run-001-frictions.md)）が単一権威。新しい F-NNN は台帳への
+摩擦 ID は台帳（`run-001-frictions.md`）が単一権威。新しい F-NNN は台帳への
 追記と同時にのみ発行する（run 記録・PR 本文のみでの新 ID 発行は不可 —
 多セッション並行時の二重採番防止。F-34 と同根・2026-07-08 の F-35〜39 台帳欠落が実例）。
 採番前に台帳の最大 ID を確認する（§2-(0) の run 採番照合と同型）。
@@ -134,7 +134,7 @@ python3 scripts/ai-loop/arbiter.py --input /path/to/input.json \
 `AUTO_APPROVED`（exit code `0`）で exec 完了後・PR 作成前に、maker と独立の
 sonnet サブエージェント（**rubric grader**）へ exec 差分を委託する
 （手順詳細・rubric 5 項目・委託プロンプト定型は
-[`ai-loop-cycle` SKILL.md](../../../.claude/skills/ai-loop-cycle/SKILL.md)
+[`ai-loop-cycle` SKILL.md](../SKILL.md)
 Step 5.5 を正本とし、本節では再定義しない）。
 
 1. maker 差分 + 計画の Goal/確定文言を grader に入力する
@@ -156,7 +156,7 @@ Step 5.5 を正本とし、本節では再定義しない）。
    `git diff --name-only <base>...HEAD` を突合し、宣言外の変更がゼロであることを確認する
    （宣言外変更あり → exec 差し戻し or C-3' 再裁定）
 2. self-review スキル（Phase 1〜13 全観点）を実行する
-3. [`plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md)
+3. `plan-review-readiness-gate.md`
    §7/§8 観点を通す
 4. [`review-feedback-loop.md`](./review-feedback-loop.md) §2 で過去に還元済みの
    観点（過去の CI 失敗・AI レビュー指摘から抽出されたチェック項目）を通す
@@ -205,7 +205,7 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
    [`review-feedback-loop.md`](./review-feedback-loop.md) §2 の L4 学習閉ループへ
    還元し、次回の強化セルフレビュー（手順 (6)）で事前に捕捉されるようにする
 5. **収束ルール**: 対応ラウンド上限は 3。超過時は human escalate
-   （[`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §7 escalate 予算
+   （[`arbiter-policy.md`](./arbiter-policy.md) §7 escalate 予算
    と接続）。新規指摘が minor / info のみになった時点で、記録を条件に
    merge-ready 判定へ進んでよい（[`00_concept.md`](./00_concept.md) §3.3）
 6. **DoD**: CI 全 job green **かつ** AI レビュー指摘がゼロ、または全件対応完了
@@ -223,7 +223,7 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
 
 ## 3. 検証可能性 4 条件への適合
 
-[`orchestrator-mode.md`](../../../.claude/rules/orchestrator-mode.md) §検証可能性
+`orchestrator-mode.md` §検証可能性
 の 4 条件に対する `arbiter.py` の適合状況:
 
 | 条件                 | 適合内容                                                                                                                                                                   |
@@ -239,15 +239,15 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
 
 - 本エンジンは PlanGate 本番フロー（WF-00〜WF-07・`bin/plangate`・
   `scripts/hooks/`）から一切呼ばれない**隔離 PoC**である
-  （[`docs/ai/ai-loop/phase3-impact-report.md`](../../ai/ai-loop/phase3-impact-report.md) §b.1
+  （`phase3-impact-report.md` §b.1
   トリガー 1 の判断記録を参照）
 - W チェック（Model A/B/C/D）の verdict 品質は **L1（本 runbook を実行する
   呼び出し側）の責務**。`arbiter.py`（L2）は入力された verdict の内容が
   正しいかどうかを検証しない（決定論ロジックの適用のみ）
 - boundary=touches-HO は W チェック結果・severity 分類・C/D 裁定の**すべて
-  をスキップする絶対条件**（[`ho-paths.md`](../../ai/ai-loop/ho-paths.md) 判定ルール）
+  をスキップする絶対条件**（[`ho-paths.md`](./ho-paths.md) 判定ルール）
 - provenance の `issued_by` は自己申告であり、署名等の発行元検証機構は
-  本 PoC のスコープ外（[`phase3-impact-report.md`](../../ai/ai-loop/phase3-impact-report.md) §d
+  本 PoC のスコープ外（`phase3-impact-report.md` §d
   リスク 5、issue #420 EH-3 発行元検証と同型の未解決課題）
 
 ---
@@ -257,12 +257,12 @@ PR 作成後、以下を **merge-ready 到達まで**繰り返す。
 - [`docs/workflows/ai-loop/adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 層自己改善ループと Scheduling / Goal / Evaluate 分離の正本
 - [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — Decision table・provenance schema・CB
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow→detect→escalate 動作フロー
-- [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — Arbiter L0 policy
-- [`docs/ai/ai-loop/phase3-impact-report.md`](../../ai/ai-loop/phase3-impact-report.md) — 分離トリガー条件・判断記録
+- [`docs/ai/ai-loop/ho-paths.md`](./ho-paths.md) — boundary=touches-HO 判定の正本
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — Arbiter L0 policy
+- `phase3-impact-report.md` — 分離トリガー条件・判断記録
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — CB-1 事後 reject / CI・AI レビュー指摘対応を L4 学習へ還元する閉ループ
-- [`.claude/rules/orchestrator-mode.md`](../../../.claude/rules/orchestrator-mode.md) — 検証可能性 4 条件の正本
+- `orchestrator-mode.md` — 検証可能性 4 条件の正本
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) §3 — PlanGate フロー共通化と C-3 置換（C-3'）・merge-ready 責務範囲の正本
-- [`docs/ai/plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md) — 強化セルフレビュー §7/§8 観点の参照元
-- [`.claude/skills/ai-loop-cycle/SKILL.md`](../../../.claude/skills/ai-loop-cycle/SKILL.md) — 本 runbook の 1 サイクルを実行する手順スキル（Model A/B/C/D 委託プロンプト定型）
-- [`.claude/skills/pr-watch/SKILL.md`](../../../.claude/skills/pr-watch/SKILL.md) — 手順 (7) の CI/AI レビュー指摘対応ループの監視・対応定型
+- `plan-review-readiness-gate.md` — 強化セルフレビュー §7/§8 観点の参照元
+- [`.claude/skills/ai-loop-cycle/SKILL.md`](../SKILL.md) — 本 runbook の 1 サイクルを実行する手順スキル（Model A/B/C/D 委託プロンプト定型）
+- `pr-watch/SKILL.md` — 手順 (7) の CI/AI レビュー指摘対応ループの監視・対応定型

--- a/plugin/plangate/skills/ai-loop-cycle/references/flow-detect.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/flow-detect.md
@@ -77,7 +77,7 @@ W チェック不一致（A=approve, B=reject）を検出した場合:
 
 **安全側既定**: 分類不能・根拠不足・判定が曖昧な場合は安全側に倒し
 **critical 扱い（human escalate）**とする（PlanGate の AC-8 安全側原則
-[`working-context.md`](../../../.claude/rules/working-context.md)
+`working-context.md`
 と整合）。
 
 #### 3.2.1 severity 分類主体（Phase 1 確定）
@@ -89,7 +89,7 @@ severity を導出する。**Model B 自身に severity を自己申告させな
 独立した分類器が行う）。
 
 **カテゴリマッピング表**（policy 扱い・改版は Human-owned 固定。第0の
-承認境界 = [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6）:
+承認境界 = [`arbiter-policy.md`](./arbiter-policy.md) §6）:
 
 | severity | reject 理由カテゴリ例 |
 | ---------- | ------------------------ |
@@ -168,9 +168,9 @@ human 昇格の洪水を防ぐため:
 
 ## 6. 関連ドキュメント
 
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — W チェック拡張の policy 定義
-- [`docs/ai/ai-loop/ho-paths.md`](../../ai/ai-loop/ho-paths.md) — boundary=touches-HO 判定の正本
-- [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — W チェック拡張の policy 定義
+- [`docs/ai/ai-loop/ho-paths.md`](./ho-paths.md) — boundary=touches-HO 判定の正本
+- [`docs/ai/ai-loop/concept.md`](./concept.md) — Arbiter の基本概念
 - [`docs/workflows/ai-loop/00_concept.md`](./00_concept.md) — WF との並立関係
 - [`docs/workflows/ai-loop/lite-criteria.md`](./lite-criteria.md) — `lite` 判定基準（§2 flow フェーズで使用）
 - [`docs/workflows/ai-loop/review-feedback-loop.md`](./review-feedback-loop.md) — Model C/D 裁定結果を L4 学習へ還元する閉ループ（§3 で本ドキュメント §3.3 と接続）

--- a/plugin/plangate/skills/ai-loop-cycle/references/hotl-merge-entry-criteria.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/hotl-merge-entry-criteria.md
@@ -25,7 +25,7 @@
 [`design-philosophy.md`](./design-philosophy.md) §1.1 は、ai-loop の統制構造が
 HIC（枠の制定者）+ HOTL（監視・停止）+ HITL（例外・境界）のハイブリッドであり、
 C-4 merge は現行 policy で **HITL 固定**（[`arbiter-policy.md`](./arbiter-policy.md) §2
-永久 Human-owned 4 項目・[`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)・
+永久 Human-owned 4 項目・`responsibility-classes.md`・
 orchestrator-mode.md AS-3）であることを明文化した。
 
 一方、[`concept.md`](./concept.md) §6 Phase 5「解禁判定: policy maturity で領域ごと
@@ -47,7 +47,7 @@ on-the-loop 委譲を拡大（人間が判定）」は、将来の HOTL merge �
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 前提条件             | `issued_by`（誰が承認したか）の自己申告を解消し、署名 / HMAC 等で発行元の真正性を検証可能にする                                                                                                                                                                                                             |
 | 現状                 | ❌ 未適用                                                                                                                                                                                                                                                                                                   |
-| 検証方法（充足条件） | (a) provenance schema（[`decision-table.md`](../../workflows/ai-loop/decision-table.md) §5）に `hmac_signature`（または同等の署名フィールド）が定義されている、かつ (b) 署名検証ロジックのテストが PASS する、かつ (c) 署名なし・改ざんされた provenance が reject されることを確認する自動テストが存在する |
+| 検証方法（充足条件） | (a) provenance schema（[`decision-table.md`](./decision-table.md) §5）に `hmac_signature`（または同等の署名フィールド）が定義されている、かつ (b) 署名検証ロジックのテストが PASS する、かつ (c) 署名なし・改ざんされた provenance が reject されることを確認する自動テストが存在する |
 | 関連                 | TASK-0123 Part B（Human 判断待ち）/ PlanGate [#420](https://github.com/s977043/plangate/issues/420) 同型 / [`design-philosophy.md`](./design-philosophy.md) I-3 既知の限界注記                                                                                                                              |
 
 ### 条件 2: 事後 revert の自動化 + post-merge 監視
@@ -57,16 +57,16 @@ on-the-loop 委譲を拡大（人間が判定）」は、将来の HOTL merge �
 | 前提条件             | merge 後に問題が判明した際、自動的に revert でき、post-merge の異常を検知する監視が CB-1〜3 と接続されている                                                                                                                                                                                  |
 | 現状                 | ❌ 未設計                                                                                                                                                                                                                                                                                     |
 | 検証方法（充足条件） | (a) revert 自動化スクリプト（または CI job）が存在し、実際に revert PR を生成するデモ実行が成功する、かつ (b) post-merge 監視が CB-1（事後 reject 即時停止）/ CB-2（連続 incident による policy 自動失効）/ CB-3（escalate 予算超過）のいずれかをトリガーできることを確認するテストが存在する |
-| 関連                 | [`decision-table.md`](../../workflows/ai-loop/decision-table.md) §6 サーキットブレーカー                                                                                                                                                                                                      |
+| 関連                 | [`decision-table.md`](./decision-table.md) §6 サーキットブレーカー                                                                                                                                                                                                      |
 
 ### 条件 3: 対象クラスの厳格限定
 
 | 項目                 | 内容                                                                                                                                                                                                                                                                                                                                               |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 前提条件             | HOTL merge を許可する対象を「docs-only / ai-loop PoC 配下 / doc-light 相当」等の低リスク帯に限定し、lite 判定の 4 軸 + 可逆性（[`design-philosophy.md`](./design-philosophy.md) I-8）を merge クラスにも適用する                                                                                                                                   |
-| 現状                 | △ [`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md) は存在するが、merge クラスは現行判定から除外されている                                                                                                                                                                                                                            |
-| 検証方法（充足条件） | (a) [`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md) §2 判定軸に「merge を含む変更」の扱いが明記され、可逆性要件（§2「可逆性要件の根拠」節）を満たすことが確認できる、かつ (b) [`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §2 の `class`（merge 含む / 含まない）軸が実データで正しく分類されることをテストで確認する |
-| 関連                 | [`design-philosophy.md`](./design-philosophy.md) 語彙集「L2 入力 4 軸」`class` / [`flow-detect.md`](../../workflows/ai-loop/flow-detect.md) §2                                                                                                                                                                                                     |
+| 現状                 | △ [`lite-criteria.md`](./lite-criteria.md) は存在するが、merge クラスは現行判定から除外されている                                                                                                                                                                                                                            |
+| 検証方法（充足条件） | (a) [`lite-criteria.md`](./lite-criteria.md) §2 判定軸に「merge を含む変更」の扱いが明記され、可逆性要件（§2「可逆性要件の根拠」節）を満たすことが確認できる、かつ (b) [`flow-detect.md`](./flow-detect.md) §2 の `class`（merge 含む / 含まない）軸が実データで正しく分類されることをテストで確認する |
+| 関連                 | [`design-philosophy.md`](./design-philosophy.md) 語彙集「L2 入力 4 軸」`class` / [`flow-detect.md`](./flow-detect.md) §2                                                                                                                                                                                                     |
 
 ### 条件 4: veto window 設計
 
@@ -83,17 +83,17 @@ on-the-loop 委譲を拡大（人間が判定）」は、将来の HOTL merge �
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 前提条件             | 誤検知率・escalate 率・CB 発火履歴等の定量指標を計測し、policy が安定運用に足る成熟度にあることを示す                                                                                                                                                                           |
 | 現状                 | ❌ 未到達                                                                                                                                                                                                                                                                       |
-| 検証方法（充足条件） | (a) 上記指標が metrics v1（[`docs/ai/metrics.md`](../metrics.md)）に接続されている、かつ (b) ai-loop PoC の実走データが一定期間（具体的な期間・サンプル数は Phase C で確定）蓄積されている、かつ (c) 指標の閾値（例: 誤検知率 X% 未満）が事前に定義され、実測値と比較可能である |
+| 検証方法（充足条件） | (a) 上記指標が metrics v1（`metrics.md`）に接続されている、かつ (b) ai-loop PoC の実走データが一定期間（具体的な期間・サンプル数は Phase C で確定）蓄積されている、かつ (c) 指標の閾値（例: 誤検知率 X% 未満）が事前に定義され、実測値と比較可能である |
 | 関連                 | [`concept.md`](./concept.md) §6 Phase 5 / metrics v1                                                                                                                                                                                                                            |
 
 ### 条件 6: 統制の実質性検証（sockpuppet 禁止との整合）
 
 | 項目                 | 内容                                                                                                                                                                                                                                                                                                                                                                                                 |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 前提条件             | auto-approve 機構（PlanGate #620 apply-script 等）が、sockpuppet マージ禁止（[`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)）と実質的に整合するかを再確認する                                                                                                                                                                                                       |
+| 前提条件             | auto-approve 機構（PlanGate #620 apply-script 等）が、sockpuppet マージ禁止（`responsibility-classes.md`）と実質的に整合するかを再確認する                                                                                                                                                                                                       |
 | 現状                 | ❌ 未検証                                                                                                                                                                                                                                                                                                                                                                                            |
-| 検証方法（充足条件） | (a) auto-approve が発行する provenance の `issued_by` が実在する人間権限に紐づくこと（条件 1 と連動）、かつ (b) auto-approve 経路が「別アカウントでの自己承認」と機能的に等価にならないことをレビューし、レビュー結果を issue に記録する、かつ (c) [`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md) の merge = Human-owned 固定の記述と矛盾しないことを人間が確認する |
-| 関連                 | [`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)                                                                                                                                                                                                                                                                                                                      |
+| 検証方法（充足条件） | (a) auto-approve が発行する provenance の `issued_by` が実在する人間権限に紐づくこと（条件 1 と連動）、かつ (b) auto-approve 経路が「別アカウントでの自己承認」と機能的に等価にならないことをレビューし、レビュー結果を issue に記録する、かつ (c) `responsibility-classes.md` の merge = Human-owned 固定の記述と矛盾しないことを人間が確認する |
+| 関連                 | `responsibility-classes.md`                                                                                                                                                                                                                                                                                                                      |
 
 ---
 
@@ -112,7 +112,7 @@ on-the-loop 委譲を拡大（人間が判定）」は、将来の HOTL merge �
 
 issue #733 の段階計画（Phase A〜D）のうち、**Phase B（前提整備・個別 PBI 化）** の候補を列挙する。
 各候補は独立 PBI として起票し、HO パスに触れる部分は apply-script 方式
-（[`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md) 準拠）で扱う。
+（`responsibility-classes.md` 準拠）で扱う。
 
 | 候補 PBI                        | 対応条件 | 概要                                                               | 備考                                                                   |
 | ------------------------------- | -------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
@@ -121,7 +121,7 @@ issue #733 の段階計画（Phase A〜D）のうち、**Phase B（前提整備�
 | veto window 機構                | 条件 4   | merge-ready 通知 → N 時間 veto 猶予 → 沈黙時 auto-merge のロジック | 通知チャネル・沈黙判定の決定論化が焦点                                 |
 
 条件 3（対象クラス限定）・条件 5（policy maturity 計測）・条件 6（統制実質性検証）は、
-Phase B で個別実装 PBI を新設するのではなく、既存の [`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)
+Phase B で個別実装 PBI を新設するのではなく、既存の [`lite-criteria.md`](./lite-criteria.md)
 （条件 3）・metrics v1 接続（条件 5・Phase C）・レビュー記録（条件 6）の**追記・確認作業**として
 扱う想定である。個別 PBI 化が必要と判断された場合は、本表に追加する。
 
@@ -153,7 +153,7 @@ design-philosophy.md 側は本書へのリンクを追加すること（design-p
 - [`design-philosophy.md`](./design-philosophy.md) §1.1 / I-1 / I-8
 - [`concept.md`](./concept.md) §6 Phase 5
 - [`arbiter-policy.md`](./arbiter-policy.md) §2 / §6
-- [`decision-table.md`](../../workflows/ai-loop/decision-table.md) §5 provenance スキーマ / §6 サーキットブレーカー
-- [`lite-criteria.md`](../../workflows/ai-loop/lite-criteria.md)
-- [`responsibility-classes.md`](../../../.claude/rules/responsibility-classes.md)
+- [`decision-table.md`](./decision-table.md) §5 provenance スキーマ / §6 サーキットブレーカー
+- [`lite-criteria.md`](./lite-criteria.md)
+- `responsibility-classes.md`
 - issue [#733](https://github.com/s977043/plangate/issues/733) / TASK-0123 Part B / PlanGate [#420](https://github.com/s977043/plangate/issues/420) / [#620](https://github.com/s977043/plangate/issues/620)

--- a/plugin/plangate/skills/ai-loop-cycle/references/lite-criteria.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/lite-criteria.md
@@ -3,7 +3,7 @@
 > 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
 > lite 基準の制定・改版は policy 扱い（第0の承認境界 =
-> [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6、Human-owned 固定）。
+> [`arbiter-policy.md`](./arbiter-policy.md) §6、Human-owned 固定）。
 > AI は基準改定の draft 提案までしか行えず、発行・適用は人間が行う
 
 ---
@@ -11,7 +11,7 @@
 ## 1. 目的
 
 ai-loop-workflow の flow フェーズにおける `lite` 軸（[`decision-table.md`](./decision-table.md)
-§2）の判定基準を具体化する。[`mode-classification.md`](../../../.claude/rules/mode-classification.md)
+§2）の判定基準を具体化する。`mode-classification.md`
 の `lite_eligible` 判定軸（PlanGate 本番向け）を継承しつつ、PoC 用に単純化し、
 **可逆性要件**を追加する。
 
@@ -112,6 +112,6 @@ else:
 
 - [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — `lite` 軸を使う Decision table 本体
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — flow フェーズでの `lite` 判定の位置づけ
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — §6 第0の承認境界（本基準の改版が Human-owned 固定である根拠）
-- [`docs/ai/ai-loop/phase3-impact-report.md`](../../ai/ai-loop/phase3-impact-report.md) — §d リスク 1・2（本ドキュメントで解消）
-- [`.claude/rules/mode-classification.md`](../../../.claude/rules/mode-classification.md) — `lite_eligible` 判定軸・AC-8 安全側・AC-11 の継承元
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — §6 第0の承認境界（本基準の改版が Human-owned 固定である根拠）
+- `phase3-impact-report.md` — §d リスク 1・2（本ドキュメントで解消）
+- `mode-classification.md` — `lite_eligible` 判定軸・AC-8 安全側・AC-11 の継承元

--- a/plugin/plangate/skills/ai-loop-cycle/references/loop-safety-gates.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/loop-safety-gates.md
@@ -2,8 +2,8 @@
 
 > 対応 issue: [#728](https://github.com/s977043/plangate/issues/728)（loop-safety gates）
 > 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ。PlanGate 本番フロー
-> （WF-00〜WF-07）には適用しない（[`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) 冒頭）。
-> 思想的根拠: [`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) **I-6「停止できないループはループではない」**
+> （WF-00〜WF-07）には適用しない（[`design-philosophy.md`](./design-philosophy.md) 冒頭）。
+> 思想的根拠: [`design-philosophy.md`](./design-philosophy.md) **I-6「停止できないループはループではない」**
 > （+ サーキットブレーカーによる自律そのものの一時停止という 2 層停止機構）。
 > 発火位置: [`flow-detect.md`](./flow-detect.md) **§2 flow フェーズへの進入前**に置く事前ゲート。
 > flow-detect.md 本体（boundary / lite / class 判定）は変更しない。本書はその手前の
@@ -140,7 +140,7 @@ flow 進入前に、以下 5 ゲートをこの順で通過確認する。**い�
   （**3 ラウンド**）は [`00_concept.md`](./00_concept.md) §「収束ルール」/
   [`adaptive-production-loop.md`](./adaptive-production-loop.md) の terminal state
   遷移表が正本。escalate 予算（severity 別の昇格上限・サーキットブレーカー連動）は
-  [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §7 /
+  [`arbiter-policy.md`](./arbiter-policy.md) §7 /
   [`decision-table.md`](./decision-table.md) §6 が正本。本ゲートはこれらの値を
   変更・再宣言せず、「budget が設定されていること」自体の存在確認のみ行う。
 - **budget 未設定の指示**: §2 の再形成テンプレートに従い soft cap を注入して
@@ -197,12 +197,12 @@ Gate 1〜4 のいずれかで停止した場合、以下の定型で報告する
 ## 6. 既存正本との不整合防止（再定義しない事項の一覧）
 
 本書は以下を**再定義しない**。値・機構の変更が必要になった場合は、当該正本の
-版上げ手続き（[`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) §6.2）に従う。
+版上げ手続き（[`design-philosophy.md`](./design-philosophy.md) §6.2）に従う。
 
 | 事項                                           | 正本                                                                                                |
 | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | 対応ラウンド上限（3 ラウンド）・terminal state | [`00_concept.md`](./00_concept.md) / [`adaptive-production-loop.md`](./adaptive-production-loop.md) |
-| escalate 予算・severity 別の昇格上限           | [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §7                                        |
+| escalate 予算・severity 別の昇格上限           | [`arbiter-policy.md`](./arbiter-policy.md) §7                                        |
 | サーキットブレーカー（CB-1〜CB-3）             | [`decision-table.md`](./decision-table.md) §6                                                       |
 | boundary / lite / class 判定                   | [`flow-detect.md`](./flow-detect.md) §2                                                             |
 | provenance スキーマ                            | [`decision-table.md`](./decision-table.md) §5                                                       |
@@ -211,10 +211,10 @@ Gate 1〜4 のいずれかで停止した場合、以下の定型で報告する
 
 ## 7. 関連ドキュメント
 
-- [`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) — I-6（本ゲートの思想的根拠）・§8 トリアージ（#728 の仕分け結果）
+- [`design-philosophy.md`](./design-philosophy.md) — I-6（本ゲートの思想的根拠）・§8 トリアージ（#728 の仕分け結果）
 - [`flow-detect.md`](./flow-detect.md) — 本ゲートの直後に発火する flow フェーズ（参照のみ、変更なし）
 - [`00_concept.md`](./00_concept.md) — 対応ラウンド上限・収束ルールの正本
 - [`adaptive-production-loop.md`](./adaptive-production-loop.md) — 1 サイクル contract（Goal/Evaluate/Stop/Memory/Schedule/Boundary）
-- [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — escalate 予算の正本
+- [`arbiter-policy.md`](./arbiter-policy.md) — escalate 予算の正本
 - [`decision-table.md`](./decision-table.md) — terminal state・サーキットブレーカーの正本
 - issue [#728](https://github.com/s977043/plangate/issues/728) — 本書の起源

--- a/plugin/plangate/skills/ai-loop-cycle/references/loopspec.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/loopspec.md
@@ -270,11 +270,11 @@ design-philosophy.md §7「同じ問いに2つのファイルが答えてはな�
 
 ## 8. 関連ドキュメント
 
-- [`../../ai/ai-loop/design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) — 第一原理（I-1〜I-9）・語彙集・§8 トリアージ正本
+- [`../../ai/ai-loop/design-philosophy.md`](./design-philosophy.md) — 第一原理（I-1〜I-9）・語彙集・§8 トリアージ正本
 - [`adaptive-production-loop.md`](./adaptive-production-loop.md) §4 — 1 サイクル contract 正本（closed loop の定義）
 - [`decision-table.md`](./decision-table.md) §5 — provenance schema 正本
 - [`execution-runbook.md`](./execution-runbook.md) §2-(7) — Scheduling 判断表・ラウンド上限（正本値）
 - [`flow-detect.md`](./flow-detect.md) — maker/checker 分離（W チェック）の判定フロー正本
 - [`review-feedback-loop.md`](./review-feedback-loop.md) — decision record の実体正本
-- [`../../ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §7 — escalate 予算正本
+- [`../../ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) §7 — escalate 予算正本
 - issue [#726](https://github.com/s977043/plangate/issues/726) — 本書の起点

--- a/plugin/plangate/skills/ai-loop-cycle/references/review-feedback-loop.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/review-feedback-loop.md
@@ -2,7 +2,7 @@
 
 > 適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ
 > 非適用: PlanGate 本番フロー（WF-00〜WF-07）
-> 位置づけ: L4 学習層（[`concept.md`](../../ai/ai-loop/concept.md) §7）の PoC 定義。
+> 位置づけ: L4 学習層（[`concept.md`](./concept.md) §7）の PoC 定義。
 > フル実装は Phase 4、本ドキュメントはフロー定義と手動運用（human-operated L4）を先行させる
 
 ---
@@ -61,7 +61,7 @@ PR レビューで受けた指摘を観点として抽出・還元し、次の P
 
 PR レビュー指摘（外部ボット・人間レビュアー）を指摘 ID（`R-NNN` 方式）付きで
 収集する。ID 採番と追記専用集約の方式は
-[`working-context.md`](../../../.claude/rules/working-context.md) の
+`working-context.md` の
 `review-external.md` 節（C-2 指摘の差分管理）を資産として継承する。指摘ゼロの
 回でも「指摘なし」を明示記録し、監査の連続性を保つ。
 
@@ -72,10 +72,10 @@ PR レビュー指摘（外部ボット・人間レビュアー）を指摘 ID�
 | 軸 | 値 | 説明 |
 | ---- | ---- | ---- |
 | 再発性 | 再発性あり / 一過性 | 同型の指摘が将来の変更でも起こり得るか |
-| severity | critical / major / minor / info | [`review-principles.md`](../../../.claude/rules/review-principles.md) §3 の 4 段階定義に従う |
+| severity | critical / major / minor / info | `review-principles.md` §3 の 4 段階定義に従う |
 
 > **注（severity の別軸性）**: ここでの severity は **PR レビュー指摘の分類**であり
-> [`review-principles.md`](../../../.claude/rules/review-principles.md) §3（info を含む 4 段階）に従う。
+> `review-principles.md` §3（info を含む 4 段階）に従う。
 > W チェック不一致の severity 分類（[`flow-detect.md`](./flow-detect.md) §3.2、low を含む 4 段階）とは
 > **別軸**であり、値域も異なる。混同しないこと。
 
@@ -88,8 +88,8 @@ PR レビュー指摘（外部ボット・人間レビュアー）を指摘 ID�
 | 還元先 | 対象 | 責務 |
 | -------- | ------ | ------ |
 | skill（例: `self-review`） | 作業手順・チェックリストで捕捉できる指摘 | AI-owned（編集可） |
-| gate 観点ドキュメント（例: [`plan-review-readiness-gate.md`](../../ai/plan-review-readiness-gate.md)） | 計画・レビュー観点で捕捉できる指摘 | AI-owned（編集可） |
-| policy | auto-approve 条件・裁定ルールに関わる指摘 | **Human-owned 固定**（第0の承認境界 = [`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6） |
+| gate 観点ドキュメント（例: `plan-review-readiness-gate.md`） | 計画・レビュー観点で捕捉できる指摘 | AI-owned（編集可） |
+| policy | auto-approve 条件・裁定ルールに関わる指摘 | **Human-owned 固定**（第0の承認境界 = [`arbiter-policy.md`](./arbiter-policy.md) §6） |
 | 還元不要 | 一過性・案件固有 | 記録のみ |
 
 policy への還元候補は AI が draft 提案までしか行えない。発行・適用は
@@ -155,11 +155,11 @@ Codex）で検出された指摘 7 件を issue #670 で還元しており、本
 
 ## 6. 安全制約
 
-- policy への還元は第0の承認境界（[`arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) §6）
+- policy への還元は第0の承認境界（[`arbiter-policy.md`](./arbiter-policy.md) §6）
   により Human-owned 固定。AI は policy draft の提案までしか行えず、発行・適用
   は人間が行う。
 - skill / gate への還元であっても、対象が HO パス
-  （[`ho-paths.md`](../../ai/ai-loop/ho-paths.md)）に触れる場合は human escalate
+  （[`ho-paths.md`](./ho-paths.md)）に触れる場合は human escalate
   へ切り替える。
 - 学習ループ自身が承認境界を侵食してはならない（「自分の枠を自分で書き換え
   ない」の L4 版）。還元ループが policy への還元を自己承認する経路を持たない
@@ -170,8 +170,8 @@ Codex）で検出された指摘 7 件を issue #670 で還元しており、本
 ## 7. 関連ドキュメント
 
 - [`docs/workflows/ai-loop/adaptive-production-loop.md`](./adaptive-production-loop.md) — 6 層自己改善ループ、Remember / Optimize 分離、`/goal` / `/loop` 責務分離の正本
-- [`docs/ai/ai-loop/concept.md`](../../ai/ai-loop/concept.md) — Arbiter の基本概念・L4 学習層（§7）
+- [`docs/ai/ai-loop/concept.md`](./concept.md) — Arbiter の基本概念・L4 学習層（§7）
 - [`docs/workflows/ai-loop/flow-detect.md`](./flow-detect.md) — W チェック・severity 分類・Model C/D 裁定
 - [`docs/workflows/ai-loop/decision-table.md`](./decision-table.md) — Decision table・provenance schema・サーキットブレーカー
-- [`docs/ai/ai-loop/arbiter-policy.md`](../../ai/ai-loop/arbiter-policy.md) — 第0の承認境界（§6）
-- [`.claude/rules/working-context.md`](../../../.claude/rules/working-context.md) — `review-external.md` R-NNN 方式（資産継承元）
+- [`docs/ai/ai-loop/arbiter-policy.md`](./arbiter-policy.md) — 第0の承認境界（§6）
+- `working-context.md` — `review-external.md` R-NNN 方式（資産継承元）

--- a/plugin/plangate/skills/ai-loop-cycle/references/unknown-discovery.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/unknown-discovery.md
@@ -1,7 +1,7 @@
 # Unknown Discovery — 未知の発見・記録・レビュー可能化
 
 > 対応 issue: [#729](https://github.com/s977043/plangate/issues/729)
-> 根拠となる第一原理: [`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) I-9（承認された宣言は実差分で再検証される — 二段 detect）
+> 根拠となる第一原理: [`design-philosophy.md`](./design-philosophy.md) I-9（承認された宣言は実差分で再検証される — 二段 detect）
 > 本書の位置づけ: design-philosophy.md §8 トリアージにおける #729 の配置先（「plan 前ゲートは
 > PlanGate 側と ai-loop 側の両建て、Deviation Log は decision record と統合検討、I-9 の運用面を補完」）
 > を具体化した**機構**正本。思想的根拠（なぜ）は design-philosophy.md に譲り、本書は「何を・いつ・
@@ -20,7 +20,7 @@ PlanGate はすでに「Plan → Review → 承認 → 実行」の統制を持�
 - 要約・コンテキスト圧縮後に「却下した理由」「計画変更の理由」「未解決の論点」が失われる
 
 Unknown Discovery は、この「未知」を **発見（Plan 前）→ 明示（Plan 中）→ 記録（実装中）** の
-3 ゲートに分けて構造化し、[`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) I-9
+3 ゲートに分けて構造化し、[`design-philosophy.md`](./design-philosophy.md) I-9
 （宣言と実差分は別命題であり、二段で検証する）の**運用面**を補完する。
 
 ---
@@ -51,7 +51,7 @@ Unknown Discovery の目的は、**Unknown Unknowns をできる限り Known Unk
 - 初めて触るコード領域
 - 認証・課金・権限・データ移行など失敗コストが高い作業
 - UI/UX のように「見ないと判断できない」作業
-- AI に長時間実装させる作業（[`mode-classification.md`](../../../.claude/rules/mode-classification.md) の high-risk / critical 相当）
+- AI に長時間実装させる作業（`mode-classification.md` の high-risk / critical 相当）
 - PR レビューで差分だけ見ても意図が分かりづらい作業
 
 ### 対象外（適用しなくてよい）
@@ -60,7 +60,7 @@ Unknown Discovery の目的は、**Unknown Unknowns をできる限り Known Unk
 - 明確なバグ修正
 - 既存パターンに沿った単純追加
 - 影響範囲が限定されているリファクタ
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) の ultra-light / light 相当
+- `mode-classification.md` の ultra-light / light 相当
 
 判定不能・境界事例は、design-philosophy I-4（安全側デフォルト）に従い**適用する側**に倒す。
 
@@ -116,7 +116,7 @@ Unknown Discovery の目的は、**Unknown Unknowns をできる限り Known Unk
 5. 次回の計画に反映すべき学び
 
 **成果物**: `plan.md` 内 `## Deviations` 節、または `docs/working/TASK-XXXX/status.md`
-の「計画からの変更点」節（[`working-context.md`](../../../.claude/rules/working-context.md)
+の「計画からの変更点」節（`working-context.md`
 既存節を流用。新規 `implementation-notes.md` は本書では採用しない — status.md が既に
 「計画からの変更点」を持つため、成果物を増やすより既存節に統合するほうが Progressive
 Disclosure（L1 で読める）と整合する）。
@@ -126,7 +126,7 @@ Disclosure（L1 で読める）と整合する）。
 - 保守的な対応（当初計画の範囲内での小さな調整）は記録のうえ続行してよい
 - 設計そのものを変える必要がある逸脱を発見した場合は、記録した上で**実行を止め**、
   人間または C-3' 相当のゲートに判断を仰ぐ（ai-loop 文脈では
-  [`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) I-1 の枠内で、
+  [`design-philosophy.md`](./design-philosophy.md) I-1 の枠内で、
   承認境界の拡大解釈を自己判断しない）
 
 ---
@@ -156,7 +156,7 @@ issue #729 の検討事項に含まれる「Review 前の Understanding / Quiz G
 本書の 3 ゲート（Discovery / Tweakable Decision / Deviation Log）とは性質が異なり
 （実装前後ではなく PR レビュー直前が対象）、PlanGate の C-4（PR レビュー）運用に接続する
 別ゲートとして扱う。本書では **導入するかどうかの検討事項として記録するに留め**、
-確定した観点定義は別途 PR レビュー関連の正本（[`review-principles.md`](../../../.claude/rules/review-principles.md)
+確定した観点定義は別途 PR レビュー関連の正本（`review-principles.md`
 等）側で扱う。
 
 想定される確認観点（参考）:
@@ -168,7 +168,7 @@ issue #729 の検討事項に含まれる「Review 前の Understanding / Quiz G
 
 ## 7. I-9 との関係（運用面の補完）
 
-[`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) I-9 は「承認された宣言
+[`design-philosophy.md`](./design-philosophy.md) I-9 は「承認された宣言
 （plan）と実差分は別命題であり、二段で検証する」という**検証構造**の原理である。
 本書の 3 ゲートは、その運用面を以下のように補完する:
 
@@ -186,9 +186,9 @@ issue #729 の検討事項に含まれる「Review 前の Understanding / Quiz G
 
 ## 8. 関連ドキュメント
 
-- [`design-philosophy.md`](../../ai/ai-loop/design-philosophy.md) §2 I-9 / §8 トリアージ（#729 行）
+- [`design-philosophy.md`](./design-philosophy.md) §2 I-9 / §8 トリアージ（#729 行）
 - [`execution-runbook.md`](./execution-runbook.md) §2-(4)（decision record 保存）
 - [`decision-table.md`](./decision-table.md) §5（provenance スキーマ）
-- [`working-context.md`](../../../.claude/rules/working-context.md)（status.md「計画からの変更点」節）
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（適用対象の mode 判定）
+- `working-context.md`（status.md「計画からの変更点」節）
+- `mode-classification.md`（適用対象の mode 判定）
 - issue [#729](https://github.com/s977043/plangate/issues/729)

--- a/scripts/_ai_loop_link_rewrite.py
+++ b/scripts/_ai_loop_link_rewrite.py
@@ -1,57 +1,92 @@
 #!/usr/bin/env python3
 """_ai_loop_link_rewrite.py — plugin bundle 用の markdown リンク自己完結化。
 
-背景（issue #790）: sync-plugin-plangate.sh の _sync_ai_loop_content が
-docs/workflows/ai-loop/*.md・docs/ai/ai-loop/*.md を verbatim cp で
-plugin/plangate/skills/ai-loop-cycle/references/ へバンドルしているため、
-正本側の `../` / `../../` / `../../../` 相対リンクが導入先（plugin
-consumer）ではリンク切れになる。本スクリプトは **plugin へ書き込む直前の
-コピー内容のみ**に対しリンクを書き換える（正本 docs/ 側は一切変更しない
-— 正本は本リポジトリ内で相対リンクが正しく解決するため）。
+背景（issue #790）: sync-plugin-plangate.sh の _sync_ai_loop_ref_content が
+docs/workflows/ai-loop/*.md・docs/ai/ai-loop/*.md を plugin/plangate/skills/
+ai-loop-cycle/references/ へバンドルしているため、正本側の `../` /
+`../../` / `../../../` 相対リンクが導入先（plugin consumer）ではリンク切れに
+なる。本スクリプトは **plugin へ書き込む直前のコピー内容のみ**に対しリンクを
+書き換える（正本 docs/ 側は一切変更しない — 正本は本リポジトリ内で相対リンク
+が正しく解決するため）。
 
-変換ルール（markdown リンク `[text](path)` / `[text](path#anchor)` のみ対象。
-コードブロック内は対象外。http(s)://・mailto:・同一ファイル内アンカー単独
-(#foo) は対象外）:
+変換ルール（markdown インラインリンク `[text](path)` /
+`[text](path#anchor)` のみ対象。フェンス付きコードブロック内・画像
+`![alt](path)`・http(s)://・mailto:・同一ファイル内アンカー単独 (#foo) は
+対象外）:
 
-1. path の basename が references/ にバンドルされる集合（bundle_basenames）
-   に含まれる → `[text](./name.md)`（アンカー保持）
-2. path が「本スキル自身の SKILL.md」（basename が SKILL.md で、
-   `skills/<skill_name>/` 配下を指す、または既に `../SKILL.md` 形式）
-   → `[text](../SKILL.md)`（アンカー保持。references/ の親に実在するため）
-   ※ 他スキルの SKILL.md（例: `skills/pr-watch/SKILL.md`）は本スキルに
-   同梱されないため、この規則の対象外とし 3 に落とす（誤った参照先を
-   防ぐための限定 — basename 一致だけで無条件に ../SKILL.md 化すると
-   別スキルの SKILL.md へ誤誘導するため）
-3. 上記いずれでもない（真に外部・bundle 非同梱）
-   → リンクを解除し、basename のインラインコード表記に統一する
-   （表示テキストは破棄。例外: 他スキルの SKILL.md は `<skill>/SKILL.md`
-   として識別性を保持する）
+1. **同一実体判定**（issue #790 MAJOR 是正）: リンクの相対パスを変換対象
+   ファイルの **ソースパス基準** で normpath 解決し、その実ファイルパスが
+   「その basename でバンドルされた元ファイルの実パス」と **一致** する場合の
+   み `[text](./name.md)`（アンカー保持）。basename が偶然バンドル集合に
+   含まれても、解決先が別実体（例: `docs/ai/subagent-delegation/README.md`
+   と `docs/ai/ai-loop/README.md`）なら 3 の外部扱いに落とす。
+2. path が「本スキル自身の SKILL.md」（`skills/<skill_name>/SKILL.md` 形式・
+   または既に `../SKILL.md`）→ `[text](../SKILL.md)`（references/ の親に実在）。
+   他スキルの SKILL.md（例 `skills/pr-watch/SKILL.md`）は同梱されないため
+   3 に落とす（basename 一致だけで無条件 ../SKILL.md 化すると誤誘導するため）。
+3. 上記いずれでもない（真に外部・bundle 非同梱、または同一実体でない）
+   → リンクを解除し **インラインコード表記** に統一する。basename が
+   バンドル集合と衝突しうる（同名がバンドルにある）場合や他スキル SKILL.md は
+   `<親ディレクトリ>/<basename>` として識別性を保つ（例
+   `subagent-delegation/README.md`・`pr-watch/SKILL.md`）。それ以外は
+   `<basename>`（例 `working-context.md`）。
 
-冪等性: 変換済みファイル（`./name.md` や `../SKILL.md`、インラインコード化
-済み）に再度適用しても不変であること。
+冪等性: 変換済み（`./name.md`・`../SKILL.md`・インラインコード化済み）に
+再適用しても不変。`./<basename>`（basename∈bundle）は既に自己完結形なので
+canonical fixed-point として素通しする（references/ 内では常に正しい sibling
+参照。本リポジトリの 2 ソースディレクトリ docs/workflows/ai-loop と
+docs/ai/ai-loop は basename 衝突が無いことを確認済みのため、sibling `./name.md`
+が別実体を指す誤変換は起きない）。
 
 Usage:
-    _ai_loop_link_rewrite.py <src_file> <skill_name> [bundle_basename ...]
+    _ai_loop_link_rewrite.py <content_src> <source_path> <skill_name> <bundle_map_tsv>
 
-標準出力に変換後の内容を書き出す（sync script 側で mktemp 経由の
-比較・書き込みに使う想定）。
+  content_src   : 変換対象の内容を読むファイル（ho-paths.md はヘッダ前置後の
+                  一時ファイル）
+  source_path   : 相対リンク解決の基準となる **論理ソースパス**（正本 doc の
+                  実パス。ho-paths.md はヘッダ前置前の元パス）
+  skill_name    : スキル名（例 ai-loop-cycle）
+  bundle_map_tsv: `basename<TAB>ソース実パス` を 1 行 1 件で列挙した TSV。
+                  この写像の key 集合がバンドル集合を成す。
+
+標準出力に変換後の内容を書き出す（sync script 側で mktemp 経由の比較・
+書き込みに使う想定）。
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 
-# フェンス付きコードブロックのみ保護対象とする（コードブロック内は変換しない）。
+# フェンス付きコードブロック（``` と ~~~ の両方）を保護対象にする
+# （コードブロック内は変換しない）。開き marker と同一 marker で閉じる
+# （``` は ``` で・~~~ は ~~~ で）ようバックリファレンスで対にする。
 # インラインコードで囲まれたリンク表示テキスト（本リポジトリの支配的記法
 # `[`text`](path)`）はリンク構造の一部として扱い、あえてマスクしない
 # （マスクすると `[` と `](path)` が分断され、リンクとして検出できなくなる）。
-_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
-_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)\s][^)]*)\)")
+_FENCE_RE = re.compile(r"(?P<fence>```|~~~).*?(?P=fence)", re.DOTALL)
+# 画像 `![...](...)` は変換対象外（直前が `!` のリンクはスキップ）。
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)\s][^)]*)\)")
 
 _EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
 
 
-def _rewrite_links_in_segment(text: str, bundle: set[str], skill_name: str) -> str:
+def _norm(path: str) -> str:
+    return os.path.normpath(path)
+
+
+def _inline(segments: list[str], basename: str, bundle: set[str]) -> str:
+    """外部リンクをインラインコード化する。basename がバンドル集合と衝突しうる
+    場合は識別性のため親ディレクトリを前置する（例 subagent-delegation/README.md）。
+    """
+    if basename in bundle and len(segments) >= 2:
+        return f"`{segments[-2]}/{basename}`"
+    return f"`{basename}`"
+
+
+def _rewrite_links_in_segment(
+    text: str, bundle: set[str], bundle_src: dict[str, str], src_dir: str, skill_name: str
+) -> str:
     def _replace(m: "re.Match[str]") -> str:
         link_text, path = m.group(1), m.group(2)
 
@@ -65,17 +100,35 @@ def _rewrite_links_in_segment(text: str, bundle: set[str], skill_name: str) -> s
             return m.group(0)
         anchor_suffix = f"#{anchor}" if sep else ""
 
-        # ディレクトリ参照（末尾 "/"、例 "../../workflows/ai-loop/"）にも対応する。
-        # 末尾スラッシュを除いた最終セグメントを basename 相当として扱う
-        # （素朴に split("/")[-1] だけだと空文字になり無変換のまま dead link が
-        # 残ってしまうため）。
-        _stripped = path_part.rstrip("/")
-        if not _stripped:
+        # ディレクトリ参照（末尾 "/"、例 "../../workflows/ai-loop/"）にも対応。
+        # 末尾スラッシュを除いた最終セグメントを basename 相当として扱う。
+        stripped = path_part.rstrip("/")
+        if not stripped:
             return m.group(0)
-        segments = _stripped.split("/")
+        segments = stripped.split("/")
         basename = segments[-1]
         if not basename:
             return m.group(0)
+
+        # canonical fixed-point（冪等性）: 既に `./<basename>`（basename∈bundle）
+        # なら references/ 内で正しい sibling 参照なので素通し。
+        if path_part == f"./{basename}" and basename in bundle:
+            return m.group(0)
+
+        # 本スキル自身の SKILL.md（構造的同一性判定）→ ../SKILL.md
+        is_own_skill_md = (
+            basename == "SKILL.md"
+            and (
+                path_part == "../SKILL.md"
+                or (
+                    len(segments) >= 3
+                    and segments[-3] == "skills"
+                    and segments[-2] == skill_name
+                )
+            )
+        )
+        if is_own_skill_md:
+            return f"[{link_text}](../SKILL.md{anchor_suffix})"
 
         is_foreign_skill_md = (
             basename == "SKILL.md"
@@ -83,43 +136,72 @@ def _rewrite_links_in_segment(text: str, bundle: set[str], skill_name: str) -> s
             and segments[-3] == "skills"
             and segments[-2] != skill_name
         )
-        if basename == "SKILL.md" and not is_foreign_skill_md:
-            return f"[{link_text}](../SKILL.md{anchor_suffix})"
-        if basename in bundle:
-            return f"[{link_text}](./{basename}{anchor_suffix})"
         if is_foreign_skill_md:
-            # 他スキルの SKILL.md は同梱されないため、識別性を保つため
-            # `<skill>/SKILL.md` の inline code に落とす（basename 単独
-            # だと ai-loop-cycle 自身の SKILL.md と区別できないため）
+            # 他スキルの SKILL.md は同梱されない → `<skill>/SKILL.md` inline
             return f"`{segments[-2]}/SKILL.md`"
-        return f"`{basename}`"
+
+        # 同一実体判定（issue #790 MAJOR）: basename がバンドル集合にあっても、
+        # 相対リンクを src_dir 基準で解決した実パスがバンドル元と一致する時のみ
+        # ./name.md 化する。不一致なら別実体なので外部扱い（inline code）。
+        if basename in bundle:
+            resolved = _norm(os.path.join(src_dir, path_part))
+            if resolved == _norm(bundle_src[basename]):
+                return f"[{link_text}](./{basename}{anchor_suffix})"
+            return _inline(segments, basename, bundle)
+
+        return _inline(segments, basename, bundle)
 
     return _LINK_RE.sub(_replace, text)
 
 
-def rewrite(content: str, bundle: set[str], skill_name: str) -> str:
+def rewrite(
+    content: str, bundle_src: dict[str, str], source_path: str, skill_name: str
+) -> str:
     """フェンス付きコードブロックを保護しつつ、それ以外にリンク変換を適用する。"""
+    bundle = set(bundle_src.keys())
+    src_dir = os.path.dirname(os.path.abspath(source_path))
     out: list[str] = []
     last = 0
     for m in _FENCE_RE.finditer(content):
-        out.append(_rewrite_links_in_segment(content[last : m.start()], bundle, skill_name))
+        out.append(
+            _rewrite_links_in_segment(
+                content[last : m.start()], bundle, bundle_src, src_dir, skill_name
+            )
+        )
         out.append(m.group(0))
         last = m.end()
-    out.append(_rewrite_links_in_segment(content[last:], bundle, skill_name))
+    out.append(
+        _rewrite_links_in_segment(content[last:], bundle, bundle_src, src_dir, skill_name)
+    )
     return "".join(out)
 
 
+def _load_bundle_map(tsv_path: str) -> dict[str, str]:
+    bundle_src: dict[str, str] = {}
+    with open(tsv_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            basename, _, abspath = line.partition("\t")
+            if not basename or not abspath:
+                continue
+            bundle_src[basename] = abspath
+    return bundle_src
+
+
 def main(argv: list[str]) -> int:
-    if len(argv) < 3:
+    if len(argv) != 5:
         sys.stderr.write(
-            "usage: _ai_loop_link_rewrite.py <src_file> <skill_name> [bundle_basename ...]\n"
+            "usage: _ai_loop_link_rewrite.py "
+            "<content_src> <source_path> <skill_name> <bundle_map_tsv>\n"
         )
         return 2
-    src_file, skill_name = argv[1], argv[2]
-    bundle = set(argv[3:])
-    with open(src_file, encoding="utf-8") as f:
+    content_src, source_path, skill_name, bundle_map_tsv = argv[1:5]
+    bundle_src = _load_bundle_map(bundle_map_tsv)
+    with open(content_src, encoding="utf-8") as f:
         content = f.read()
-    sys.stdout.write(rewrite(content, bundle, skill_name))
+    sys.stdout.write(rewrite(content, bundle_src, source_path, skill_name))
     return 0
 
 

--- a/scripts/_ai_loop_link_rewrite.py
+++ b/scripts/_ai_loop_link_rewrite.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""_ai_loop_link_rewrite.py — plugin bundle 用の markdown リンク自己完結化。
+
+背景（issue #790）: sync-plugin-plangate.sh の _sync_ai_loop_content が
+docs/workflows/ai-loop/*.md・docs/ai/ai-loop/*.md を verbatim cp で
+plugin/plangate/skills/ai-loop-cycle/references/ へバンドルしているため、
+正本側の `../` / `../../` / `../../../` 相対リンクが導入先（plugin
+consumer）ではリンク切れになる。本スクリプトは **plugin へ書き込む直前の
+コピー内容のみ**に対しリンクを書き換える（正本 docs/ 側は一切変更しない
+— 正本は本リポジトリ内で相対リンクが正しく解決するため）。
+
+変換ルール（markdown リンク `[text](path)` / `[text](path#anchor)` のみ対象。
+コードブロック内は対象外。http(s)://・mailto:・同一ファイル内アンカー単独
+(#foo) は対象外）:
+
+1. path の basename が references/ にバンドルされる集合（bundle_basenames）
+   に含まれる → `[text](./name.md)`（アンカー保持）
+2. path が「本スキル自身の SKILL.md」（basename が SKILL.md で、
+   `skills/<skill_name>/` 配下を指す、または既に `../SKILL.md` 形式）
+   → `[text](../SKILL.md)`（アンカー保持。references/ の親に実在するため）
+   ※ 他スキルの SKILL.md（例: `skills/pr-watch/SKILL.md`）は本スキルに
+   同梱されないため、この規則の対象外とし 3 に落とす（誤った参照先を
+   防ぐための限定 — basename 一致だけで無条件に ../SKILL.md 化すると
+   別スキルの SKILL.md へ誤誘導するため）
+3. 上記いずれでもない（真に外部・bundle 非同梱）
+   → リンクを解除し、basename のインラインコード表記に統一する
+   （表示テキストは破棄。例外: 他スキルの SKILL.md は `<skill>/SKILL.md`
+   として識別性を保持する）
+
+冪等性: 変換済みファイル（`./name.md` や `../SKILL.md`、インラインコード化
+済み）に再度適用しても不変であること。
+
+Usage:
+    _ai_loop_link_rewrite.py <src_file> <skill_name> [bundle_basename ...]
+
+標準出力に変換後の内容を書き出す（sync script 側で mktemp 経由の
+比較・書き込みに使う想定）。
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# フェンス付きコードブロックのみ保護対象とする（コードブロック内は変換しない）。
+# インラインコードで囲まれたリンク表示テキスト（本リポジトリの支配的記法
+# `[`text`](path)`）はリンク構造の一部として扱い、あえてマスクしない
+# （マスクすると `[` と `](path)` が分断され、リンクとして検出できなくなる）。
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)\s][^)]*)\)")
+
+_EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
+
+
+def _rewrite_links_in_segment(text: str, bundle: set[str], skill_name: str) -> str:
+    def _replace(m: "re.Match[str]") -> str:
+        link_text, path = m.group(1), m.group(2)
+
+        if path.startswith(_EXTERNAL_SCHEMES):
+            return m.group(0)
+        if path.startswith("#"):
+            return m.group(0)
+
+        path_part, sep, anchor = path.partition("#")
+        if not path_part:
+            return m.group(0)
+        anchor_suffix = f"#{anchor}" if sep else ""
+
+        # ディレクトリ参照（末尾 "/"、例 "../../workflows/ai-loop/"）にも対応する。
+        # 末尾スラッシュを除いた最終セグメントを basename 相当として扱う
+        # （素朴に split("/")[-1] だけだと空文字になり無変換のまま dead link が
+        # 残ってしまうため）。
+        _stripped = path_part.rstrip("/")
+        if not _stripped:
+            return m.group(0)
+        segments = _stripped.split("/")
+        basename = segments[-1]
+        if not basename:
+            return m.group(0)
+
+        is_foreign_skill_md = (
+            basename == "SKILL.md"
+            and len(segments) >= 3
+            and segments[-3] == "skills"
+            and segments[-2] != skill_name
+        )
+        if basename == "SKILL.md" and not is_foreign_skill_md:
+            return f"[{link_text}](../SKILL.md{anchor_suffix})"
+        if basename in bundle:
+            return f"[{link_text}](./{basename}{anchor_suffix})"
+        if is_foreign_skill_md:
+            # 他スキルの SKILL.md は同梱されないため、識別性を保つため
+            # `<skill>/SKILL.md` の inline code に落とす（basename 単独
+            # だと ai-loop-cycle 自身の SKILL.md と区別できないため）
+            return f"`{segments[-2]}/SKILL.md`"
+        return f"`{basename}`"
+
+    return _LINK_RE.sub(_replace, text)
+
+
+def rewrite(content: str, bundle: set[str], skill_name: str) -> str:
+    """フェンス付きコードブロックを保護しつつ、それ以外にリンク変換を適用する。"""
+    out: list[str] = []
+    last = 0
+    for m in _FENCE_RE.finditer(content):
+        out.append(_rewrite_links_in_segment(content[last : m.start()], bundle, skill_name))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_rewrite_links_in_segment(content[last:], bundle, skill_name))
+    return "".join(out)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        sys.stderr.write(
+            "usage: _ai_loop_link_rewrite.py <src_file> <skill_name> [bundle_basename ...]\n"
+        )
+        return 2
+    src_file, skill_name = argv[1], argv[2]
+    bundle = set(argv[3:])
+    with open(src_file, encoding="utf-8") as f:
+        content = f.read()
+    sys.stdout.write(rewrite(content, bundle, skill_name))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/_ai_loop_link_rewrite.py
+++ b/scripts/_ai_loop_link_rewrite.py
@@ -71,8 +71,12 @@ _LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)\s][^)]*)\)")
 _EXTERNAL_SCHEMES = ("http://", "https://", "mailto:")
 
 
-def _norm(path: str) -> str:
-    return os.path.normpath(path)
+def _real(path: str) -> str:
+    # 同一実体判定は symlink を解決してから比較する（macOS の /tmp→/private/tmp 等で
+    # リンク解決先とバンドル元 abspath の表現が食い違い、同一実体を「別」と誤判定して
+    # 過剰に inline code 化するのを防ぐ / gemini MEDIUM）。realpath は存在しない末尾
+    # 要素にも安全（字句的に正規化）で、存在ファイルには symlink 解決も効く。
+    return os.path.realpath(path)
 
 
 def _inline(segments: list[str], basename: str, bundle: set[str]) -> str:
@@ -144,8 +148,8 @@ def _rewrite_links_in_segment(
         # 相対リンクを src_dir 基準で解決した実パスがバンドル元と一致する時のみ
         # ./name.md 化する。不一致なら別実体なので外部扱い（inline code）。
         if basename in bundle:
-            resolved = _norm(os.path.join(src_dir, path_part))
-            if resolved == _norm(bundle_src[basename]):
+            resolved = _real(os.path.join(src_dir, path_part))
+            if resolved == _real(bundle_src[basename]):
                 return f"[{link_text}](./{basename}{anchor_suffix})"
             return _inline(segments, basename, bundle)
 
@@ -159,7 +163,8 @@ def rewrite(
 ) -> str:
     """フェンス付きコードブロックを保護しつつ、それ以外にリンク変換を適用する。"""
     bundle = set(bundle_src.keys())
-    src_dir = os.path.dirname(os.path.abspath(source_path))
+    # source_path も realpath 化して基準ディレクトリを求める（両辺 symlink 解決で一致判定）
+    src_dir = os.path.dirname(os.path.realpath(source_path))
     out: list[str] = []
     last = 0
     for m in _FENCE_RE.finditer(content):
@@ -180,7 +185,7 @@ def _load_bundle_map(tsv_path: str) -> dict[str, str]:
     bundle_src: dict[str, str] = {}
     with open(tsv_path, encoding="utf-8") as f:
         for line in f:
-            line = line.rstrip("\n")
+            line = line.rstrip("\r\n")  # CRLF 環境で末尾 \r を残さない（gemini MEDIUM）
             if not line:
                 continue
             basename, _, abspath = line.partition("\t")

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -30,7 +30,11 @@ _normalize_model() {
 }
 _tmp_norm=""
 _ai_loop_map_file=""
-trap 'rm -f "${_tmp_norm:-}" "${_ai_loop_map_file:-}"' EXIT INT TERM
+# per-file 一時ファイルも trap 対象にして中断時 leak を塞ぐ（gemini MEDIUM）。
+# POSIX sh に local は無く関数内代入も global なので、最後に割り当てた値を trap が掃除する。
+_tmp_rewritten=""
+_tmp_ho=""
+trap 'rm -f "${_tmp_norm:-}" "${_ai_loop_map_file:-}" "${_tmp_rewritten:-}" "${_tmp_ho:-}"' EXIT INT TERM
 
 sync_dir() {
   _src="$1"; _dst="$2"; _label="$3"

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -101,18 +101,28 @@ done
 #   内部管理系は対象外）→ 同上 references/（ho-paths.md のみ雛形注記ヘッダを前置）
 # - scripts/ai-loop/{arbiter,test_arbiter}.py → .../ai-loop-cycle/scripts/
 # 旧同期先（plugin/plangate/docs/ 全体・plugin/plangate/scripts/ai-loop/）は廃止。
+#
+# issue #790: references/ へ書き込む内容は正本 verbatim ではなく、
+# scripts/_ai_loop_link_rewrite.py で markdown リンクを自己完結化してから
+# 書き込む（正本側の `../`/`../../`/`../../../` 相対リンクは plugin 導入先で
+# リンク切れになるため）。変換は plugin コピーにのみ適用し、正本
+# docs/workflows/ai-loop/*.md・docs/ai/ai-loop/*.md 自体は変更しない。
 AI_LOOP_WORKFLOWS_DIR="$REPO_ROOT/docs/workflows/ai-loop"
 AI_LOOP_SPEC_DIR="$REPO_ROOT/docs/ai/ai-loop"
 AI_LOOP_SCRIPTS_DIR="$REPO_ROOT/scripts/ai-loop"
-PLUGIN_AI_LOOP_SKILL_DIR="$PLUGIN_DIR/skills/ai-loop-cycle"
+PLUGIN_AI_LOOP_SKILL_NAME="ai-loop-cycle"
+PLUGIN_AI_LOOP_SKILL_DIR="$PLUGIN_DIR/skills/$PLUGIN_AI_LOOP_SKILL_NAME"
 PLUGIN_AI_LOOP_REFS="$PLUGIN_AI_LOOP_SKILL_DIR/references"
 PLUGIN_AI_LOOP_SCRIPTS="$PLUGIN_AI_LOOP_SKILL_DIR/scripts"
+AI_LOOP_LINK_REWRITER="$REPO_ROOT/scripts/_ai_loop_link_rewrite.py"
 
 # docs/ai/ai-loop から同梱する思想・仕様層ファイル名（内部管理系除外の選定結果）
 _ai_loop_spec_files="design-philosophy.md arbiter-policy.md concept.md README.md hotl-merge-entry-criteria.md related-specs.md"
 
 _sync_ai_loop_file() {
-  # $1=src file, $2=dst dir, $3=label（ログ用）
+  # $1=src file, $2=dst dir, $3=label（ログ用）— リンク変換なしの単純コピー
+  # （scripts/*.py 等、markdown リンクを含まない同期対象向け。references/ の
+  #  markdown は _sync_ai_loop_ref_content を使う）
   _f="$1"; _dst_dir="$2"; _label="$3"
   mkdir -p "$_dst_dir"
   _base="$(basename "$_f")"
@@ -127,27 +137,64 @@ _sync_ai_loop_file() {
 # references/ はフラット配置（workflows 10 本 + spec 6 本 + ho-paths.md = 17 本、
 # ファイル名衝突なしを確認済み）。SKILL.md は本ループの対象外（親ディレクトリに
 # 配置されるため references/*.md の glob には含まれず、削除ループの対象にもならない）
+#
+# bundle 集合（_ai_loop_expected_refs）はリンク変換（issue #790）の判定にも使う
+# ため、コピーより前に全件を確定させる（二段構成: (1) 期待 basename 一覧を確定
+# → (2) 内容を変換しつつ書き込み。先にコピーしながら集合を積み上げると、後半で
+# 追加される bundle ファイルへの内部リンクを前半ファイルの変換時点でまだ判定
+# できない）。
 _ai_loop_expected_refs=""
 if [ -d "$AI_LOOP_WORKFLOWS_DIR" ]; then
   for _f in "$AI_LOOP_WORKFLOWS_DIR"/*.md; do
     [ -f "$_f" ] || continue
-    _sync_ai_loop_file "$_f" "$PLUGIN_AI_LOOP_REFS" "skills/ai-loop-cycle/references"
     _ai_loop_expected_refs="$_ai_loop_expected_refs $(basename "$_f")"
+  done
+fi
+if [ -d "$AI_LOOP_SPEC_DIR" ]; then
+  for _name in $_ai_loop_spec_files; do
+    [ -f "$AI_LOOP_SPEC_DIR/$_name" ] || continue
+    _ai_loop_expected_refs="$_ai_loop_expected_refs $_name"
+  done
+  if [ -f "$AI_LOOP_SPEC_DIR/ho-paths.md" ]; then
+    _ai_loop_expected_refs="$_ai_loop_expected_refs ho-paths.md"
+  fi
+fi
+
+_sync_ai_loop_ref_content() {
+  # $1=content src file（変換前の内容。ho-paths.md はヘッダ前置後の tmp file）
+  # $2=dst basename（例: 00_concept.md）、$3=label（ログ用）
+  # references/ へ書き込む直前に markdown リンクを自己完結化する（issue #790）:
+  #   bundle 内部参照 → ./name.md、本スキル自身の SKILL.md → ../SKILL.md、
+  #   それ以外の外部正本参照 → リンク解除してインラインコード化
+  _content_src="$1"; _base="$2"; _label="$3"
+  mkdir -p "$PLUGIN_AI_LOOP_REFS"
+  _dfile="$PLUGIN_AI_LOOP_REFS/$_base"
+  _tmp_rewritten="$(mktemp)"
+  python3 "$AI_LOOP_LINK_REWRITER" "$_content_src" "$PLUGIN_AI_LOOP_SKILL_NAME" $_ai_loop_expected_refs > "$_tmp_rewritten"
+  if [ ! -f "$_dfile" ] || ! cmp -s "$_tmp_rewritten" "$_dfile"; then
+    if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD COPY (links self-contained): $_label/$_base"
+    else cp "$_tmp_rewritten" "$_dfile"; _log "COPY (links self-contained): $_label/$_base"; fi
+    changed=1
+  fi
+  rm -f "$_tmp_rewritten"
+}
+
+if [ -d "$AI_LOOP_WORKFLOWS_DIR" ]; then
+  for _f in "$AI_LOOP_WORKFLOWS_DIR"/*.md; do
+    [ -f "$_f" ] || continue
+    _sync_ai_loop_ref_content "$_f" "$(basename "$_f")" "skills/ai-loop-cycle/references"
   done
 fi
 if [ -d "$AI_LOOP_SPEC_DIR" ]; then
   for _name in $_ai_loop_spec_files; do
     _f="$AI_LOOP_SPEC_DIR/$_name"
     [ -f "$_f" ] || continue
-    _sync_ai_loop_file "$_f" "$PLUGIN_AI_LOOP_REFS" "skills/ai-loop-cycle/references"
-    _ai_loop_expected_refs="$_ai_loop_expected_refs $_name"
+    _sync_ai_loop_ref_content "$_f" "$_name" "skills/ai-loop-cycle/references"
   done
 
-  # ho-paths.md はプロジェクト固有のため、雛形注記ヘッダを前置してコピーする
+  # ho-paths.md はプロジェクト固有のため、雛形注記ヘッダを前置してからリンク変換する
   _ho_src="$AI_LOOP_SPEC_DIR/ho-paths.md"
   if [ -f "$_ho_src" ]; then
-    mkdir -p "$PLUGIN_AI_LOOP_REFS"
-    _ho_dst="$PLUGIN_AI_LOOP_REFS/ho-paths.md"
     _tmp_ho="$(mktemp)"
     {
       printf '%s\n' '> **雛形注記**: 本ファイルは PlanGate リポジトリでの運用実績を示す配布時の参考例です。'
@@ -156,13 +203,8 @@ if [ -d "$AI_LOOP_SPEC_DIR" ]; then
       printf '\n'
       cat "$_ho_src"
     } > "$_tmp_ho"
-    if [ ! -f "$_ho_dst" ] || ! cmp -s "$_tmp_ho" "$_ho_dst"; then
-      if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD COPY (template header prepended): skills/ai-loop-cycle/references/ho-paths.md"
-      else cp "$_tmp_ho" "$_ho_dst"; _log "COPY (template header prepended): skills/ai-loop-cycle/references/ho-paths.md"; fi
-      changed=1
-    fi
+    _sync_ai_loop_ref_content "$_tmp_ho" "ho-paths.md" "skills/ai-loop-cycle/references"
     rm -f "$_tmp_ho"
-    _ai_loop_expected_refs="$_ai_loop_expected_refs ho-paths.md"
   fi
 fi
 # plugin 側の skills/ai-loop-cycle/references/ から、正本側に存在しなくなったファイルを削除する
@@ -181,7 +223,8 @@ if [ -d "$PLUGIN_AI_LOOP_REFS" ]; then
   done
 fi
 
-# arbiter 裁定エンジン + テストを同期（__pycache__ は対象外）
+# arbiter 裁定エンジン + テストを同期（__pycache__ は対象外。markdown リンクを
+# 含まないためリンク変換は不要、単純コピーの _sync_ai_loop_file を使う）
 if [ -d "$AI_LOOP_SCRIPTS_DIR" ]; then
   for _f in "$AI_LOOP_SCRIPTS_DIR/arbiter.py" "$AI_LOOP_SCRIPTS_DIR/test_arbiter.py"; do
     [ -f "$_f" ] || continue

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -29,7 +29,8 @@ _normalize_model() {
   sed '1,/^---$/{s/^model: .*/model: inherit/;}' "$1"
 }
 _tmp_norm=""
-trap 'rm -f "${_tmp_norm:-}"' EXIT INT TERM
+_ai_loop_map_file=""
+trap 'rm -f "${_tmp_norm:-}" "${_ai_loop_map_file:-}"' EXIT INT TERM
 
 sync_dir() {
   _src="$1"; _dst="$2"; _label="$3"
@@ -143,34 +144,47 @@ _sync_ai_loop_file() {
 # → (2) 内容を変換しつつ書き込み。先にコピーしながら集合を積み上げると、後半で
 # 追加される bundle ファイルへの内部リンクを前半ファイルの変換時点でまだ判定
 # できない）。
+#
+# issue #790 MAJOR 是正: リンク変換は basename 単独では別実体へ誤ポイントし得る
+# （例 docs/ai/subagent-delegation/README.md が ai-loop の README.md と basename
+# 衝突）。同一実体判定のため basename → **バンドル元ソース実パス** の写像も
+# ここで確定し TSV でリライタへ渡す（key 集合がバンドル集合を成す）。
 _ai_loop_expected_refs=""
+_ai_loop_map_file="$(mktemp)"
+: > "$_ai_loop_map_file"
 if [ -d "$AI_LOOP_WORKFLOWS_DIR" ]; then
   for _f in "$AI_LOOP_WORKFLOWS_DIR"/*.md; do
     [ -f "$_f" ] || continue
-    _ai_loop_expected_refs="$_ai_loop_expected_refs $(basename "$_f")"
+    _b="$(basename "$_f")"
+    _ai_loop_expected_refs="$_ai_loop_expected_refs $_b"
+    printf '%s\t%s\n' "$_b" "$_f" >> "$_ai_loop_map_file"
   done
 fi
 if [ -d "$AI_LOOP_SPEC_DIR" ]; then
   for _name in $_ai_loop_spec_files; do
     [ -f "$AI_LOOP_SPEC_DIR/$_name" ] || continue
     _ai_loop_expected_refs="$_ai_loop_expected_refs $_name"
+    printf '%s\t%s\n' "$_name" "$AI_LOOP_SPEC_DIR/$_name" >> "$_ai_loop_map_file"
   done
   if [ -f "$AI_LOOP_SPEC_DIR/ho-paths.md" ]; then
     _ai_loop_expected_refs="$_ai_loop_expected_refs ho-paths.md"
+    printf '%s\t%s\n' "ho-paths.md" "$AI_LOOP_SPEC_DIR/ho-paths.md" >> "$_ai_loop_map_file"
   fi
 fi
 
 _sync_ai_loop_ref_content() {
   # $1=content src file（変換前の内容。ho-paths.md はヘッダ前置後の tmp file）
-  # $2=dst basename（例: 00_concept.md）、$3=label（ログ用）
+  # $2=source path（相対リンク解決の基準となる論理ソースパス。ho-paths.md は
+  #    ヘッダ前置前の元パス）、$3=dst basename（例: 00_concept.md）、$4=label
   # references/ へ書き込む直前に markdown リンクを自己完結化する（issue #790）:
-  #   bundle 内部参照 → ./name.md、本スキル自身の SKILL.md → ../SKILL.md、
-  #   それ以外の外部正本参照 → リンク解除してインラインコード化
-  _content_src="$1"; _base="$2"; _label="$3"
+  #   同一実体のバンドル内部参照 → ./name.md、本スキル自身の SKILL.md →
+  #   ../SKILL.md、それ以外（外部正本・別実体）→ リンク解除しインラインコード化
+  _content_src="$1"; _source_path="$2"; _base="$3"; _label="$4"
   mkdir -p "$PLUGIN_AI_LOOP_REFS"
   _dfile="$PLUGIN_AI_LOOP_REFS/$_base"
   _tmp_rewritten="$(mktemp)"
-  python3 "$AI_LOOP_LINK_REWRITER" "$_content_src" "$PLUGIN_AI_LOOP_SKILL_NAME" $_ai_loop_expected_refs > "$_tmp_rewritten"
+  python3 "$AI_LOOP_LINK_REWRITER" "$_content_src" "$_source_path" \
+    "$PLUGIN_AI_LOOP_SKILL_NAME" "$_ai_loop_map_file" > "$_tmp_rewritten"
   if [ ! -f "$_dfile" ] || ! cmp -s "$_tmp_rewritten" "$_dfile"; then
     if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD COPY (links self-contained): $_label/$_base"
     else cp "$_tmp_rewritten" "$_dfile"; _log "COPY (links self-contained): $_label/$_base"; fi
@@ -182,14 +196,14 @@ _sync_ai_loop_ref_content() {
 if [ -d "$AI_LOOP_WORKFLOWS_DIR" ]; then
   for _f in "$AI_LOOP_WORKFLOWS_DIR"/*.md; do
     [ -f "$_f" ] || continue
-    _sync_ai_loop_ref_content "$_f" "$(basename "$_f")" "skills/ai-loop-cycle/references"
+    _sync_ai_loop_ref_content "$_f" "$_f" "$(basename "$_f")" "skills/ai-loop-cycle/references"
   done
 fi
 if [ -d "$AI_LOOP_SPEC_DIR" ]; then
   for _name in $_ai_loop_spec_files; do
     _f="$AI_LOOP_SPEC_DIR/$_name"
     [ -f "$_f" ] || continue
-    _sync_ai_loop_ref_content "$_f" "$_name" "skills/ai-loop-cycle/references"
+    _sync_ai_loop_ref_content "$_f" "$_f" "$_name" "skills/ai-loop-cycle/references"
   done
 
   # ho-paths.md はプロジェクト固有のため、雛形注記ヘッダを前置してからリンク変換する
@@ -203,7 +217,7 @@ if [ -d "$AI_LOOP_SPEC_DIR" ]; then
       printf '\n'
       cat "$_ho_src"
     } > "$_tmp_ho"
-    _sync_ai_loop_ref_content "$_tmp_ho" "ho-paths.md" "skills/ai-loop-cycle/references"
+    _sync_ai_loop_ref_content "$_tmp_ho" "$_ho_src" "ho-paths.md" "skills/ai-loop-cycle/references"
     rm -f "$_tmp_ho"
   fi
 fi

--- a/tests/extras/ta-54-ai-loop-link-selfcontained.sh
+++ b/tests/extras/ta-54-ai-loop-link-selfcontained.sh
@@ -1,0 +1,97 @@
+# tests/extras/ta-54-ai-loop-link-selfcontained.sh
+# Sourced by tests/run-tests.sh — uses $pass / $fail counters
+# issue #790: plugin/plangate/skills/ai-loop-cycle/references/ の markdown リンクを
+# 自己完結化（bundle内部 → ./name.md、本スキル自身の SKILL.md → ../SKILL.md、
+# それ以外の外部正本 → インラインコード化）する sync-plugin-plangate.sh 改修の検証。
+
+printf '\n=== TA-54: ai-loop plugin bundle link self-containment (issue #790) ===\n'
+
+PG_T54_ROOT="$(CDPATH= cd -- "$FIXTURES_DIR/../.." && pwd)"
+PG_T54_SCRIPT="$PG_T54_ROOT/scripts/sync-plugin-plangate.sh"
+PG_T54_REWRITER="$PG_T54_ROOT/scripts/_ai_loop_link_rewrite.py"
+PG_T54_PLUGIN="$PG_T54_ROOT/plugin/plangate"
+PG_T54_REFS="$PG_T54_PLUGIN/skills/ai-loop-cycle/references"
+
+t54_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
+t54_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
+
+# TC-00: rewriter helper 存在・構文チェック（scripts/_*.py は HO 外 / mode-classification.md）
+if [ -f "$PG_T54_REWRITER" ] && python3 -m py_compile "$PG_T54_REWRITER" 2>/dev/null; then
+  t54_pass "TC-00 _ai_loop_link_rewrite.py 存在・compile OK"
+else
+  t54_fail "TC-00 _ai_loop_link_rewrite.py 不在 or compile error"
+fi
+
+# 実行前に plugin/plangate 全体をバックアップ（ta-26 と同じ流儀。テスト実行が
+# 他テストや実リポジトリ状態を汚染しないようにする / #530-3 trap 非依存）
+PG_T54_TMPDIR=$(mktemp -d)
+register_cleanup "$PG_T54_TMPDIR"
+cp -r "$PG_T54_PLUGIN" "$PG_T54_TMPDIR/plugin_backup"
+
+# 1 回目の sync 実行（dead-link 0 検証・変換内容検証はこの後の状態に対して行う）
+sh "$PG_T54_SCRIPT" >/dev/null 2>&1 || true
+
+# TC-01: dead-link 0 検証。ただし本スキル自身の SKILL.md 参照（../SKILL.md）は
+# references/ の親ディレクトリに実在するため意図的な例外として除外する
+# （rule 2）。それ以外の `](../` パターンが 1 件でも残っていれば dead link。
+if [ -d "$PG_T54_REFS" ]; then
+  _t54_dead=$(grep -rnE '\]\(\.\./' "$PG_T54_REFS"/*.md 2>/dev/null | grep -v '](\.\./SKILL\.md' || true)
+else
+  _t54_dead="NO_REFS_DIR"
+fi
+if [ -z "$_t54_dead" ]; then
+  t54_pass "TC-01 dead-link 0（../SKILL.md 以外の ](../ パターンなし）"
+else
+  t54_fail "TC-01 dead link 残存: $_t54_dead"
+fi
+
+# TC-02: 冪等性 — 2 回目の sync 実行で references/ に追加差分が出ないこと
+_t54_hash_before=$(find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | md5sum 2>/dev/null || find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | cksum)
+sh "$PG_T54_SCRIPT" >/dev/null 2>&1 || true
+_t54_hash_after=$(find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | md5sum 2>/dev/null || find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | cksum)
+if [ "$_t54_hash_before" = "$_t54_hash_after" ]; then
+  t54_pass "TC-02 2 回目の sync で references/ に差分なし（冪等性）"
+else
+  t54_fail "TC-02 2 回目の sync で references/ に差分あり（冪等性違反）"
+fi
+
+# TC-03: 変換の正しさ — bundle 内部参照（00_concept.md）が ./00_concept.md に、
+# 外部参照（working-context.md）が inline code に変換されていること
+if [ -f "$PG_T54_REFS/adaptive-production-loop.md" ] \
+  && grep -q '](\./00_concept\.md)' "$PG_T54_REFS/adaptive-production-loop.md" 2>/dev/null; then
+  t54_pass "TC-03a bundle 内部参照が ./00_concept.md に変換されている"
+else
+  t54_fail "TC-03a bundle 内部参照（00_concept.md）の変換を確認できない"
+fi
+
+if [ -f "$PG_T54_REFS/00_concept.md" ] \
+  && grep -q '`working-context\.md`' "$PG_T54_REFS/00_concept.md" 2>/dev/null \
+  && ! grep -q '\]\([^)]*working-context\.md\)' "$PG_T54_REFS/00_concept.md" 2>/dev/null; then
+  t54_pass "TC-03b 外部参照（working-context.md）がインラインコードに変換されている"
+else
+  t54_fail "TC-03b 外部参照（working-context.md）のインラインコード変換を確認できない"
+fi
+
+# TC-04: 本スキル自身の SKILL.md 参照は ../SKILL.md のまま維持される（rule 2、
+# references/ の親に実在するため dead link ではない）
+if [ -f "$PG_T54_REFS/execution-runbook.md" ] \
+  && grep -q '](\.\./SKILL\.md)' "$PG_T54_REFS/execution-runbook.md" 2>/dev/null; then
+  t54_pass "TC-04 本スキル自身の SKILL.md 参照が ../SKILL.md に正規化されている"
+else
+  t54_fail "TC-04 ../SKILL.md への正規化を確認できない"
+fi
+
+# TC-05: 正本 docs/workflows/ai-loop/*.md・docs/ai/ai-loop/*.md は変更されない
+# （リンク変換は plugin コピーにのみ適用。sync 実行によるワークツリー差分が
+# 正本側に出ていないことを git status で確認）
+_t54_src_dirty=$(git -C "$PG_T54_ROOT" status --porcelain -- docs/workflows/ai-loop docs/ai/ai-loop 2>/dev/null || true)
+if [ -z "$_t54_src_dirty" ]; then
+  t54_pass "TC-05 正本 docs/workflows/ai-loop・docs/ai/ai-loop は無変更"
+else
+  t54_fail "TC-05 正本 docs に意図しない差分: $_t54_src_dirty"
+fi
+
+# restore（ta-26 と同じ流儀 — テストが実リポジトリ state を変えたままにしない）
+rm -rf "$PG_T54_PLUGIN"
+cp -r "$PG_T54_TMPDIR/plugin_backup" "$PG_T54_PLUGIN"
+rm -rf "$PG_T54_TMPDIR"

--- a/tests/extras/ta-54-ai-loop-link-selfcontained.sh
+++ b/tests/extras/ta-54-ai-loop-link-selfcontained.sh
@@ -1,8 +1,10 @@
 # tests/extras/ta-54-ai-loop-link-selfcontained.sh
 # Sourced by tests/run-tests.sh — uses $pass / $fail counters
 # issue #790: plugin/plangate/skills/ai-loop-cycle/references/ の markdown リンクを
-# 自己完結化（bundle内部 → ./name.md、本スキル自身の SKILL.md → ../SKILL.md、
-# それ以外の外部正本 → インラインコード化）する sync-plugin-plangate.sh 改修の検証。
+# 自己完結化（同一実体のbundle内部 → ./name.md、本スキル自身の SKILL.md →
+# ../SKILL.md、それ以外の外部・別実体 → インラインコード化）する
+# sync-plugin-plangate.sh 改修の検証。3 レーンレビュー反映（basename 衝突の
+# 誤ポイント是正・変換差分検証力の強化・dead-link 走査の拡張）。
 
 printf '\n=== TA-54: ai-loop plugin bundle link self-containment (issue #790) ===\n'
 
@@ -33,14 +35,16 @@ sh "$PG_T54_SCRIPT" >/dev/null 2>&1 || true
 
 # TC-01: dead-link 0 検証。ただし本スキル自身の SKILL.md 参照（../SKILL.md）は
 # references/ の親ディレクトリに実在するため意図的な例外として除外する
-# （rule 2）。それ以外の `](../` パターンが 1 件でも残っていれば dead link。
+# （rule 2）。inline link `](../` に加え、参照定義 `]: ../` と autolink
+# `<../...>` も検出対象に含める（現コーパスに無くても将来の堅牢化 / F2）。
 if [ -d "$PG_T54_REFS" ]; then
-  _t54_dead=$(grep -rnE '\]\(\.\./' "$PG_T54_REFS"/*.md 2>/dev/null | grep -v '](\.\./SKILL\.md' || true)
+  _t54_dead=$(grep -rnE '\]\(\.\./|\]:[[:space:]]*\.\./|<\.\./' "$PG_T54_REFS"/*.md 2>/dev/null \
+    | grep -v '](\.\./SKILL\.md' || true)
 else
   _t54_dead="NO_REFS_DIR"
 fi
 if [ -z "$_t54_dead" ]; then
-  t54_pass "TC-01 dead-link 0（../SKILL.md 以外の ](../ パターンなし）"
+  t54_pass "TC-01 dead-link 0（../SKILL.md 以外の ../ 参照が inline/ref/autolink とも 0）"
 else
   t54_fail "TC-01 dead link 残存: $_t54_dead"
 fi
@@ -55,21 +59,39 @@ else
   t54_fail "TC-02 2 回目の sync で references/ に差分あり（冪等性違反）"
 fi
 
-# TC-03: 変換の正しさ — bundle 内部参照（00_concept.md）が ./00_concept.md に、
-# 外部参照（working-context.md）が inline code に変換されていること
+# TC-03a: 変換差分検証力（F3）— **実際に変換された行**を assert する。
+# adaptive-production-loop.md の arbiter-policy 参照は正本で
+# `](../../ai/ai-loop/arbiter-policy.md)`（cross-dir 相対）であり、変換後は
+# `](./arbiter-policy.md)` になる。同時に正本側には `./arbiter-policy.md` が
+# **無い**ことを確認し、無変換でも PASS してしまう空振りを防ぐ。
 if [ -f "$PG_T54_REFS/adaptive-production-loop.md" ] \
-  && grep -q '](\./00_concept\.md)' "$PG_T54_REFS/adaptive-production-loop.md" 2>/dev/null; then
-  t54_pass "TC-03a bundle 内部参照が ./00_concept.md に変換されている"
+  && grep -q '](\./arbiter-policy\.md)' "$PG_T54_REFS/adaptive-production-loop.md" 2>/dev/null \
+  && ! grep -q '](\./arbiter-policy\.md)' "$PG_T54_ROOT/docs/workflows/ai-loop/adaptive-production-loop.md" 2>/dev/null; then
+  t54_pass "TC-03a cross-dir bundle 参照が実際に ./arbiter-policy.md へ変換された（正本には無い）"
 else
-  t54_fail "TC-03a bundle 内部参照（00_concept.md）の変換を確認できない"
+  t54_fail "TC-03a ./arbiter-policy.md への変換を確認できない（変換差分検証力）"
 fi
 
+# TC-03b: 外部参照（working-context.md）がインラインコードに変換されていること
 if [ -f "$PG_T54_REFS/00_concept.md" ] \
   && grep -q '`working-context\.md`' "$PG_T54_REFS/00_concept.md" 2>/dev/null \
   && ! grep -q '\]\([^)]*working-context\.md\)' "$PG_T54_REFS/00_concept.md" 2>/dev/null; then
   t54_pass "TC-03b 外部参照（working-context.md）がインラインコードに変換されている"
 else
   t54_fail "TC-03b 外部参照（working-context.md）のインラインコード変換を確認できない"
+fi
+
+# TC-03c: basename 衝突の誤ポイント回帰固定（Finding 1）。
+# design-philosophy.md の `../subagent-delegation/README.md`（= 委譲プロトコル
+# README、別実体）が basename `README.md` の衝突で ai-loop の README へ silent
+# 誤ポイントしていた。同一実体判定により inline code `subagent-delegation/README.md`
+# になり、`](./README.md)` 誤リンクが **存在しない** ことを assert する。
+if [ -f "$PG_T54_REFS/design-philosophy.md" ] \
+  && grep -q '`subagent-delegation/README\.md`' "$PG_T54_REFS/design-philosophy.md" 2>/dev/null \
+  && ! grep -q '](\./README\.md)' "$PG_T54_REFS/design-philosophy.md" 2>/dev/null; then
+  t54_pass "TC-03c basename 衝突が別実体として inline 化・./README.md 誤リンクなし"
+else
+  t54_fail "TC-03c 誤ポイント是正を確認できない（subagent-delegation/README.md）"
 fi
 
 # TC-04: 本スキル自身の SKILL.md 参照は ../SKILL.md のまま維持される（rule 2、
@@ -91,7 +113,17 @@ else
   t54_fail "TC-05 正本 docs に意図しない差分: $_t54_src_dirty"
 fi
 
-# restore（ta-26 と同じ流儀 — テストが実リポジトリ state を変えたままにしない）
-rm -rf "$PG_T54_PLUGIN"
-cp -r "$PG_T54_TMPDIR/plugin_backup" "$PG_T54_PLUGIN"
+# restore（RiverReview I-3 hardening）— backup 存在を検証してから破壊的復元し、
+# 復元失敗を検知して非ゼロ終了（$fail 加算）する。CI の tmp 書込失敗時に real
+# plugin/plangate を破壊したまま復旧できずツリー汚染する経路を塞ぐ。
+if [ -d "$PG_T54_TMPDIR/plugin_backup" ] && [ -n "$(ls -A "$PG_T54_TMPDIR/plugin_backup" 2>/dev/null)" ]; then
+  rm -rf "$PG_T54_PLUGIN"
+  if cp -r "$PG_T54_TMPDIR/plugin_backup" "$PG_T54_PLUGIN" 2>/dev/null; then
+    :
+  else
+    t54_fail "TC-restore plugin/plangate の復元に失敗（ツリー汚染の可能性・要手動復旧）"
+  fi
+else
+  t54_fail "TC-restore backup 不在のため復元スキップ（plugin/plangate を破壊しない）"
+fi
 rm -rf "$PG_T54_TMPDIR"

--- a/tests/extras/ta-54-ai-loop-link-selfcontained.sh
+++ b/tests/extras/ta-54-ai-loop-link-selfcontained.sh
@@ -17,6 +17,15 @@ PG_T54_REFS="$PG_T54_PLUGIN/skills/ai-loop-cycle/references"
 t54_pass() { pass=$((pass + 1)); printf '  [PASS] %s\n' "$1"; }
 t54_fail() { fail=$((fail + 1)); printf '  [FAIL] %s\n' "$1" >&2; }
 
+# _t54_hash: references/ 内の全ファイル内容を安定ハッシュ化する。
+# xargs cat は BSD/macOS では空入力時に cat を引数なし実行 → stdin 待ちで永久
+# ハングするため使わない（gemini HIGH）。空入力でも while ループ本体が走らず
+# md5sum/cksum が空ハッシュを返すのでハングしない。
+_t54_hash() {
+  find "$1" -type f 2>/dev/null | sort | while IFS= read -r _hf; do cat "$_hf"; done \
+    | { md5sum 2>/dev/null || cksum; }
+}
+
 # TC-00: rewriter helper 存在・構文チェック（scripts/_*.py は HO 外 / mode-classification.md）
 if [ -f "$PG_T54_REWRITER" ] && python3 -m py_compile "$PG_T54_REWRITER" 2>/dev/null; then
   t54_pass "TC-00 _ai_loop_link_rewrite.py 存在・compile OK"
@@ -50,9 +59,9 @@ else
 fi
 
 # TC-02: 冪等性 — 2 回目の sync 実行で references/ に追加差分が出ないこと
-_t54_hash_before=$(find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | md5sum 2>/dev/null || find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | cksum)
+_t54_hash_before=$(_t54_hash "$PG_T54_REFS")
 sh "$PG_T54_SCRIPT" >/dev/null 2>&1 || true
-_t54_hash_after=$(find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | md5sum 2>/dev/null || find "$PG_T54_REFS" -type f 2>/dev/null | sort | xargs cat 2>/dev/null | cksum)
+_t54_hash_after=$(_t54_hash "$PG_T54_REFS")
 if [ "$_t54_hash_before" = "$_t54_hash_after" ]; then
   t54_pass "TC-02 2 回目の sync で references/ に差分なし（冪等性）"
 else


### PR DESCRIPTION
## 概要

plugin 配布物（`plugin/plangate/skills/ai-loop-cycle/references/`）を **リンク切れゼロで自己完結**させ、「plugin を入れるだけで skill が動く」状態を実現する。従来 sync は verbatim cp のみで、references 17 本中 15 本が `../` 系リンクを持ち導入先で dead link だった。

## 目的（ユーザー要件）

**plugin 配布のみで完結させたい** → arbiter.py（実行本体）は既に自立実行を実測確認済みで、残るギャップは docs のリンク健全化のみだった。本 PR がそれを閉じる。

## 変更（18 ファイル）

- **新規 `scripts/_ai_loop_link_rewrite.py`**: sync 時に markdown リンクを変換
  - bundle 内に**同一実体**がある参照 → `./name.md`
  - 自 skill の SKILL.md → `../SKILL.md`（親に実在）
  - 真に外部（`working-context.md` 等）→ インラインコード化（リンク解除）
- **`scripts/sync-plugin-plangate.sh`**: Phase 1 で `basename → ソース実パス` 写像を構築し rewriter へ渡す
- **`references/*.md` 15 本**再生成（リンク変換済み）
- **新テスト `tests/extras/ta-54-*.sh`**: dead-link 0 / 冪等性 / 変換正しさ / 誤ポイント回帰固定

正本 `docs/workflows/ai-loop/` `docs/ai/ai-loop/` は**不変**（リポジトリ内では相対リンクが正しく解決するため、変換は plugin コピーにのみ適用）。

## レビュー体制（3レーン + 統合検証）

- 実装: sonnet 委託（worktree 分離・2 commit）
- レビュー **3レーン**: **敵対的（opus）+ RiverReview（code/testing）+ Codex**
  - **敵対的レーンが MAJOR を実験証明**: basename 単独判定で `../subagent-delegation/README.md`（委譲プロトコル）が ai-loop の `./README.md`（別文書）へ **silent 誤ポイント**（リンク先が実在するため dead-link チェックをすり抜ける意味的欠陥）。RiverReview は dead-link 0 で PASS を出しており、独立レーンを分けた意義が明確に出た
  - **是正**: basename 単独判定 → **元パスの normpath 実解決がバンドル元と同一実体か検証**（不一致は inline code）。`subagent-delegation/README.md` は inline code に、同一実体の `arbiter-policy.md` は `./` を維持（実測確認）
  - テスト強化（TC-03a 空振り是正・誤ポイント TC-03c 追加・dead-link 走査に参照定義/autolink 追加）+ `~~~`フェンス/画像 hardening + ta-54 restore の tree 汚染防止
  - **Codex レーン**: codex-companion バックグラウンド（`task-mrd7ojp5-281e4m`）で dispatch 済み。headless では結果回収不可のため `/codex:status` で取得可能（未反映指摘があれば follow-up）

## 検証（実測）

- Finding 1 解消: `subagent-delegation/README.md` inline 化・誤リンク `](./README.md)` = 0
- dead-link 0（`../SKILL.md` 自己参照 2 件のみ・実在）
- 冪等性: 2 回 sync で references byte 一致
- arbiter 自立: /tmp コピーで 63 テスト PASS
- フルスイート: **403 passed / 0 failed**（新 TC-54 含む・変換前では新 TC が FAIL することも実証）
- 正本不変（git 実測）

## 既知の defer（follow-up 候補）

- bundle 済 `arbiter.py` が inline code 表示（dead ではない・.md 限定バンドルの設計上）。scripts への相互リンク化は別 issue 候補
- 4-space インデントコードブロック / パスに `)` を含むケースの変換 hardening（現コーパス不在・regex 複雑化の回帰リスクで未実装）

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)