### PR TITLE
feat: breakdown-gate スキル新設 — 着手前のタスク粒度 intake ゲート

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -20,6 +20,7 @@
 
 | 迷ったら | 選ぶスキル | 理由 |
 |---------|-----------|------|
+| **着手前**にタスクを分割すべきか判定したい | `breakdown-gate` | PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。mode 判定・C-1 の代替ではない |
 | plan の品質を**軽くスコアリング**したい | `plan-quality-check`（.claude 専用） | `bin/plangate plan-check` に配線された軽量ゲート。C-1 の代替ではない |
 | C-1/C-2/C-3 の**正式ゲート判定**を回したい | `plan-review-gate` | ゲート列の判定と exec 可否確認の正本フロー |
 | plan を**外部レビュアー視点で講評**してほしい | `plan-quality-reviewer`（.claude 専用） | スコアでなく講評を返す。正式ゲートの代替ではない |
@@ -54,7 +55,7 @@ WF-01〜WF-05 の各 phase で呼び出す再利用可能スキル。
 | `systematic-debugging` | エビデンスベースの体系的デバッグ |
 | `subagent-driven-development` | サブエージェント駆動の2段階レビュー開発 |
 | `codex-multi-agent` | Codex CLI を用いたマルチエージェント並列実行 |
-| `breakdown-gate` | 実装着手前にタスク粒度を5要素で判定するintakeゲート（PlanGate起動前・#799） |
+| `breakdown-gate` | PlanGate 起動前の intake 判定 — タスク粒度を5要素で判定し分割候補を提示（#799） |
 
 ## Skill 運用スキル（Claude Code / Codex CLI 共用）
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -54,6 +54,7 @@ WF-01〜WF-05 の各 phase で呼び出す再利用可能スキル。
 | `systematic-debugging` | エビデンスベースの体系的デバッグ |
 | `subagent-driven-development` | サブエージェント駆動の2段階レビュー開発 |
 | `codex-multi-agent` | Codex CLI を用いたマルチエージェント並列実行 |
+| `breakdown-gate` | 実装着手前にタスク粒度を5要素で判定するintakeゲート（PlanGate起動前・#799） |
 
 ## Skill 運用スキル（Claude Code / Codex CLI 共用）
 

--- a/.agents/skills/breakdown-gate/SKILL.md
+++ b/.agents/skills/breakdown-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: breakdown-gate
-description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+description: "PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示する。Use when: PlanGate を起動すべきか迷う軽量タスクの判定時、PBI 化の前に分割要否を確かめたい時、「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」。出典: growth-core task-breakdown-gate 由来（#799）。"
 ---
 
 # Breakdown Gate
@@ -25,6 +25,8 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
 | 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+| 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
+| plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
 
 本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
 
@@ -95,6 +97,7 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 ## 関連
 
 - [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
-- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
 - [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.agents/skills/breakdown-gate/SKILL.md
+++ b/.agents/skills/breakdown-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: breakdown-gate
+description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+---
+
+# Breakdown Gate
+
+実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
+
+## Iron Law
+
+`ONE TASK = ONE PURPOSE, ONE PR-SIZED DIFF, ONE VERIFIABLE OUTCOME`
+
+目的・差分・検証結果のどれか 1 つでも複数に見えたら分割を検討する。
+
+## 役割分界（オーガナイザー設計 / issue #799）
+
+| 段階 | 担当 | 本スキルとの関係 |
+|---|---|---|
+| 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
+| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+
+本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「まとめて実装した方が速い」 | 大きいタスクほど迷走する |
+| 「DB 変更と API 変更は一緒じゃないと意味がない」 | migration+API+test 同梱は最多の失敗パターン |
+| 「テストは後で」 | 後でとは永遠のこと |
+| 「Rollback は考えなくていい」 | 書けないなら設計が固まっていない証拠 |
+
+## 手順
+
+### Phase 1: タスク一覧の確認
+
+判定対象のタスク一覧を取得する。`docs/working/TASK-XXXX/todo.md` が既に存在する場合はそれを読み、記載されたタスクを入力とする。存在しない場合はユーザーの依頼文から判定対象タスクを列挙する。
+
+### Phase 2: 5 要素チェック
+
+各タスクについて以下 5 要素を判定する。いずれかが「書けない」または「複数になる」場合は分割候補へ回す。
+
+- □ **目的**（1 文・複数動詞なし）
+- □ **変更対象**（file / module / API / DB を限定可）
+- □ **完了条件**（観測可能・検証可能）
+- □ **検証方法**（unit / integration / manual / lint+typecheck+build）
+- □ **Rollback**（1 手順で書ける）
+
+### Phase 3: 粒度サイズ判定
+
+| 目安 | 判定 |
+|---|---|
+| 30 分〜2 時間 | 理想 |
+| 半日〜1 日 | 許容 |
+| 2 日以上 | 分割必須 |
+| DB + API + UI + テスト同梱 | 分割必須 |
+| 目的が複数（「〜して、さらに〜」） | 分割必須 |
+
+### Phase 4: 分割候補の提示
+
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+
+## 出力フォーマット
+
+タスクごとに以下を出力する:
+
+```markdown
+### タスク: <タスク名>
+
+| 要素 | 判定 |
+|---|---|
+| 目的 | OK / NG（理由） |
+| 変更対象 | OK / NG（理由） |
+| 完了条件 | OK / NG（理由） |
+| 検証方法 | OK / NG（理由） |
+| Rollback | OK / NG（理由） |
+
+**粒度判定**: 理想 / 許容 / 分割必須
+
+**分割要否**: 不要 / 必要
+
+**分割候補**（分割必要の場合）:
+1. <候補1>（依存: なし）
+2. <候補2>（依存: 候補1完了後）
+...
+```
+
+## 関連
+
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
+- [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.agents/skills/breakdown-gate/SKILL.md
+++ b/.agents/skills/breakdown-gate/SKILL.md
@@ -5,6 +5,11 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 
 # Breakdown Gate
 
+> **Provenance（出典・vendoring 規約）**: growth-core `task-breakdown-gate`
+> （upstream: Growth-Teams-Agent@5219642 / 2026-07-03 時点）を PlanGate 向けに
+> 汎用化して取り込み（#799）。上流への自動追従はしない — 上流更新の反映は
+> **意図的に** diff をレビューして行う（provenance 追跡 + 意図的更新の vendoring 標準）。
+
 実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
 
 ## Iron Law

--- a/.agents/skills/breakdown-gate/SKILL.md
+++ b/.agents/skills/breakdown-gate/SKILL.md
@@ -23,7 +23,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 | 段階 | 担当 | 本スキルとの関係 |
 |---|---|---|
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
-| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| 起動後の規模判定 | `.claude/rules/mode-classification.md`（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
 | 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
 | plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
@@ -67,7 +67,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ### Phase 4: 分割候補の提示
 
-分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（`.claude/rules/mode-classification.md`）の Mode 判定にかける導線を示す。
 
 ## 出力フォーマット
 
@@ -96,7 +96,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ## 関連
 
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `.claude/rules/mode-classification.md` — 規模判定の正本。本スキルは mode を決めない
 - `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
 - `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -14,6 +14,7 @@ PlanGate ワークフロー v5 / v6 / **v7** で使用するスキル群。
 | `codex-multi-agent` | マルチエージェントでタスク分解・委譲・並列実行・結果統合 | workflow |
 | `setup-team` | タスク規模・モードに応じた最適チーム設計とエージェント委譲準備 | workflow |
 | `ref-integrity-scan` | 削除・移動・改名前後の被参照（inbound）全走査（#691 outbound の相補 / #798） | developer-tools |
+| `breakdown-gate` | PlanGate 起動前の intake 判定 — タスク粒度を5要素で判定し分割候補を提示（#799） | workflow |
 
 ## v7 ハイブリッドアーキテクチャ用 Skill（10 個）
 

--- a/.claude/skills/breakdown-gate/SKILL.md
+++ b/.claude/skills/breakdown-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: breakdown-gate
-description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+description: "PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示する。Use when: PlanGate を起動すべきか迷う軽量タスクの判定時、PBI 化の前に分割要否を確かめたい時、「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」。出典: growth-core task-breakdown-gate 由来（#799）。"
 ---
 
 # Breakdown Gate
@@ -25,6 +25,8 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
 | 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+| 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
+| plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
 
 本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
 
@@ -95,6 +97,7 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 ## 関連
 
 - [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
-- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
 - [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.claude/skills/breakdown-gate/SKILL.md
+++ b/.claude/skills/breakdown-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: breakdown-gate
+description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+---
+
+# Breakdown Gate
+
+実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
+
+## Iron Law
+
+`ONE TASK = ONE PURPOSE, ONE PR-SIZED DIFF, ONE VERIFIABLE OUTCOME`
+
+目的・差分・検証結果のどれか 1 つでも複数に見えたら分割を検討する。
+
+## 役割分界（オーガナイザー設計 / issue #799）
+
+| 段階 | 担当 | 本スキルとの関係 |
+|---|---|---|
+| 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
+| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+
+本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「まとめて実装した方が速い」 | 大きいタスクほど迷走する |
+| 「DB 変更と API 変更は一緒じゃないと意味がない」 | migration+API+test 同梱は最多の失敗パターン |
+| 「テストは後で」 | 後でとは永遠のこと |
+| 「Rollback は考えなくていい」 | 書けないなら設計が固まっていない証拠 |
+
+## 手順
+
+### Phase 1: タスク一覧の確認
+
+判定対象のタスク一覧を取得する。`docs/working/TASK-XXXX/todo.md` が既に存在する場合はそれを読み、記載されたタスクを入力とする。存在しない場合はユーザーの依頼文から判定対象タスクを列挙する。
+
+### Phase 2: 5 要素チェック
+
+各タスクについて以下 5 要素を判定する。いずれかが「書けない」または「複数になる」場合は分割候補へ回す。
+
+- □ **目的**（1 文・複数動詞なし）
+- □ **変更対象**（file / module / API / DB を限定可）
+- □ **完了条件**（観測可能・検証可能）
+- □ **検証方法**（unit / integration / manual / lint+typecheck+build）
+- □ **Rollback**（1 手順で書ける）
+
+### Phase 3: 粒度サイズ判定
+
+| 目安 | 判定 |
+|---|---|
+| 30 分〜2 時間 | 理想 |
+| 半日〜1 日 | 許容 |
+| 2 日以上 | 分割必須 |
+| DB + API + UI + テスト同梱 | 分割必須 |
+| 目的が複数（「〜して、さらに〜」） | 分割必須 |
+
+### Phase 4: 分割候補の提示
+
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+
+## 出力フォーマット
+
+タスクごとに以下を出力する:
+
+```markdown
+### タスク: <タスク名>
+
+| 要素 | 判定 |
+|---|---|
+| 目的 | OK / NG（理由） |
+| 変更対象 | OK / NG（理由） |
+| 完了条件 | OK / NG（理由） |
+| 検証方法 | OK / NG（理由） |
+| Rollback | OK / NG（理由） |
+
+**粒度判定**: 理想 / 許容 / 分割必須
+
+**分割要否**: 不要 / 必要
+
+**分割候補**（分割必要の場合）:
+1. <候補1>（依存: なし）
+2. <候補2>（依存: 候補1完了後）
+...
+```
+
+## 関連
+
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
+- [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.claude/skills/breakdown-gate/SKILL.md
+++ b/.claude/skills/breakdown-gate/SKILL.md
@@ -5,6 +5,11 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 
 # Breakdown Gate
 
+> **Provenance（出典・vendoring 規約）**: growth-core `task-breakdown-gate`
+> （upstream: Growth-Teams-Agent@5219642 / 2026-07-03 時点）を PlanGate 向けに
+> 汎用化して取り込み（#799）。上流への自動追従はしない — 上流更新の反映は
+> **意図的に** diff をレビューして行う（provenance 追跡 + 意図的更新の vendoring 標準）。
+
 実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
 
 ## Iron Law

--- a/.claude/skills/breakdown-gate/SKILL.md
+++ b/.claude/skills/breakdown-gate/SKILL.md
@@ -23,7 +23,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 | 段階 | 担当 | 本スキルとの関係 |
 |---|---|---|
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
-| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| 起動後の規模判定 | `.claude/rules/mode-classification.md`（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
 | 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
 | plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
@@ -67,7 +67,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ### Phase 4: 分割候補の提示
 
-分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（`.claude/rules/mode-classification.md`）の Mode 判定にかける導線を示す。
 
 ## 出力フォーマット
 
@@ -96,7 +96,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ## 関連
 
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `.claude/rules/mode-classification.md` — 規模判定の正本。本スキルは mode を決めない
 - `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
 - `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用

--- a/.claude/skills/intent-classifier/SKILL.md
+++ b/.claude/skills/intent-classifier/SKILL.md
@@ -150,3 +150,4 @@ intent-classifier は **Intent 8 分類のみ**を担う。Mode 判定・`lite_e
 ## 関連 Skill
 
 - **skill-policy-router**: Intent + Mode を受け取り GatePolicy を返す。intent-classifier の出力をそのまま渡せる
+- **breakdown-gate**: タスク粒度の intake ゲート。intent-classifier のさらに前段で、分割が必要な粗粒度タスクを検出する（`.agents/skills/breakdown-gate/`）

--- a/.claude/skills/skill-policy-router/SKILL.md
+++ b/.claude/skills/skill-policy-router/SKILL.md
@@ -188,3 +188,4 @@ Intent に応じて optionalSkills を追加・調整する:
 ## 関連 Skill
 
 - **intent-classifier**: ユーザー依頼文から Intent を判定する。このスキルの前段として使用
+- **breakdown-gate**: タスク粒度の intake ゲート。intent-classifier よりさらに前段（PlanGate 起動前）でタスク分割要否を判定する（`.agents/skills/breakdown-gate/`）

--- a/.codex/skills/breakdown-gate/SKILL.md
+++ b/.codex/skills/breakdown-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: breakdown-gate
-description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+description: "PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示する。Use when: PlanGate を起動すべきか迷う軽量タスクの判定時、PBI 化の前に分割要否を確かめたい時、「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」。出典: growth-core task-breakdown-gate 由来（#799）。"
 ---
 
 # Breakdown Gate
@@ -25,6 +25,8 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
 | 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+| 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
+| plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
 
 本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
 
@@ -95,6 +97,7 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 ## 関連
 
 - [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
-- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
 - [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.codex/skills/breakdown-gate/SKILL.md
+++ b/.codex/skills/breakdown-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: breakdown-gate
+description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+---
+
+# Breakdown Gate
+
+実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
+
+## Iron Law
+
+`ONE TASK = ONE PURPOSE, ONE PR-SIZED DIFF, ONE VERIFIABLE OUTCOME`
+
+目的・差分・検証結果のどれか 1 つでも複数に見えたら分割を検討する。
+
+## 役割分界（オーガナイザー設計 / issue #799）
+
+| 段階 | 担当 | 本スキルとの関係 |
+|---|---|---|
+| 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
+| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+
+本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「まとめて実装した方が速い」 | 大きいタスクほど迷走する |
+| 「DB 変更と API 変更は一緒じゃないと意味がない」 | migration+API+test 同梱は最多の失敗パターン |
+| 「テストは後で」 | 後でとは永遠のこと |
+| 「Rollback は考えなくていい」 | 書けないなら設計が固まっていない証拠 |
+
+## 手順
+
+### Phase 1: タスク一覧の確認
+
+判定対象のタスク一覧を取得する。`docs/working/TASK-XXXX/todo.md` が既に存在する場合はそれを読み、記載されたタスクを入力とする。存在しない場合はユーザーの依頼文から判定対象タスクを列挙する。
+
+### Phase 2: 5 要素チェック
+
+各タスクについて以下 5 要素を判定する。いずれかが「書けない」または「複数になる」場合は分割候補へ回す。
+
+- □ **目的**（1 文・複数動詞なし）
+- □ **変更対象**（file / module / API / DB を限定可）
+- □ **完了条件**（観測可能・検証可能）
+- □ **検証方法**（unit / integration / manual / lint+typecheck+build）
+- □ **Rollback**（1 手順で書ける）
+
+### Phase 3: 粒度サイズ判定
+
+| 目安 | 判定 |
+|---|---|
+| 30 分〜2 時間 | 理想 |
+| 半日〜1 日 | 許容 |
+| 2 日以上 | 分割必須 |
+| DB + API + UI + テスト同梱 | 分割必須 |
+| 目的が複数（「〜して、さらに〜」） | 分割必須 |
+
+### Phase 4: 分割候補の提示
+
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+
+## 出力フォーマット
+
+タスクごとに以下を出力する:
+
+```markdown
+### タスク: <タスク名>
+
+| 要素 | 判定 |
+|---|---|
+| 目的 | OK / NG（理由） |
+| 変更対象 | OK / NG（理由） |
+| 完了条件 | OK / NG（理由） |
+| 検証方法 | OK / NG（理由） |
+| Rollback | OK / NG（理由） |
+
+**粒度判定**: 理想 / 許容 / 分割必須
+
+**分割要否**: 不要 / 必要
+
+**分割候補**（分割必要の場合）:
+1. <候補1>（依存: なし）
+2. <候補2>（依存: 候補1完了後）
+...
+```
+
+## 関連
+
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
+- [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/.codex/skills/breakdown-gate/SKILL.md
+++ b/.codex/skills/breakdown-gate/SKILL.md
@@ -5,6 +5,11 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 
 # Breakdown Gate
 
+> **Provenance（出典・vendoring 規約）**: growth-core `task-breakdown-gate`
+> （upstream: Growth-Teams-Agent@5219642 / 2026-07-03 時点）を PlanGate 向けに
+> 汎用化して取り込み（#799）。上流への自動追従はしない — 上流更新の反映は
+> **意図的に** diff をレビューして行う（provenance 追跡 + 意図的更新の vendoring 標準）。
+
 実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
 
 ## Iron Law

--- a/.codex/skills/breakdown-gate/SKILL.md
+++ b/.codex/skills/breakdown-gate/SKILL.md
@@ -23,7 +23,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 | 段階 | 担当 | 本スキルとの関係 |
 |---|---|---|
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
-| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| 起動後の規模判定 | `.claude/rules/mode-classification.md`（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
 | 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
 | plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
@@ -67,7 +67,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ### Phase 4: 分割候補の提示
 
-分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（`.claude/rules/mode-classification.md`）の Mode 判定にかける導線を示す。
 
 ## 出力フォーマット
 
@@ -96,7 +96,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ## 関連
 
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `.claude/rules/mode-classification.md` — 規模判定の正本。本スキルは mode を決めない
 - `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
 - `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用

--- a/.codex/skills/breakdown-gate/agents/openai.yaml
+++ b/.codex/skills/breakdown-gate/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "breakdown-gate"
-  short_description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割し..."
+  short_description: "PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。実装着手前..."
   icon_small: "./assets/plangate-small.svg"
   icon_large: "./assets/plangate-small.svg"
   default_prompt: "Use $breakdown-gate to assist with this project."

--- a/.codex/skills/breakdown-gate/agents/openai.yaml
+++ b/.codex/skills/breakdown-gate/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "breakdown-gate"
+  short_description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割し..."
+  icon_small: "./assets/plangate-small.svg"
+  icon_large: "./assets/plangate-small.svg"
+  default_prompt: "Use $breakdown-gate to assist with this project."
+  brand_color: "#1A56DB"

--- a/.codex/skills/breakdown-gate/assets/plangate-small.svg
+++ b/.codex/skills/breakdown-gate/assets/plangate-small.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
+  <text x="16" y="22" font-family="monospace" font-size="18" font-weight="bold" text-anchor="middle" fill="#6c63ff">P</text>
+</svg>

--- a/plugin/plangate/skills/README.md
+++ b/plugin/plangate/skills/README.md
@@ -45,6 +45,7 @@ WF-01〜WF-05 の各 phase で呼び出す再利用可能スキル。
 | `systematic-debugging` | エビデンスベースの体系的デバッグ |
 | `subagent-driven-development` | サブエージェント駆動の2段階レビュー開発 |
 | `codex-multi-agent` | Codex CLI を用いたマルチエージェント並列実行 |
+| `breakdown-gate` | PlanGate 起動前の intake 判定 — タスク粒度を5要素で判定し分割候補を提示（#799） |
 
 ## Skill 運用スキル（Claude Code / Codex CLI 共用）
 

--- a/plugin/plangate/skills/breakdown-gate/SKILL.md
+++ b/plugin/plangate/skills/breakdown-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: breakdown-gate
-description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+description: "PlanGate 起動前の intake 判定（mode-classification にかける前の分割要否）。実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示する。Use when: PlanGate を起動すべきか迷う軽量タスクの判定時、PBI 化の前に分割要否を確かめたい時、「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」。出典: growth-core task-breakdown-gate 由来（#799）。"
 ---
 
 # Breakdown Gate
@@ -25,6 +25,8 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
 | 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+| 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
+| plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
 
 本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
 
@@ -95,6 +97,7 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 ## 関連
 
 - [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
-- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
 - [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/plugin/plangate/skills/breakdown-gate/SKILL.md
+++ b/plugin/plangate/skills/breakdown-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: breakdown-gate
+description: "実装着手前にタスク粒度を5要素で判定し、必要なら分割候補を提示するintakeゲート。Use when: 「タスクを分割して」「粒度が大きすぎる」「1 PRに複数目的が入っている」、PlanGateを起動すべきか迷う軽量タスクの判定時。出典: growth-core task-breakdown-gate 由来（#799）。"
+---
+
+# Breakdown Gate
+
+実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
+
+## Iron Law
+
+`ONE TASK = ONE PURPOSE, ONE PR-SIZED DIFF, ONE VERIFIABLE OUTCOME`
+
+目的・差分・検証結果のどれか 1 つでも複数に見えたら分割を検討する。
+
+## 役割分界（オーガナイザー設計 / issue #799）
+
+| 段階 | 担当 | 本スキルとの関係 |
+|---|---|---|
+| 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
+| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
+
+本スキルは PlanGate の Mode 判定・C-1 レビューを代替しない。あくまで「PlanGate を起動する前に、そもそも 1 タスクとして扱ってよい粒度か」を判定する前段ゲート。
+
+## Common Rationalizations
+
+| こう思ったら | 現実 |
+|---|---|
+| 「まとめて実装した方が速い」 | 大きいタスクほど迷走する |
+| 「DB 変更と API 変更は一緒じゃないと意味がない」 | migration+API+test 同梱は最多の失敗パターン |
+| 「テストは後で」 | 後でとは永遠のこと |
+| 「Rollback は考えなくていい」 | 書けないなら設計が固まっていない証拠 |
+
+## 手順
+
+### Phase 1: タスク一覧の確認
+
+判定対象のタスク一覧を取得する。`docs/working/TASK-XXXX/todo.md` が既に存在する場合はそれを読み、記載されたタスクを入力とする。存在しない場合はユーザーの依頼文から判定対象タスクを列挙する。
+
+### Phase 2: 5 要素チェック
+
+各タスクについて以下 5 要素を判定する。いずれかが「書けない」または「複数になる」場合は分割候補へ回す。
+
+- □ **目的**（1 文・複数動詞なし）
+- □ **変更対象**（file / module / API / DB を限定可）
+- □ **完了条件**（観測可能・検証可能）
+- □ **検証方法**（unit / integration / manual / lint+typecheck+build）
+- □ **Rollback**（1 手順で書ける）
+
+### Phase 3: 粒度サイズ判定
+
+| 目安 | 判定 |
+|---|---|
+| 30 分〜2 時間 | 理想 |
+| 半日〜1 日 | 許容 |
+| 2 日以上 | 分割必須 |
+| DB + API + UI + テスト同梱 | 分割必須 |
+| 目的が複数（「〜して、さらに〜」） | 分割必須 |
+
+### Phase 4: 分割候補の提示
+
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+
+## 出力フォーマット
+
+タスクごとに以下を出力する:
+
+```markdown
+### タスク: <タスク名>
+
+| 要素 | 判定 |
+|---|---|
+| 目的 | OK / NG（理由） |
+| 変更対象 | OK / NG（理由） |
+| 完了条件 | OK / NG（理由） |
+| 検証方法 | OK / NG（理由） |
+| Rollback | OK / NG（理由） |
+
+**粒度判定**: 理想 / 許容 / 分割必須
+
+**分割要否**: 不要 / 必要
+
+**分割候補**（分割必要の場合）:
+1. <候補1>（依存: なし）
+2. <候補2>（依存: 候補1完了後）
+...
+```
+
+## 関連
+
+- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング
+- [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用
+- [`brainstorming`](../brainstorming/SKILL.md) — 要件そのものが曖昧な場合はこちらを先に使う（本スキルは要件確定後の粒度判定）

--- a/plugin/plangate/skills/breakdown-gate/SKILL.md
+++ b/plugin/plangate/skills/breakdown-gate/SKILL.md
@@ -5,6 +5,11 @@ description: "実装着手前にタスク粒度を5要素で判定し、必要�
 
 # Breakdown Gate
 
+> **Provenance（出典・vendoring 規約）**: growth-core `task-breakdown-gate`
+> （upstream: Growth-Teams-Agent@5219642 / 2026-07-03 時点）を PlanGate 向けに
+> 汎用化して取り込み（#799）。上流への自動追従はしない — 上流更新の反映は
+> **意図的に** diff をレビューして行う（provenance 追跡 + 意図的更新の vendoring 標準）。
+
 実装着手**前**にタスクの粒度を判定し、粗すぎる場合は分割候補を提示する intake ゲート。growth-core `task-breakdown-gate` から蒸留。
 
 ## Iron Law

--- a/plugin/plangate/skills/breakdown-gate/SKILL.md
+++ b/plugin/plangate/skills/breakdown-gate/SKILL.md
@@ -23,7 +23,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 | 段階 | 担当 | 本スキルとの関係 |
 |---|---|---|
 | 起動前 intake | **breakdown-gate（本スキル）** | 5 要素 + 粒度判定 → 分割候補提示 |
-| 起動後の規模判定 | [`mode-classification.md`](../../../.claude/rules/mode-classification.md)（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
+| 起動後の規模判定 | `.claude/rules/mode-classification.md`（正本・不変） | 本スキルは **mode を決めない**（判定基準は参照のみ） |
 | plan 生成後の粒度検査 | C-1 ToDo チェック「タスク粒度」（不変） | 本スキルは plan 生成**前** |
 | 規模 L 以上の MVP scoping | `codex-mvp-split`（既存・`.agents/skills/codex-mvp-split/`） | 本スキルは**分割要否の判定**まで。規模 L 以上と判明したら codex-mvp-split で最小 MVP（Phase 1）分割へ |
 | plan 生成後の品質スコア | `plan-quality-check`（既存・`.claude/skills/` 専用） | 5 要素は同系だがタイミングが異なる（本スキル=plan **前** / plan-quality-check=plan **後**）。チェックリストの正本は各自 — 変更時は相互参照 |
@@ -67,7 +67,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ### Phase 4: 分割候補の提示
 
-分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（[`mode-classification.md`](../../../.claude/rules/mode-classification.md)）の Mode 判定にかける導線を示す。
+分割が必要と判定したタスクについて、各分割候補が Iron Law（1 目的・1 PR 規模・1 検証）を満たす形で列挙し、依存順を明示する。分割後の各タスクは個別に PlanGate（`.claude/rules/mode-classification.md`）の Mode 判定にかける導線を示す。
 
 ## 出力フォーマット
 
@@ -96,7 +96,7 @@ description: "PlanGate 起動前の intake 判定（mode-classification にか�
 
 ## 関連
 
-- [`mode-classification.md`](../../../.claude/rules/mode-classification.md) — 規模判定の正本。本スキルは mode を決めない
+- `.claude/rules/mode-classification.md` — 規模判定の正本。本スキルは mode を決めない
 - `codex-mvp-split`（`.agents/skills/codex-mvp-split/`） — 規模 L 以上の最小 MVP（Phase 1）選定。本スキルの分割要否判定の後段
 - `plan-quality-check`（`.claude/skills/plan-quality-check/`） — plan 生成後の品質スコアリング（本スキルは plan 生成前。変更時は相互参照）
 - [`subagent-driven-development`](../subagent-driven-development/SKILL.md) — 分割後の各タスクをサブエージェントへ委譲する際に使用


### PR DESCRIPTION
## 概要

新スキル `breakdown-gate`: 実装着手**前**にタスク粒度を 5 要素（目的/変更対象/完了条件/検証方法/Rollback）で判定し、必要なら分割候補を提示する intake ゲート。Iron Law: `ONE TASK = ONE PURPOSE, ONE PR-SIZED DIFF, ONE VERIFIABLE OUTCOME`。

## 役割分界（計画レビューで近傍 2 スキルを追加）

| 段階 | 担当 |
|---|---|
| 起動前 intake（分割要否） | **breakdown-gate（本スキル）** |
| 規模 L 以上の MVP scoping | codex-mvp-split（既存・L 以上と判明したらこちらへ） |
| 起動後の規模判定 | mode-classification（正本・不変 — 本スキルは mode を決めない） |
| plan 生成後の品質スコア | plan-quality-check（既存・タイミング差を明記） |
| plan 生成後の粒度検査 | C-1 ToDo チェック（不変） |

- intent-classifier / skill-policy-router へ参照 1 行を接続（非 HO のみ・HO 該当なしを grep 実測）
- growth-core と**同名にせず**衝突回避 + description の Use when を「**PlanGate 起動前の intake 判定**」第一トリガに差別化（併用環境での起動先曖昧化を防止）

## 品質プロセス

- **計画自体を river-review でレビュー** → A-2（トリガ差別化）/ A-6（近傍スキル分界の欠落）/ B-1（索引 README 3 種）を反映
- **vendoring 標準を適用**: Provenance ブロック（upstream@5219642 pin + 意図的更新規約）
- 検証: 4 配置 cmp byte 一致 / collision 正常形のみ / markdownlint 0 / フルスイート **403 passed / 0 failed**

Closes #799 / Refs #794 #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)