### PR TITLE
fix: slsa-attestation の action pin を実在 SHA（v4.1.1）へ更新

### DIFF
--- a/.github/workflows/slsa-attestation.yml
+++ b/.github/workflows/slsa-attestation.yml
@@ -31,7 +31,7 @@ jobs:
           echo "ARCHIVE=plangate-${RELEASE_TAG}.tar.gz" >> "$GITHUB_ENV"
 
       - name: Generate SLSA provenance attestation
-        uses: actions/attest-build-provenance@e8d4baa0b41c87f71bb46de40f28fe2e2aaee96f # v2.4.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ env.ARCHIVE }}
 


### PR DESCRIPTION
## 概要

release published で起動する SLSA Provenance workflow が、**上流に存在しない SHA**（`e8d4baa…` # v2.4.0 表記・422 実測）の pin により**毎リリース即時 failure** していた（#784・v8.16.0 で実害）。実在する **v4.1.1**（`0f67c3f4856b2e3261c31976d6725780e5e4c373`・上流 tag を適用直前に再実測）へ更新。

## 互換性検証（実測）

- 本 workflow の使用は `subject-path` のみ（基本入力・全版共通）
- v3.0.0 = node24 ランタイム更新 / v4.0.0 = `actions/attest` の wrapper 化 — 上流 release note が「**既存アプリはそのまま使い続けてよい**」と明記。breaking 影響なし

## 責務分界

HO パス（`.github/workflows/`）のため **sed 適用 = Human 実行**（済み）→ PR 化 = AI → C-4 = Human。

## マージ後（AI 実施予定）

v8.16.0 の failed SLSA run を re-run し provenance 発行を確認（本 PR とは独立の後続確認）。

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)