### PR TITLE
fix: ai-loop Phase 1 安全前提の機械層配線 — fail-closed + allowed_paths + パス正規化（#809）

### DIFF
--- a/.agents/skills/ai-loop-cycle/SKILL.md
+++ b/.agents/skills/ai-loop-cycle/SKILL.md
@@ -47,6 +47,8 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで宣言する。**いずれかの軸が
 判定不能なら false**（AC-8 安全側、虚偽宣言禁止）。
 
+`allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
+
 - `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
@@ -60,6 +62,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 ```json
 {
   "changed_files": ["docs/example.md"],
+  "allowed_paths": ["docs/example.md"],
   "lite": {
     "size_ok": true,
     "no_new_design": true,

--- a/.claude/skills/ai-loop-cycle/SKILL.md
+++ b/.claude/skills/ai-loop-cycle/SKILL.md
@@ -38,13 +38,15 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
 - `reversible`: 可逆か（`git revert` 一発等、機械的な巻き戻し手順があるか）
 
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
-`target_sha` は対象コミットの SHA。
+`target_sha` は対象コミットの SHA。`allowed_paths` は LoopSpec の `scope.allowed_paths`
+宣言をそのまま渡す（#809）。
 
 入力 JSON の例:
 
 ```json
 {
   "changed_files": ["docs/workflows/ai-loop/example.md"],
+  "allowed_paths": ["docs/workflows/ai-loop/example.md"],
   "lite": {
     "size_ok": true,
     "no_new_design": true,

--- a/.codex/skills/ai-loop-cycle/SKILL.md
+++ b/.codex/skills/ai-loop-cycle/SKILL.md
@@ -5,6 +5,20 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 # ai-loop-cycle
 
+> **配置に関する注記（#809）**: 本 `.codex/skills/ai-loop-cycle/` 配置は
+> bundled resources（`references/`・`scripts/`）を**同梱していない**（本文中の
+> 記述は `.agents/skills/ai-loop-cycle/SKILL.md` と共通のテキストであり、
+> bundled 配置を前提とした文言を含むが、実体の `references/`・`scripts/`
+> ディレクトリはここには存在しない）。判定ロジック・provenance スキーマの
+> 実装は repo 正本 [`scripts/ai-loop/arbiter.py`](../../../scripts/ai-loop/arbiter.py)、
+> 手順・分岐表の正本は [`docs/workflows/ai-loop/`](../../../docs/workflows/ai-loop/)
+> を参照すること。`.agents/` → `.codex/` の同期は
+> `scripts/install-plangate-skills-to-codex.sh` によるが、3 配置
+> （`.agents/` / `.codex/` / `plugin/plangate/`）の SKILL.md 内容同一性を
+> 機械的に強制するテストは現状存在しない（手動同期依存）。
+
+<!-- 以下は .agents/skills/ai-loop-cycle/SKILL.md と共通のテキスト（bundled 配置前提の文言を含む） -->
+
 > 本スキルは **bundled resources**（`references/`・`scripts/`）で自己完結する。
 > スキルディレクトリ直下の `references/<name>.md` と `scripts/arbiter.py` を同梱し、
 > 導入先が独自の正本（`docs/workflows/ai-loop/` 等）を別途保持している場合は

--- a/docs/workflows/ai-loop/00_concept.md
+++ b/docs/workflows/ai-loop/00_concept.md
@@ -20,9 +20,9 @@ ai-loop-workflow は Phase 0（本リポジトリの `docs/workflows/ai-loop/` �
 1. **ho-paths の導入先確定**: 導入先プロジェクトが自身の HO（Hardening
    Override）境界を [`ho-paths.md`](../../ai/ai-loop/ho-paths.md) 相当の形で
    確定していること。未確定のまま run を開始することは**規範違反**であり、
-   L1 は run を開始してはならない（現行 `arbiter.py` は plangate 固有の
-   HO パターンを内蔵するのみで、導入先 ho-paths の実行時解決・未確定検知
-   による全件 escalate は**未実装**。機械化は follow-up #809）
+   L1 は run を開始してはならない（`arbiter.py` は ho-paths.md を実行時解決
+   し、導入先 ho-paths の未確定・パース結果 0 件時は全件 human escalate する
+   fail-closed 機械化を実装済み — #809）
 2. **LoopSpec `scope.allowed_paths` の宣言**: [`loopspec.md`](./loopspec.md)
    の既存必須フィールドで、run ごとの変更可能範囲を宣言していること
 
@@ -33,7 +33,9 @@ ai-loop-workflow は Phase 0（本リポジトリの `docs/workflows/ai-loop/` �
 `AUTO_APPROVED` 対象に含めてよい**（Human 決定・2026-07-10）。Phase 0 時点の
 「事実上 docs 級のみ」（issue #782 実測）から拡張する。`lite.size_ok` は
 当面**申告制のまま**とし、git 由来の機械算出 blast-radius boolean への置換
-（#780 slice C）が、申告制に伴う保証強化の unlock として残る。
+（#780 slice C）が、申告制に伴う保証強化の unlock として残る。導入先での
+実機能 auto-approve の実運用開始は `lite.size_ok` の機械算出（#780 slice C）
+導入を前提とする（順序制約）。
 
 ### plangate 本体の扱い（据え置き）
 
@@ -44,8 +46,8 @@ plangate 本体（本リポジトリ）における ai-loop-workflow の適用�
 ### 不変条件（安全側 — 承認境界は不動。Phase 1 でも緩和しない）
 
 - HO 接触 = 無条件 escalate（fail-closed）。ho-paths 未確定時の全件
-  escalate は現状**規範層**（前提 1 の開始禁止）であり、機械層のガードは
-  follow-up #809
+  escalate は**規範層**（前提 1 の開始禁止）に加え、`arbiter.py` の
+  実行時解決 fail-closed（#809）で**機械層のガードも実装済み**
 - **NO MERGE BY AI** / escalate の自己解決禁止 / 対応ラウンド上限 3
 - W チェック独立 2 体（Model A/B、必要なら C/D）
 - lite 4 軸の AC-8 安全側（判定不能→false・虚偽宣言禁止）

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -52,6 +52,24 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
+### priority 0 / 1.5（#809 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+
+上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
+2 チェックは `scripts/ai-loop/arbiter.py`（#809）が実装する**前置・割込み
+チェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
+
+| priority | 内容 | → 裁定 |
+| ---------- | ------ | -------- |
+| **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
+| **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
+
+- priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
+  （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
+  （判定不能を clean 扱いにする）は絶対に行わない
+- priority 1.5 は priority 1（touches-HO）の**後**に評価する。
+  `allowed_paths` に HO パスを宣言していても HO escalate は免れない
+  （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
+
 ### 裁定ラベルと provenance 値の対応
 
 | Decision table の裁定ラベル | provenance `decision` 値 |
@@ -94,7 +112,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v0（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v1（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -102,8 +120,14 @@ boundary_check:     clean
 target_sha:         <変更対象コミット SHA（差し替え検知用）>
 lite_check:         true
 class_check:        no-merge
+scope_check:        in_scope
 timestamp:          <ISO 8601>
 ```
+
+> **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
+> ho-paths 実行時解決の fail-closed 機械化）。`@v0` 時点の PoC は
+> `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
+> ロジックが変わった本改版で policy バージョンを進めた。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 
@@ -127,9 +151,10 @@ w_check:
 | `w_check.model_a` | ✅ | Model A の判定結果 |
 | `w_check.model_b` | ✅ | Model B の判定結果 |
 | `target_sha` | ✅ | 対象コミット SHA（差し替え検知用。replay 攻撃は検知・別途防止機構が必要。計画時/実装後の意味論は下記参照） |
-| `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ） |
+| `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ。ho-paths 未解決 fail-closed 時は `unresolved`） |
 | `lite_check` | ✅ | lite 判定結果（auto-approve は true のみ） |
 | `class_check` | ✅ | class 判定結果（auto-approve は no-merge のみ） |
+| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope` / `scope_violation` / `unresolved`（auto-approve は `in_scope` のみ） |
 | `timestamp` | ✅ | 刻印日時（ISO 8601） |
 | `w_check.severity` | C/D 時のみ | 不一致の severity 分類 |
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -121,6 +121,8 @@ target_sha:         <変更対象コミット SHA（差し替え検知用）>
 lite_check:         true
 class_check:        no-merge
 scope_check:        in_scope
+ho_paths_source:    docs/ai/ai-loop/ho-paths.md（解決された ho-paths のパス。未解決時は null）
+ho_pattern_count:   18（解決した HO パターン抽出件数）
 timestamp:          <ISO 8601>
 ```
 
@@ -154,7 +156,9 @@ w_check:
 | `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ。ho-paths 未解決 fail-closed 時は `unresolved`） |
 | `lite_check` | ✅ | lite 判定結果（auto-approve は true のみ） |
 | `class_check` | ✅ | class 判定結果（auto-approve は no-merge のみ） |
-| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope` / `scope_violation` / `unresolved`（auto-approve は `in_scope` のみ） |
+| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope`（priority 1.5 の scope 検査を実際に通過）/ `scope_violation`（逸脱検出）/ `unresolved`（ho-paths 未解決 fail-closed）/ `not_evaluated`（touches-HO 等 scope 検査より前で確定し未評価。既定値。`in_scope` と誤読させないため #809 敵対的レビュー minor 反映で導入）。auto-approve は `in_scope` のみ |
+| `ho_paths_source` | ✅（#809 追加） | 解決された ho-paths.md のパス（未解決 fail-closed 時は `null`）。全裁定経路で刻む |
+| `ho_pattern_count` | ✅（#809 追加） | 解決した HO パターン抽出件数（int。未解決時は 0）。「`boundary=clean` だが `ho_pattern_count=1`」のような過少網羅を監査で検知するための可視化フィールド（fail-closed 閾値そのものは 0 のまま — 導入先ごとに妥当な最小 HO クラス数が異なるため件数閾値化はしない） |
 | `timestamp` | ✅ | 刻印日時（ISO 8601） |
 | `w_check.severity` | C/D 時のみ | 不一致の severity 分類 |
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |

--- a/docs/workflows/ai-loop/execution-runbook.md
+++ b/docs/workflows/ai-loop/execution-runbook.md
@@ -16,8 +16,9 @@
    `docs/ai/ai-loop/ho-paths.md`（plugin 導入先は `references/ho-paths.md`）の
    雛形ヘッダ（同梱版に前置される「本ファイルは...配布時の参考例」注記）を
    参照しつつ、導入先固有のパス一覧として定義する。未確定のまま run を
-   開始してはならない（規範。arbiter による未確定検知・全件 escalate の
-   機械化は未実装 — follow-up #809）
+   開始してはならない（規範。`arbiter.py` は `--ho-paths` 明示指定 → CWD →
+   スクリプト位置基準の順で実行時解決し、未確定・パース結果 0 件時は
+   全件 human escalate する fail-closed を実装済み — #809）
 2. **LoopSpec に `scope.allowed_paths` を宣言する**: [`loopspec.md`](./loopspec.md)
    の既存必須フィールドで、当該 run の変更可能範囲を明示する
 3. **初回 run は escalate 前提で回す**: 導入初回は W チェック・境界判定の

--- a/plugin/plangate/skills/ai-loop-cycle/SKILL.md
+++ b/plugin/plangate/skills/ai-loop-cycle/SKILL.md
@@ -47,6 +47,8 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで宣言する。**いずれかの軸が
 判定不能なら false**（AC-8 安全側、虚偽宣言禁止）。
 
+`allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
+
 - `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
@@ -60,6 +62,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 ```json
 {
   "changed_files": ["docs/example.md"],
+  "allowed_paths": ["docs/example.md"],
   "lite": {
     "size_ok": true,
     "no_new_design": true,

--- a/plugin/plangate/skills/ai-loop-cycle/references/00_concept.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/00_concept.md
@@ -20,9 +20,9 @@ ai-loop-workflow は Phase 0（本リポジトリの `docs/workflows/ai-loop/` �
 1. **ho-paths の導入先確定**: 導入先プロジェクトが自身の HO（Hardening
    Override）境界を [`ho-paths.md`](./ho-paths.md) 相当の形で
    確定していること。未確定のまま run を開始することは**規範違反**であり、
-   L1 は run を開始してはならない（現行 `arbiter.py` は plangate 固有の
-   HO パターンを内蔵するのみで、導入先 ho-paths の実行時解決・未確定検知
-   による全件 escalate は**未実装**。機械化は follow-up #809）
+   L1 は run を開始してはならない（`arbiter.py` は ho-paths.md を実行時解決
+   し、導入先 ho-paths の未確定・パース結果 0 件時は全件 human escalate する
+   fail-closed 機械化を実装済み — #809）
 2. **LoopSpec `scope.allowed_paths` の宣言**: [`loopspec.md`](./loopspec.md)
    の既存必須フィールドで、run ごとの変更可能範囲を宣言していること
 
@@ -33,7 +33,9 @@ ai-loop-workflow は Phase 0（本リポジトリの `docs/workflows/ai-loop/` �
 `AUTO_APPROVED` 対象に含めてよい**（Human 決定・2026-07-10）。Phase 0 時点の
 「事実上 docs 級のみ」（issue #782 実測）から拡張する。`lite.size_ok` は
 当面**申告制のまま**とし、git 由来の機械算出 blast-radius boolean への置換
-（#780 slice C）が、申告制に伴う保証強化の unlock として残る。
+（#780 slice C）が、申告制に伴う保証強化の unlock として残る。導入先での
+実機能 auto-approve の実運用開始は `lite.size_ok` の機械算出（#780 slice C）
+導入を前提とする（順序制約）。
 
 ### plangate 本体の扱い（据え置き）
 
@@ -44,8 +46,8 @@ plangate 本体（本リポジトリ）における ai-loop-workflow の適用�
 ### 不変条件（安全側 — 承認境界は不動。Phase 1 でも緩和しない）
 
 - HO 接触 = 無条件 escalate（fail-closed）。ho-paths 未確定時の全件
-  escalate は現状**規範層**（前提 1 の開始禁止）であり、機械層のガードは
-  follow-up #809
+  escalate は**規範層**（前提 1 の開始禁止）に加え、`arbiter.py` の
+  実行時解決 fail-closed（#809）で**機械層のガードも実装済み**
 - **NO MERGE BY AI** / escalate の自己解決禁止 / 対応ラウンド上限 3
 - W チェック独立 2 体（Model A/B、必要なら C/D）
 - lite 4 軸の AC-8 安全側（判定不能→false・虚偽宣言禁止）

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -52,6 +52,24 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
+### priority 0 / 1.5（#809 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+
+上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
+2 チェックは `scripts/ai-loop/arbiter.py`（#809）が実装する**前置・割込み
+チェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
+
+| priority | 内容 | → 裁定 |
+| ---------- | ------ | -------- |
+| **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
+| **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
+
+- priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
+  （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
+  （判定不能を clean 扱いにする）は絶対に行わない
+- priority 1.5 は priority 1（touches-HO）の**後**に評価する。
+  `allowed_paths` に HO パスを宣言していても HO escalate は免れない
+  （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
+
 ### 裁定ラベルと provenance 値の対応
 
 | Decision table の裁定ラベル | provenance `decision` 値 |
@@ -94,7 +112,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v0（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v1（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -102,8 +120,14 @@ boundary_check:     clean
 target_sha:         <変更対象コミット SHA（差し替え検知用）>
 lite_check:         true
 class_check:        no-merge
+scope_check:        in_scope
 timestamp:          <ISO 8601>
 ```
+
+> **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
+> ho-paths 実行時解決の fail-closed 機械化）。`@v0` 時点の PoC は
+> `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
+> ロジックが変わった本改版で policy バージョンを進めた。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 
@@ -127,9 +151,10 @@ w_check:
 | `w_check.model_a` | ✅ | Model A の判定結果 |
 | `w_check.model_b` | ✅ | Model B の判定結果 |
 | `target_sha` | ✅ | 対象コミット SHA（差し替え検知用。replay 攻撃は検知・別途防止機構が必要。計画時/実装後の意味論は下記参照） |
-| `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ） |
+| `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ。ho-paths 未解決 fail-closed 時は `unresolved`） |
 | `lite_check` | ✅ | lite 判定結果（auto-approve は true のみ） |
 | `class_check` | ✅ | class 判定結果（auto-approve は no-merge のみ） |
+| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope` / `scope_violation` / `unresolved`（auto-approve は `in_scope` のみ） |
 | `timestamp` | ✅ | 刻印日時（ISO 8601） |
 | `w_check.severity` | C/D 時のみ | 不一致の severity 分類 |
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -121,6 +121,8 @@ target_sha:         <変更対象コミット SHA（差し替え検知用）>
 lite_check:         true
 class_check:        no-merge
 scope_check:        in_scope
+ho_paths_source:    docs/ai/ai-loop/ho-paths.md（解決された ho-paths のパス。未解決時は null）
+ho_pattern_count:   18（解決した HO パターン抽出件数）
 timestamp:          <ISO 8601>
 ```
 
@@ -154,7 +156,9 @@ w_check:
 | `boundary_check` | ✅ | boundary 判定結果（auto-approve は clean のみ。ho-paths 未解決 fail-closed 時は `unresolved`） |
 | `lite_check` | ✅ | lite 判定結果（auto-approve は true のみ） |
 | `class_check` | ✅ | class 判定結果（auto-approve は no-merge のみ） |
-| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope` / `scope_violation` / `unresolved`（auto-approve は `in_scope` のみ） |
+| `scope_check` | ✅（#809 追加） | allowed_paths 判定結果。`in_scope`（priority 1.5 の scope 検査を実際に通過）/ `scope_violation`（逸脱検出）/ `unresolved`（ho-paths 未解決 fail-closed）/ `not_evaluated`（touches-HO 等 scope 検査より前で確定し未評価。既定値。`in_scope` と誤読させないため #809 敵対的レビュー minor 反映で導入）。auto-approve は `in_scope` のみ |
+| `ho_paths_source` | ✅（#809 追加） | 解決された ho-paths.md のパス（未解決 fail-closed 時は `null`）。全裁定経路で刻む |
+| `ho_pattern_count` | ✅（#809 追加） | 解決した HO パターン抽出件数（int。未解決時は 0）。「`boundary=clean` だが `ho_pattern_count=1`」のような過少網羅を監査で検知するための可視化フィールド（fail-closed 閾値そのものは 0 のまま — 導入先ごとに妥当な最小 HO クラス数が異なるため件数閾値化はしない） |
 | `timestamp` | ✅ | 刻印日時（ISO 8601） |
 | `w_check.severity` | C/D 時のみ | 不一致の severity 分類 |
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |

--- a/plugin/plangate/skills/ai-loop-cycle/references/execution-runbook.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/execution-runbook.md
@@ -16,8 +16,9 @@
    `docs/ai/ai-loop/ho-paths.md`（plugin 導入先は `references/ho-paths.md`）の
    雛形ヘッダ（同梱版に前置される「本ファイルは...配布時の参考例」注記）を
    参照しつつ、導入先固有のパス一覧として定義する。未確定のまま run を
-   開始してはならない（規範。arbiter による未確定検知・全件 escalate の
-   機械化は未実装 — follow-up #809）
+   開始してはならない（規範。`arbiter.py` は `--ho-paths` 明示指定 → CWD →
+   スクリプト位置基準の順で実行時解決し、未確定・パース結果 0 件時は
+   全件 human escalate する fail-closed を実装済み — #809）
 2. **LoopSpec に `scope.allowed_paths` を宣言する**: [`loopspec.md`](./loopspec.md)
    の既存必須フィールドで、当該 run の変更可能範囲を明示する
 3. **初回 run は escalate 前提で回す**: 導入初回は W チェック・境界判定の

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import posixpath
 import re
 import sys
 from datetime import datetime, timezone
@@ -239,10 +240,56 @@ def boundary_check(
         ho_patterns, _source, _searched = resolve_ho_patterns()
     matched: list[dict[str, str]] = []
     for path in changed_files:
-        hit, pattern, classification = matches_ho_pattern(path, ho_patterns)
+        norm, err = _safe_normalized_path(path)
+        if err is not None:
+            # 不正パス（ルート外 traversal 等）は判定不能＝安全側で touches-HO
+            # 相当として扱う（本来は validate_input が exit 1 で拒否する第一
+            # 防壁があるが、判定関数単体でも fail-open にしない第二防壁）。
+            matched.append({"path": path, "pattern": "", "classification": f"unsafe-path（{err}）"})
+            continue
+        hit, pattern, classification = matches_ho_pattern(norm, ho_patterns)
         if hit:
             matched.append({"path": path, "pattern": pattern or "", "classification": classification or ""})
     return ("touches-HO" if matched else "clean"), matched
+
+
+# ---------------------------------------------------------------------------
+# パス正規化・安全性検査（#809 敵対的レビュー major 反映）
+# ---------------------------------------------------------------------------
+# changed_files / allowed_paths を素の文字列のまま正規表現に当てると、
+# `./bin/plangate`（先頭 ./ 変種）や `docs/ai/ai-loop/../../../bin/plangate`
+# （traversal）が HO パターンに一致せず boundary=clean となり、touches-HO
+# 絶対条件（design-philosophy I-1）を迂回して AUTO_APPROVED に到達し得る。
+# 2 層防御で封鎖する:
+#   第一防壁（入力段）: validate_input が不正パス（正規化後も `..` 残存・
+#     絶対パス・空セグメント //）を InputError（exit 1）で拒否
+#   第二防壁（判定段）: boundary_check / check_allowed_paths がマッチ直前に
+#     posixpath.normpath で畳み込んでから評価。判定関数単体に不正パスが
+#     渡った場合も安全側（touches-HO 相当 / scope violation）に倒す
+def _safe_normalized_path(path: str) -> tuple[str, str | None]:
+    """パスを正規化し、リポジトリ相対として不正なら理由文字列を返す。
+
+    戻り値: (正規化後パス, エラー理由 or None)
+    エラー条件: 空 / 絶対パス（先頭 /）/ 空セグメント（//）/
+    `..` セグメントを含む（traversal。normpath でルート内に畳み込める場合も
+    含めて一律拒否 — 正規パス表現以外を受理しない）。
+    先頭 `./` は normpath が畳み込むためエラーにしない（正規化後の実体で
+    マッチ評価する）。
+    """
+    stripped = path.strip()
+    if stripped == "":
+        return stripped, "空のパス"
+    if stripped.startswith("/"):
+        return stripped, "絶対パス"
+    if "//" in stripped:
+        return stripped, "空セグメント（//）"
+    if ".." in stripped.split("/"):
+        return stripped, "`..` セグメント（traversal）"
+    norm = posixpath.normpath(stripped)
+    # 上の検査で `..` は既に拒否済みだが、normpath 結果にも残さない（防御的既定）
+    if norm == ".." or norm.startswith("../"):
+        return norm, "リポジトリルート外（.. セグメント残存）"
+    return norm, None
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +308,16 @@ def check_allowed_paths(changed_files: list[str], allowed_paths: list[str]) -> t
     入れ替えてはならない。
     """
     regexes = [_ho_pattern_to_regex(pattern) for pattern in allowed_paths]
-    violations = [path for path in changed_files if not any(rx.match(path) for rx in regexes)]
+    violations: list[str] = []
+    for path in changed_files:
+        norm, err = _safe_normalized_path(path)
+        if err is not None:
+            # 不正パスは定義上 scope 外（安全側）。第一防壁（validate_input）
+            # を経ない直接呼び出しでも fail-open にしない。
+            violations.append(path)
+            continue
+        if not any(rx.match(norm) for rx in regexes):
+            violations.append(path)
     return (len(violations) == 0), violations
 
 
@@ -353,6 +409,12 @@ def validate_input(data: Any) -> dict[str, Any]:
         isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
         "changed_files は string のリストである必要があります",
     )
+    for path in changed_files:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"changed_files に不正なパスがあります（{err}。リポジトリ相対の正規パスのみ受理）: {path!r}",
+        )
 
     allowed_paths = data.get("allowed_paths")
     _require(
@@ -361,6 +423,12 @@ def validate_input(data: Any) -> dict[str, Any]:
         and all(isinstance(p, str) and p != "" for p in allowed_paths),
         "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
     )
+    for path in allowed_paths:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"allowed_paths に不正なパターンがあります（{err}。リポジトリ相対の正規パターンのみ受理）: {path!r}",
+        )
 
     lite = data.get("lite")
     _require(isinstance(lite, dict), "lite は object である必要があります")

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -63,6 +63,7 @@ exit code:
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import pathlib
 import posixpath
@@ -160,7 +161,10 @@ def resolve_ho_patterns(
             continue
         try:
             content = candidate.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, ValueError):
+            # UnicodeDecodeError（ValueError サブクラス。不正 UTF-8 / バイナリ）は
+            # OSError で捕捉されない。fail-closed を維持するため当該候補を skip し
+            # 次候補へ（全候補失敗なら patterns=[] → arbitrate が全件 escalate）。
             continue
         patterns = parse_ho_paths_table(content)
         if patterns:
@@ -170,12 +174,18 @@ def resolve_ho_patterns(
     return [], None, searched
 
 
+@functools.lru_cache(maxsize=None)
 def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
     """HO パターン文字列をセグメント境界を尊重した正規表現へ変換する。
 
     `*` は 1 セグメント内、`**` は 0 個以上のセグメント（"/" をまたぐ）に
     マッチする。fnmatch / pathlib.PurePath.match はいずれもこの意味論を
     正しく提供しないため、自前で構築する。
+
+    ho-paths.md の動的読み込み化（#809）で本関数は matches_ho_pattern /
+    check_allowed_paths のループから同一パターンで繰り返し呼ばれるため、
+    lru_cache でコンパイル済み regex をメモ化する（gemini medium・挙動不変）。
+    入力はイミュータブルな str のみ・純関数のためキャッシュ安全。
     """
     segments = pattern.split("/")
     n = len(segments)
@@ -270,15 +280,23 @@ def _safe_normalized_path(path: str) -> tuple[str, str | None]:
     """パスを正規化し、リポジトリ相対として不正なら理由文字列を返す。
 
     戻り値: (正規化後パス, エラー理由 or None)
-    エラー条件: 空 / 絶対パス（先頭 /）/ 空セグメント（//）/
+    エラー条件: 空 / バックスラッシュ（\\）/ 絶対パス（先頭 /）/ 空セグメント（//）/
     `..` セグメントを含む（traversal。normpath でルート内に畳み込める場合も
     含めて一律拒否 — 正規パス表現以外を受理しない）。
     先頭 `./` は normpath が畳み込むためエラーにしない（正規化後の実体で
     マッチ評価する）。
+
+    バックスラッシュ拒否の根拠（gemini security-high / #809）: `.split("/")`
+    は `/` でしか分割しないため、`foo\\..\\bar` のようなバックスラッシュ
+    区切り path は `..` チェックをすり抜ける（Windows / 一部ツールが `\\` を
+    セパレータ扱いする場合の traversal 迂回）。Git のパスは常に `/` 区切りの
+    ため、`\\` を含む path は一律不正として拒否する。
     """
     stripped = path.strip()
     if stripped == "":
         return stripped, "空のパス"
+    if "\\" in stripped:
+        return stripped, "バックスラッシュ（\\）"
     if stripped.startswith("/"):
         return stripped, "絶対パス"
     if "//" in stripped:

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -19,6 +19,7 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 入力（JSON、stdin または --input <file>）:
     {
       "changed_files": [str, ...],
+      "allowed_paths": [str, ...],
       "lite": {
         "size_ok": bool,
         "no_new_design": bool,
@@ -36,6 +37,18 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
       "target_sha": str
     }
 
+`allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
+そのまま渡す非空の string リスト。必須。`changed_files` の各パスがこの
+リストのいずれの glob にも一致しない場合、scope 逸脱として human escalate
+する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
+allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
+I-1 不変条件）。
+
+CLI:
+    --input <file>      入力 JSON ファイル（省略時は stdin）
+    --ho-paths <file>   HO パス一覧（ho-paths.md）の明示パス（#809）。
+                        省略時は実行時解決（下記）。
+
 出力:
     stdout — provenance JSON（decision-table.md §5 準拠）
     stderr — 人間可読の裁定サマリ（適用 priority と理由）
@@ -51,18 +64,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import re
 import sys
 from datetime import datetime, timezone
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# boundary 判定: HO（Hardening Override）パス一覧
+# boundary 判定: HO（Hardening Override）パス一覧（実行時解決 + fail-closed / #809）
 # ---------------------------------------------------------------------------
-# 出典: docs/ai/ai-loop/ho-paths.md（本リポジトリの正本）。
-# 各エントリは (glob パターン, HO 分類) のタプル。パターン文字列は
-# ho-paths.md 本文の表記と 1 文字も違わず一致させること（test_arbiter.py の
-# drift テストが本文中の存在を検証する）。
+# 出典: docs/ai/ai-loop/ho-paths.md（本リポジトリの正本）の「## HO パス一覧」表。
+# ハードコード定数は持たず、実行時に ho-paths.md 本文をパースして
+# (glob パターン, HO 分類) のリストを構築する（導入先リポジトリ固有の
+# ho-paths.md にも同一コードで対応するため）。
 #
 # パターン記法（ho-paths.md の記法をそのまま踏襲）:
 #   - `*`  : 1 パスセグメント内の任意文字列（"/" をまたがない）
@@ -70,26 +84,89 @@ from typing import Any
 # fnmatch はパスセグメント非対応（`*` が "/" をまたいでしまう）ため、
 # 本モジュールでは独自のセグメントベース matcher（_ho_pattern_to_regex）を
 # 使用する。
-HO_PATTERNS: list[tuple[str, str]] = [
-    ("bin/plangate", "HO-core"),  # 実行エンジン本体。AI 直接編集不可
-    ("scripts/hooks/**", "HO-hook"),  # フック本体（全ファイル）
-    ("schemas/**", "HO-schema"),  # バリデーション定義（全ファイル）
-    (".claude/rules/*.md", "HO-rules"),  # L0 契約正本
-    (".claude/settings*.json", "HO-settings"),  # Human-owned 設定
-    (".claude/settings.local.json", "HO-settings"),  # ローカル設定
-    ("CLAUDE.md", "HO-contract"),  # AI-Human 間の基本契約
-    ("AGENTS.md", "HO-contract"),  # 同上（Codex 用）
-    ("docs/ai/core-contract.md", "HO-contract"),  # Iron Law 正本
-    ("docs/ai/*.md", "HO-contract"),  # トップレベルの md のみ（docs/ai/ai-loop/ 配下は対象外。単一セグメント matcher により自動的に除外される）
-    (".github/workflows/*.yml", "HO-ci"),  # CI/CD 定義（yml）
-    ("**/approvals/*.json", "HO-approval"),  # 人間承認トークン（全階層）
-    (".claude/commands/*.md", "HO-rules"),  # コマンド定義
-    (".claude/agents/*.md", "HO-rules"),  # Agent 行動契約
-    (".claude/settings.example.json", "HO-settings"),  # settings 契約例
-    (".github/workflows/*.yaml", "HO-ci"),  # CI/CD 定義（yaml）
-    ("plugin/plangate/**", "HO-plugin"),  # プラグイン本体
-    ("docs/ai/ai-loop/ho-paths.md", "HO-contract"),  # HO 境界定義そのもの。自己改変防止（ho-paths.md 原則 1 の機械層）
-]
+
+#: ho-paths.md 本文の「## HO パス一覧」表の 1 行から第 1 列（バッククォート
+#: 内のパターン文字列）を抽出する正規表現。列内に注釈括弧（例:
+#: `` `docs/ai/*.md`（トップレベルの md のみ。`docs/ai/ai-loop/` 配下は対象外） ``）
+#: が付随する場合も、**最初の** バッククォート区間のみを採用することで
+#: 注釈中の入れ子バッククォート例を誤って拾わない。
+_HO_TABLE_PATTERN_RE = re.compile(r"`([^`]+)`")
+
+#: CLI 未指定時に解決を試みる既定候補（本リポジトリ本体配置）。
+_DEFAULT_HO_PATHS_RELATIVE = ("docs", "ai", "ai-loop", "ho-paths.md")
+#: CLI 未指定時に解決を試みる第 2 候補（plugin bundled 配置。スクリプト自身の
+#: 配置ディレクトリの親 = スキルルート、その配下の references/ho-paths.md）。
+_BUNDLED_HO_PATHS_RELATIVE = ("references", "ho-paths.md")
+
+
+def parse_ho_paths_table(content: str) -> list[tuple[str, str]]:
+    """ho-paths.md 本文の「## HO パス一覧」表から (pattern, classification) を抽出する。
+
+    行が「`| `pattern`（backtick 区切り） | 分類 | 理由 |`」形式であることのみを前提とする
+    （バッククォート付き第 1 列を持つ行のみが対象。見出し行・区切り行・
+    「## 分類定義」等の他表はバッククォート付き第 1 列を持たないため自動的に
+    除外される）。パース結果が 0 件の場合は空リストを返す（fail-closed の
+    判断は呼び出し側 resolve_ho_patterns / arbitrate が担う）。
+    """
+    patterns: list[tuple[str, str]] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = stripped.split("|")
+        if len(cells) < 4:
+            continue
+        match = _HO_TABLE_PATTERN_RE.search(cells[1])
+        if not match:
+            continue
+        classification = cells[2].strip()
+        if not classification:
+            continue
+        patterns.append((match.group(1), classification))
+    return patterns
+
+
+def _candidate_ho_paths_sources(cli_path: str | None) -> list[pathlib.Path]:
+    """ho-paths.md の解決候補パスを優先順位順に返す。
+
+    解決順（#809）: (1) CLI 明示指定 → (2) CWD の docs/ai/ai-loop/ho-paths.md
+    → (3) スクリプト位置基準の ../references/ho-paths.md（plugin bundled 配置用）。
+    CLI 指定時は他候補を一切試さない（明示指定を無条件優先）。
+    """
+    if cli_path:
+        return [pathlib.Path(cli_path)]
+    script_dir = pathlib.Path(__file__).resolve().parent
+    return [
+        pathlib.Path.cwd().joinpath(*_DEFAULT_HO_PATHS_RELATIVE),
+        script_dir.parent.joinpath(*_BUNDLED_HO_PATHS_RELATIVE),
+    ]
+
+
+def resolve_ho_patterns(
+    cli_path: str | None = None,
+) -> tuple[list[tuple[str, str]], str | None, list[str]]:
+    """HO パターンを実行時解決する（fail-closed / #809）。
+
+    戻り値: (patterns, resolved_source_path or None, searched_paths)
+    いずれの候補も存在しない、または存在するがパース結果が 0 件の場合は
+    patterns=[] を返す（呼び出し側 arbitrate() が全件 HUMAN_ESCALATED に
+    フォールバックする責務を持つ。fail-open は絶対に行わない）。
+    """
+    searched: list[str] = []
+    for candidate in _candidate_ho_paths_sources(cli_path):
+        searched.append(str(candidate))
+        if not candidate.is_file():
+            continue
+        try:
+            content = candidate.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        patterns = parse_ho_paths_table(content)
+        if patterns:
+            return patterns, str(candidate), searched
+        # ファイルは存在するがパース結果 0 件 → このソースは不採用、次候補へ
+        # （CLI 明示指定時は候補が 1 つのみのため、この分岐通過後は fail-closed）
+    return [], None, searched
 
 
 def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
@@ -131,35 +208,61 @@ def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
     return re.compile(regex)
 
 
-_HO_REGEXES: list[tuple[re.Pattern[str], str, str]] = [
-    (_ho_pattern_to_regex(pattern), pattern, classification)
-    for pattern, classification in HO_PATTERNS
-]
-
-
-def matches_ho_pattern(path: str) -> tuple[bool, str | None, str | None]:
-    """path がいずれかの HO パターンに一致するかを判定する。
+def matches_ho_pattern(
+    path: str, ho_patterns: list[tuple[str, str]]
+) -> tuple[bool, str | None, str | None]:
+    """path が ho_patterns のいずれかに一致するかを判定する。
 
     戻り値: (一致したか, 一致パターン文字列 or None, HO 分類 or None)
     """
-    for regex, pattern, classification in _HO_REGEXES:
-        if regex.match(path):
+    for pattern, classification in ho_patterns:
+        if _ho_pattern_to_regex(pattern).match(path):
             return True, pattern, classification
     return False, None, None
 
 
-def boundary_check(changed_files: list[str]) -> tuple[str, list[dict[str, str]]]:
+def boundary_check(
+    changed_files: list[str], ho_patterns: list[tuple[str, str]] | None = None
+) -> tuple[str, list[dict[str, str]]]:
     """boundary 判定: touches-HO | clean。
 
     出典: docs/ai/ai-loop/ho-paths.md 判定アルゴリズム。
     1 つでも HO パターンに一致すれば touches-HO（即確定）。
+
+    `ho_patterns` 省略時は resolve_ho_patterns() の既定解決（CLI 指定なし）
+    を用いる。fail-closed（解決不能）の判定は呼び出し側（主に arbitrate()）
+    の責務であり、本関数はパターン集合が空なら単に touches-HO 0 件
+    （＝見かけ上 clean）を返す点に注意 — fail-closed を保証したい呼び出し元は
+    resolve_ho_patterns() の戻り値を直接チェックしてから本関数を呼ぶこと。
     """
+    if ho_patterns is None:
+        ho_patterns, _source, _searched = resolve_ho_patterns()
     matched: list[dict[str, str]] = []
     for path in changed_files:
-        hit, pattern, classification = matches_ho_pattern(path)
+        hit, pattern, classification = matches_ho_pattern(path, ho_patterns)
         if hit:
             matched.append({"path": path, "pattern": pattern or "", "classification": classification or ""})
     return ("touches-HO" if matched else "clean"), matched
+
+
+# ---------------------------------------------------------------------------
+# scope 判定: allowed_paths 逸脱チェック（#809）
+# ---------------------------------------------------------------------------
+def check_allowed_paths(changed_files: list[str], allowed_paths: list[str]) -> tuple[bool, list[str]]:
+    """changed_files の各パスが allowed_paths のいずれかの glob に一致するか検証する。
+
+    出典: LoopSpec scope.allowed_paths（既存必須フィールド）。パターン記法は
+    ho-paths.md と同一のセグメント意味論（_ho_pattern_to_regex を再利用）。
+
+    戻り値: (全件 in-scope か, 逸脱パスのリスト)
+    優先順位注意: この関数は boundary_check（touches-HO 判定）より**後**に
+    呼び出すこと。allowed_paths に HO パスを宣言していても HO escalate は
+    免れない（design-philosophy.md I-1 不変条件）ため、呼び出し順序を
+    入れ替えてはならない。
+    """
+    regexes = [_ho_pattern_to_regex(pattern) for pattern in allowed_paths]
+    violations = [path for path in changed_files if not any(rx.match(path) for rx in regexes)]
+    return (len(violations) == 0), violations
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +332,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v0"
+POLICY_REF = "auto-approve-lite-clean@v1"
 
 
 class InputError(ValueError):
@@ -249,6 +352,14 @@ def validate_input(data: Any) -> dict[str, Any]:
     _require(
         isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
         "changed_files は string のリストである必要があります",
+    )
+
+    allowed_paths = data.get("allowed_paths")
+    _require(
+        isinstance(allowed_paths, list)
+        and len(allowed_paths) > 0
+        and all(isinstance(p, str) and p != "" for p in allowed_paths),
+        "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
     )
 
     lite = data.get("lite")
@@ -305,8 +416,14 @@ def build_provenance(
     model_c: str | None = None,
     model_d: str | None = None,
     reject_category: str | None = None,
+    scope_check: str = "in_scope",
 ) -> dict[str, Any]:
-    """decision-table.md §5 準拠の provenance JSON を構築する。"""
+    """decision-table.md §5 準拠の provenance JSON を構築する。
+
+    `scope_check`（#809 追加フィールド）: allowed_paths 逸脱チェックの結果。
+    "in_scope" | "scope_violation" | "unresolved"（ho-paths 未解決で
+    boundary 判定自体に到達しなかった場合）。
+    """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
         w_check["severity"] = severity
@@ -326,16 +443,30 @@ def build_provenance(
         "boundary_check": boundary,
         "lite_check": lite_result,
         "class_check": class_value,
+        "scope_check": scope_check,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
 
-def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
+def arbitrate(
+    data: dict[str, Any], *, ho_paths_path: str | None = None
+) -> tuple[dict[str, Any], str]:
     """decision-table.md §3 priority 1〜6 を順に評価し、provenance と適用理由を返す。
+
+    priority 0（#809 追加・decision-table.md 非記載の fail-closed 前置チェック）:
+    ho-paths.md が実行時解決できない、またはパース結果が 0 件の場合、boundary
+    判定そのものが実行不能なため、lite / class / verdict にかかわらず全件
+    HUMAN_ESCALATED とする（fail-open 禁止・絶対条件）。
+
+    priority 1.5（#809 追加・decision-table.md 非記載の scope チェック）:
+    boundary=touches-HO の判定（priority 1）より**後**、priority 2（lite）より
+    **前**に、changed_files が allowed_paths の宣言範囲内かを検証する。
+    範囲外のパスが 1 つでもあれば human escalate とする。
 
     戻り値: (provenance dict, 人間可読の理由サマリ)
     """
     changed_files: list[str] = data["changed_files"]
+    allowed_paths: list[str] = data["allowed_paths"]
     lite_input = data["lite"]
     class_value: str = data["class"]
     verdicts: dict[str, Any] = data["verdicts"]
@@ -347,8 +478,29 @@ def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
 
-    boundary, matched = boundary_check(changed_files)
     lite_result = lite_check(lite_input)
+
+    ho_patterns, _ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+
+    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
+    # 絶対条件として全件 human escalate とする。
+    if not ho_patterns:
+        provenance = build_provenance(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
+            lite_result=lite_result,
+            class_value=class_value,
+            target_sha=target_sha,
+            model_a=model_a,
+            model_b=model_b,
+            reject_category=reject_category,
+            scope_check="unresolved",
+        )
+        searched_desc = ", ".join(ho_searched)
+        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {searched_desc}"
+        return provenance, reason
+
+    boundary, matched = boundary_check(changed_files, ho_patterns)
 
     # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
     if boundary == "touches-HO":
@@ -364,6 +516,27 @@ def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
         )
         matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
         reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
+        return provenance, reason
+
+    # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
+    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
+    if not scope_ok:
+        provenance = build_provenance(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary=boundary,
+            lite_result=lite_result,
+            class_value=class_value,
+            target_sha=target_sha,
+            model_a=model_a,
+            model_b=model_b,
+            reject_category=reject_category,
+            scope_check="scope_violation",
+        )
+        violations_desc = ", ".join(violations)
+        reason = (
+            f"priority 1.5: boundary=clean だが scope_violation"
+            f"（allowed_paths 逸脱パス: {violations_desc}）"
+        )
         return provenance, reason
 
     # priority 2: lite=false は human escalate。
@@ -504,6 +677,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="入力 JSON ファイルのパス（省略時は stdin から読む）",
     )
+    parser.add_argument(
+        "--ho-paths",
+        dest="ho_paths_path",
+        default=None,
+        help="HO パス一覧（ho-paths.md）の明示パス（省略時は実行時解決 / #809）",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -528,7 +707,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[arbiter] 入力エラー: {exc}", file=sys.stderr)
         return 1
 
-    provenance, reason = arbitrate(validated)
+    provenance, reason = arbitrate(validated, ho_paths_path=args.ho_paths_path)
     decision = provenance["decision"]
 
     print(json.dumps(provenance, ensure_ascii=False, indent=2, sort_keys=True))

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -484,13 +484,25 @@ def build_provenance(
     model_c: str | None = None,
     model_d: str | None = None,
     reject_category: str | None = None,
-    scope_check: str = "in_scope",
+    scope_check: str = "not_evaluated",
+    ho_paths_source: str | None = None,
+    ho_pattern_count: int = 0,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
     `scope_check`（#809 追加フィールド）: allowed_paths 逸脱チェックの結果。
-    "in_scope" | "scope_violation" | "unresolved"（ho-paths 未解決で
-    boundary 判定自体に到達しなかった場合）。
+    - "in_scope": priority 1.5 の scope 検査を**実際に通過**した（合格）
+    - "scope_violation": priority 1.5 で allowed_paths 逸脱を検出した
+    - "unresolved": ho-paths 未解決（fail-closed）で boundary 判定自体に
+      到達しなかった
+    - "not_evaluated": scope 検査より前で return した経路（touches-HO 等）で
+      scope が未評価。既定値はこれ（未評価を "in_scope" と誤読させないため
+      #809 敵対的レビュー minor 反映で "in_scope" → "not_evaluated" に変更）
+
+    `ho_paths_source`（#809 追加）: 解決された ho-paths.md のパス（未解決時は
+    None）。`ho_pattern_count`（#809 追加）: 解決した HO パターン抽出件数。
+    「boundary=clean だが ho_pattern_count=1」のような過少網羅を監査で
+    検知できるようにする（fail-closed 閾値そのものは 0 のまま — 可視化に留める）。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -512,6 +524,8 @@ def build_provenance(
         "lite_check": lite_result,
         "class_check": class_value,
         "scope_check": scope_check,
+        "ho_paths_source": ho_paths_source,
+        "ho_pattern_count": ho_pattern_count,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
@@ -548,20 +562,30 @@ def arbitrate(
 
     lite_result = lite_check(lite_input)
 
-    ho_patterns, _ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+    ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+    ho_pattern_count = len(ho_patterns)
 
-    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
-    # 絶対条件として全件 human escalate とする。
-    if not ho_patterns:
-        provenance = build_provenance(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary="unresolved",
+    # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
+    # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
+    def _mk(**kw: Any) -> dict[str, Any]:
+        return build_provenance(
             lite_result=lite_result,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
             model_b=model_b,
             reject_category=reject_category,
+            ho_paths_source=ho_source,
+            ho_pattern_count=ho_pattern_count,
+            **kw,
+        )
+
+    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
+    # 絶対条件として全件 human escalate とする。
+    if not ho_patterns:
+        provenance = _mk(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
             scope_check="unresolved",
         )
         searched_desc = ", ".join(ho_searched)
@@ -571,16 +595,12 @@ def arbitrate(
     boundary, matched = boundary_check(changed_files, ho_patterns)
 
     # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
+    # scope 検査（priority 1.5）より前で return するため scope_check は not_evaluated。
     if boundary == "touches-HO":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="not_evaluated",
         )
         matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
         reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
@@ -589,15 +609,9 @@ def arbitrate(
     # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     if not scope_ok:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
             scope_check="scope_violation",
         )
         violations_desc = ", ".join(violations)
@@ -607,31 +621,22 @@ def arbitrate(
         )
         return provenance, reason
 
+    # ここに到達＝scope 検査を実際に通過（合格）。以降の全経路は in_scope を刻む。
     # priority 2: lite=false は human escalate。
     if not lite_result:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"
 
     # priority 3: class=merge は human escalate（merge=Human-owned 固定）。
     if class_value == "merge":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 3: class=merge（Human-owned 固定）"
 
@@ -639,29 +644,19 @@ def arbitrate(
 
     # priority 4: reject-reject / reject-approve は blocked。
     if verdict in ("reject-reject", "reject-approve"):
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_BLOCKED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, f"priority 4: verdict={verdict}（A が設計妥当性で NG、または両者合意で NG）"
 
     # priority 6: approve-approve は auto-approve。
     if verdict == "approve-approve":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_AUTO_APPROVED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 6: verdict=approve-approve（合意）"
 
@@ -671,15 +666,10 @@ def arbitrate(
     severity = classify_severity(reject_category)
 
     if severity in ("critical", "major"):
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
             severity=severity,
         )
         return (
@@ -690,15 +680,10 @@ def arbitrate(
     # severity=minor/low → Model C/D 裁定。
     # C か D が欠落している場合は安全側で human escalate。
     if model_c is None or model_d is None:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
             severity=severity,
             model_c=model_c,
             model_d=model_d,
@@ -716,15 +701,10 @@ def arbitrate(
     else:
         decision = DECISION_HUMAN_ESCALATED
 
-    provenance = build_provenance(
+    provenance = _mk(
         decision=decision,
         boundary=boundary,
-        lite_result=lite_result,
-        class_value=class_value,
-        target_sha=target_sha,
-        model_a=model_a,
-        model_b=model_b,
-        reject_category=reject_category,
+        scope_check="in_scope",
         severity=severity,
         model_c=model_c,
         model_d=model_d,

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -924,6 +924,114 @@ class HoPathsProvenanceVisibilityTests(unittest.TestCase):
             self.assertEqual(provenance["ho_pattern_count"], 1)
 
 
+class GeminiSecurityHardeningTests(unittest.TestCase):
+    """PR #813 gemini レビュー反映（#809）: バックスラッシュ traversal / read_text
+    の ValueError / regex キャッシュ。
+    """
+
+    # --- 修正 1（security-high）: バックスラッシュ経路の traversal 封鎖 ---
+
+    def test_backslash_traversal_rejected_in_validate(self):
+        """`foo\\..\\bar`（バックスラッシュ traversal）は入力段で拒否。"""
+        data = _base_input(changed_files=["foo\\..\\bar"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_plain_backslash_rejected_in_validate(self):
+        """`foo\\bar`（.. を含まない単なるバックスラッシュ区切り）も一律拒否。"""
+        data = _base_input(changed_files=["foo\\bar"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_backslash_rejected_in_allowed_paths(self):
+        data = _base_input(allowed_paths=["foo\\..\\**"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_safe_normalized_path_flags_backslash(self):
+        _norm, err = arbiter._safe_normalized_path("foo\\..\\bar")
+        self.assertIsNotNone(err)
+        self.assertIn("\\", err)
+
+    def test_backslash_boundary_check_is_safe_side(self):
+        """判定関数単体でも、バックスラッシュ経路は clean にせず touches-HO 相当に倒す。"""
+        boundary, matched = arbiter.boundary_check(["foo\\..\\bin\\plangate"])
+        self.assertEqual(boundary, "touches-HO")
+        self.assertTrue(matched)
+
+    def _run_main_with_stdin(self, payload):
+        import io
+
+        old_stdin, old_stdout, old_stderr = sys.stdin, sys.stdout, sys.stderr
+        sys.stdin = io.StringIO(json.dumps(payload))
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            code = arbiter.main([])
+            out, err = sys.stdout.getvalue(), sys.stderr.getvalue()
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = old_stdin, old_stdout, old_stderr
+        return code, out, err
+
+    def test_e2e_backslash_traversal_exits_1_never_auto_approves(self):
+        """再現固定: バックスラッシュ traversal は exit 1（入力エラー）で
+        AUTO_APPROVED / clean にならない。
+        """
+        data = _base_input(changed_files=["foo\\..\\bin\\plangate"], allowed_paths=["**"])
+        code, out, err = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertNotIn("AUTO_APPROVED", out)
+        self.assertIn("入力エラー", err)
+
+    # --- 修正 2（medium）: read_text の UnicodeDecodeError（ValueError）で fail-closed ---
+
+    def test_resolve_ho_patterns_skips_undecodable_file(self):
+        """不正 UTF-8 の ho-paths 明示指定 → 当該候補 skip、他候補なしで fail-closed（patterns=[]）。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "bad-ho-paths.md"
+            bad.write_bytes(b"\xff\xfe\x00\x01 invalid utf-8 \x80\x81")
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(bad))
+            self.assertEqual(patterns, [])
+            self.assertIsNone(source)
+            self.assertEqual(searched, [str(bad)])
+
+    def test_arbitrate_fail_closed_on_undecodable_ho_paths(self):
+        """不正 UTF-8 の ho-paths 指定時、arbitrate は全件 HUMAN_ESCALATED（fail-closed）。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "bad-ho-paths.md"
+            bad.write_bytes(b"\xff\xfe\x00\x01\x80\x81\x82")
+            data = _base_input()  # 本来なら AUTO_APPROVED になる happy-path 入力
+            provenance, reason = arbiter.arbitrate(data, ho_paths_path=str(bad))
+            self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+            self.assertEqual(provenance["boundary_check"], "unresolved")
+            self.assertIn("fail-closed", reason)
+
+    # --- 修正 3（medium・perf）: regex キャッシュ導入後も判定不変（回帰） ---
+
+    def test_regex_cache_preserves_boundary_semantics(self):
+        """キャッシュ導入後も既存 boundary 判定が全て不変であることの回帰確認。"""
+        cases = [
+            (["bin/plangate"], "touches-HO"),
+            (["scripts/hooks/check-plan-hash.sh"], "touches-HO"),
+            (["schemas/plan.schema.json"], "touches-HO"),
+            ([".claude/rules/mode-classification.md"], "touches-HO"),
+            (["docs/ai/ai-loop/ho-paths.md"], "touches-HO"),
+            (["docs/ai/ai-loop/concept.md"], "clean"),
+            (["docs/workflows/ai-loop/decision-table.md"], "clean"),
+            (["plugin/plangate/index.js"], "touches-HO"),
+        ]
+        for changed, expected in cases:
+            with self.subTest(changed=changed):
+                boundary, _ = arbiter.boundary_check(changed)
+                self.assertEqual(boundary, expected)
+
+    def test_regex_cache_returns_identical_compiled_object(self):
+        """同一パターンの再変換がキャッシュされ、同一 compiled regex を返す（メモ化の実証）。"""
+        first = arbiter._ho_pattern_to_regex("scripts/hooks/**")
+        second = arbiter._ho_pattern_to_regex("scripts/hooks/**")
+        self.assertIs(first, second)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -29,6 +30,7 @@ HO_PATHS_MD = next((p for p in _HO_PATHS_CANDIDATES if p.exists()), _HO_PATHS_CA
 def _base_input(**overrides):
     data = {
         "changed_files": ["docs/workflows/ai-loop/decision-table.md"],
+        "allowed_paths": ["docs/workflows/ai-loop/**"],
         "lite": {
             "size_ok": True,
             "no_new_design": True,
@@ -143,17 +145,23 @@ class BoundaryCheckTests(unittest.TestCase):
         self.assertEqual(matched, [])
 
     def test_ho_pattern_drift_against_source_of_truth(self):
-        """HO_PATTERNS の各パターン文字列が ho-paths.md 本文に存在することを検証する。
+        """実行時パースされた全パターンが ho-paths.md 本文に存在することを検証する（#809）。
 
-        正本（docs/ai/ai-loop/ho-paths.md）とのドリフトを検出する。
+        #809 により HO_PATTERNS ハードコード定数は廃止され、ho-paths.md 本文を
+        実行時にパースする方式へ変更された。ドリフトは構造的に発生しなくなるが、
+        パーサの抽出内容が本文の記述と食い違っていないこと（例: 注釈括弧の
+        誤混入）を継続して検証する。
         """
         self.assertTrue(HO_PATHS_MD.exists(), f"正本ファイルが見つかりません: {HO_PATHS_MD}")
         content = HO_PATHS_MD.read_text(encoding="utf-8")
-        missing = [pattern for pattern, _ in arbiter.HO_PATTERNS if pattern not in content]
+        patterns, source, _searched = arbiter.resolve_ho_patterns()
+        self.assertIsNotNone(source, "ho-paths.md の実行時解決に失敗しました")
+        self.assertGreaterEqual(len(patterns), 18, f"パース件数が想定を下回ります: {len(patterns)}")
+        missing = [pattern for pattern, _classification in patterns if pattern not in content]
         self.assertEqual(
             missing,
             [],
-            f"HO_PATTERNS に ho-paths.md 本文と同期していないパターンがあります: {missing}",
+            f"パースされたパターンが ho-paths.md 本文に見当たりません: {missing}",
         )
 
 
@@ -421,11 +429,13 @@ class ProvenanceSchemaTests(unittest.TestCase):
             "boundary_check",
             "lite_check",
             "class_check",
+            "scope_check",
             "timestamp",
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v0")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
         # 決定論であることの確認（同一入力 → 同一 decision）
@@ -454,6 +464,181 @@ class InputValidationTests(unittest.TestCase):
     def test_non_dict_input_raises(self):
         with self.assertRaises(arbiter.InputError):
             arbiter.validate_input(["not", "a", "dict"])
+
+    def test_missing_allowed_paths_raises(self):
+        """TC-7: allowed_paths 欠落は入力エラー（#809 必須化）。"""
+        data = _base_input()
+        del data["allowed_paths"]
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_empty_allowed_paths_raises(self):
+        """TC-7: allowed_paths が空リストは入力エラー（非空 string リスト要件）。"""
+        data = _base_input(allowed_paths=[])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_non_list_allowed_paths_raises(self):
+        """TC-7: allowed_paths が非リスト（例: string）は入力エラー。"""
+        data = _base_input(allowed_paths="docs/workflows/ai-loop/**")
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_non_string_item_in_allowed_paths_raises(self):
+        """TC-7: allowed_paths の要素に非 string が混じる場合は入力エラー。"""
+        data = _base_input(allowed_paths=["docs/workflows/ai-loop/**", 123])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+
+class HoPathsResolutionTests(unittest.TestCase):
+    """TC-1〜TC-4: ho-paths.md 実行時解決の優先順位 + fail-closed（#809）。"""
+
+    def test_tc1_cli_explicit_path_takes_priority(self):
+        """TC-1: --ho-paths 相当（cli_path 明示指定）は CWD/script-relative より優先される。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom = pathlib.Path(tmpdir) / "custom-ho-paths.md"
+            custom.write_text(
+                "## HO パス一覧\n\n"
+                "| パス | 分類 | 変更禁止理由 |\n"
+                "|------|------|------------|\n"
+                "| `only-in-custom/**` | HO-custom | テスト専用パターン |\n",
+                encoding="utf-8",
+            )
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(custom))
+            self.assertEqual(patterns, [("only-in-custom/**", "HO-custom")])
+            self.assertEqual(source, str(custom))
+            self.assertEqual(searched, [str(custom)])
+
+    def test_tc2_candidate_order_cwd_before_bundled(self):
+        """TC-2: cli_path 未指定時の候補順序は (1) CWD の docs/ai/ai-loop/ho-paths.md
+        → (2) スクリプト位置基準 ../references/ho-paths.md の順。
+        """
+        candidates = arbiter._candidate_ho_paths_sources(None)
+        self.assertEqual(len(candidates), 2)
+        self.assertTrue(str(candidates[0]).endswith(str(pathlib.Path("docs/ai/ai-loop/ho-paths.md"))))
+        self.assertTrue(str(candidates[1]).endswith(str(pathlib.Path("references/ho-paths.md"))))
+
+    def test_tc3_fail_closed_when_explicit_path_missing(self):
+        """TC-3: 明示パスが存在しない場合、fail-closed（patterns=[], source=None）。"""
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        patterns, source, searched = arbiter.resolve_ho_patterns(missing_path)
+        self.assertEqual(patterns, [])
+        self.assertIsNone(source)
+        self.assertEqual(searched, [missing_path])
+
+    def test_tc4_fail_closed_when_zero_parseable_rows(self):
+        """TC-4: ファイルは存在するがパース可能な行が 0 件 → fail-closed。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_doc = pathlib.Path(tmpdir) / "empty-ho-paths.md"
+            empty_doc.write_text("# HO パス一覧\n\n本文にはテーブル行が一切ない。\n", encoding="utf-8")
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(empty_doc))
+            self.assertEqual(patterns, [])
+            self.assertIsNone(source)
+            self.assertEqual(searched, [str(empty_doc)])
+
+
+class HoPathsTableParsingTests(unittest.TestCase):
+    """TC-6: parse_ho_paths_table の注釈括弧除去・境界動作。"""
+
+    def test_tc6_annotation_parenthetical_excluded_from_pattern(self):
+        content = (
+            "## HO パス一覧\n\n"
+            "| パス | 分類 | 変更禁止理由 |\n"
+            "|------|------|------------|\n"
+            "| `docs/ai/*.md`（トップレベルの md のみ。`docs/ai/ai-loop/` 配下は対象外） "
+            "| HO-contract | 理由 |\n"
+        )
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [("docs/ai/*.md", "HO-contract")])
+
+    def test_tc6_header_and_separator_rows_ignored(self):
+        content = (
+            "| パス | 分類 | 変更禁止理由 |\n"
+            "|------|------|------------|\n"
+            "| `bin/plangate` | HO-core | 理由 |\n"
+        )
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [("bin/plangate", "HO-core")])
+
+    def test_tc6_non_table_lines_ignored(self):
+        content = "本文の説明文。バッククォート `example` を含むが表ではない。\n"
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [])
+
+
+class FailClosedIntegrationTests(unittest.TestCase):
+    """TC-5: ho-paths 未解決時、arbitrate() は verdict/lite/class を問わず全件escalate。"""
+
+    def test_tc5_unresolved_ho_paths_escalates_regardless_of_verdicts(self):
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        data = _base_input()  # approve-approve・lite 全 true・class=no-merge（本来なら auto-approve 相当）
+        provenance, reason = arbiter.arbitrate(data, ho_paths_path=missing_path)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertIn("fail-closed", reason)
+        self.assertIn("priority 0", reason)
+
+    def test_tc5_unresolved_ho_paths_escalates_even_with_reject_reject(self):
+        """fail-closed は「厳しい裁定を優先」より前段の絶対条件。reject-reject（本来 BLOCKED）でも
+        ho-paths 未解決時は HUMAN_ESCALATED（boundary 判定不能を明示する decision）を返す。
+        """
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _reason = arbiter.arbitrate(data, ho_paths_path=missing_path)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+
+class AllowedPathsScopeTests(unittest.TestCase):
+    """TC-8〜TC-10: allowed_paths 必須化・scope 逸脱 escalate・touches-HO 優先順位。"""
+
+    def test_tc8_in_scope_change_proceeds_to_normal_evaluation(self):
+        """TC-8: allowed_paths 内の変更は scope チェックを通過し通常の priority 評価へ進む。"""
+        data = _base_input(allowed_paths=["docs/workflows/ai-loop/**"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+        self.assertIn("priority 6", reason)
+
+    def test_tc9_out_of_scope_change_escalates(self):
+        """TC-9: changed_files が allowed_paths のどの glob にも一致しない → human escalate。"""
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/decision-table.md", "scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertIn("scripts/unrelated/tool.py", reason)
+
+    def test_tc10_touches_ho_overrides_even_when_allowed_paths_declares_it(self):
+        """TC-10: allowed_paths に HO パスそのものを宣言していても HO escalate は免れない
+        （design-philosophy.md I-1 不変条件・優先順位は touches-HO が常に先）。
+        """
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            allowed_paths=["bin/plangate"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.5", reason)
+
+
+class PolicyRefVersionTests(unittest.TestCase):
+    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。"""
+
+    def test_tc11_policy_ref_is_v1(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v1")
+
+    def test_tc11_provenance_policy_ref_is_v1(self):
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
 
 
 class MainExitCodeTests(unittest.TestCase):

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -798,6 +798,132 @@ class PathNormalizationSecurityTests(unittest.TestCase):
         self.assertEqual(provenance["scope_check"], "in_scope")
 
 
+class ScopeCheckNotEvaluatedTests(unittest.TestCase):
+    """敵対的レビュー minor（Finding 3・#809）: scope 未評価経路の scope_check 明示。"""
+
+    def test_touches_ho_record_marks_scope_not_evaluated(self):
+        """touches-HO 経路（priority 1）は scope 検査より前で return するため
+        scope_check == "not_evaluated"（"in_scope" と誤読させない）。
+        """
+        data = _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["scope_check"], "not_evaluated")
+
+    def test_fail_closed_record_marks_scope_unresolved(self):
+        """fail-closed 経路（priority 0）は scope_check == "unresolved"（従来どおり）。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "unresolved")
+
+    def test_scope_violation_record_marks_scope_violation(self):
+        data = _base_input(
+            changed_files=["scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+
+    def test_auto_approved_record_still_in_scope(self):
+        """scope 検査を通過した AUTO_APPROVED は従来どおり scope_check == "in_scope"。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+    def test_lite_false_after_scope_pass_is_in_scope(self):
+        """lite=false（priority 2）は scope 検査通過後に評価されるため in_scope。"""
+        data = _base_input(
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True}
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+    def test_build_provenance_default_scope_check_is_not_evaluated(self):
+        """build_provenance の scope_check 既定値は "not_evaluated"（"in_scope" ではない）。"""
+        prov = arbiter.build_provenance(
+            decision="HUMAN_ESCALATED",
+            boundary="touches-HO",
+            lite_result=True,
+            class_value="no-merge",
+            target_sha="abc1234",
+            model_a="approve",
+            model_b="approve",
+        )
+        self.assertEqual(prov["scope_check"], "not_evaluated")
+
+
+class HoPathsProvenanceVisibilityTests(unittest.TestCase):
+    """敵対的レビュー minor（Finding 2・#809）: ho-paths 出典・抽出件数の record 刻印。"""
+
+    def test_all_records_carry_ho_paths_source_and_count(self):
+        """全裁定経路の record に ho_paths_source（非 null）と ho_pattern_count（正の int）が刻まれる。"""
+        scenarios = [
+            ("auto_approved", _base_input()),
+            ("touches_ho", _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])),
+            (
+                "scope_violation",
+                _base_input(
+                    changed_files=["scripts/unrelated/tool.py"],
+                    allowed_paths=["docs/workflows/ai-loop/**"],
+                ),
+            ),
+            (
+                "lite_false",
+                _base_input(
+                    lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True}
+                ),
+            ),
+        ]
+        for name, data in scenarios:
+            with self.subTest(scenario=name):
+                provenance, _ = arbiter.arbitrate(data)
+                self.assertIn("ho_paths_source", provenance)
+                self.assertIn("ho_pattern_count", provenance)
+                self.assertIsNotNone(provenance["ho_paths_source"], "解決時は非 null")
+                self.assertIsInstance(provenance["ho_pattern_count"], int)
+                self.assertGreater(provenance["ho_pattern_count"], 0)
+
+    def test_ho_paths_source_matches_resolved_path(self):
+        data = _base_input()
+        patterns, source, _searched = arbiter.resolve_ho_patterns()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["ho_paths_source"], source)
+        self.assertEqual(provenance["ho_pattern_count"], len(patterns))
+
+    def test_fail_closed_record_has_null_source_and_zero_count(self):
+        """解決不能（fail-closed）時は ho_paths_source == None・ho_pattern_count == 0。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertIsNone(provenance["ho_paths_source"])
+        self.assertEqual(provenance["ho_pattern_count"], 0)
+
+    def test_under_coverage_is_detectable_via_count(self):
+        """過少網羅（1 行 ho-paths.md）を ho_pattern_count で検知できる（可視化）。"""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tiny = pathlib.Path(tmpdir) / "tiny-ho-paths.md"
+            tiny.write_text(
+                "## HO パス一覧\n\n"
+                "| パス | 分類 | 変更禁止理由 |\n"
+                "|------|------|------------|\n"
+                "| `bin/plangate` | HO-core | 唯一の HO パターン |\n",
+                encoding="utf-8",
+            )
+            data = _base_input(
+                changed_files=["docs/workflows/ai-loop/example.md"],
+                allowed_paths=["docs/workflows/ai-loop/**"],
+            )
+            provenance, _ = arbiter.arbitrate(data, ho_paths_path=str(tiny))
+            # boundary=clean だが ho_pattern_count=1 の過少網羅が record から読める
+            self.assertEqual(provenance["boundary_check"], "clean")
+            self.assertEqual(provenance["ho_pattern_count"], 1)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -641,6 +641,163 @@ class PolicyRefVersionTests(unittest.TestCase):
         self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
 
 
+class PathNormalizationSecurityTests(unittest.TestCase):
+    """敵対的レビュー major 反映（#809）: パス正規化欠如による touches-HO 迂回の封鎖。
+
+    2 層防御:
+    - 第一防壁（入力段）: validate_input が正規化後 `..` 残存・絶対パス・
+      空セグメント（//）を InputError（exit 1）で拒否する
+    - 第二防壁（判定段）: boundary_check / check_allowed_paths がマッチ直前に
+      normpath で畳み込み、`./bin/plangate` 等の変種でも HO を捕捉する。
+      判定関数単体に不正パスが渡った場合も安全側（escalate 相当）に倒す
+    """
+
+    # --- 第二防壁: 正規化後マッチ（./ 変種で HO 捕捉） ---
+
+    def test_dot_slash_prefix_variant_is_caught_as_touches_ho(self):
+        """`./bin/plangate` は正規化後に bin/plangate として touches-HO 捕捉。"""
+        data = _base_input(changed_files=["./bin/plangate"], allowed_paths=["**"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+
+    def test_boundary_check_normalizes_before_matching(self):
+        boundary, matched = arbiter.boundary_check(["./bin/plangate"])
+        self.assertEqual(boundary, "touches-HO")
+        self.assertEqual(matched[0]["classification"], "HO-core")
+
+    def test_interior_dotdot_collapsing_to_ho_paths_md_is_caught(self):
+        """自己改変 traversal: `docs/ai/ai-loop/x/../ho-paths.md` は正規化後に
+        ho-paths.md 本体として touches-HO 捕捉（clean にしない / #808 防止の維持）。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/x/../ho-paths.md"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_arbitrate_direct_call_with_root_escaping_path_is_safe_side(self):
+        """validate_input を経ない arbitrate() 直呼びでも、ルート外へ抜ける
+        `..` パスは安全側（escalate。AUTO_APPROVED 到達不可）に倒れる。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _reason = arbiter.arbitrate(data)
+        self.assertNotEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+    # --- 第一防壁: validate_input での拒否 ---
+
+    def test_validate_rejects_root_escaping_traversal(self):
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_empty_segment(self):
+        data = _base_input(changed_files=["bin//plangate"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_absolute_path(self):
+        data = _base_input(changed_files=["/etc/passwd"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_traversal_in_allowed_paths(self):
+        data = _base_input(allowed_paths=["../**"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    # --- CLI e2e: exit code 固定 ---
+
+    def _run_main_with_stdin(self, payload):
+        import io
+
+        old_stdin = sys.stdin
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdin = io.StringIO(json.dumps(payload))
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            code = arbiter.main([])
+            stdout_value = sys.stdout.getvalue()
+            stderr_value = sys.stderr.getvalue()
+        finally:
+            sys.stdin = old_stdin
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        return code, stdout_value, stderr_value
+
+    def test_e2e_traversal_exits_1_and_never_auto_approves(self):
+        """再現ケース固定: traversal + narrow allowed_paths は exit 1（入力エラー）。
+        AUTO_APPROVED（exit 0）に到達しないことを固定する。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        code, stdout_value, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertNotIn("AUTO_APPROVED", stdout_value)
+        self.assertIn("入力エラー", stderr_value)
+        self.assertIn("bin/plangate", stderr_value)
+
+    def test_e2e_dot_slash_variant_escalates_exit_2(self):
+        """再現ケース固定: `./bin/plangate` + allowed=** は touches-HO escalate（exit 2）。"""
+        data = _base_input(changed_files=["./bin/plangate"], allowed_paths=["**"])
+        code, stdout_value, _ = self._run_main_with_stdin(data)
+        self.assertEqual(code, 2)
+        self.assertEqual(json.loads(stdout_value)["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(json.loads(stdout_value)["boundary_check"], "touches-HO")
+
+    def test_e2e_empty_segment_exits_1(self):
+        data = _base_input(changed_files=["bin//plangate"])
+        code, _, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertIn("入力エラー", stderr_value)
+
+    def test_e2e_absolute_path_exits_1(self):
+        data = _base_input(changed_files=["/etc/passwd"])
+        code, _, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertIn("入力エラー", stderr_value)
+
+    # --- 回帰: 正規の素パスは従来どおり ---
+
+    def test_regression_plain_ho_path_still_escalates(self):
+        data = _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_regression_plain_ho_paths_md_still_escalates(self):
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/ho-paths.md"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_regression_happy_path_still_auto_approves(self):
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/example.md"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import posixpath
 import re
 import sys
 from datetime import datetime, timezone
@@ -239,10 +240,56 @@ def boundary_check(
         ho_patterns, _source, _searched = resolve_ho_patterns()
     matched: list[dict[str, str]] = []
     for path in changed_files:
-        hit, pattern, classification = matches_ho_pattern(path, ho_patterns)
+        norm, err = _safe_normalized_path(path)
+        if err is not None:
+            # 不正パス（ルート外 traversal 等）は判定不能＝安全側で touches-HO
+            # 相当として扱う（本来は validate_input が exit 1 で拒否する第一
+            # 防壁があるが、判定関数単体でも fail-open にしない第二防壁）。
+            matched.append({"path": path, "pattern": "", "classification": f"unsafe-path（{err}）"})
+            continue
+        hit, pattern, classification = matches_ho_pattern(norm, ho_patterns)
         if hit:
             matched.append({"path": path, "pattern": pattern or "", "classification": classification or ""})
     return ("touches-HO" if matched else "clean"), matched
+
+
+# ---------------------------------------------------------------------------
+# パス正規化・安全性検査（#809 敵対的レビュー major 反映）
+# ---------------------------------------------------------------------------
+# changed_files / allowed_paths を素の文字列のまま正規表現に当てると、
+# `./bin/plangate`（先頭 ./ 変種）や `docs/ai/ai-loop/../../../bin/plangate`
+# （traversal）が HO パターンに一致せず boundary=clean となり、touches-HO
+# 絶対条件（design-philosophy I-1）を迂回して AUTO_APPROVED に到達し得る。
+# 2 層防御で封鎖する:
+#   第一防壁（入力段）: validate_input が不正パス（正規化後も `..` 残存・
+#     絶対パス・空セグメント //）を InputError（exit 1）で拒否
+#   第二防壁（判定段）: boundary_check / check_allowed_paths がマッチ直前に
+#     posixpath.normpath で畳み込んでから評価。判定関数単体に不正パスが
+#     渡った場合も安全側（touches-HO 相当 / scope violation）に倒す
+def _safe_normalized_path(path: str) -> tuple[str, str | None]:
+    """パスを正規化し、リポジトリ相対として不正なら理由文字列を返す。
+
+    戻り値: (正規化後パス, エラー理由 or None)
+    エラー条件: 空 / 絶対パス（先頭 /）/ 空セグメント（//）/
+    `..` セグメントを含む（traversal。normpath でルート内に畳み込める場合も
+    含めて一律拒否 — 正規パス表現以外を受理しない）。
+    先頭 `./` は normpath が畳み込むためエラーにしない（正規化後の実体で
+    マッチ評価する）。
+    """
+    stripped = path.strip()
+    if stripped == "":
+        return stripped, "空のパス"
+    if stripped.startswith("/"):
+        return stripped, "絶対パス"
+    if "//" in stripped:
+        return stripped, "空セグメント（//）"
+    if ".." in stripped.split("/"):
+        return stripped, "`..` セグメント（traversal）"
+    norm = posixpath.normpath(stripped)
+    # 上の検査で `..` は既に拒否済みだが、normpath 結果にも残さない（防御的既定）
+    if norm == ".." or norm.startswith("../"):
+        return norm, "リポジトリルート外（.. セグメント残存）"
+    return norm, None
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +308,16 @@ def check_allowed_paths(changed_files: list[str], allowed_paths: list[str]) -> t
     入れ替えてはならない。
     """
     regexes = [_ho_pattern_to_regex(pattern) for pattern in allowed_paths]
-    violations = [path for path in changed_files if not any(rx.match(path) for rx in regexes)]
+    violations: list[str] = []
+    for path in changed_files:
+        norm, err = _safe_normalized_path(path)
+        if err is not None:
+            # 不正パスは定義上 scope 外（安全側）。第一防壁（validate_input）
+            # を経ない直接呼び出しでも fail-open にしない。
+            violations.append(path)
+            continue
+        if not any(rx.match(norm) for rx in regexes):
+            violations.append(path)
     return (len(violations) == 0), violations
 
 
@@ -353,6 +409,12 @@ def validate_input(data: Any) -> dict[str, Any]:
         isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
         "changed_files は string のリストである必要があります",
     )
+    for path in changed_files:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"changed_files に不正なパスがあります（{err}。リポジトリ相対の正規パスのみ受理）: {path!r}",
+        )
 
     allowed_paths = data.get("allowed_paths")
     _require(
@@ -361,6 +423,12 @@ def validate_input(data: Any) -> dict[str, Any]:
         and all(isinstance(p, str) and p != "" for p in allowed_paths),
         "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
     )
+    for path in allowed_paths:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"allowed_paths に不正なパターンがあります（{err}。リポジトリ相対の正規パターンのみ受理）: {path!r}",
+        )
 
     lite = data.get("lite")
     _require(isinstance(lite, dict), "lite は object である必要があります")

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -63,6 +63,7 @@ exit code:
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import pathlib
 import posixpath
@@ -160,7 +161,10 @@ def resolve_ho_patterns(
             continue
         try:
             content = candidate.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, ValueError):
+            # UnicodeDecodeError（ValueError サブクラス。不正 UTF-8 / バイナリ）は
+            # OSError で捕捉されない。fail-closed を維持するため当該候補を skip し
+            # 次候補へ（全候補失敗なら patterns=[] → arbitrate が全件 escalate）。
             continue
         patterns = parse_ho_paths_table(content)
         if patterns:
@@ -170,12 +174,18 @@ def resolve_ho_patterns(
     return [], None, searched
 
 
+@functools.lru_cache(maxsize=None)
 def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
     """HO パターン文字列をセグメント境界を尊重した正規表現へ変換する。
 
     `*` は 1 セグメント内、`**` は 0 個以上のセグメント（"/" をまたぐ）に
     マッチする。fnmatch / pathlib.PurePath.match はいずれもこの意味論を
     正しく提供しないため、自前で構築する。
+
+    ho-paths.md の動的読み込み化（#809）で本関数は matches_ho_pattern /
+    check_allowed_paths のループから同一パターンで繰り返し呼ばれるため、
+    lru_cache でコンパイル済み regex をメモ化する（gemini medium・挙動不変）。
+    入力はイミュータブルな str のみ・純関数のためキャッシュ安全。
     """
     segments = pattern.split("/")
     n = len(segments)
@@ -270,15 +280,23 @@ def _safe_normalized_path(path: str) -> tuple[str, str | None]:
     """パスを正規化し、リポジトリ相対として不正なら理由文字列を返す。
 
     戻り値: (正規化後パス, エラー理由 or None)
-    エラー条件: 空 / 絶対パス（先頭 /）/ 空セグメント（//）/
+    エラー条件: 空 / バックスラッシュ（\\）/ 絶対パス（先頭 /）/ 空セグメント（//）/
     `..` セグメントを含む（traversal。normpath でルート内に畳み込める場合も
     含めて一律拒否 — 正規パス表現以外を受理しない）。
     先頭 `./` は normpath が畳み込むためエラーにしない（正規化後の実体で
     マッチ評価する）。
+
+    バックスラッシュ拒否の根拠（gemini security-high / #809）: `.split("/")`
+    は `/` でしか分割しないため、`foo\\..\\bar` のようなバックスラッシュ
+    区切り path は `..` チェックをすり抜ける（Windows / 一部ツールが `\\` を
+    セパレータ扱いする場合の traversal 迂回）。Git のパスは常に `/` 区切りの
+    ため、`\\` を含む path は一律不正として拒否する。
     """
     stripped = path.strip()
     if stripped == "":
         return stripped, "空のパス"
+    if "\\" in stripped:
+        return stripped, "バックスラッシュ（\\）"
     if stripped.startswith("/"):
         return stripped, "絶対パス"
     if "//" in stripped:

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -19,6 +19,7 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 入力（JSON、stdin または --input <file>）:
     {
       "changed_files": [str, ...],
+      "allowed_paths": [str, ...],
       "lite": {
         "size_ok": bool,
         "no_new_design": bool,
@@ -36,6 +37,18 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
       "target_sha": str
     }
 
+`allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
+そのまま渡す非空の string リスト。必須。`changed_files` の各パスがこの
+リストのいずれの glob にも一致しない場合、scope 逸脱として human escalate
+する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
+allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
+I-1 不変条件）。
+
+CLI:
+    --input <file>      入力 JSON ファイル（省略時は stdin）
+    --ho-paths <file>   HO パス一覧（ho-paths.md）の明示パス（#809）。
+                        省略時は実行時解決（下記）。
+
 出力:
     stdout — provenance JSON（decision-table.md §5 準拠）
     stderr — 人間可読の裁定サマリ（適用 priority と理由）
@@ -51,18 +64,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import re
 import sys
 from datetime import datetime, timezone
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# boundary 判定: HO（Hardening Override）パス一覧
+# boundary 判定: HO（Hardening Override）パス一覧（実行時解決 + fail-closed / #809）
 # ---------------------------------------------------------------------------
-# 出典: docs/ai/ai-loop/ho-paths.md（本リポジトリの正本）。
-# 各エントリは (glob パターン, HO 分類) のタプル。パターン文字列は
-# ho-paths.md 本文の表記と 1 文字も違わず一致させること（test_arbiter.py の
-# drift テストが本文中の存在を検証する）。
+# 出典: docs/ai/ai-loop/ho-paths.md（本リポジトリの正本）の「## HO パス一覧」表。
+# ハードコード定数は持たず、実行時に ho-paths.md 本文をパースして
+# (glob パターン, HO 分類) のリストを構築する（導入先リポジトリ固有の
+# ho-paths.md にも同一コードで対応するため）。
 #
 # パターン記法（ho-paths.md の記法をそのまま踏襲）:
 #   - `*`  : 1 パスセグメント内の任意文字列（"/" をまたがない）
@@ -70,26 +84,89 @@ from typing import Any
 # fnmatch はパスセグメント非対応（`*` が "/" をまたいでしまう）ため、
 # 本モジュールでは独自のセグメントベース matcher（_ho_pattern_to_regex）を
 # 使用する。
-HO_PATTERNS: list[tuple[str, str]] = [
-    ("bin/plangate", "HO-core"),  # 実行エンジン本体。AI 直接編集不可
-    ("scripts/hooks/**", "HO-hook"),  # フック本体（全ファイル）
-    ("schemas/**", "HO-schema"),  # バリデーション定義（全ファイル）
-    (".claude/rules/*.md", "HO-rules"),  # L0 契約正本
-    (".claude/settings*.json", "HO-settings"),  # Human-owned 設定
-    (".claude/settings.local.json", "HO-settings"),  # ローカル設定
-    ("CLAUDE.md", "HO-contract"),  # AI-Human 間の基本契約
-    ("AGENTS.md", "HO-contract"),  # 同上（Codex 用）
-    ("docs/ai/core-contract.md", "HO-contract"),  # Iron Law 正本
-    ("docs/ai/*.md", "HO-contract"),  # トップレベルの md のみ（docs/ai/ai-loop/ 配下は対象外。単一セグメント matcher により自動的に除外される）
-    (".github/workflows/*.yml", "HO-ci"),  # CI/CD 定義（yml）
-    ("**/approvals/*.json", "HO-approval"),  # 人間承認トークン（全階層）
-    (".claude/commands/*.md", "HO-rules"),  # コマンド定義
-    (".claude/agents/*.md", "HO-rules"),  # Agent 行動契約
-    (".claude/settings.example.json", "HO-settings"),  # settings 契約例
-    (".github/workflows/*.yaml", "HO-ci"),  # CI/CD 定義（yaml）
-    ("plugin/plangate/**", "HO-plugin"),  # プラグイン本体
-    ("docs/ai/ai-loop/ho-paths.md", "HO-contract"),  # HO 境界定義そのもの。自己改変防止（ho-paths.md 原則 1 の機械層）
-]
+
+#: ho-paths.md 本文の「## HO パス一覧」表の 1 行から第 1 列（バッククォート
+#: 内のパターン文字列）を抽出する正規表現。列内に注釈括弧（例:
+#: `` `docs/ai/*.md`（トップレベルの md のみ。`docs/ai/ai-loop/` 配下は対象外） ``）
+#: が付随する場合も、**最初の** バッククォート区間のみを採用することで
+#: 注釈中の入れ子バッククォート例を誤って拾わない。
+_HO_TABLE_PATTERN_RE = re.compile(r"`([^`]+)`")
+
+#: CLI 未指定時に解決を試みる既定候補（本リポジトリ本体配置）。
+_DEFAULT_HO_PATHS_RELATIVE = ("docs", "ai", "ai-loop", "ho-paths.md")
+#: CLI 未指定時に解決を試みる第 2 候補（plugin bundled 配置。スクリプト自身の
+#: 配置ディレクトリの親 = スキルルート、その配下の references/ho-paths.md）。
+_BUNDLED_HO_PATHS_RELATIVE = ("references", "ho-paths.md")
+
+
+def parse_ho_paths_table(content: str) -> list[tuple[str, str]]:
+    """ho-paths.md 本文の「## HO パス一覧」表から (pattern, classification) を抽出する。
+
+    行が「`| `pattern`（backtick 区切り） | 分類 | 理由 |`」形式であることのみを前提とする
+    （バッククォート付き第 1 列を持つ行のみが対象。見出し行・区切り行・
+    「## 分類定義」等の他表はバッククォート付き第 1 列を持たないため自動的に
+    除外される）。パース結果が 0 件の場合は空リストを返す（fail-closed の
+    判断は呼び出し側 resolve_ho_patterns / arbitrate が担う）。
+    """
+    patterns: list[tuple[str, str]] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = stripped.split("|")
+        if len(cells) < 4:
+            continue
+        match = _HO_TABLE_PATTERN_RE.search(cells[1])
+        if not match:
+            continue
+        classification = cells[2].strip()
+        if not classification:
+            continue
+        patterns.append((match.group(1), classification))
+    return patterns
+
+
+def _candidate_ho_paths_sources(cli_path: str | None) -> list[pathlib.Path]:
+    """ho-paths.md の解決候補パスを優先順位順に返す。
+
+    解決順（#809）: (1) CLI 明示指定 → (2) CWD の docs/ai/ai-loop/ho-paths.md
+    → (3) スクリプト位置基準の ../references/ho-paths.md（plugin bundled 配置用）。
+    CLI 指定時は他候補を一切試さない（明示指定を無条件優先）。
+    """
+    if cli_path:
+        return [pathlib.Path(cli_path)]
+    script_dir = pathlib.Path(__file__).resolve().parent
+    return [
+        pathlib.Path.cwd().joinpath(*_DEFAULT_HO_PATHS_RELATIVE),
+        script_dir.parent.joinpath(*_BUNDLED_HO_PATHS_RELATIVE),
+    ]
+
+
+def resolve_ho_patterns(
+    cli_path: str | None = None,
+) -> tuple[list[tuple[str, str]], str | None, list[str]]:
+    """HO パターンを実行時解決する（fail-closed / #809）。
+
+    戻り値: (patterns, resolved_source_path or None, searched_paths)
+    いずれの候補も存在しない、または存在するがパース結果が 0 件の場合は
+    patterns=[] を返す（呼び出し側 arbitrate() が全件 HUMAN_ESCALATED に
+    フォールバックする責務を持つ。fail-open は絶対に行わない）。
+    """
+    searched: list[str] = []
+    for candidate in _candidate_ho_paths_sources(cli_path):
+        searched.append(str(candidate))
+        if not candidate.is_file():
+            continue
+        try:
+            content = candidate.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        patterns = parse_ho_paths_table(content)
+        if patterns:
+            return patterns, str(candidate), searched
+        # ファイルは存在するがパース結果 0 件 → このソースは不採用、次候補へ
+        # （CLI 明示指定時は候補が 1 つのみのため、この分岐通過後は fail-closed）
+    return [], None, searched
 
 
 def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
@@ -131,35 +208,61 @@ def _ho_pattern_to_regex(pattern: str) -> re.Pattern[str]:
     return re.compile(regex)
 
 
-_HO_REGEXES: list[tuple[re.Pattern[str], str, str]] = [
-    (_ho_pattern_to_regex(pattern), pattern, classification)
-    for pattern, classification in HO_PATTERNS
-]
-
-
-def matches_ho_pattern(path: str) -> tuple[bool, str | None, str | None]:
-    """path がいずれかの HO パターンに一致するかを判定する。
+def matches_ho_pattern(
+    path: str, ho_patterns: list[tuple[str, str]]
+) -> tuple[bool, str | None, str | None]:
+    """path が ho_patterns のいずれかに一致するかを判定する。
 
     戻り値: (一致したか, 一致パターン文字列 or None, HO 分類 or None)
     """
-    for regex, pattern, classification in _HO_REGEXES:
-        if regex.match(path):
+    for pattern, classification in ho_patterns:
+        if _ho_pattern_to_regex(pattern).match(path):
             return True, pattern, classification
     return False, None, None
 
 
-def boundary_check(changed_files: list[str]) -> tuple[str, list[dict[str, str]]]:
+def boundary_check(
+    changed_files: list[str], ho_patterns: list[tuple[str, str]] | None = None
+) -> tuple[str, list[dict[str, str]]]:
     """boundary 判定: touches-HO | clean。
 
     出典: docs/ai/ai-loop/ho-paths.md 判定アルゴリズム。
     1 つでも HO パターンに一致すれば touches-HO（即確定）。
+
+    `ho_patterns` 省略時は resolve_ho_patterns() の既定解決（CLI 指定なし）
+    を用いる。fail-closed（解決不能）の判定は呼び出し側（主に arbitrate()）
+    の責務であり、本関数はパターン集合が空なら単に touches-HO 0 件
+    （＝見かけ上 clean）を返す点に注意 — fail-closed を保証したい呼び出し元は
+    resolve_ho_patterns() の戻り値を直接チェックしてから本関数を呼ぶこと。
     """
+    if ho_patterns is None:
+        ho_patterns, _source, _searched = resolve_ho_patterns()
     matched: list[dict[str, str]] = []
     for path in changed_files:
-        hit, pattern, classification = matches_ho_pattern(path)
+        hit, pattern, classification = matches_ho_pattern(path, ho_patterns)
         if hit:
             matched.append({"path": path, "pattern": pattern or "", "classification": classification or ""})
     return ("touches-HO" if matched else "clean"), matched
+
+
+# ---------------------------------------------------------------------------
+# scope 判定: allowed_paths 逸脱チェック（#809）
+# ---------------------------------------------------------------------------
+def check_allowed_paths(changed_files: list[str], allowed_paths: list[str]) -> tuple[bool, list[str]]:
+    """changed_files の各パスが allowed_paths のいずれかの glob に一致するか検証する。
+
+    出典: LoopSpec scope.allowed_paths（既存必須フィールド）。パターン記法は
+    ho-paths.md と同一のセグメント意味論（_ho_pattern_to_regex を再利用）。
+
+    戻り値: (全件 in-scope か, 逸脱パスのリスト)
+    優先順位注意: この関数は boundary_check（touches-HO 判定）より**後**に
+    呼び出すこと。allowed_paths に HO パスを宣言していても HO escalate は
+    免れない（design-philosophy.md I-1 不変条件）ため、呼び出し順序を
+    入れ替えてはならない。
+    """
+    regexes = [_ho_pattern_to_regex(pattern) for pattern in allowed_paths]
+    violations = [path for path in changed_files if not any(rx.match(path) for rx in regexes)]
+    return (len(violations) == 0), violations
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +332,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v0"
+POLICY_REF = "auto-approve-lite-clean@v1"
 
 
 class InputError(ValueError):
@@ -249,6 +352,14 @@ def validate_input(data: Any) -> dict[str, Any]:
     _require(
         isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
         "changed_files は string のリストである必要があります",
+    )
+
+    allowed_paths = data.get("allowed_paths")
+    _require(
+        isinstance(allowed_paths, list)
+        and len(allowed_paths) > 0
+        and all(isinstance(p, str) and p != "" for p in allowed_paths),
+        "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
     )
 
     lite = data.get("lite")
@@ -305,8 +416,14 @@ def build_provenance(
     model_c: str | None = None,
     model_d: str | None = None,
     reject_category: str | None = None,
+    scope_check: str = "in_scope",
 ) -> dict[str, Any]:
-    """decision-table.md §5 準拠の provenance JSON を構築する。"""
+    """decision-table.md §5 準拠の provenance JSON を構築する。
+
+    `scope_check`（#809 追加フィールド）: allowed_paths 逸脱チェックの結果。
+    "in_scope" | "scope_violation" | "unresolved"（ho-paths 未解決で
+    boundary 判定自体に到達しなかった場合）。
+    """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
         w_check["severity"] = severity
@@ -326,16 +443,30 @@ def build_provenance(
         "boundary_check": boundary,
         "lite_check": lite_result,
         "class_check": class_value,
+        "scope_check": scope_check,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
 
-def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
+def arbitrate(
+    data: dict[str, Any], *, ho_paths_path: str | None = None
+) -> tuple[dict[str, Any], str]:
     """decision-table.md §3 priority 1〜6 を順に評価し、provenance と適用理由を返す。
+
+    priority 0（#809 追加・decision-table.md 非記載の fail-closed 前置チェック）:
+    ho-paths.md が実行時解決できない、またはパース結果が 0 件の場合、boundary
+    判定そのものが実行不能なため、lite / class / verdict にかかわらず全件
+    HUMAN_ESCALATED とする（fail-open 禁止・絶対条件）。
+
+    priority 1.5（#809 追加・decision-table.md 非記載の scope チェック）:
+    boundary=touches-HO の判定（priority 1）より**後**、priority 2（lite）より
+    **前**に、changed_files が allowed_paths の宣言範囲内かを検証する。
+    範囲外のパスが 1 つでもあれば human escalate とする。
 
     戻り値: (provenance dict, 人間可読の理由サマリ)
     """
     changed_files: list[str] = data["changed_files"]
+    allowed_paths: list[str] = data["allowed_paths"]
     lite_input = data["lite"]
     class_value: str = data["class"]
     verdicts: dict[str, Any] = data["verdicts"]
@@ -347,8 +478,29 @@ def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
 
-    boundary, matched = boundary_check(changed_files)
     lite_result = lite_check(lite_input)
+
+    ho_patterns, _ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+
+    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
+    # 絶対条件として全件 human escalate とする。
+    if not ho_patterns:
+        provenance = build_provenance(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
+            lite_result=lite_result,
+            class_value=class_value,
+            target_sha=target_sha,
+            model_a=model_a,
+            model_b=model_b,
+            reject_category=reject_category,
+            scope_check="unresolved",
+        )
+        searched_desc = ", ".join(ho_searched)
+        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {searched_desc}"
+        return provenance, reason
+
+    boundary, matched = boundary_check(changed_files, ho_patterns)
 
     # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
     if boundary == "touches-HO":
@@ -364,6 +516,27 @@ def arbitrate(data: dict[str, Any]) -> tuple[dict[str, Any], str]:
         )
         matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
         reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
+        return provenance, reason
+
+    # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
+    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
+    if not scope_ok:
+        provenance = build_provenance(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary=boundary,
+            lite_result=lite_result,
+            class_value=class_value,
+            target_sha=target_sha,
+            model_a=model_a,
+            model_b=model_b,
+            reject_category=reject_category,
+            scope_check="scope_violation",
+        )
+        violations_desc = ", ".join(violations)
+        reason = (
+            f"priority 1.5: boundary=clean だが scope_violation"
+            f"（allowed_paths 逸脱パス: {violations_desc}）"
+        )
         return provenance, reason
 
     # priority 2: lite=false は human escalate。
@@ -504,6 +677,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="入力 JSON ファイルのパス（省略時は stdin から読む）",
     )
+    parser.add_argument(
+        "--ho-paths",
+        dest="ho_paths_path",
+        default=None,
+        help="HO パス一覧（ho-paths.md）の明示パス（省略時は実行時解決 / #809）",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -528,7 +707,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[arbiter] 入力エラー: {exc}", file=sys.stderr)
         return 1
 
-    provenance, reason = arbitrate(validated)
+    provenance, reason = arbitrate(validated, ho_paths_path=args.ho_paths_path)
     decision = provenance["decision"]
 
     print(json.dumps(provenance, ensure_ascii=False, indent=2, sort_keys=True))

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -484,13 +484,25 @@ def build_provenance(
     model_c: str | None = None,
     model_d: str | None = None,
     reject_category: str | None = None,
-    scope_check: str = "in_scope",
+    scope_check: str = "not_evaluated",
+    ho_paths_source: str | None = None,
+    ho_pattern_count: int = 0,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
     `scope_check`（#809 追加フィールド）: allowed_paths 逸脱チェックの結果。
-    "in_scope" | "scope_violation" | "unresolved"（ho-paths 未解決で
-    boundary 判定自体に到達しなかった場合）。
+    - "in_scope": priority 1.5 の scope 検査を**実際に通過**した（合格）
+    - "scope_violation": priority 1.5 で allowed_paths 逸脱を検出した
+    - "unresolved": ho-paths 未解決（fail-closed）で boundary 判定自体に
+      到達しなかった
+    - "not_evaluated": scope 検査より前で return した経路（touches-HO 等）で
+      scope が未評価。既定値はこれ（未評価を "in_scope" と誤読させないため
+      #809 敵対的レビュー minor 反映で "in_scope" → "not_evaluated" に変更）
+
+    `ho_paths_source`（#809 追加）: 解決された ho-paths.md のパス（未解決時は
+    None）。`ho_pattern_count`（#809 追加）: 解決した HO パターン抽出件数。
+    「boundary=clean だが ho_pattern_count=1」のような過少網羅を監査で
+    検知できるようにする（fail-closed 閾値そのものは 0 のまま — 可視化に留める）。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -512,6 +524,8 @@ def build_provenance(
         "lite_check": lite_result,
         "class_check": class_value,
         "scope_check": scope_check,
+        "ho_paths_source": ho_paths_source,
+        "ho_pattern_count": ho_pattern_count,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
@@ -548,20 +562,30 @@ def arbitrate(
 
     lite_result = lite_check(lite_input)
 
-    ho_patterns, _ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+    ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
+    ho_pattern_count = len(ho_patterns)
 
-    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
-    # 絶対条件として全件 human escalate とする。
-    if not ho_patterns:
-        provenance = build_provenance(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary="unresolved",
+    # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
+    # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
+    def _mk(**kw: Any) -> dict[str, Any]:
+        return build_provenance(
             lite_result=lite_result,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
             model_b=model_b,
             reject_category=reject_category,
+            ho_paths_source=ho_source,
+            ho_pattern_count=ho_pattern_count,
+            **kw,
+        )
+
+    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
+    # 絶対条件として全件 human escalate とする。
+    if not ho_patterns:
+        provenance = _mk(
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
             scope_check="unresolved",
         )
         searched_desc = ", ".join(ho_searched)
@@ -571,16 +595,12 @@ def arbitrate(
     boundary, matched = boundary_check(changed_files, ho_patterns)
 
     # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
+    # scope 検査（priority 1.5）より前で return するため scope_check は not_evaluated。
     if boundary == "touches-HO":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="not_evaluated",
         )
         matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
         reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
@@ -589,15 +609,9 @@ def arbitrate(
     # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     if not scope_ok:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
             scope_check="scope_violation",
         )
         violations_desc = ", ".join(violations)
@@ -607,31 +621,22 @@ def arbitrate(
         )
         return provenance, reason
 
+    # ここに到達＝scope 検査を実際に通過（合格）。以降の全経路は in_scope を刻む。
     # priority 2: lite=false は human escalate。
     if not lite_result:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"
 
     # priority 3: class=merge は human escalate（merge=Human-owned 固定）。
     if class_value == "merge":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 3: class=merge（Human-owned 固定）"
 
@@ -639,29 +644,19 @@ def arbitrate(
 
     # priority 4: reject-reject / reject-approve は blocked。
     if verdict in ("reject-reject", "reject-approve"):
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_BLOCKED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, f"priority 4: verdict={verdict}（A が設計妥当性で NG、または両者合意で NG）"
 
     # priority 6: approve-approve は auto-approve。
     if verdict == "approve-approve":
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_AUTO_APPROVED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
         )
         return provenance, "priority 6: verdict=approve-approve（合意）"
 
@@ -671,15 +666,10 @@ def arbitrate(
     severity = classify_severity(reject_category)
 
     if severity in ("critical", "major"):
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
             severity=severity,
         )
         return (
@@ -690,15 +680,10 @@ def arbitrate(
     # severity=minor/low → Model C/D 裁定。
     # C か D が欠落している場合は安全側で human escalate。
     if model_c is None or model_d is None:
-        provenance = build_provenance(
+        provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
             boundary=boundary,
-            lite_result=lite_result,
-            class_value=class_value,
-            target_sha=target_sha,
-            model_a=model_a,
-            model_b=model_b,
-            reject_category=reject_category,
+            scope_check="in_scope",
             severity=severity,
             model_c=model_c,
             model_d=model_d,
@@ -716,15 +701,10 @@ def arbitrate(
     else:
         decision = DECISION_HUMAN_ESCALATED
 
-    provenance = build_provenance(
+    provenance = _mk(
         decision=decision,
         boundary=boundary,
-        lite_result=lite_result,
-        class_value=class_value,
-        target_sha=target_sha,
-        model_a=model_a,
-        model_b=model_b,
-        reject_category=reject_category,
+        scope_check="in_scope",
         severity=severity,
         model_c=model_c,
         model_d=model_d,

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -924,6 +924,114 @@ class HoPathsProvenanceVisibilityTests(unittest.TestCase):
             self.assertEqual(provenance["ho_pattern_count"], 1)
 
 
+class GeminiSecurityHardeningTests(unittest.TestCase):
+    """PR #813 gemini レビュー反映（#809）: バックスラッシュ traversal / read_text
+    の ValueError / regex キャッシュ。
+    """
+
+    # --- 修正 1（security-high）: バックスラッシュ経路の traversal 封鎖 ---
+
+    def test_backslash_traversal_rejected_in_validate(self):
+        """`foo\\..\\bar`（バックスラッシュ traversal）は入力段で拒否。"""
+        data = _base_input(changed_files=["foo\\..\\bar"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_plain_backslash_rejected_in_validate(self):
+        """`foo\\bar`（.. を含まない単なるバックスラッシュ区切り）も一律拒否。"""
+        data = _base_input(changed_files=["foo\\bar"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_backslash_rejected_in_allowed_paths(self):
+        data = _base_input(allowed_paths=["foo\\..\\**"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_safe_normalized_path_flags_backslash(self):
+        _norm, err = arbiter._safe_normalized_path("foo\\..\\bar")
+        self.assertIsNotNone(err)
+        self.assertIn("\\", err)
+
+    def test_backslash_boundary_check_is_safe_side(self):
+        """判定関数単体でも、バックスラッシュ経路は clean にせず touches-HO 相当に倒す。"""
+        boundary, matched = arbiter.boundary_check(["foo\\..\\bin\\plangate"])
+        self.assertEqual(boundary, "touches-HO")
+        self.assertTrue(matched)
+
+    def _run_main_with_stdin(self, payload):
+        import io
+
+        old_stdin, old_stdout, old_stderr = sys.stdin, sys.stdout, sys.stderr
+        sys.stdin = io.StringIO(json.dumps(payload))
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            code = arbiter.main([])
+            out, err = sys.stdout.getvalue(), sys.stderr.getvalue()
+        finally:
+            sys.stdin, sys.stdout, sys.stderr = old_stdin, old_stdout, old_stderr
+        return code, out, err
+
+    def test_e2e_backslash_traversal_exits_1_never_auto_approves(self):
+        """再現固定: バックスラッシュ traversal は exit 1（入力エラー）で
+        AUTO_APPROVED / clean にならない。
+        """
+        data = _base_input(changed_files=["foo\\..\\bin\\plangate"], allowed_paths=["**"])
+        code, out, err = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertNotIn("AUTO_APPROVED", out)
+        self.assertIn("入力エラー", err)
+
+    # --- 修正 2（medium）: read_text の UnicodeDecodeError（ValueError）で fail-closed ---
+
+    def test_resolve_ho_patterns_skips_undecodable_file(self):
+        """不正 UTF-8 の ho-paths 明示指定 → 当該候補 skip、他候補なしで fail-closed（patterns=[]）。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "bad-ho-paths.md"
+            bad.write_bytes(b"\xff\xfe\x00\x01 invalid utf-8 \x80\x81")
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(bad))
+            self.assertEqual(patterns, [])
+            self.assertIsNone(source)
+            self.assertEqual(searched, [str(bad)])
+
+    def test_arbitrate_fail_closed_on_undecodable_ho_paths(self):
+        """不正 UTF-8 の ho-paths 指定時、arbitrate は全件 HUMAN_ESCALATED（fail-closed）。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "bad-ho-paths.md"
+            bad.write_bytes(b"\xff\xfe\x00\x01\x80\x81\x82")
+            data = _base_input()  # 本来なら AUTO_APPROVED になる happy-path 入力
+            provenance, reason = arbiter.arbitrate(data, ho_paths_path=str(bad))
+            self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+            self.assertEqual(provenance["boundary_check"], "unresolved")
+            self.assertIn("fail-closed", reason)
+
+    # --- 修正 3（medium・perf）: regex キャッシュ導入後も判定不変（回帰） ---
+
+    def test_regex_cache_preserves_boundary_semantics(self):
+        """キャッシュ導入後も既存 boundary 判定が全て不変であることの回帰確認。"""
+        cases = [
+            (["bin/plangate"], "touches-HO"),
+            (["scripts/hooks/check-plan-hash.sh"], "touches-HO"),
+            (["schemas/plan.schema.json"], "touches-HO"),
+            ([".claude/rules/mode-classification.md"], "touches-HO"),
+            (["docs/ai/ai-loop/ho-paths.md"], "touches-HO"),
+            (["docs/ai/ai-loop/concept.md"], "clean"),
+            (["docs/workflows/ai-loop/decision-table.md"], "clean"),
+            (["plugin/plangate/index.js"], "touches-HO"),
+        ]
+        for changed, expected in cases:
+            with self.subTest(changed=changed):
+                boundary, _ = arbiter.boundary_check(changed)
+                self.assertEqual(boundary, expected)
+
+    def test_regex_cache_returns_identical_compiled_object(self):
+        """同一パターンの再変換がキャッシュされ、同一 compiled regex を返す（メモ化の実証）。"""
+        first = arbiter._ho_pattern_to_regex("scripts/hooks/**")
+        second = arbiter._ho_pattern_to_regex("scripts/hooks/**")
+        self.assertIs(first, second)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -29,6 +30,7 @@ HO_PATHS_MD = next((p for p in _HO_PATHS_CANDIDATES if p.exists()), _HO_PATHS_CA
 def _base_input(**overrides):
     data = {
         "changed_files": ["docs/workflows/ai-loop/decision-table.md"],
+        "allowed_paths": ["docs/workflows/ai-loop/**"],
         "lite": {
             "size_ok": True,
             "no_new_design": True,
@@ -143,17 +145,23 @@ class BoundaryCheckTests(unittest.TestCase):
         self.assertEqual(matched, [])
 
     def test_ho_pattern_drift_against_source_of_truth(self):
-        """HO_PATTERNS の各パターン文字列が ho-paths.md 本文に存在することを検証する。
+        """実行時パースされた全パターンが ho-paths.md 本文に存在することを検証する（#809）。
 
-        正本（docs/ai/ai-loop/ho-paths.md）とのドリフトを検出する。
+        #809 により HO_PATTERNS ハードコード定数は廃止され、ho-paths.md 本文を
+        実行時にパースする方式へ変更された。ドリフトは構造的に発生しなくなるが、
+        パーサの抽出内容が本文の記述と食い違っていないこと（例: 注釈括弧の
+        誤混入）を継続して検証する。
         """
         self.assertTrue(HO_PATHS_MD.exists(), f"正本ファイルが見つかりません: {HO_PATHS_MD}")
         content = HO_PATHS_MD.read_text(encoding="utf-8")
-        missing = [pattern for pattern, _ in arbiter.HO_PATTERNS if pattern not in content]
+        patterns, source, _searched = arbiter.resolve_ho_patterns()
+        self.assertIsNotNone(source, "ho-paths.md の実行時解決に失敗しました")
+        self.assertGreaterEqual(len(patterns), 18, f"パース件数が想定を下回ります: {len(patterns)}")
+        missing = [pattern for pattern, _classification in patterns if pattern not in content]
         self.assertEqual(
             missing,
             [],
-            f"HO_PATTERNS に ho-paths.md 本文と同期していないパターンがあります: {missing}",
+            f"パースされたパターンが ho-paths.md 本文に見当たりません: {missing}",
         )
 
 
@@ -421,11 +429,13 @@ class ProvenanceSchemaTests(unittest.TestCase):
             "boundary_check",
             "lite_check",
             "class_check",
+            "scope_check",
             "timestamp",
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v0")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
         # 決定論であることの確認（同一入力 → 同一 decision）
@@ -454,6 +464,181 @@ class InputValidationTests(unittest.TestCase):
     def test_non_dict_input_raises(self):
         with self.assertRaises(arbiter.InputError):
             arbiter.validate_input(["not", "a", "dict"])
+
+    def test_missing_allowed_paths_raises(self):
+        """TC-7: allowed_paths 欠落は入力エラー（#809 必須化）。"""
+        data = _base_input()
+        del data["allowed_paths"]
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_empty_allowed_paths_raises(self):
+        """TC-7: allowed_paths が空リストは入力エラー（非空 string リスト要件）。"""
+        data = _base_input(allowed_paths=[])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_non_list_allowed_paths_raises(self):
+        """TC-7: allowed_paths が非リスト（例: string）は入力エラー。"""
+        data = _base_input(allowed_paths="docs/workflows/ai-loop/**")
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_non_string_item_in_allowed_paths_raises(self):
+        """TC-7: allowed_paths の要素に非 string が混じる場合は入力エラー。"""
+        data = _base_input(allowed_paths=["docs/workflows/ai-loop/**", 123])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+
+class HoPathsResolutionTests(unittest.TestCase):
+    """TC-1〜TC-4: ho-paths.md 実行時解決の優先順位 + fail-closed（#809）。"""
+
+    def test_tc1_cli_explicit_path_takes_priority(self):
+        """TC-1: --ho-paths 相当（cli_path 明示指定）は CWD/script-relative より優先される。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom = pathlib.Path(tmpdir) / "custom-ho-paths.md"
+            custom.write_text(
+                "## HO パス一覧\n\n"
+                "| パス | 分類 | 変更禁止理由 |\n"
+                "|------|------|------------|\n"
+                "| `only-in-custom/**` | HO-custom | テスト専用パターン |\n",
+                encoding="utf-8",
+            )
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(custom))
+            self.assertEqual(patterns, [("only-in-custom/**", "HO-custom")])
+            self.assertEqual(source, str(custom))
+            self.assertEqual(searched, [str(custom)])
+
+    def test_tc2_candidate_order_cwd_before_bundled(self):
+        """TC-2: cli_path 未指定時の候補順序は (1) CWD の docs/ai/ai-loop/ho-paths.md
+        → (2) スクリプト位置基準 ../references/ho-paths.md の順。
+        """
+        candidates = arbiter._candidate_ho_paths_sources(None)
+        self.assertEqual(len(candidates), 2)
+        self.assertTrue(str(candidates[0]).endswith(str(pathlib.Path("docs/ai/ai-loop/ho-paths.md"))))
+        self.assertTrue(str(candidates[1]).endswith(str(pathlib.Path("references/ho-paths.md"))))
+
+    def test_tc3_fail_closed_when_explicit_path_missing(self):
+        """TC-3: 明示パスが存在しない場合、fail-closed（patterns=[], source=None）。"""
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        patterns, source, searched = arbiter.resolve_ho_patterns(missing_path)
+        self.assertEqual(patterns, [])
+        self.assertIsNone(source)
+        self.assertEqual(searched, [missing_path])
+
+    def test_tc4_fail_closed_when_zero_parseable_rows(self):
+        """TC-4: ファイルは存在するがパース可能な行が 0 件 → fail-closed。"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_doc = pathlib.Path(tmpdir) / "empty-ho-paths.md"
+            empty_doc.write_text("# HO パス一覧\n\n本文にはテーブル行が一切ない。\n", encoding="utf-8")
+            patterns, source, searched = arbiter.resolve_ho_patterns(str(empty_doc))
+            self.assertEqual(patterns, [])
+            self.assertIsNone(source)
+            self.assertEqual(searched, [str(empty_doc)])
+
+
+class HoPathsTableParsingTests(unittest.TestCase):
+    """TC-6: parse_ho_paths_table の注釈括弧除去・境界動作。"""
+
+    def test_tc6_annotation_parenthetical_excluded_from_pattern(self):
+        content = (
+            "## HO パス一覧\n\n"
+            "| パス | 分類 | 変更禁止理由 |\n"
+            "|------|------|------------|\n"
+            "| `docs/ai/*.md`（トップレベルの md のみ。`docs/ai/ai-loop/` 配下は対象外） "
+            "| HO-contract | 理由 |\n"
+        )
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [("docs/ai/*.md", "HO-contract")])
+
+    def test_tc6_header_and_separator_rows_ignored(self):
+        content = (
+            "| パス | 分類 | 変更禁止理由 |\n"
+            "|------|------|------------|\n"
+            "| `bin/plangate` | HO-core | 理由 |\n"
+        )
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [("bin/plangate", "HO-core")])
+
+    def test_tc6_non_table_lines_ignored(self):
+        content = "本文の説明文。バッククォート `example` を含むが表ではない。\n"
+        patterns = arbiter.parse_ho_paths_table(content)
+        self.assertEqual(patterns, [])
+
+
+class FailClosedIntegrationTests(unittest.TestCase):
+    """TC-5: ho-paths 未解決時、arbitrate() は verdict/lite/class を問わず全件escalate。"""
+
+    def test_tc5_unresolved_ho_paths_escalates_regardless_of_verdicts(self):
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        data = _base_input()  # approve-approve・lite 全 true・class=no-merge（本来なら auto-approve 相当）
+        provenance, reason = arbiter.arbitrate(data, ho_paths_path=missing_path)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertIn("fail-closed", reason)
+        self.assertIn("priority 0", reason)
+
+    def test_tc5_unresolved_ho_paths_escalates_even_with_reject_reject(self):
+        """fail-closed は「厳しい裁定を優先」より前段の絶対条件。reject-reject（本来 BLOCKED）でも
+        ho-paths 未解決時は HUMAN_ESCALATED（boundary 判定不能を明示する decision）を返す。
+        """
+        missing_path = "/nonexistent/path/does-not-exist-ho-paths.md"
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _reason = arbiter.arbitrate(data, ho_paths_path=missing_path)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+
+class AllowedPathsScopeTests(unittest.TestCase):
+    """TC-8〜TC-10: allowed_paths 必須化・scope 逸脱 escalate・touches-HO 優先順位。"""
+
+    def test_tc8_in_scope_change_proceeds_to_normal_evaluation(self):
+        """TC-8: allowed_paths 内の変更は scope チェックを通過し通常の priority 評価へ進む。"""
+        data = _base_input(allowed_paths=["docs/workflows/ai-loop/**"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+        self.assertIn("priority 6", reason)
+
+    def test_tc9_out_of_scope_change_escalates(self):
+        """TC-9: changed_files が allowed_paths のどの glob にも一致しない → human escalate。"""
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/decision-table.md", "scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertIn("scripts/unrelated/tool.py", reason)
+
+    def test_tc10_touches_ho_overrides_even_when_allowed_paths_declares_it(self):
+        """TC-10: allowed_paths に HO パスそのものを宣言していても HO escalate は免れない
+        （design-philosophy.md I-1 不変条件・優先順位は touches-HO が常に先）。
+        """
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            allowed_paths=["bin/plangate"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.5", reason)
+
+
+class PolicyRefVersionTests(unittest.TestCase):
+    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。"""
+
+    def test_tc11_policy_ref_is_v1(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v1")
+
+    def test_tc11_provenance_policy_ref_is_v1(self):
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
 
 
 class MainExitCodeTests(unittest.TestCase):

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -798,6 +798,132 @@ class PathNormalizationSecurityTests(unittest.TestCase):
         self.assertEqual(provenance["scope_check"], "in_scope")
 
 
+class ScopeCheckNotEvaluatedTests(unittest.TestCase):
+    """敵対的レビュー minor（Finding 3・#809）: scope 未評価経路の scope_check 明示。"""
+
+    def test_touches_ho_record_marks_scope_not_evaluated(self):
+        """touches-HO 経路（priority 1）は scope 検査より前で return するため
+        scope_check == "not_evaluated"（"in_scope" と誤読させない）。
+        """
+        data = _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["scope_check"], "not_evaluated")
+
+    def test_fail_closed_record_marks_scope_unresolved(self):
+        """fail-closed 経路（priority 0）は scope_check == "unresolved"（従来どおり）。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "unresolved")
+
+    def test_scope_violation_record_marks_scope_violation(self):
+        data = _base_input(
+            changed_files=["scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+
+    def test_auto_approved_record_still_in_scope(self):
+        """scope 検査を通過した AUTO_APPROVED は従来どおり scope_check == "in_scope"。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+    def test_lite_false_after_scope_pass_is_in_scope(self):
+        """lite=false（priority 2）は scope 検査通過後に評価されるため in_scope。"""
+        data = _base_input(
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True}
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+    def test_build_provenance_default_scope_check_is_not_evaluated(self):
+        """build_provenance の scope_check 既定値は "not_evaluated"（"in_scope" ではない）。"""
+        prov = arbiter.build_provenance(
+            decision="HUMAN_ESCALATED",
+            boundary="touches-HO",
+            lite_result=True,
+            class_value="no-merge",
+            target_sha="abc1234",
+            model_a="approve",
+            model_b="approve",
+        )
+        self.assertEqual(prov["scope_check"], "not_evaluated")
+
+
+class HoPathsProvenanceVisibilityTests(unittest.TestCase):
+    """敵対的レビュー minor（Finding 2・#809）: ho-paths 出典・抽出件数の record 刻印。"""
+
+    def test_all_records_carry_ho_paths_source_and_count(self):
+        """全裁定経路の record に ho_paths_source（非 null）と ho_pattern_count（正の int）が刻まれる。"""
+        scenarios = [
+            ("auto_approved", _base_input()),
+            ("touches_ho", _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])),
+            (
+                "scope_violation",
+                _base_input(
+                    changed_files=["scripts/unrelated/tool.py"],
+                    allowed_paths=["docs/workflows/ai-loop/**"],
+                ),
+            ),
+            (
+                "lite_false",
+                _base_input(
+                    lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True}
+                ),
+            ),
+        ]
+        for name, data in scenarios:
+            with self.subTest(scenario=name):
+                provenance, _ = arbiter.arbitrate(data)
+                self.assertIn("ho_paths_source", provenance)
+                self.assertIn("ho_pattern_count", provenance)
+                self.assertIsNotNone(provenance["ho_paths_source"], "解決時は非 null")
+                self.assertIsInstance(provenance["ho_pattern_count"], int)
+                self.assertGreater(provenance["ho_pattern_count"], 0)
+
+    def test_ho_paths_source_matches_resolved_path(self):
+        data = _base_input()
+        patterns, source, _searched = arbiter.resolve_ho_patterns()
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["ho_paths_source"], source)
+        self.assertEqual(provenance["ho_pattern_count"], len(patterns))
+
+    def test_fail_closed_record_has_null_source_and_zero_count(self):
+        """解決不能（fail-closed）時は ho_paths_source == None・ho_pattern_count == 0。"""
+        data = _base_input()
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertIsNone(provenance["ho_paths_source"])
+        self.assertEqual(provenance["ho_pattern_count"], 0)
+
+    def test_under_coverage_is_detectable_via_count(self):
+        """過少網羅（1 行 ho-paths.md）を ho_pattern_count で検知できる（可視化）。"""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tiny = pathlib.Path(tmpdir) / "tiny-ho-paths.md"
+            tiny.write_text(
+                "## HO パス一覧\n\n"
+                "| パス | 分類 | 変更禁止理由 |\n"
+                "|------|------|------------|\n"
+                "| `bin/plangate` | HO-core | 唯一の HO パターン |\n",
+                encoding="utf-8",
+            )
+            data = _base_input(
+                changed_files=["docs/workflows/ai-loop/example.md"],
+                allowed_paths=["docs/workflows/ai-loop/**"],
+            )
+            provenance, _ = arbiter.arbitrate(data, ho_paths_path=str(tiny))
+            # boundary=clean だが ho_pattern_count=1 の過少網羅が record から読める
+            self.assertEqual(provenance["boundary_check"], "clean")
+            self.assertEqual(provenance["ho_pattern_count"], 1)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -641,6 +641,163 @@ class PolicyRefVersionTests(unittest.TestCase):
         self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
 
 
+class PathNormalizationSecurityTests(unittest.TestCase):
+    """敵対的レビュー major 反映（#809）: パス正規化欠如による touches-HO 迂回の封鎖。
+
+    2 層防御:
+    - 第一防壁（入力段）: validate_input が正規化後 `..` 残存・絶対パス・
+      空セグメント（//）を InputError（exit 1）で拒否する
+    - 第二防壁（判定段）: boundary_check / check_allowed_paths がマッチ直前に
+      normpath で畳み込み、`./bin/plangate` 等の変種でも HO を捕捉する。
+      判定関数単体に不正パスが渡った場合も安全側（escalate 相当）に倒す
+    """
+
+    # --- 第二防壁: 正規化後マッチ（./ 変種で HO 捕捉） ---
+
+    def test_dot_slash_prefix_variant_is_caught_as_touches_ho(self):
+        """`./bin/plangate` は正規化後に bin/plangate として touches-HO 捕捉。"""
+        data = _base_input(changed_files=["./bin/plangate"], allowed_paths=["**"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+
+    def test_boundary_check_normalizes_before_matching(self):
+        boundary, matched = arbiter.boundary_check(["./bin/plangate"])
+        self.assertEqual(boundary, "touches-HO")
+        self.assertEqual(matched[0]["classification"], "HO-core")
+
+    def test_interior_dotdot_collapsing_to_ho_paths_md_is_caught(self):
+        """自己改変 traversal: `docs/ai/ai-loop/x/../ho-paths.md` は正規化後に
+        ho-paths.md 本体として touches-HO 捕捉（clean にしない / #808 防止の維持）。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/x/../ho-paths.md"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_arbitrate_direct_call_with_root_escaping_path_is_safe_side(self):
+        """validate_input を経ない arbitrate() 直呼びでも、ルート外へ抜ける
+        `..` パスは安全側（escalate。AUTO_APPROVED 到達不可）に倒れる。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _reason = arbiter.arbitrate(data)
+        self.assertNotEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+    # --- 第一防壁: validate_input での拒否 ---
+
+    def test_validate_rejects_root_escaping_traversal(self):
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_empty_segment(self):
+        data = _base_input(changed_files=["bin//plangate"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_absolute_path(self):
+        data = _base_input(changed_files=["/etc/passwd"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_validate_rejects_traversal_in_allowed_paths(self):
+        data = _base_input(allowed_paths=["../**"])
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    # --- CLI e2e: exit code 固定 ---
+
+    def _run_main_with_stdin(self, payload):
+        import io
+
+        old_stdin = sys.stdin
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdin = io.StringIO(json.dumps(payload))
+        sys.stdout = io.StringIO()
+        sys.stderr = io.StringIO()
+        try:
+            code = arbiter.main([])
+            stdout_value = sys.stdout.getvalue()
+            stderr_value = sys.stderr.getvalue()
+        finally:
+            sys.stdin = old_stdin
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+        return code, stdout_value, stderr_value
+
+    def test_e2e_traversal_exits_1_and_never_auto_approves(self):
+        """再現ケース固定: traversal + narrow allowed_paths は exit 1（入力エラー）。
+        AUTO_APPROVED（exit 0）に到達しないことを固定する。
+        """
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/../../../bin/plangate"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        code, stdout_value, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertNotIn("AUTO_APPROVED", stdout_value)
+        self.assertIn("入力エラー", stderr_value)
+        self.assertIn("bin/plangate", stderr_value)
+
+    def test_e2e_dot_slash_variant_escalates_exit_2(self):
+        """再現ケース固定: `./bin/plangate` + allowed=** は touches-HO escalate（exit 2）。"""
+        data = _base_input(changed_files=["./bin/plangate"], allowed_paths=["**"])
+        code, stdout_value, _ = self._run_main_with_stdin(data)
+        self.assertEqual(code, 2)
+        self.assertEqual(json.loads(stdout_value)["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(json.loads(stdout_value)["boundary_check"], "touches-HO")
+
+    def test_e2e_empty_segment_exits_1(self):
+        data = _base_input(changed_files=["bin//plangate"])
+        code, _, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertIn("入力エラー", stderr_value)
+
+    def test_e2e_absolute_path_exits_1(self):
+        data = _base_input(changed_files=["/etc/passwd"])
+        code, _, stderr_value = self._run_main_with_stdin(data)
+        self.assertEqual(code, 1)
+        self.assertIn("入力エラー", stderr_value)
+
+    # --- 回帰: 正規の素パスは従来どおり ---
+
+    def test_regression_plain_ho_path_still_escalates(self):
+        data = _base_input(changed_files=["bin/plangate"], allowed_paths=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_regression_plain_ho_paths_md_still_escalates(self):
+        data = _base_input(
+            changed_files=["docs/ai/ai-loop/ho-paths.md"],
+            allowed_paths=["docs/ai/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+
+    def test_regression_happy_path_still_auto_approves(self):
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/example.md"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["scope_check"], "in_scope")
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 


### PR DESCRIPTION
## 概要

#809。ai-loop Phase 1（#807/#808）で「規範層にのみ存在し機械層に未配線」だった安全前提を、決定論エンジン `scripts/ai-loop/arbiter.py` へ配線する。#808 の review-team 多レーンレビューで 3 レーン consensus 検出されたギャップの解消。

feat/807（#808）から派生していたため、#808 squash マージ後に `git rebase --onto origin/main` で本 PBI 固有 5 コミットのみを新 main へ載せ替え済み（feat/807 分の重複なし・diff 検証済み）。

## 変更内容

- **ho-paths 実行時解決 + fail-closed**: `HO_PATTERNS` ハードコードを廃し、`--ho-paths` > CWD `docs/ai/ai-loop/ho-paths.md` > スクリプト隣接 `../references/ho-paths.md` の順で表をパース。**解決不能・パース 0 件なら全件 `HUMAN_ESCALATED`**（導入先固有パスが clean 判定される fail-open を封鎖）
- **allowed_paths 必須化 + scope 逸脱 escalate**: LoopSpec `scope.allowed_paths` を arbiter 入力の必須フィールドに。changed_files が範囲外なら escalate。**touches-HO は allowed_paths に HO を書いても優先**（design-philosophy I-1 不変）
- **パス正規化**（敵対的レビュー major 反映）: `..`/`./`/絶対パス/空セグメントを含む changed_files を入力段で拒否（exit 1）+ 判定段で正規化。traversal による touches-HO 迂回（`docs/ai/ai-loop/../../../bin/plangate` → AUTO_APPROVED）を封鎖
- **provenance 強化**（敵対的レビュー minor 反映）: `ho_paths_source` / `ho_pattern_count` を全裁定に刻印（過少網羅の監査）+ scope 未評価経路の `scope_check` を "not_evaluated" 明示
- **POLICY_REF @v1**（方針改版・Human-owned 手続き）

## レビュー（多レーン・実測ベース）

- opus 敵対的レビュー: 7 攻撃面 → **major 1（パス正規化欠如の traversal バイパス・CONFIRMED）** 検出 → 2 層防壁で封鎖 → 統合側で traversal→exit 1 を実測。minor 2 も反映済み
- 統合側プローブ: fail-closed / scope 逸脱 / HO 免除不可 / happy path / #808 自己改変防止の回帰 / 欠落→exit1 を全て実測 PASS

## 検証（実測）

- `test_arbiter.py` **107/107 OK**（repo 正本 + plugin bundled 配置の両方で自立 PASS）
- `scripts/ai-loop/arbiter.py` と plugin 同梱コピー cmp IDENTICAL
- decision-table.md §5 に新フィールド追記・markdownlint 0

## 関連

Closes #809。後続: Slice D 後半（record への run 刻印・#780）/ Slice B（plan 品質 hard gate）。minor follow-up（1 行 ho-paths.md での境界実質無効化＝fail-closed 閾値の件数化検討）は #809 コメントに記録。

🤖 Generated with [Claude Code](https://claude.com/claude-code)