### PR TITLE
chore: diff-audit 改名の HO 適用結果（agents 参照更新 + plugin 伝播）

### DIFF
--- a/.claude/agents/implementation-agent.md
+++ b/.claude/agents/implementation-agent.md
@@ -21,7 +21,7 @@ model: inherit
 ## 呼び出し Skill
 
 - `feature-implement` — 個別機能の実装（WF-04 主体 / v7 責務ベース Skill 10 個のうち Build カテゴリ）
-- `self-review`（既存 Skill、v7 の 10 Skill には含まれないが併用可）— 実装直後の構造化セルフレビュー
+- `diff-audit`（既存 Skill、v7 の 10 Skill には含まれないが併用可）— 実装直後の構造化セルフレビュー
 - `known-issues-log` — 妥協点・既知課題の記録（WF-05 との橋渡し）
 
 ## 委譲関係

--- a/.claude/agents/workflow-conductor.md
+++ b/.claude/agents/workflow-conductor.md
@@ -449,7 +449,7 @@ conductor が Implementer サブエージェントに文脈を構成する際の
 |-------------|--------|----------------|
 | brainstorm | brainstorming skill | ユーザー入力 + コードベース調査結果 |
 | plan生成 | project-planner agent | pbi-input.md全文 |
-| C-1 | self-review skill（17項目チェック） | plan + todo + test-cases + pbi-input |
+| C-1 | diff-audit skill（17項目チェック） | plan + todo + test-cases + pbi-input |
 | C-2 | 利用可能なサブエージェント | plan + todo + test-cases + review-self |
 | exec: 実装 | implementer agent（タスクごとに新規） | タスク詳細（抽出済み）+ テストケース（抽出済み）+ 既存パターン |
 | L-0: autofix/AI修正 | linter-fixer agent | リンター設定 + 違反一覧 + 該当コード |
@@ -513,7 +513,7 @@ conductorはstatus.mdに以下のMarkdownセクションを管理する（YAML f
 - **plangate.md** — PlanGateガイド（全体像・設計思想）
 - **ai-driven-development.md** — ワークフロー詳細・プロンプト集
 - **brainstorming/SKILL.md** — Phase 0で利用
-- **self-review/SKILL.md** — Phase C-1で利用
+- **diff-audit/SKILL.md** — Phase C-1で利用
 - **subagent-driven-development/SKILL.md** — Phase Dで利用
 - **working-context.md** — ディレクトリ構造・ファイル定義
 

--- a/plugin/plangate/agents/implementation-agent.md
+++ b/plugin/plangate/agents/implementation-agent.md
@@ -21,7 +21,7 @@ model: inherit
 ## 呼び出し Skill
 
 - `feature-implement` — 個別機能の実装（WF-04 主体 / v7 責務ベース Skill 10 個のうち Build カテゴリ）
-- `self-review`（既存 Skill、v7 の 10 Skill には含まれないが併用可）— 実装直後の構造化セルフレビュー
+- `diff-audit`（既存 Skill、v7 の 10 Skill には含まれないが併用可）— 実装直後の構造化セルフレビュー
 - `known-issues-log` — 妥協点・既知課題の記録（WF-05 との橋渡し）
 
 ## 委譲関係

--- a/plugin/plangate/agents/workflow-conductor.md
+++ b/plugin/plangate/agents/workflow-conductor.md
@@ -449,7 +449,7 @@ conductor が Implementer サブエージェントに文脈を構成する際の
 |-------------|--------|----------------|
 | brainstorm | brainstorming skill | ユーザー入力 + コードベース調査結果 |
 | plan生成 | project-planner agent | pbi-input.md全文 |
-| C-1 | self-review skill（17項目チェック） | plan + todo + test-cases + pbi-input |
+| C-1 | diff-audit skill（17項目チェック） | plan + todo + test-cases + pbi-input |
 | C-2 | 利用可能なサブエージェント | plan + todo + test-cases + review-self |
 | exec: 実装 | implementer agent（タスクごとに新規） | タスク詳細（抽出済み）+ テストケース（抽出済み）+ 既存パターン |
 | L-0: autofix/AI修正 | linter-fixer agent | リンター設定 + 違反一覧 + 該当コード |
@@ -513,6 +513,19 @@ conductorはstatus.mdに以下のMarkdownセクションを管理する（YAML f
 - **plangate.md** — PlanGateガイド（全体像・設計思想）
 - **ai-driven-development.md** — ワークフロー詳細・プロンプト集
 - **brainstorming/SKILL.md** — Phase 0で利用
-- **self-review/SKILL.md** — Phase C-1で利用
+- **diff-audit/SKILL.md** — Phase C-1で利用
 - **subagent-driven-development/SKILL.md** — Phase Dで利用
 - **working-context.md** — ディレクトリ構造・ファイル定義
+
+---
+
+## validation_bias の供給（TASK-0147 / #527・非強制の補足）
+
+strict profile（`model-profiles.yaml` の `validation_bias: strict`）で EHS-1/2/3 を
+実 run 発火させたい場合、conductor は V フェーズの CLI 呼び出しに `--profile=<key>` を
+渡す（**等号形式必須**。例: `bin/plangate verify <TASK> --mode=<m> --profile=gpt-5_5_pro`。
+`--mode` と同じく `--flag=value` 形式のみ受理し、スペース区切り `--profile <key>` は無視される）。CLI が
+`model-profiles.yaml` から `validation_bias` を解決し `PLANGATE_VALIDATION_BIAS` を
+内部 export する。env で明示注入済みならそれを尊重する。normal/lenient profile では
+従来どおり非発火（既存挙動不変）。**強制は CLI 側（`bin/plangate`）に閉じており、
+本補足は運用ガイドであって強制力を持たない**。


### PR DESCRIPTION
## 概要

#796（self-review → diff-audit 改名）の残タスクだった **HO パス 2 ファイルの参照更新**。`scripts/apply-diff-audit-rename.sh --apply`（**Human 実行**・冪等 SKIP を実測）+ `sync-plugin-plangate.sh` の結果を PR 化。

- `.claude/agents/implementation-agent.md`（1 箇所）/ `workflow-conductor.md`（2 箇所）の `self-review` スキル参照を `diff-audit` へ
- plugin 側 2 ファイルへ sync 伝播。**workflow-conductor の plugin コピーは既存未同期ドリフト（validation_bias 分）の healing を含む**（全文コピーの同期契約どおり・#795 の review-gate healing と同型）

## 検証（実測）

- 4 ファイルとも `self-review` 残存 **0**（grep 実測）
- apply スクリプト 2 回目実行 → **SKIP**（冪等）
- 責務分界: HO 適用 = Human（apply 実行済み）→ PR 化 = AI → C-4 = Human

これで #796 の改名は全配置（.claude/.agents/.codex/plugin/.cursor + HO agents）で完結。

Refs #796 #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)