### PR TITLE
feat: ai-loop 計測基盤を実データで稼働 — arbiter が record に run メタを刻印（#780 Slice D 後半）

### DIFF
--- a/.agents/skills/ai-loop-cycle/SKILL.md
+++ b/.agents/skills/ai-loop-cycle/SKILL.md
@@ -57,6 +57,8 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+
 入力 JSON の例:
 
 ```json
@@ -77,7 +79,12 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_c": null,
     "model_d": null
   },
-  "target_sha": "abc1234"
+  "target_sha": "abc1234",
+  "run": {
+    "run_id": "run-022",
+    "round_index": 1,
+    "task_id": "TASK-XXXX"
+  }
 }
 ```
 

--- a/.agents/skills/ai-loop-cycle/SKILL.md
+++ b/.agents/skills/ai-loop-cycle/SKILL.md
@@ -57,7 +57,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
-`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
 入力 JSON の例:
 

--- a/.claude/skills/ai-loop-cycle/SKILL.md
+++ b/.claude/skills/ai-loop-cycle/SKILL.md
@@ -41,7 +41,7 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
 `target_sha` は対象コミットの SHA。`allowed_paths` は LoopSpec の `scope.allowed_paths`
 宣言をそのまま渡す（#809）。
 
-`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
 入力 JSON の例:
 

--- a/.claude/skills/ai-loop-cycle/SKILL.md
+++ b/.claude/skills/ai-loop-cycle/SKILL.md
@@ -41,6 +41,8 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
 `target_sha` は対象コミットの SHA。`allowed_paths` は LoopSpec の `scope.allowed_paths`
 宣言をそのまま渡す（#809）。
 
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+
 入力 JSON の例:
 
 ```json
@@ -61,7 +63,12 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
     "model_c": null,
     "model_d": null
   },
-  "target_sha": "abc1234"
+  "target_sha": "abc1234",
+  "run": {
+    "run_id": "run-022",
+    "round_index": 1,
+    "task_id": "TASK-XXXX"
+  }
 }
 ```
 

--- a/.codex/skills/ai-loop-cycle/SKILL.md
+++ b/.codex/skills/ai-loop-cycle/SKILL.md
@@ -69,7 +69,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
-`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
 入力 JSON の例:
 

--- a/.codex/skills/ai-loop-cycle/SKILL.md
+++ b/.codex/skills/ai-loop-cycle/SKILL.md
@@ -69,6 +69,8 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+
 入力 JSON の例:
 
 ```json
@@ -88,7 +90,12 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_c": null,
     "model_d": null
   },
-  "target_sha": "abc1234"
+  "target_sha": "abc1234",
+  "run": {
+    "run_id": "run-022",
+    "round_index": 1,
+    "task_id": "TASK-XXXX"
+  }
 }
 ```
 

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -142,6 +142,22 @@ w_check:
   model_d:   approve
 ```
 
+### run メタ（#780 Slice D 後半 追加・additive・任意）
+
+呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。省略時は `run: null`。
+
+```text
+run:
+  run_id:        run-022（run 単位の連番識別子。非空 string 必須）
+  round_index:   1（同一 run 内の再試行回数。0 起点。int 必須・bool 不可）
+  task_id:       TASK-XXXX（対象 PBI 識別子。string 必須）
+  repair_action: reject 指摘に基づき修正（再試行時のみ・任意・string）
+```
+
+`run` は `scripts/ai-loop/metrics.py`（#812）が run 単位の集計（first-pass rate 等）に
+用いる消費契約。gate 挙動（POLICY_REF）は変えない純粋な additive provenance 拡張であり、
+本追加による policy バージョン改版は行わない（`auto-approve-lite-clean@v1` 据え置き）。
+
 ### フィールド定義
 
 | フィールド | 必須 | 説明 |
@@ -164,6 +180,11 @@ w_check:
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |
 | `w_check.model_d` | C/D 時のみ | Model D の判定 |
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
+| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。省略時は `null`。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
+| `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
+| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
+| `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
+| `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
 
 ### `target_sha` の計画時 vs 実装後の意味論（issue #782 P3）
 

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -144,7 +144,7 @@ w_check:
 
 ### run メタ（#780 Slice D 後半 追加・additive・任意）
 
-呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。省略時は `run: null`。
+呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。**省略時は `run` キー自体を刻まない**（`run: null` は出力しない）。これにより `metrics.py` は当該 record を legacy（run メタ未計装・集計対象外の正常レコード）に分類し、invalid_run_meta（run メタを主張するが run_id が falsy＝要注意）へ誤計上しない。
 
 ```text
 run:
@@ -180,7 +180,7 @@ run:
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |
 | `w_check.model_d` | C/D 時のみ | Model D の判定 |
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
-| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。省略時は `null`。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
+| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。**省略時はキー自体を刻まない**（`null` も出力しない → metrics で legacy 分類）。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
 | `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
 | `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -149,7 +149,7 @@ w_check:
 ```text
 run:
   run_id:        run-022（run 単位の連番識別子。非空 string 必須）
-  round_index:   1（同一 run 内の再試行回数。0 起点。int 必須・bool 不可）
+  round_index:   1（初回呼び出し=1、再試行ごとに +1。**1 起点**。int 必須・bool 不可。metrics は round_index==1 を初回 sentinel として first_pass を判定するため 0 起点は不可）
   task_id:       TASK-XXXX（対象 PBI 識別子。string 必須）
   repair_action: reject 指摘に基づき修正（再試行時のみ・任意・string）
 ```
@@ -182,7 +182,7 @@ run:
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
 | `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。**省略時はキー自体を刻まない**（`null` も出力しない → metrics で legacy 分類）。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
 | `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
-| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
+| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。**1 起点**（初回呼び出し=1、再試行ごとに +1）。`metrics.py` は round_index==1 を初回ラウンドの sentinel として first_pass を判定するため、0 起点にすると成功 run が恒久的に first_pass 分子から漏れる |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
 | `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
 

--- a/plugin/plangate/skills/ai-loop-cycle/SKILL.md
+++ b/plugin/plangate/skills/ai-loop-cycle/SKILL.md
@@ -57,6 +57,8 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+
 入力 JSON の例:
 
 ```json
@@ -77,7 +79,12 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_c": null,
     "model_d": null
   },
-  "target_sha": "abc1234"
+  "target_sha": "abc1234",
+  "run": {
+    "run_id": "run-022",
+    "round_index": 1,
+    "task_id": "TASK-XXXX"
+  }
 }
 ```
 

--- a/plugin/plangate/skills/ai-loop-cycle/SKILL.md
+++ b/plugin/plangate/skills/ai-loop-cycle/SKILL.md
@@ -57,7 +57,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
-`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（再試行ごとに +1）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
+`run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
 入力 JSON の例:
 

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -142,6 +142,22 @@ w_check:
   model_d:   approve
 ```
 
+### run メタ（#780 Slice D 後半 追加・additive・任意）
+
+呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。省略時は `run: null`。
+
+```text
+run:
+  run_id:        run-022（run 単位の連番識別子。非空 string 必須）
+  round_index:   1（同一 run 内の再試行回数。0 起点。int 必須・bool 不可）
+  task_id:       TASK-XXXX（対象 PBI 識別子。string 必須）
+  repair_action: reject 指摘に基づき修正（再試行時のみ・任意・string）
+```
+
+`run` は `scripts/ai-loop/metrics.py`（#812）が run 単位の集計（first-pass rate 等）に
+用いる消費契約。gate 挙動（POLICY_REF）は変えない純粋な additive provenance 拡張であり、
+本追加による policy バージョン改版は行わない（`auto-approve-lite-clean@v1` 据え置き）。
+
 ### フィールド定義
 
 | フィールド | 必須 | 説明 |
@@ -164,6 +180,11 @@ w_check:
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |
 | `w_check.model_d` | C/D 時のみ | Model D の判定 |
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
+| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。省略時は `null`。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
+| `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
+| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
+| `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
+| `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
 
 ### `target_sha` の計画時 vs 実装後の意味論（issue #782 P3）
 

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -144,7 +144,7 @@ w_check:
 
 ### run メタ（#780 Slice D 後半 追加・additive・任意）
 
-呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。省略時は `run: null`。
+呼び出し側入力の `run`（省略可）をそのまま provenance に刻む。**省略時は `run` キー自体を刻まない**（`run: null` は出力しない）。これにより `metrics.py` は当該 record を legacy（run メタ未計装・集計対象外の正常レコード）に分類し、invalid_run_meta（run メタを主張するが run_id が falsy＝要注意）へ誤計上しない。
 
 ```text
 run:
@@ -180,7 +180,7 @@ run:
 | `w_check.model_c` | C/D 時のみ | Model C の判定 |
 | `w_check.model_d` | C/D 時のみ | Model D の判定 |
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
-| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。省略時は `null`。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
+| `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。**省略時はキー自体を刻まない**（`null` も出力しない → metrics で legacy 分類）。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
 | `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
 | `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -149,7 +149,7 @@ w_check:
 ```text
 run:
   run_id:        run-022（run 単位の連番識別子。非空 string 必須）
-  round_index:   1（同一 run 内の再試行回数。0 起点。int 必須・bool 不可）
+  round_index:   1（初回呼び出し=1、再試行ごとに +1。**1 起点**。int 必須・bool 不可。metrics は round_index==1 を初回 sentinel として first_pass を判定するため 0 起点は不可）
   task_id:       TASK-XXXX（対象 PBI 識別子。string 必須）
   repair_action: reject 指摘に基づき修正（再試行時のみ・任意・string）
 ```
@@ -182,7 +182,7 @@ run:
 | `w_check.reject_category` | model_b=reject 時のみ（omit 方式） | reject 理由カテゴリ（severity 分類の入力元。model_b=approve 時はキー自体を省略） |
 | `run` | 任意（#780 追加・additive） | 呼び出し側入力の run メタをそのまま刻む。**省略時はキー自体を刻まない**（`null` も出力しない → metrics で legacy 分類）。`scripts/ai-loop/metrics.py`（#812）の run 単位集計（first-pass rate 等）の入力契約 |
 | `run.run_id` | run 提供時のみ | 非空 string（run 単位の連番識別子。空文字・空白のみは入力エラー） |
-| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。同一 run 内の再試行回数（0 起点） |
+| `run.round_index` | run 提供時のみ | int（bool 不可・必須）。**1 起点**（初回呼び出し=1、再試行ごとに +1）。`metrics.py` は round_index==1 を初回ラウンドの sentinel として first_pass を判定するため、0 起点にすると成功 run が恒久的に first_pass 分子から漏れる |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
 | `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -513,8 +513,8 @@ def validate_input(data: Any) -> dict[str, Any]:
         )
         task_id = run.get("task_id")
         _require(
-            isinstance(task_id, str),
-            "run.task_id は string である必要があります",
+            isinstance(task_id, str) and task_id.strip() != "",
+            "run.task_id は非空の string である必要があります",
         )
         repair_action = run.get("repair_action")
         _require(

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -40,7 +40,7 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "round_index": int,             #   bool 不可・必須（run 提供時）
         "task_id": str,
         "repair_action": str            #   任意（再試行時のみ）
-      } | null                          # 省略時は provenance に "run": null として刻む
+      } | 省略可                        # 省略時は provenance に run キー自体を刻まない（null も出さない）
     }
 
 `allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
@@ -53,7 +53,9 @@ I-1 不変条件）。
 `run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
 provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
 集計（first-pass rate 等）に用いる。省略可・後方互換（既存呼び出しを壊さない）。
-gate 挙動は変えないため POLICY_REF のバージョンは進めない。
+**省略時は provenance に `run` キー自体を刻まない**（`"run": null` を出さない）ため、
+metrics.py は当該 record を legacy（run メタ未計装）に分類し invalid_run_meta へ
+誤計上しない。gate 挙動は変えないため POLICY_REF のバージョンは進めない。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -559,9 +561,13 @@ def build_provenance(
 
     `run`（#780 Slice D 後半 追加・additive・任意）: 呼び出し側入力の
     `run`（{run_id, round_index, task_id, repair_action?}）をそのまま刻む。
-    省略時は None（`"run": null` として出力）。metrics.py（#812）が
-    run 単位の集計（first-pass rate 等）に用いる。gate 挙動（POLICY_REF）は
-    変えない純粋な additive provenance 拡張。
+    **run が None（未指定）のときは `run` キー自体を刻まない**（`"run": null` は
+    出力しない）。これにより metrics.py（#812）は当該 record を legacy（run メタ
+    未計装・集計対象外の正常レコード）に分類でき、invalid_run_meta（run メタを
+    主張するが run_id が falsy＝要注意）への誤計上を避けられる。run が与えられた
+    ときのみ 4 サブフィールドを刻む。metrics.py が run 単位の集計（first-pass
+    rate 等）に用いる。gate 挙動（POLICY_REF）は変えない純粋な additive
+    provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -573,7 +579,7 @@ def build_provenance(
     if model_b == "reject" and reject_category is not None:
         w_check["reject_category"] = reject_category
 
-    return {
+    provenance: dict[str, Any] = {
         "decision": decision,
         "issued_by": ISSUED_BY,
         "policy_ref": POLICY_REF,
@@ -585,9 +591,14 @@ def build_provenance(
         "scope_check": scope_check,
         "ho_paths_source": ho_paths_source,
         "ho_pattern_count": ho_pattern_count,
-        "run": run,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    # run 未指定時は `run` キー自体を省略する（`"run": null` を出さない）。
+    # metrics.py の legacy（キー欠落）/ invalid_run_meta（キー有だが run_id falsy）
+    # 分類において、未計装を legacy に落とすため（#780 コーディネータ指摘）。
+    if run is not None:
+        provenance["run"] = run
+    return provenance
 
 
 def arbitrate(

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -34,7 +34,13 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "model_c": "approve" | "reject" | null,
         "model_d": "approve" | "reject" | null
       },
-      "target_sha": str
+      "target_sha": str,
+      "run": {                          # 任意（#780 Slice D 後半 追加・additive）
+        "run_id": str,                  #   非空 string（run 単位の連番識別子）
+        "round_index": int,             #   bool 不可・必須（run 提供時）
+        "task_id": str,
+        "repair_action": str            #   任意（再試行時のみ）
+      } | null                          # 省略時は provenance に "run": null として刻む
     }
 
 `allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
@@ -43,6 +49,11 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
 allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
 I-1 不変条件）。
+
+`run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
+provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
+集計（first-pass rate 等）に用いる。省略可・後方互換（既存呼び出しを壊さない）。
+gate 挙動は変えないため POLICY_REF のバージョンは進めない。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -486,6 +497,29 @@ def validate_input(data: Any) -> dict[str, Any]:
     target_sha = data.get("target_sha")
     _require(isinstance(target_sha, str) and target_sha != "", "target_sha は非空の string である必要があります")
 
+    run = data.get("run")
+    if run is not None:
+        _require(isinstance(run, dict), "run は object または省略である必要があります")
+        run_id = run.get("run_id")
+        _require(
+            isinstance(run_id, str) and run_id.strip() != "",
+            "run.run_id は非空の string である必要があります",
+        )
+        _require(
+            "round_index" in run and type(run.get("round_index")) is int,
+            "run.round_index は int である必要があります（bool 不可・必須）",
+        )
+        task_id = run.get("task_id")
+        _require(
+            isinstance(task_id, str),
+            "run.task_id は string である必要があります",
+        )
+        repair_action = run.get("repair_action")
+        _require(
+            repair_action is None or isinstance(repair_action, str),
+            "run.repair_action は string または省略である必要があります",
+        )
+
     return data
 
 
@@ -505,6 +539,7 @@ def build_provenance(
     scope_check: str = "not_evaluated",
     ho_paths_source: str | None = None,
     ho_pattern_count: int = 0,
+    run: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
@@ -521,6 +556,12 @@ def build_provenance(
     None）。`ho_pattern_count`（#809 追加）: 解決した HO パターン抽出件数。
     「boundary=clean だが ho_pattern_count=1」のような過少網羅を監査で
     検知できるようにする（fail-closed 閾値そのものは 0 のまま — 可視化に留める）。
+
+    `run`（#780 Slice D 後半 追加・additive・任意）: 呼び出し側入力の
+    `run`（{run_id, round_index, task_id, repair_action?}）をそのまま刻む。
+    省略時は None（`"run": null` として出力）。metrics.py（#812）が
+    run 単位の集計（first-pass rate 等）に用いる。gate 挙動（POLICY_REF）は
+    変えない純粋な additive provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -544,6 +585,7 @@ def build_provenance(
         "scope_check": scope_check,
         "ho_paths_source": ho_paths_source,
         "ho_pattern_count": ho_pattern_count,
+        "run": run,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
@@ -577,6 +619,7 @@ def arbitrate(
     model_c: str | None = verdicts.get("model_c")
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
+    run: dict[str, Any] | None = data.get("run")
 
     lite_result = lite_check(lite_input)
 
@@ -595,6 +638,7 @@ def arbitrate(
             reject_category=reject_category,
             ho_paths_source=ho_source,
             ho_pattern_count=ho_pattern_count,
+            run=run,
             **kw,
         )
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/metrics.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/metrics.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""metrics.py — ai-loop 計測基盤: decision record 集計スクリプト。
+
+適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ。
+PlanGate 本番フロー（bin/plangate・scripts/hooks/）からは一切呼ばれない
+隔離 PoC スクリプト（arbiter.py と同じ位置付け）。
+
+入力: docs/working/ai-loop-runs/*.json（arbiter.py が発行する裁定 record）。
+現行スキーマのキー: boundary_check / class_check / decision / issued_by /
+lite_check / policy_ref / target_sha / timestamp / w_check。
+
+将来スキーマ（#809 後に arbiter が刻印予定・additive）: 任意フィールド
+`run` = {"run_id": str, "round_index": int, "task_id": str,
+"repair_action": str（再試行時のみ・1 行）}。
+
+record の分類（無言の合算・無言の除外の両方を禁止）:
+- legacy: `run` フィールドの無い record。集計母数から除外し、除外件数を
+  legacy_count として必ず出力へ明示する
+- invalid run meta: `run` フィールドはあるが run_id が非空文字列でない
+  record（None / "" / 空白のみ / 非 str）。run として集約せず
+  invalid_run_meta_count として明示する（falsy run_id の誤集約により
+  first-pass rate が歪むことを防ぐ）
+- skipped: 破損 JSON / スキーマ外 / round_index の型不正（int 以外。
+  bool も不正扱い）。skip 理由と件数を出力に含める（fail-silent 禁止）。
+  round_index の型不正は当該 record のみ除外し、run 全体は残す
+- run record: 上記以外。run_id 単位に集約し round_index 昇順に並べる。
+  round_index 欠落は 0 として扱う（sort 上は先頭に来るが、first_pass 判定
+  は round_index == 1 の record を明示探索するため、欠落 record が sort
+  先頭にあっても first_pass 判定に影響しない）
+
+first_pass 導出: 各 run について round_index == 1 の record を明示探索し、
+それが decision == "AUTO_APPROVED" なら first_pass=true。round_index == 1
+の record が存在しない run は first_pass 分子に加算しない（「round 1 が
+無い run は first-pass ではない」）。ただし run 単位の分母には含める。
+
+同一 run 内で round_index が重複した場合は warnings 配列
+（例: "run-X: duplicate round_index 1"）として明示し、集計は継続する。
+
+本モジュールは python3 標準ライブラリのみに依存する（外部依存なし）。
+
+CLI:
+    python3 scripts/ai-loop/metrics.py [--runs-dir docs/working/ai-loop-runs]
+        [--format md|json]
+
+exit code:
+    0 = 正常（skip / warning があっても 0）
+    1 = 入力ディレクトリ不在等の明示エラー（stderr にメッセージ必須）
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def _load_records(
+    runs_dir: Path,
+) -> tuple[list[tuple[str, dict[str, Any]]], list[dict[str, str]]]:
+    """runs_dir 配下の *.json を読み込む。
+
+    戻り値: ((file_path, record) のリスト, skip した file の {file, reason} のリスト)。
+    破損 JSON・非 dict のトップレベル値・decision 欠落は skip する
+    （fail-silent 禁止で理由を記録）。
+
+    ディレクトリ探索は Path.glob を使う（glob.glob(str(...)) は runs_dir パスに
+    ブラケット等の glob 特殊文字が含まれるとワイルドカードとして誤解釈される）。
+    """
+    entries: list[tuple[str, dict[str, Any]]] = []
+    skipped: list[dict[str, str]] = []
+
+    for path in sorted(runs_dir.glob("*.json")):
+        file_path = str(path)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            skipped.append({"file": file_path, "reason": f"JSON parse error: {exc}"})
+            continue
+
+        if not isinstance(data, dict):
+            skipped.append(
+                {"file": file_path, "reason": "top-level JSON value is not an object"}
+            )
+            continue
+
+        if "decision" not in data:
+            skipped.append(
+                {"file": file_path, "reason": "missing required key 'decision'"}
+            )
+            continue
+
+        entries.append((file_path, data))
+
+    return entries, skipped
+
+
+def _has_valid_run_id(run_meta: Any) -> bool:
+    """run メタが有効な run_id（非空文字列）を持つかを判定する。
+
+    run_id が None / "" / 空白のみ / 非 str の場合は False（invalid run meta）。
+    """
+    if not isinstance(run_meta, dict):
+        return False
+    run_id = run_meta.get("run_id")
+    return isinstance(run_id, str) and run_id.strip() != ""
+
+
+def _has_valid_round_index(run_meta: dict[str, Any]) -> bool:
+    """round_index が妥当（欠落 or 厳密な int）かを判定する。
+
+    bool は int のサブクラスだが round_index として不正（type(x) is int で除外）。
+    """
+    if "round_index" not in run_meta:
+        return True  # 欠落は 0 扱いで許容（module docstring 参照）
+    return type(run_meta["round_index"]) is int
+
+
+def _group_by_run(
+    records: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """run_id ごとに record をグルーピングし、round_index 昇順に並べる。
+
+    呼び出し前に round_index の型検証（_has_valid_round_index）が済んでいる
+    前提（int のみ。欠落は 0 扱い）。
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        run_id = record["run"]["run_id"]
+        grouped.setdefault(run_id, []).append(record)
+
+    for run_id, run_records in grouped.items():
+        run_records.sort(key=lambda r: r["run"].get("round_index", 0))
+
+    return grouped
+
+
+def collect(runs_dir: Path) -> dict[str, Any]:
+    """runs_dir 配下の decision record を集計する。
+
+    仕様:
+    - run グルーピング: 有効な run_id（非空文字列）を持つ record を run 単位に
+      集約（round_index 昇順）
+    - first_pass 導出: 各 run で round_index == 1 の record を明示探索し、
+      それが decision == "AUTO_APPROVED" なら first_pass=true（集計側で計算・
+      record には刻印しない）。round_index == 1 が存在しない run は分子に
+      入れないが分母には含める
+    - failure_category: reject ラウンドの w_check.reject_category（存在すれば）
+      を分類キーに使う（新フィールドは発明しない）
+    - legacy / invalid run meta / skipped の分類は module docstring 参照。
+      いずれも件数を出力へ明示する（無言の合算・無言の除外の両方を禁止）
+    - 同一 run 内の round_index 重複は warnings として明示し集計は継続する
+    """
+    entries, skipped = _load_records(runs_dir)
+
+    legacy_records: list[dict[str, Any]] = []
+    invalid_meta_records: list[dict[str, Any]] = []
+    run_records: list[dict[str, Any]] = []
+
+    for file_path, record in entries:
+        if "run" not in record:
+            legacy_records.append(record)
+            continue
+        if not _has_valid_run_id(record.get("run")):
+            invalid_meta_records.append(record)
+            continue
+        if not _has_valid_round_index(record["run"]):
+            bad_value = record["run"]["round_index"]
+            skipped.append(
+                {
+                    "file": file_path,
+                    "reason": (
+                        "invalid round_index type: "
+                        f"{type(bad_value).__name__} ({bad_value!r}) — int のみ許容"
+                    ),
+                }
+            )
+            continue
+        run_records.append(record)
+
+    grouped = _group_by_run(run_records)
+
+    decision_counts: Counter[str] = Counter()
+    round_distribution: Counter[int] = Counter()
+    failure_category_breakdown: Counter[str] = Counter()
+    warnings: list[str] = []
+    first_pass_numerator = 0
+    first_pass_denominator = 0
+
+    for run_id, rounds in grouped.items():
+        round_distribution[len(rounds)] += 1
+        first_pass_denominator += 1
+
+        # 同一 run 内の round_index 重複検知（round 数の過大計上を明示）
+        index_counter = Counter(r["run"].get("round_index", 0) for r in rounds)
+        for index_value, count in sorted(index_counter.items()):
+            if count > 1:
+                warnings.append(f"{run_id}: duplicate round_index {index_value}")
+
+        # first_pass 判定は sort 先頭でなく round_index == 1 を明示探索する
+        # （round_index 欠落=0 扱いの record が sort 先頭に来ても取りこぼさない）
+        first_round = next(
+            (r for r in rounds if r["run"].get("round_index") == 1), None
+        )
+        if first_round is not None and first_round.get("decision") == "AUTO_APPROVED":
+            first_pass_numerator += 1
+
+        for rec in rounds:
+            decision_counts[rec.get("decision", "UNKNOWN")] += 1
+            if rec.get("decision") != "AUTO_APPROVED":
+                w_check = rec.get("w_check")
+                category = None
+                if isinstance(w_check, dict):
+                    category = w_check.get("reject_category")
+                if category:
+                    failure_category_breakdown[category] += 1
+
+    # legacy / invalid run meta も decision 別件数には反映する（総件数の可視性
+    # を保つため）。ただし first-pass rate 等の run 単位指標には一切含めない。
+    for rec in legacy_records + invalid_meta_records:
+        decision_counts[rec.get("decision", "UNKNOWN")] += 1
+
+    rate = (
+        first_pass_numerator / first_pass_denominator
+        if first_pass_denominator > 0
+        else None
+    )
+
+    return {
+        "total_records": len(legacy_records)
+        + len(invalid_meta_records)
+        + len(run_records),
+        "legacy_count": len(legacy_records),
+        "invalid_run_meta_count": len(invalid_meta_records),
+        "run_count": len(grouped),
+        "first_pass": {
+            "numerator": first_pass_numerator,
+            "denominator": first_pass_denominator,
+            "rate": rate,
+        },
+        "decision_counts": dict(decision_counts),
+        "round_distribution": dict(round_distribution),
+        "failure_category_breakdown": dict(failure_category_breakdown),
+        "warnings": warnings,
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """report を Markdown 形式にレンダリングする。"""
+    lines: list[str] = []
+    lines.append("# ai-loop metrics report")
+    lines.append("")
+    lines.append(f"- total records: {report['total_records']}")
+    lines.append(
+        f"- legacy record {report['legacy_count']} 件（run メタ無し・集計対象外）"
+    )
+    lines.append(
+        f"- invalid run meta {report['invalid_run_meta_count']} 件"
+        "（run_id が非空文字列でない・run 集計対象外）"
+    )
+    lines.append(f"- run 数: {report['run_count']}")
+
+    fp = report["first_pass"]
+    if fp["denominator"] > 0:
+        rate_pct = fp["rate"] * 100
+        lines.append(
+            f"- first-pass rate: {fp['numerator']}/{fp['denominator']}"
+            f" ({rate_pct:.1f}%)（run メタ有り run のみ・分母={fp['denominator']}）"
+        )
+    else:
+        lines.append(
+            "- first-pass rate: N/A（run メタ有り record が 0 件のため算出不可・分母=0）"
+        )
+
+    lines.append("")
+    lines.append("## decision 別件数")
+    if report["decision_counts"]:
+        for decision, count in sorted(report["decision_counts"].items()):
+            lines.append(f"- {decision}: {count}")
+    else:
+        lines.append("- (該当データなし)")
+
+    lines.append("")
+    lines.append("## run あたり round 数分布")
+    if report["round_distribution"]:
+        for rounds, count in sorted(report["round_distribution"].items()):
+            lines.append(f"- {rounds} round: {count} run")
+    else:
+        lines.append("- (該当データなし・run メタ有り record が 0 件)")
+
+    lines.append("")
+    lines.append("## failure_category 内訳")
+    if report["failure_category_breakdown"]:
+        for category, count in sorted(report["failure_category_breakdown"].items()):
+            lines.append(f"- {category}: {count}")
+    else:
+        lines.append("- (該当データなし)")
+
+    if report["warnings"]:
+        lines.append("")
+        lines.append("## warnings")
+        for warning in report["warnings"]:
+            lines.append(f"- {warning}")
+
+    lines.append("")
+    lines.append("## skip 件数")
+    lines.append(f"- skipped: {report['skipped_count']} 件")
+    for item in report["skipped"]:
+        lines.append(f"  - {item['file']}: {item['reason']}")
+
+    return "\n".join(lines)
+
+
+def render_json(report: dict[str, Any]) -> str:
+    """report を JSON 文字列にレンダリングする。"""
+    return json.dumps(report, ensure_ascii=False, indent=2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="ai-loop decision record 集計スクリプト（stdlib のみ）"
+    )
+    parser.add_argument(
+        "--runs-dir",
+        default="docs/working/ai-loop-runs",
+        help="decision record (*.json) が置かれたディレクトリ（default: %(default)s）",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("md", "json"),
+        default="md",
+        help="出力形式（default: %(default)s）",
+    )
+    args = parser.parse_args(argv)
+
+    runs_dir = Path(args.runs_dir)
+    if not runs_dir.is_dir():
+        print(
+            f"ERROR: --runs-dir が存在しないディレクトリです: {runs_dir}",
+            file=sys.stderr,
+        )
+        return 1
+
+    report = collect(runs_dir)
+
+    if args.format == "json":
+        print(render_json(report))
+    else:
+        print(render_markdown(report))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1111,11 +1111,14 @@ class RunMetaProvenanceTests(unittest.TestCase):
 
     RUN_META = {"run_id": "run-999", "round_index": 1, "task_id": "TASK-0780"}
 
-    def test_run_absent_yields_null(self):
+    def test_run_absent_omits_run_key(self):
+        """入力に run が無いときは provenance に run キー自体を刻まない
+        （`run: null` を出さない）。metrics.py がこれを legacy（run キー欠落）に
+        正しく分類できるようにするため（invalid_run_meta 誤計上の回避）。"""
         data = _base_input()
         self.assertNotIn("run", data)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertIsNone(provenance["run"])
+        self.assertNotIn("run", provenance)
 
     def test_priority0_fail_closed_carries_run(self):
         data = _base_input(run=self.RUN_META)
@@ -1261,22 +1264,18 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
         self.assertEqual(report["first_pass"]["denominator"], 1)
         self.assertEqual(report["first_pass"]["rate"], 1.0)
 
-    def test_run_input_omitted_yields_explicit_null_classified_as_invalid_run_meta(self):
-        """入力に run が無い呼び出しは record に `"run": null` を刻む（欠落ではない）。
-
-        metrics.py の分類基準（module docstring）では legacy は「run キー自体が
-        無い record」（#780 以前に発行された真の旧 record）専用であり、
-        `"run": null` は run キーが存在するが run_id が無効（None）なため
-        invalid_run_meta に分類される（legacy とは別カウント）。この区別により
-        「#780 以降に arbiter を run メタ無しで呼んだ」ケースと「#780 より前の
-        本当の旧 record」を metrics 側で判別できる。
-        """
+    def test_run_omitted_record_is_classified_as_legacy_not_invalid_run_meta(self):
+        """入力に run が無い後方互換呼び出しは provenance に run キーを刻まない
+        （`run: null` を出さない）。これにより metrics.py は当該 record を
+        legacy（run メタ未計装・集計対象外の正常レコード）に分類し、
+        invalid_run_meta（run メタを主張するが run_id が falsy＝要注意）には
+        入れない。未計装が要注意カテゴリに水増しされる問題（#780 コーディネータ
+        指摘）を防ぐ。"""
         legacy = _base_input()
         self.assertNotIn("run", legacy)
         arbiter.validate_input(legacy)
         prov_legacy, _ = arbiter.arbitrate(legacy)
-        self.assertIsNone(prov_legacy["run"])
-        self.assertIn("run", prov_legacy)  # キー自体は常に存在する（欠落ではなく null）
+        self.assertNotIn("run", prov_legacy)  # run キーは刻まれない（null でもない）
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)
@@ -1284,30 +1283,11 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
 
             report = self.metrics.collect(tmp_path)
 
-        self.assertEqual(report["legacy_count"], 0)
-        self.assertEqual(report["invalid_run_meta_count"], 1)
-        self.assertEqual(report["run_count"], 0)
-        self.assertEqual(report["first_pass"]["denominator"], 0)
-        self.assertIsNone(report["first_pass"]["rate"])
-
-    def test_true_legacy_record_missing_run_key_entirely_is_classified_as_legacy(self):
-        """`run` キー自体が存在しない真の legacy record（#780 以前）は legacy_count に入る。"""
-        prov_legacy, _ = arbiter.arbitrate(_base_input())
-        record_without_run_key = dict(prov_legacy)
-        del record_without_run_key["run"]
-        self.assertNotIn("run", record_without_run_key)
-
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = pathlib.Path(tmp)
-            (tmp_path / "true-legacy.json").write_text(
-                json.dumps(record_without_run_key), encoding="utf-8"
-            )
-
-            report = self.metrics.collect(tmp_path)
-
         self.assertEqual(report["legacy_count"], 1)
         self.assertEqual(report["invalid_run_meta_count"], 0)
         self.assertEqual(report["run_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 0)
+        self.assertIsNone(report["first_pass"]["rate"])
 
 
 class MainExitCodeTests(unittest.TestCase):

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1098,6 +1098,18 @@ class RunMetaValidationTests(unittest.TestCase):
         with self.assertRaises(arbiter.InputError):
             arbiter.validate_input(data)
 
+    def test_task_id_empty_string_raises(self):
+        """task_id は run_id と対称に非空 str 必須（空文字は exit 1 / gemini medium）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": ""})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_task_id_whitespace_only_raises(self):
+        """task_id 空白のみ（strip 後空）は非空要件を満たさず exit 1（gemini medium 実測是正）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": "   "})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
     def test_repair_action_non_string_raises(self):
         data = _base_input(
             run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780", "repair_action": 5}

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1032,6 +1032,284 @@ class GeminiSecurityHardeningTests(unittest.TestCase):
         self.assertIs(first, second)
 
 
+class RunMetaValidationTests(unittest.TestCase):
+    """#780 Slice D 後半: 入力 `run`（任意フィールド）のバリデーション。"""
+
+    def test_run_absent_passes_validation(self):
+        data = _base_input()
+        validated = arbiter.validate_input(data)
+        self.assertNotIn("run", validated)
+
+    def test_run_valid_without_repair_action_passes(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780"})
+        validated = arbiter.validate_input(data)
+        self.assertEqual(validated["run"]["run_id"], "run-001")
+
+    def test_run_valid_with_repair_action_passes(self):
+        data = _base_input(
+            run={
+                "run_id": "run-001",
+                "round_index": 2,
+                "task_id": "TASK-0780",
+                "repair_action": "reject 指摘に基づき修正",
+            }
+        )
+        validated = arbiter.validate_input(data)
+        self.assertEqual(validated["run"]["repair_action"], "reject 指摘に基づき修正")
+
+    def test_run_non_dict_raises(self):
+        data = _base_input(run="not-a-dict")
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_empty_string_raises(self):
+        data = _base_input(run={"run_id": "", "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_whitespace_only_raises(self):
+        data = _base_input(run={"run_id": "   ", "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_non_string_raises(self):
+        data = _base_input(run={"run_id": 123, "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_string_raises(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": "1", "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_bool_raises(self):
+        """round_index は bool を除外した厳密 int（bool は int のサブクラス）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": True, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_missing_raises(self):
+        data = _base_input(run={"run_id": "run-001", "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_task_id_int_raises(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": 780})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_repair_action_non_string_raises(self):
+        data = _base_input(
+            run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780", "repair_action": 5}
+        )
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+
+class RunMetaProvenanceTests(unittest.TestCase):
+    """#780 Slice D 後半: provenance への run 刻印（全裁定経路で additive に刻む）。"""
+
+    RUN_META = {"run_id": "run-999", "round_index": 1, "task_id": "TASK-0780"}
+
+    def test_run_absent_yields_null(self):
+        data = _base_input()
+        self.assertNotIn("run", data)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertIsNone(provenance["run"])
+
+    def test_priority0_fail_closed_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority1_touches_ho_carries_run(self):
+        data = _base_input(run=self.RUN_META, changed_files=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority1_5_scope_violation_carries_run(self):
+        data = _base_input(run=self.RUN_META, changed_files=["out/of/scope.md"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority2_lite_false_carries_run(self):
+        data = _base_input(
+            run=self.RUN_META,
+            lite={
+                "size_ok": False,
+                "no_new_design": True,
+                "follows_pattern": True,
+                "reversible": True,
+            },
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority3_merge_carries_run(self):
+        data = _base_input(run=self.RUN_META, **{"class": "merge"})
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority4_blocked_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "BLOCKED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority5_human_escalated_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"  # severity=major
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority5_cd_auto_approved_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"  # severity=minor
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority6_auto_approved_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_policy_ref_unchanged_when_run_present(self):
+        """run は additive provenance であり policy 改版ではない（@v1 据え置き）。"""
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+
+
+class ArbiterMetricsIntegrationTests(unittest.TestCase):
+    """#780 Slice D 後半の核心: arbiter が刻んだ run 付き record を実際に
+    metrics.py（#812 消費側）へ渡し、first_pass 判定が正しく機能することを実証する。
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import metrics as metrics_module  # noqa: E402  (sys.path は本ファイル冒頭で設定済み)
+
+        cls.metrics = metrics_module
+
+    def test_first_pass_false_when_round1_rejected_then_round2_auto_approved(self):
+        run_id = "run-780-int-reject-then-approve"
+
+        round1 = _base_input(run={"run_id": run_id, "round_index": 1, "task_id": "TASK-0780"})
+        round1["verdicts"]["model_a"] = "reject"
+        round1["verdicts"]["model_b"] = "reject"
+        arbiter.validate_input(round1)
+        prov1, _ = arbiter.arbitrate(round1)
+        self.assertEqual(prov1["decision"], "BLOCKED")
+
+        round2 = _base_input(
+            run={
+                "run_id": run_id,
+                "round_index": 2,
+                "task_id": "TASK-0780",
+                "repair_action": "reject 指摘（reject-reject）に基づき修正",
+            }
+        )
+        arbiter.validate_input(round2)
+        prov2, _ = arbiter.arbitrate(round2)
+        self.assertEqual(prov2["decision"], "AUTO_APPROVED")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "round1.json").write_text(json.dumps(prov1), encoding="utf-8")
+            (tmp_path / "round2.json").write_text(json.dumps(prov2), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["run_count"], 1)
+        self.assertEqual(report["legacy_count"], 0)
+        self.assertEqual(report["invalid_run_meta_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 1)
+        self.assertEqual(report["first_pass"]["numerator"], 0)
+        self.assertEqual(report["first_pass"]["rate"], 0.0)
+        self.assertEqual(report["round_distribution"], {2: 1})
+
+    def test_first_pass_true_when_round1_auto_approved(self):
+        run_id = "run-780-int-first-pass"
+
+        round1 = _base_input(run={"run_id": run_id, "round_index": 1, "task_id": "TASK-0780"})
+        arbiter.validate_input(round1)
+        prov1, _ = arbiter.arbitrate(round1)
+        self.assertEqual(prov1["decision"], "AUTO_APPROVED")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "round1.json").write_text(json.dumps(prov1), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["run_count"], 1)
+        self.assertEqual(report["first_pass"]["numerator"], 1)
+        self.assertEqual(report["first_pass"]["denominator"], 1)
+        self.assertEqual(report["first_pass"]["rate"], 1.0)
+
+    def test_run_input_omitted_yields_explicit_null_classified_as_invalid_run_meta(self):
+        """入力に run が無い呼び出しは record に `"run": null` を刻む（欠落ではない）。
+
+        metrics.py の分類基準（module docstring）では legacy は「run キー自体が
+        無い record」（#780 以前に発行された真の旧 record）専用であり、
+        `"run": null` は run キーが存在するが run_id が無効（None）なため
+        invalid_run_meta に分類される（legacy とは別カウント）。この区別により
+        「#780 以降に arbiter を run メタ無しで呼んだ」ケースと「#780 より前の
+        本当の旧 record」を metrics 側で判別できる。
+        """
+        legacy = _base_input()
+        self.assertNotIn("run", legacy)
+        arbiter.validate_input(legacy)
+        prov_legacy, _ = arbiter.arbitrate(legacy)
+        self.assertIsNone(prov_legacy["run"])
+        self.assertIn("run", prov_legacy)  # キー自体は常に存在する（欠落ではなく null）
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "no-run-input.json").write_text(json.dumps(prov_legacy), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["legacy_count"], 0)
+        self.assertEqual(report["invalid_run_meta_count"], 1)
+        self.assertEqual(report["run_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 0)
+        self.assertIsNone(report["first_pass"]["rate"])
+
+    def test_true_legacy_record_missing_run_key_entirely_is_classified_as_legacy(self):
+        """`run` キー自体が存在しない真の legacy record（#780 以前）は legacy_count に入る。"""
+        prov_legacy, _ = arbiter.arbitrate(_base_input())
+        record_without_run_key = dict(prov_legacy)
+        del record_without_run_key["run"]
+        self.assertNotIn("run", record_without_run_key)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "true-legacy.json").write_text(
+                json.dumps(record_without_run_key), encoding="utf-8"
+            )
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["legacy_count"], 1)
+        self.assertEqual(report["invalid_run_meta_count"], 0)
+        self.assertEqual(report["run_count"], 0)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1289,6 +1289,44 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
         self.assertEqual(report["first_pass"]["denominator"], 0)
         self.assertIsNone(report["first_pass"]["rate"])
 
+    def test_round_index_origin_contract_1_counts_0_does_not(self):
+        """round_index 起点契約の回帰固定（レビュー major 反映）。
+
+        metrics.py（変更禁止・#812）は round_index==1 を初回ラウンドの sentinel
+        として first_pass を判定する（`next(r for r in rounds if
+        r["run"].get("round_index") == 1)`）。したがって呼び出し側は初回に
+        round_index=1 を刻まねばならず、doc が誤って「0 起点」を指示すると
+        成功 run が恒久的に first_pass 分子から漏れる（サイレント過小集計）。
+
+        arbiter は round_index の値をそのまま刻む（int 検証のみ）ため、この
+        テストは arbiter→metrics の実経路で「1 起点=分子に入る / 0 起点=入らない」
+        を明示アサートし、doc/実装契約の再ズレを検知する。"""
+        # 起点=1 の AUTO record 単独 → first_pass 分子に入る
+        r1 = _base_input(run={"run_id": "run-origin-1", "round_index": 1, "task_id": "TASK-0780"})
+        arbiter.validate_input(r1)
+        prov1, _ = arbiter.arbitrate(r1)
+        self.assertEqual(prov1["decision"], "AUTO_APPROVED")
+        self.assertEqual(prov1["run"]["round_index"], 1)
+
+        # 起点=0 の AUTO record 単独（0 起点の初回を模擬）→ 分子に入らない
+        r0 = _base_input(run={"run_id": "run-origin-0", "round_index": 0, "task_id": "TASK-0780"})
+        arbiter.validate_input(r0)
+        prov0, _ = arbiter.arbitrate(r0)
+        self.assertEqual(prov0["decision"], "AUTO_APPROVED")
+        self.assertEqual(prov0["run"]["round_index"], 0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "origin-1.json").write_text(json.dumps(prov1), encoding="utf-8")
+            (tmp_path / "origin-0.json").write_text(json.dumps(prov0), encoding="utf-8")
+            report = self.metrics.collect(tmp_path)
+
+        # 2 run とも分母（run 単位）には入るが、分子は round_index==1 の run のみ
+        self.assertEqual(report["run_count"], 2)
+        self.assertEqual(report["first_pass"]["denominator"], 2)
+        self.assertEqual(report["first_pass"]["numerator"], 1)
+        self.assertEqual(report["first_pass"]["rate"], 0.5)
+
 
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -513,8 +513,8 @@ def validate_input(data: Any) -> dict[str, Any]:
         )
         task_id = run.get("task_id")
         _require(
-            isinstance(task_id, str),
-            "run.task_id は string である必要があります",
+            isinstance(task_id, str) and task_id.strip() != "",
+            "run.task_id は非空の string である必要があります",
         )
         repair_action = run.get("repair_action")
         _require(

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -40,7 +40,7 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "round_index": int,             #   bool 不可・必須（run 提供時）
         "task_id": str,
         "repair_action": str            #   任意（再試行時のみ）
-      } | null                          # 省略時は provenance に "run": null として刻む
+      } | 省略可                        # 省略時は provenance に run キー自体を刻まない（null も出さない）
     }
 
 `allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
@@ -53,7 +53,9 @@ I-1 不変条件）。
 `run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
 provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
 集計（first-pass rate 等）に用いる。省略可・後方互換（既存呼び出しを壊さない）。
-gate 挙動は変えないため POLICY_REF のバージョンは進めない。
+**省略時は provenance に `run` キー自体を刻まない**（`"run": null` を出さない）ため、
+metrics.py は当該 record を legacy（run メタ未計装）に分類し invalid_run_meta へ
+誤計上しない。gate 挙動は変えないため POLICY_REF のバージョンは進めない。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -559,9 +561,13 @@ def build_provenance(
 
     `run`（#780 Slice D 後半 追加・additive・任意）: 呼び出し側入力の
     `run`（{run_id, round_index, task_id, repair_action?}）をそのまま刻む。
-    省略時は None（`"run": null` として出力）。metrics.py（#812）が
-    run 単位の集計（first-pass rate 等）に用いる。gate 挙動（POLICY_REF）は
-    変えない純粋な additive provenance 拡張。
+    **run が None（未指定）のときは `run` キー自体を刻まない**（`"run": null` は
+    出力しない）。これにより metrics.py（#812）は当該 record を legacy（run メタ
+    未計装・集計対象外の正常レコード）に分類でき、invalid_run_meta（run メタを
+    主張するが run_id が falsy＝要注意）への誤計上を避けられる。run が与えられた
+    ときのみ 4 サブフィールドを刻む。metrics.py が run 単位の集計（first-pass
+    rate 等）に用いる。gate 挙動（POLICY_REF）は変えない純粋な additive
+    provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -573,7 +579,7 @@ def build_provenance(
     if model_b == "reject" and reject_category is not None:
         w_check["reject_category"] = reject_category
 
-    return {
+    provenance: dict[str, Any] = {
         "decision": decision,
         "issued_by": ISSUED_BY,
         "policy_ref": POLICY_REF,
@@ -585,9 +591,14 @@ def build_provenance(
         "scope_check": scope_check,
         "ho_paths_source": ho_paths_source,
         "ho_pattern_count": ho_pattern_count,
-        "run": run,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    # run 未指定時は `run` キー自体を省略する（`"run": null` を出さない）。
+    # metrics.py の legacy（キー欠落）/ invalid_run_meta（キー有だが run_id falsy）
+    # 分類において、未計装を legacy に落とすため（#780 コーディネータ指摘）。
+    if run is not None:
+        provenance["run"] = run
+    return provenance
 
 
 def arbitrate(

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -34,7 +34,13 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "model_c": "approve" | "reject" | null,
         "model_d": "approve" | "reject" | null
       },
-      "target_sha": str
+      "target_sha": str,
+      "run": {                          # 任意（#780 Slice D 後半 追加・additive）
+        "run_id": str,                  #   非空 string（run 単位の連番識別子）
+        "round_index": int,             #   bool 不可・必須（run 提供時）
+        "task_id": str,
+        "repair_action": str            #   任意（再試行時のみ）
+      } | null                          # 省略時は provenance に "run": null として刻む
     }
 
 `allowed_paths` は LoopSpec `scope.allowed_paths`（既存必須フィールド）宣言を
@@ -43,6 +49,11 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
 allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
 I-1 不変条件）。
+
+`run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
+provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
+集計（first-pass rate 等）に用いる。省略可・後方互換（既存呼び出しを壊さない）。
+gate 挙動は変えないため POLICY_REF のバージョンは進めない。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -486,6 +497,29 @@ def validate_input(data: Any) -> dict[str, Any]:
     target_sha = data.get("target_sha")
     _require(isinstance(target_sha, str) and target_sha != "", "target_sha は非空の string である必要があります")
 
+    run = data.get("run")
+    if run is not None:
+        _require(isinstance(run, dict), "run は object または省略である必要があります")
+        run_id = run.get("run_id")
+        _require(
+            isinstance(run_id, str) and run_id.strip() != "",
+            "run.run_id は非空の string である必要があります",
+        )
+        _require(
+            "round_index" in run and type(run.get("round_index")) is int,
+            "run.round_index は int である必要があります（bool 不可・必須）",
+        )
+        task_id = run.get("task_id")
+        _require(
+            isinstance(task_id, str),
+            "run.task_id は string である必要があります",
+        )
+        repair_action = run.get("repair_action")
+        _require(
+            repair_action is None or isinstance(repair_action, str),
+            "run.repair_action は string または省略である必要があります",
+        )
+
     return data
 
 
@@ -505,6 +539,7 @@ def build_provenance(
     scope_check: str = "not_evaluated",
     ho_paths_source: str | None = None,
     ho_pattern_count: int = 0,
+    run: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
@@ -521,6 +556,12 @@ def build_provenance(
     None）。`ho_pattern_count`（#809 追加）: 解決した HO パターン抽出件数。
     「boundary=clean だが ho_pattern_count=1」のような過少網羅を監査で
     検知できるようにする（fail-closed 閾値そのものは 0 のまま — 可視化に留める）。
+
+    `run`（#780 Slice D 後半 追加・additive・任意）: 呼び出し側入力の
+    `run`（{run_id, round_index, task_id, repair_action?}）をそのまま刻む。
+    省略時は None（`"run": null` として出力）。metrics.py（#812）が
+    run 単位の集計（first-pass rate 等）に用いる。gate 挙動（POLICY_REF）は
+    変えない純粋な additive provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -544,6 +585,7 @@ def build_provenance(
         "scope_check": scope_check,
         "ho_paths_source": ho_paths_source,
         "ho_pattern_count": ho_pattern_count,
+        "run": run,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
@@ -577,6 +619,7 @@ def arbitrate(
     model_c: str | None = verdicts.get("model_c")
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
+    run: dict[str, Any] | None = data.get("run")
 
     lite_result = lite_check(lite_input)
 
@@ -595,6 +638,7 @@ def arbitrate(
             reject_category=reject_category,
             ho_paths_source=ho_source,
             ho_pattern_count=ho_pattern_count,
+            run=run,
             **kw,
         )
 

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1111,11 +1111,14 @@ class RunMetaProvenanceTests(unittest.TestCase):
 
     RUN_META = {"run_id": "run-999", "round_index": 1, "task_id": "TASK-0780"}
 
-    def test_run_absent_yields_null(self):
+    def test_run_absent_omits_run_key(self):
+        """入力に run が無いときは provenance に run キー自体を刻まない
+        （`run: null` を出さない）。metrics.py がこれを legacy（run キー欠落）に
+        正しく分類できるようにするため（invalid_run_meta 誤計上の回避）。"""
         data = _base_input()
         self.assertNotIn("run", data)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertIsNone(provenance["run"])
+        self.assertNotIn("run", provenance)
 
     def test_priority0_fail_closed_carries_run(self):
         data = _base_input(run=self.RUN_META)
@@ -1261,22 +1264,18 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
         self.assertEqual(report["first_pass"]["denominator"], 1)
         self.assertEqual(report["first_pass"]["rate"], 1.0)
 
-    def test_run_input_omitted_yields_explicit_null_classified_as_invalid_run_meta(self):
-        """入力に run が無い呼び出しは record に `"run": null` を刻む（欠落ではない）。
-
-        metrics.py の分類基準（module docstring）では legacy は「run キー自体が
-        無い record」（#780 以前に発行された真の旧 record）専用であり、
-        `"run": null` は run キーが存在するが run_id が無効（None）なため
-        invalid_run_meta に分類される（legacy とは別カウント）。この区別により
-        「#780 以降に arbiter を run メタ無しで呼んだ」ケースと「#780 より前の
-        本当の旧 record」を metrics 側で判別できる。
-        """
+    def test_run_omitted_record_is_classified_as_legacy_not_invalid_run_meta(self):
+        """入力に run が無い後方互換呼び出しは provenance に run キーを刻まない
+        （`run: null` を出さない）。これにより metrics.py は当該 record を
+        legacy（run メタ未計装・集計対象外の正常レコード）に分類し、
+        invalid_run_meta（run メタを主張するが run_id が falsy＝要注意）には
+        入れない。未計装が要注意カテゴリに水増しされる問題（#780 コーディネータ
+        指摘）を防ぐ。"""
         legacy = _base_input()
         self.assertNotIn("run", legacy)
         arbiter.validate_input(legacy)
         prov_legacy, _ = arbiter.arbitrate(legacy)
-        self.assertIsNone(prov_legacy["run"])
-        self.assertIn("run", prov_legacy)  # キー自体は常に存在する（欠落ではなく null）
+        self.assertNotIn("run", prov_legacy)  # run キーは刻まれない（null でもない）
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = pathlib.Path(tmp)
@@ -1284,30 +1283,11 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
 
             report = self.metrics.collect(tmp_path)
 
-        self.assertEqual(report["legacy_count"], 0)
-        self.assertEqual(report["invalid_run_meta_count"], 1)
-        self.assertEqual(report["run_count"], 0)
-        self.assertEqual(report["first_pass"]["denominator"], 0)
-        self.assertIsNone(report["first_pass"]["rate"])
-
-    def test_true_legacy_record_missing_run_key_entirely_is_classified_as_legacy(self):
-        """`run` キー自体が存在しない真の legacy record（#780 以前）は legacy_count に入る。"""
-        prov_legacy, _ = arbiter.arbitrate(_base_input())
-        record_without_run_key = dict(prov_legacy)
-        del record_without_run_key["run"]
-        self.assertNotIn("run", record_without_run_key)
-
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = pathlib.Path(tmp)
-            (tmp_path / "true-legacy.json").write_text(
-                json.dumps(record_without_run_key), encoding="utf-8"
-            )
-
-            report = self.metrics.collect(tmp_path)
-
         self.assertEqual(report["legacy_count"], 1)
         self.assertEqual(report["invalid_run_meta_count"], 0)
         self.assertEqual(report["run_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 0)
+        self.assertIsNone(report["first_pass"]["rate"])
 
 
 class MainExitCodeTests(unittest.TestCase):

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1098,6 +1098,18 @@ class RunMetaValidationTests(unittest.TestCase):
         with self.assertRaises(arbiter.InputError):
             arbiter.validate_input(data)
 
+    def test_task_id_empty_string_raises(self):
+        """task_id は run_id と対称に非空 str 必須（空文字は exit 1 / gemini medium）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": ""})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_task_id_whitespace_only_raises(self):
+        """task_id 空白のみ（strip 後空）は非空要件を満たさず exit 1（gemini medium 実測是正）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": "   "})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
     def test_repair_action_non_string_raises(self):
         data = _base_input(
             run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780", "repair_action": 5}

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1032,6 +1032,284 @@ class GeminiSecurityHardeningTests(unittest.TestCase):
         self.assertIs(first, second)
 
 
+class RunMetaValidationTests(unittest.TestCase):
+    """#780 Slice D 後半: 入力 `run`（任意フィールド）のバリデーション。"""
+
+    def test_run_absent_passes_validation(self):
+        data = _base_input()
+        validated = arbiter.validate_input(data)
+        self.assertNotIn("run", validated)
+
+    def test_run_valid_without_repair_action_passes(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780"})
+        validated = arbiter.validate_input(data)
+        self.assertEqual(validated["run"]["run_id"], "run-001")
+
+    def test_run_valid_with_repair_action_passes(self):
+        data = _base_input(
+            run={
+                "run_id": "run-001",
+                "round_index": 2,
+                "task_id": "TASK-0780",
+                "repair_action": "reject 指摘に基づき修正",
+            }
+        )
+        validated = arbiter.validate_input(data)
+        self.assertEqual(validated["run"]["repair_action"], "reject 指摘に基づき修正")
+
+    def test_run_non_dict_raises(self):
+        data = _base_input(run="not-a-dict")
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_empty_string_raises(self):
+        data = _base_input(run={"run_id": "", "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_whitespace_only_raises(self):
+        data = _base_input(run={"run_id": "   ", "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_run_id_non_string_raises(self):
+        data = _base_input(run={"run_id": 123, "round_index": 1, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_string_raises(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": "1", "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_bool_raises(self):
+        """round_index は bool を除外した厳密 int（bool は int のサブクラス）。"""
+        data = _base_input(run={"run_id": "run-001", "round_index": True, "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_round_index_missing_raises(self):
+        data = _base_input(run={"run_id": "run-001", "task_id": "TASK-0780"})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_task_id_int_raises(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 1, "task_id": 780})
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+    def test_repair_action_non_string_raises(self):
+        data = _base_input(
+            run={"run_id": "run-001", "round_index": 1, "task_id": "TASK-0780", "repair_action": 5}
+        )
+        with self.assertRaises(arbiter.InputError):
+            arbiter.validate_input(data)
+
+
+class RunMetaProvenanceTests(unittest.TestCase):
+    """#780 Slice D 後半: provenance への run 刻印（全裁定経路で additive に刻む）。"""
+
+    RUN_META = {"run_id": "run-999", "round_index": 1, "task_id": "TASK-0780"}
+
+    def test_run_absent_yields_null(self):
+        data = _base_input()
+        self.assertNotIn("run", data)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertIsNone(provenance["run"])
+
+    def test_priority0_fail_closed_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority1_touches_ho_carries_run(self):
+        data = _base_input(run=self.RUN_META, changed_files=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority1_5_scope_violation_carries_run(self):
+        data = _base_input(run=self.RUN_META, changed_files=["out/of/scope.md"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority2_lite_false_carries_run(self):
+        data = _base_input(
+            run=self.RUN_META,
+            lite={
+                "size_ok": False,
+                "no_new_design": True,
+                "follows_pattern": True,
+                "reversible": True,
+            },
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority3_merge_carries_run(self):
+        data = _base_input(run=self.RUN_META, **{"class": "merge"})
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority4_blocked_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "BLOCKED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority5_human_escalated_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"  # severity=major
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority5_cd_auto_approved_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"  # severity=minor
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_priority6_auto_approved_carries_run(self):
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["run"], self.RUN_META)
+
+    def test_policy_ref_unchanged_when_run_present(self):
+        """run は additive provenance であり policy 改版ではない（@v1 据え置き）。"""
+        data = _base_input(run=self.RUN_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+
+
+class ArbiterMetricsIntegrationTests(unittest.TestCase):
+    """#780 Slice D 後半の核心: arbiter が刻んだ run 付き record を実際に
+    metrics.py（#812 消費側）へ渡し、first_pass 判定が正しく機能することを実証する。
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import metrics as metrics_module  # noqa: E402  (sys.path は本ファイル冒頭で設定済み)
+
+        cls.metrics = metrics_module
+
+    def test_first_pass_false_when_round1_rejected_then_round2_auto_approved(self):
+        run_id = "run-780-int-reject-then-approve"
+
+        round1 = _base_input(run={"run_id": run_id, "round_index": 1, "task_id": "TASK-0780"})
+        round1["verdicts"]["model_a"] = "reject"
+        round1["verdicts"]["model_b"] = "reject"
+        arbiter.validate_input(round1)
+        prov1, _ = arbiter.arbitrate(round1)
+        self.assertEqual(prov1["decision"], "BLOCKED")
+
+        round2 = _base_input(
+            run={
+                "run_id": run_id,
+                "round_index": 2,
+                "task_id": "TASK-0780",
+                "repair_action": "reject 指摘（reject-reject）に基づき修正",
+            }
+        )
+        arbiter.validate_input(round2)
+        prov2, _ = arbiter.arbitrate(round2)
+        self.assertEqual(prov2["decision"], "AUTO_APPROVED")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "round1.json").write_text(json.dumps(prov1), encoding="utf-8")
+            (tmp_path / "round2.json").write_text(json.dumps(prov2), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["run_count"], 1)
+        self.assertEqual(report["legacy_count"], 0)
+        self.assertEqual(report["invalid_run_meta_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 1)
+        self.assertEqual(report["first_pass"]["numerator"], 0)
+        self.assertEqual(report["first_pass"]["rate"], 0.0)
+        self.assertEqual(report["round_distribution"], {2: 1})
+
+    def test_first_pass_true_when_round1_auto_approved(self):
+        run_id = "run-780-int-first-pass"
+
+        round1 = _base_input(run={"run_id": run_id, "round_index": 1, "task_id": "TASK-0780"})
+        arbiter.validate_input(round1)
+        prov1, _ = arbiter.arbitrate(round1)
+        self.assertEqual(prov1["decision"], "AUTO_APPROVED")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "round1.json").write_text(json.dumps(prov1), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["run_count"], 1)
+        self.assertEqual(report["first_pass"]["numerator"], 1)
+        self.assertEqual(report["first_pass"]["denominator"], 1)
+        self.assertEqual(report["first_pass"]["rate"], 1.0)
+
+    def test_run_input_omitted_yields_explicit_null_classified_as_invalid_run_meta(self):
+        """入力に run が無い呼び出しは record に `"run": null` を刻む（欠落ではない）。
+
+        metrics.py の分類基準（module docstring）では legacy は「run キー自体が
+        無い record」（#780 以前に発行された真の旧 record）専用であり、
+        `"run": null` は run キーが存在するが run_id が無効（None）なため
+        invalid_run_meta に分類される（legacy とは別カウント）。この区別により
+        「#780 以降に arbiter を run メタ無しで呼んだ」ケースと「#780 より前の
+        本当の旧 record」を metrics 側で判別できる。
+        """
+        legacy = _base_input()
+        self.assertNotIn("run", legacy)
+        arbiter.validate_input(legacy)
+        prov_legacy, _ = arbiter.arbitrate(legacy)
+        self.assertIsNone(prov_legacy["run"])
+        self.assertIn("run", prov_legacy)  # キー自体は常に存在する（欠落ではなく null）
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "no-run-input.json").write_text(json.dumps(prov_legacy), encoding="utf-8")
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["legacy_count"], 0)
+        self.assertEqual(report["invalid_run_meta_count"], 1)
+        self.assertEqual(report["run_count"], 0)
+        self.assertEqual(report["first_pass"]["denominator"], 0)
+        self.assertIsNone(report["first_pass"]["rate"])
+
+    def test_true_legacy_record_missing_run_key_entirely_is_classified_as_legacy(self):
+        """`run` キー自体が存在しない真の legacy record（#780 以前）は legacy_count に入る。"""
+        prov_legacy, _ = arbiter.arbitrate(_base_input())
+        record_without_run_key = dict(prov_legacy)
+        del record_without_run_key["run"]
+        self.assertNotIn("run", record_without_run_key)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "true-legacy.json").write_text(
+                json.dumps(record_without_run_key), encoding="utf-8"
+            )
+
+            report = self.metrics.collect(tmp_path)
+
+        self.assertEqual(report["legacy_count"], 1)
+        self.assertEqual(report["invalid_run_meta_count"], 0)
+        self.assertEqual(report["run_count"], 0)
+
+
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""
 

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1289,6 +1289,44 @@ class ArbiterMetricsIntegrationTests(unittest.TestCase):
         self.assertEqual(report["first_pass"]["denominator"], 0)
         self.assertIsNone(report["first_pass"]["rate"])
 
+    def test_round_index_origin_contract_1_counts_0_does_not(self):
+        """round_index 起点契約の回帰固定（レビュー major 反映）。
+
+        metrics.py（変更禁止・#812）は round_index==1 を初回ラウンドの sentinel
+        として first_pass を判定する（`next(r for r in rounds if
+        r["run"].get("round_index") == 1)`）。したがって呼び出し側は初回に
+        round_index=1 を刻まねばならず、doc が誤って「0 起点」を指示すると
+        成功 run が恒久的に first_pass 分子から漏れる（サイレント過小集計）。
+
+        arbiter は round_index の値をそのまま刻む（int 検証のみ）ため、この
+        テストは arbiter→metrics の実経路で「1 起点=分子に入る / 0 起点=入らない」
+        を明示アサートし、doc/実装契約の再ズレを検知する。"""
+        # 起点=1 の AUTO record 単独 → first_pass 分子に入る
+        r1 = _base_input(run={"run_id": "run-origin-1", "round_index": 1, "task_id": "TASK-0780"})
+        arbiter.validate_input(r1)
+        prov1, _ = arbiter.arbitrate(r1)
+        self.assertEqual(prov1["decision"], "AUTO_APPROVED")
+        self.assertEqual(prov1["run"]["round_index"], 1)
+
+        # 起点=0 の AUTO record 単独（0 起点の初回を模擬）→ 分子に入らない
+        r0 = _base_input(run={"run_id": "run-origin-0", "round_index": 0, "task_id": "TASK-0780"})
+        arbiter.validate_input(r0)
+        prov0, _ = arbiter.arbitrate(r0)
+        self.assertEqual(prov0["decision"], "AUTO_APPROVED")
+        self.assertEqual(prov0["run"]["round_index"], 0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            (tmp_path / "origin-1.json").write_text(json.dumps(prov1), encoding="utf-8")
+            (tmp_path / "origin-0.json").write_text(json.dumps(prov0), encoding="utf-8")
+            report = self.metrics.collect(tmp_path)
+
+        # 2 run とも分母（run 単位）には入るが、分子は round_index==1 の run のみ
+        self.assertEqual(report["run_count"], 2)
+        self.assertEqual(report["first_pass"]["denominator"], 2)
+        self.assertEqual(report["first_pass"]["numerator"], 1)
+        self.assertEqual(report["first_pass"]["rate"], 0.5)
+
 
 class MainExitCodeTests(unittest.TestCase):
     """main() の exit code 契約（0/2/3/1）を stdin 経由で確認する。"""

--- a/scripts/sync-plugin-plangate.sh
+++ b/scripts/sync-plugin-plangate.sh
@@ -276,10 +276,13 @@ if [ -d "$PLUGIN_AI_LOOP_REFS" ]; then
   done
 fi
 
-# arbiter 裁定エンジン + テストを同期（__pycache__ は対象外。markdown リンクを
-# 含まないためリンク変換は不要、単純コピーの _sync_ai_loop_file を使う）
+# arbiter 裁定エンジン + テスト + metrics（#780 Slice D 後半: test_arbiter.py の
+# ArbiterMetricsIntegrationTests が同ディレクトリの metrics モジュールを import
+# するため、bundled 配置でも自立実行できるよう metrics.py も同梱する）を同期
+# （__pycache__ は対象外。markdown リンクを含まないためリンク変換は不要、
+# 単純コピーの _sync_ai_loop_file を使う）
 if [ -d "$AI_LOOP_SCRIPTS_DIR" ]; then
-  for _f in "$AI_LOOP_SCRIPTS_DIR/arbiter.py" "$AI_LOOP_SCRIPTS_DIR/test_arbiter.py"; do
+  for _f in "$AI_LOOP_SCRIPTS_DIR/arbiter.py" "$AI_LOOP_SCRIPTS_DIR/test_arbiter.py" "$AI_LOOP_SCRIPTS_DIR/metrics.py"; do
     [ -f "$_f" ] || continue
     _sync_ai_loop_file "$_f" "$PLUGIN_AI_LOOP_SCRIPTS" "skills/ai-loop-cycle/scripts"
   done
@@ -289,7 +292,7 @@ if [ -d "$PLUGIN_AI_LOOP_SCRIPTS" ]; then
     [ -f "$_f" ] || continue
     _base="$(basename "$_f")"
     case "$_base" in
-      arbiter.py|test_arbiter.py) : ;;
+      arbiter.py|test_arbiter.py|metrics.py) : ;;
       *)
         if [ "$DRY_RUN" = "1" ]; then _drylog "WOULD DELETE: skills/ai-loop-cycle/scripts/$_base"
         else rm "$_f"; _log "DELETE: skills/ai-loop-cycle/scripts/$_base"; fi


### PR DESCRIPTION
## 概要

#780 Slice D 後半。#812 で新設した `metrics.py`（first-pass rate 集計）を**実データで稼働**させる。arbiter.py が入力の任意フィールド `run`（run_id / round_index / task_id / repair_action?）を受理し decision record（provenance）に刻むことで、arbiter→metrics のパイプラインが接続する。

外部評価（2026-07-11）の「first-pass rate が集計不能・主張不可」の解消に向けた仕上げ。

計画: `docs/working/TASK-0780/plan-slice-d-back.md`。

## 変更内容

- **arbiter が run を受理・刻印**: 任意フィールド `run`。型検証（run_id 非空 str / round_index int・bool 除外 / task_id str / repair_action 任意 str）。全裁定経路（fail-closed / touches-HO / scope / lite / merge / auto-approve / C-D）で刻む
- **後方互換**: run 未指定時は `run` キーを**刻まない**（metrics で legacy＝集計対象外・正常 に分類。`run: null` を出して invalid_run_meta に誤計上する初版バグを是正）
- **POLICY_REF @v1 据え置き**: run は additive provenance であり gate 挙動を変えないため policy 改版ではない
- **round_index 契約の統一**: **1 起点**（初回=1・再試行ごとに +1）。metrics の初回 sentinel（`round_index==1`）と decision-table.md / SKILL 4 配置を整合（初版は「0 起点」と記載しており、仕様どおり初回に 0 を刻むと first_pass が恒常過小集計されるバグだった）
- SKILL 4 配置 + decision-table.md に run 仕様を追記。sync-plugin-plangate.sh に metrics.py 同梱を追加（bundled 自立 PASS のため）

## レビュー（多レーン・実測ベース）

- 統合側実測: run:null → invalid_run_meta 誤分類を検出 → 修正
- ロジックレーン（reviewer-logic）: **round_index 0起点 doc の major を検出**（first_pass サイレント過小集計）→ 修正 + 契約固定の回帰テスト追加

## 検証（実測）

- `test_arbiter.py` 144 / `test_metrics.py` 32 全 PASS（repo 正本 + plugin bundled 両方で自立 PASS）
- arbiter→metrics **結合実証**: run 付き record を arbiter で生成 → metrics.collect() で first_pass 判定（1起点=分子 / 0起点=分子外・rate=0.5 を実測）
- arbiter.py / test_arbiter.py / metrics.py 全て plugin コピーと cmp IDENTICAL・markdownlint 0

## 関連

Refs #780。後続: #814（arbiter リファクタ）→ Slice B（plan 品質 hard gate）。follow-up: test_metrics.py の sync manifest 登録（#812 由来）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)