### PR TITLE
refactor: ai-loop arbiter の arbitrate 分岐テーブル化 + 責務抽出（動作不変・#814）

### DIFF
--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -705,16 +705,15 @@ def arbitrate(
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
 
-    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
-    # ho_patterns が空（fail-closed）でも呼び出し可能（lite_result はその場合も
-    # 同一値。詳細は _evaluate_signals の docstring）。
-    signals = _evaluate_signals(data, ho_patterns)
-
     # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
     # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
-    def _mk(**kw: Any) -> dict[str, Any]:
+    # lite_result は fail-closed（priority 0）経路でも刻む必要があるため、
+    # signals 未算出の priority 0 経路では data["lite"] から直接評価する
+    # （lite_check は ho_patterns の解決可否と無関係な純関数のため、signals
+    # 経由でも直接でも同一値。gemini medium 反映の early-return 化に伴う）。
+    def _mk(lite_value: bool, **kw: Any) -> dict[str, Any]:
         return build_provenance(
-            lite_result=signals.lite_result,
+            lite_result=lite_value,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
@@ -726,20 +725,39 @@ def arbitrate(
             **kw,
         )
 
-    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
+    # priority 0: ho-paths 未解決（fail-closed）は boundary=unresolved 固定で
+    # signals（boundary/scope）を一切使わないため、_evaluate_signals を呼ぶ前に
+    # early-return する（gemini medium 反映 / TASK-0814 R3+）。これにより
+    # 不要なパス正規化・boundary_check・check_allowed_paths を fail-closed 経路
+    # で実行しない（eager 評価の解消）。fail-open は絶対に行わない。
+    if not ho_patterns:
+        provenance = _mk(
+            lite_value=lite_check(data["lite"]),
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
+            scope_check="unresolved",
+        )
+        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"
+        return provenance, reason
+
+    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
+    # priority 0（fail-closed）は上で early-return 済みのため、ここに到達する
+    # 時点で ho_patterns は非空。
+    signals = _evaluate_signals(data, ho_patterns)
+
+    # priority 1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
     # decision-table.md §3 の対応 priority 行 1 つに対応する (label, guard,
     # decision, boundary_value, scope_check, reason_fn)。guard が True に
     # なった最初の行が採用される（元の if/return 連鎖と同一の短絡評価）。
     # scope 検査（priority 1.5）通過後の全行は in_scope を刻む（既存優先順位）。
-    # priority 5（approve-reject の severity 分類 + C/D 裁定）は 2 段判定で
-    # 分岐が複雑なため、無理にテーブルへ押し込まず本テーブルの後で個別処理
-    # として残す（TASK-0814 plan の over-engineering 回避方針）。
+    # priority 0（fail-closed）は上で early-return 済み。priority 5
+    # （approve-reject の severity 分類 + C/D 裁定）は 2 段判定で分岐が複雑な
+    # ため、無理にテーブルへ押し込まず本テーブルの後で個別処理として残す
+    # （TASK-0814 plan の over-engineering 回避方針）。
     def _matched_desc() -> str:
         return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
 
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
-        ("priority 0", not ho_patterns, DECISION_HUMAN_ESCALATED, "unresolved", "unresolved",
-         lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"),
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
         ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
@@ -756,7 +774,9 @@ def arbitrate(
 
     for _label, guard, decision, boundary_value, scope_check, reason_fn in priority_table:
         if guard:
-            provenance = _mk(decision=decision, boundary=boundary_value, scope_check=scope_check)
+            provenance = _mk(
+                lite_value=signals.lite_result, decision=decision, boundary=boundary_value, scope_check=scope_check
+            )
             return provenance, reason_fn()
 
     # priority 5: approve-reject → severity 分類 → C/D 裁定。
@@ -768,6 +788,7 @@ def arbitrate(
 
     if severity in ("critical", "major"):
         provenance = _mk(
+            lite_value=signals.lite_result,
             decision=DECISION_HUMAN_ESCALATED,
             boundary=signals.boundary,
             scope_check="in_scope",
@@ -782,6 +803,7 @@ def arbitrate(
     # C か D が欠落している場合は安全側で human escalate。
     if model_c is None or model_d is None:
         provenance = _mk(
+            lite_value=signals.lite_result,
             decision=DECISION_HUMAN_ESCALATED,
             boundary=signals.boundary,
             scope_check="in_scope",
@@ -803,6 +825,7 @@ def arbitrate(
         decision = DECISION_HUMAN_ESCALATED
 
     provenance = _mk(
+        lite_value=signals.lite_result,
         decision=decision,
         boundary=signals.boundary,
         scope_check="in_scope",

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -76,6 +76,7 @@ exit code:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import functools
 import json
 import pathlib
@@ -431,35 +432,50 @@ def _require(condition: bool, message: str) -> None:
         raise InputError(message)
 
 
+def _require_normalized_path_list(
+    value: Any, field: str, *, kind: str, require_non_empty: bool = False
+) -> None:
+    """changed_files / allowed_paths 共通の list 検証を集約する（TASK-0814 R3）。
+
+    手順は「(1) value が string のリストであること（require_non_empty=True
+    なら非空リスト・非空文字列要素も要求）→ (2) 各要素を
+    _safe_normalized_path で検証 → 不正なら _require で InputError」の
+    同型 2 回（changed_files / allowed_paths）を 1 関数に集約したもの。
+
+    `require_non_empty`（allowed_paths のみ True）: 空リスト・空文字列要素を
+    リスト構造検査の時点で拒否する（LoopSpec scope.allowed_paths 宣言は
+    非空必須のため）。changed_files（False）は空文字列要素の拒否を
+    _safe_normalized_path（空文字列は「空のパス」エラー）に委ねる —
+    元コードの挙動をそのまま踏襲する。
+    `kind`: エラーメッセージ中の名詞（changed_files="パス" /
+    allowed_paths="パターン"）。
+    """
+    if require_non_empty:
+        _require(
+            isinstance(value, list) and len(value) > 0 and all(isinstance(p, str) and p != "" for p in value),
+            f"{field} は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
+        )
+    else:
+        _require(
+            isinstance(value, list) and all(isinstance(p, str) for p in value),
+            f"{field} は string のリストである必要があります",
+        )
+    for path in value:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"{field} に不正な{kind}があります（{err}。リポジトリ相対の正規{kind}のみ受理）: {path!r}",
+        )
+
+
 def validate_input(data: Any) -> dict[str, Any]:
     """入力 JSON の構造を検証し、明示的失敗（理由メッセージ付き）を返す。"""
     _require(isinstance(data, dict), "入力は JSON object である必要があります")
 
-    changed_files = data.get("changed_files")
-    _require(
-        isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
-        "changed_files は string のリストである必要があります",
+    _require_normalized_path_list(data.get("changed_files"), "changed_files", kind="パス")
+    _require_normalized_path_list(
+        data.get("allowed_paths"), "allowed_paths", kind="パターン", require_non_empty=True
     )
-    for path in changed_files:
-        _norm, err = _safe_normalized_path(path)
-        _require(
-            err is None,
-            f"changed_files に不正なパスがあります（{err}。リポジトリ相対の正規パスのみ受理）: {path!r}",
-        )
-
-    allowed_paths = data.get("allowed_paths")
-    _require(
-        isinstance(allowed_paths, list)
-        and len(allowed_paths) > 0
-        and all(isinstance(p, str) and p != "" for p in allowed_paths),
-        "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
-    )
-    for path in allowed_paths:
-        _norm, err = _safe_normalized_path(path)
-        _require(
-            err is None,
-            f"allowed_paths に不正なパターンがあります（{err}。リポジトリ相対の正規パターンのみ受理）: {path!r}",
-        )
 
     lite = data.get("lite")
     _require(isinstance(lite, dict), "lite は object である必要があります")
@@ -601,6 +617,63 @@ def build_provenance(
     return provenance
 
 
+# ---------------------------------------------------------------------------
+# 判定前処理（TASK-0814 R2）: boundary / scope / lite / verdict の集約
+# ---------------------------------------------------------------------------
+@dataclasses.dataclass(frozen=True)
+class Signals:
+    """arbitrate() の priority 分岐に先立つ判定前処理の結果（TASK-0814 R2）。
+
+    _evaluate_signals() の戻り値。boundary_check / check_allowed_paths /
+    lite_check / verdict 正規化（model_a-model_b 文字列化）を 1 箇所に
+    集約し、arbitrate() は本 dataclass を見て priority 分岐のみを行う。
+    """
+
+    boundary: str
+    matched: list[dict[str, str]]
+    scope_ok: bool
+    violations: list[str]
+    lite_result: bool
+    verdict: str
+
+
+def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) -> Signals:
+    """priority 分岐に先立つ判定前処理をまとめて評価する（TASK-0814 R2）。
+
+    出典: docs/workflows/ai-loop/decision-table.md §3。ここで評価する
+    boundary_check（priority 1）/ check_allowed_paths（priority 1.5）/
+    lite_check（priority 2）/ verdict 正規化（priority 4/6 判定用の
+    "{model_a}-{model_b}" 文字列）は、いずれも純関数の組み合わせであり
+    副作用を持たない。
+
+    `ho_patterns` が空（resolve_ho_patterns 未解決・fail-closed 前提）でも
+    本関数は呼び出し可能。その場合 `boundary_check` は仕様上 "clean"
+    （touches-HO 0 件）を返すが、priority 0（ho-paths 未解決）は
+    arbitrate() 側で本関数呼び出しより前に確定判断されるため、当該経路の
+    provenance には boundary/scope_ok/violations の値は反映されない。
+    `lite_result` は ho_patterns の解決可否と無関係に `data["lite"]` の
+    4 軸判定のみで決まるため、priority 0 経路でも同じ値が使われる
+    （元コードの計算順序と同一の観測結果）。
+    """
+    changed_files: list[str] = data["changed_files"]
+    allowed_paths: list[str] = data["allowed_paths"]
+    verdicts: dict[str, Any] = data["verdicts"]
+
+    boundary, matched = boundary_check(changed_files, ho_patterns)
+    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
+    lite_result = lite_check(data["lite"])
+    verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
+
+    return Signals(
+        boundary=boundary,
+        matched=matched,
+        scope_ok=scope_ok,
+        violations=violations,
+        lite_result=lite_result,
+        verdict=verdict,
+    )
+
+
 def arbitrate(
     data: dict[str, Any], *, ho_paths_path: str | None = None
 ) -> tuple[dict[str, Any], str]:
@@ -618,9 +691,6 @@ def arbitrate(
 
     戻り値: (provenance dict, 人間可読の理由サマリ)
     """
-    changed_files: list[str] = data["changed_files"]
-    allowed_paths: list[str] = data["allowed_paths"]
-    lite_input = data["lite"]
     class_value: str = data["class"]
     verdicts: dict[str, Any] = data["verdicts"]
     target_sha: str = data["target_sha"]
@@ -632,16 +702,19 @@ def arbitrate(
     reject_category: str | None = verdicts.get("reject_category")
     run: dict[str, Any] | None = data.get("run")
 
-    lite_result = lite_check(lite_input)
-
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
+
+    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
+    # ho_patterns が空（fail-closed）でも呼び出し可能（lite_result はその場合も
+    # 同一値。詳細は _evaluate_signals の docstring）。
+    signals = _evaluate_signals(data, ho_patterns)
 
     # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
     # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
     def _mk(**kw: Any) -> dict[str, Any]:
         return build_provenance(
-            lite_result=lite_result,
+            lite_result=signals.lite_result,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
@@ -653,95 +726,50 @@ def arbitrate(
             **kw,
         )
 
-    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
-    # 絶対条件として全件 human escalate とする。
-    if not ho_patterns:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary="unresolved",
-            scope_check="unresolved",
-        )
-        searched_desc = ", ".join(ho_searched)
-        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {searched_desc}"
-        return provenance, reason
+    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
+    # decision-table.md §3 の対応 priority 行 1 つに対応する (label, guard,
+    # decision, boundary_value, scope_check, reason_fn)。guard が True に
+    # なった最初の行が採用される（元の if/return 連鎖と同一の短絡評価）。
+    # scope 検査（priority 1.5）通過後の全行は in_scope を刻む（既存優先順位）。
+    # priority 5（approve-reject の severity 分類 + C/D 裁定）は 2 段判定で
+    # 分岐が複雑なため、無理にテーブルへ押し込まず本テーブルの後で個別処理
+    # として残す（TASK-0814 plan の over-engineering 回避方針）。
+    def _matched_desc() -> str:
+        return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
 
-    boundary, matched = boundary_check(changed_files, ho_patterns)
+    priority_table: list[tuple[str, bool, str, str, str, Any]] = [
+        ("priority 0", not ho_patterns, DECISION_HUMAN_ESCALATED, "unresolved", "unresolved",
+         lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"),
+        ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
+         lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
+        ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
+         lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
+        ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
+        ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         lambda: "priority 3: class=merge（Human-owned 固定）"),
+        ("priority 4", signals.verdict in ("reject-reject", "reject-approve"), DECISION_BLOCKED, signals.boundary, "in_scope",
+         lambda: f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）"),
+        ("priority 6", signals.verdict == "approve-approve", DECISION_AUTO_APPROVED, signals.boundary, "in_scope",
+         lambda: "priority 6: verdict=approve-approve（合意）"),
+    ]
 
-    # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
-    # scope 検査（priority 1.5）より前で return するため scope_check は not_evaluated。
-    if boundary == "touches-HO":
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
-            scope_check="not_evaluated",
-        )
-        matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
-        reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
-        return provenance, reason
-
-    # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
-    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
-    if not scope_ok:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
-            scope_check="scope_violation",
-        )
-        violations_desc = ", ".join(violations)
-        reason = (
-            f"priority 1.5: boundary=clean だが scope_violation"
-            f"（allowed_paths 逸脱パス: {violations_desc}）"
-        )
-        return provenance, reason
-
-    # ここに到達＝scope 検査を実際に通過（合格）。以降の全経路は in_scope を刻む。
-    # priority 2: lite=false は human escalate。
-    if not lite_result:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"
-
-    # priority 3: class=merge は human escalate（merge=Human-owned 固定）。
-    if class_value == "merge":
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 3: class=merge（Human-owned 固定）"
-
-    verdict = f"{model_a}-{model_b}"
-
-    # priority 4: reject-reject / reject-approve は blocked。
-    if verdict in ("reject-reject", "reject-approve"):
-        provenance = _mk(
-            decision=DECISION_BLOCKED,
-            boundary=boundary,
-            scope_check="in_scope",
-        )
-        return provenance, f"priority 4: verdict={verdict}（A が設計妥当性で NG、または両者合意で NG）"
-
-    # priority 6: approve-approve は auto-approve。
-    if verdict == "approve-approve":
-        provenance = _mk(
-            decision=DECISION_AUTO_APPROVED,
-            boundary=boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 6: verdict=approve-approve（合意）"
+    for _label, guard, decision, boundary_value, scope_check, reason_fn in priority_table:
+        if guard:
+            provenance = _mk(decision=decision, boundary=boundary_value, scope_check=scope_check)
+            return provenance, reason_fn()
 
     # priority 5: approve-reject → severity 分類 → C/D 裁定。
     # (verdict は入力バリデーションで approve/reject の 2 値に限定済みのため、
-    #  ここに到達する場合は必ず approve-reject)
+    #  ここに到達する場合は必ず approve-reject。テーブル化しない理由は
+    #  TASK-0814 plan 参照 — severity 分類 + C/D 裁定の 2 段判定で分岐が
+    #  複雑なため個別処理のまま維持する）
     severity = classify_severity(reject_category)
 
     if severity in ("critical", "major"):
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
             severity=severity,
         )
@@ -755,7 +783,7 @@ def arbitrate(
     if model_c is None or model_d is None:
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
             severity=severity,
             model_c=model_c,
@@ -776,7 +804,7 @@ def arbitrate(
 
     provenance = _mk(
         decision=decision,
-        boundary=boundary,
+        boundary=signals.boundary,
         scope_check="in_scope",
         severity=severity,
         model_c=model_c,

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1384,5 +1384,501 @@ class MainExitCodeTests(unittest.TestCase):
         self.assertIn("入力エラー", stderr_value)
 
 
+
+
+class ArbitrateCharacterizationTests(unittest.TestCase):
+    """TASK-0814 R0: arbitrate() のリファクタリング（動作不変）に対する固定基準。
+
+    全 priority 経路（0 fail-closed / 1 touches-HO / 1.5 scope_violation /
+    2 lite=false / 3 class=merge / 4 verdict reject（reject-reject と
+    reject-approve の両方）/ 5 approve-reject（severity critical/major、
+    minor 側は C/D 裁定の 4 パターン + 欠落ケース）/ 6 approve-approve、
+    加えて run メタ付き（#780 Slice D 後半・additive）を網羅する。
+
+    各シナリオの (provenance dict, reason str) を **リファクタ前の現行コード
+    で実測して固定した値** と突き合わせる。`timestamp` は実行時刻依存のため
+    比較対象から除外し、`ho_paths_source` は cwd 依存の絶対パスのため
+    `_NORMALIZED_HO_SOURCE` プレースホルダに正規化してから比較する
+    （いずれも arbitrate() の priority 分岐ロジックとは無関係な環境依存
+    フィールドであり、正規化してもバイト一致検証の意味は損なわない）。
+
+    Python dict の等価性は JSON へ sort_keys=True でダンプした文字列の
+    等価性と同値（キー集合・値が完全一致すれば同一 JSON 文字列になる）
+    ため、本テストの assertEqual(dict, dict) が「record バイト一致」の
+    機械証明として機能する。
+
+    このテストが緑のまま Step 1〜3（_evaluate_signals 抽出 → priority
+    テーブル化 → _require_normalized_path_list 抽出）を完了できることが
+    「動作不変」の機械証明となる。
+    """
+
+    _NORMALIZED_HO_SOURCE = "<HO_PATHS_SOURCE>"
+
+    @classmethod
+    def _normalize(cls, provenance):
+        normalized = dict(provenance)
+        normalized.pop("timestamp", None)
+        if normalized.get("ho_paths_source") is not None:
+            normalized["ho_paths_source"] = cls._NORMALIZED_HO_SOURCE
+        return normalized
+
+    def _run(self, data, **kwargs):
+        provenance, reason = arbiter.arbitrate(data, **kwargs)
+        return self._normalize(provenance), reason
+
+    def _assert_json_roundtrip_stable(self, provenance):
+        """provenance を sort_keys=True JSON にダンプ→再ロードして元と一致
+        することを確認する（「バイト一致」の直接的な機械証明の補強）。"""
+        dumped = json.dumps(provenance, ensure_ascii=False, sort_keys=True)
+        self.assertEqual(json.loads(dumped), provenance)
+
+    def test_priority0_fail_closed(self):
+        data = _base_input()
+        provenance, reason = self._run(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "unresolved",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": None,
+                "ho_pattern_count": 0,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "unresolved",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 0: ho-paths unresolved (fail-closed)。探索パス: /nonexistent/ho-paths.md",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority1_touches_ho(self):
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            lite={"size_ok": False, "no_new_design": False, "follows_pattern": False, "reversible": False},
+            **{"class": "merge"},
+        )
+        data["verdicts"] = {
+            "model_a": "reject",
+            "model_b": "reject",
+            "reject_category": None,
+            "model_c": None,
+            "model_d": None,
+        }
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "touches-HO",
+                "class_check": "merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": False,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "not_evaluated",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "reject"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: bin/plangate (bin/plangate / HO-core)",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority1_5_scope_violation(self):
+        data = _base_input(changed_files=["docs/other/outside.md"], allowed_paths=["docs/workflows/ai-loop/**"])
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "scope_violation",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: docs/other/outside.md）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority2_lite_false(self):
+        data = _base_input(lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": False,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority3_class_merge(self):
+        data = _base_input(**{"class": "merge"})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 3: class=merge（Human-owned 固定）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority4_reject_reject(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "reject"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 4: verdict=reject-reject（A が設計妥当性で NG、または両者合意で NG）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority4_reject_approve(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 4: verdict=reject-approve（A が設計妥当性で NG、または両者合意で NG）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority6_approve_approve(self):
+        data = _base_input()
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 6: verdict=approve-approve（合意）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_severity_critical(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "security_break"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "reject_category": "security_break",
+                    "severity": "critical",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: verdict=approve-reject, severity=critical（reject_category='security_break'）→ human escalate 固定",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_severity_major(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "reject_category": "auth_change",
+                    "severity": "major",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: verdict=approve-reject, severity=major（reject_category='auth_change'）→ human escalate 固定",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_missing(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = None
+        data["verdicts"]["model_d"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_d": "approve",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor だが model_c/model_d のいずれかが欠落 → human escalate（安全側）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_approve_approve(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "approve",
+                    "model_d": "approve",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=approve-approve → AUTO_APPROVED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_reject_reject(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "reject"
+        data["verdicts"]["model_d"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "reject",
+                    "model_d": "reject",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=reject-reject → BLOCKED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_mixed(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "approve",
+                    "model_d": "reject",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=approve-reject → HUMAN_ESCALATED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_with_run_meta_approve_approve(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 0, "task_id": "TASK-0814", "repair_action": None})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "run": {
+                    "repair_action": None,
+                    "round_index": 0,
+                    "run_id": "run-001",
+                    "task_id": "TASK-0814",
+                },
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 6: verdict=approve-approve（合意）")
+        self._assert_json_roundtrip_stable(provenance)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -76,6 +76,7 @@ exit code:
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import functools
 import json
 import pathlib
@@ -601,6 +602,63 @@ def build_provenance(
     return provenance
 
 
+# ---------------------------------------------------------------------------
+# 判定前処理（TASK-0814 R2）: boundary / scope / lite / verdict の集約
+# ---------------------------------------------------------------------------
+@dataclasses.dataclass(frozen=True)
+class Signals:
+    """arbitrate() の priority 分岐に先立つ判定前処理の結果（TASK-0814 R2）。
+
+    _evaluate_signals() の戻り値。boundary_check / check_allowed_paths /
+    lite_check / verdict 正規化（model_a-model_b 文字列化）を 1 箇所に
+    集約し、arbitrate() は本 dataclass を見て priority 分岐のみを行う。
+    """
+
+    boundary: str
+    matched: list[dict[str, str]]
+    scope_ok: bool
+    violations: list[str]
+    lite_result: bool
+    verdict: str
+
+
+def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) -> Signals:
+    """priority 分岐に先立つ判定前処理をまとめて評価する（TASK-0814 R2）。
+
+    出典: docs/workflows/ai-loop/decision-table.md §3。ここで評価する
+    boundary_check（priority 1）/ check_allowed_paths（priority 1.5）/
+    lite_check（priority 2）/ verdict 正規化（priority 4/6 判定用の
+    "{model_a}-{model_b}" 文字列）は、いずれも純関数の組み合わせであり
+    副作用を持たない。
+
+    `ho_patterns` が空（resolve_ho_patterns 未解決・fail-closed 前提）でも
+    本関数は呼び出し可能。その場合 `boundary_check` は仕様上 "clean"
+    （touches-HO 0 件）を返すが、priority 0（ho-paths 未解決）は
+    arbitrate() 側で本関数呼び出しより前に確定判断されるため、当該経路の
+    provenance には boundary/scope_ok/violations の値は反映されない。
+    `lite_result` は ho_patterns の解決可否と無関係に `data["lite"]` の
+    4 軸判定のみで決まるため、priority 0 経路でも同じ値が使われる
+    （元コードの計算順序と同一の観測結果）。
+    """
+    changed_files: list[str] = data["changed_files"]
+    allowed_paths: list[str] = data["allowed_paths"]
+    verdicts: dict[str, Any] = data["verdicts"]
+
+    boundary, matched = boundary_check(changed_files, ho_patterns)
+    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
+    lite_result = lite_check(data["lite"])
+    verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
+
+    return Signals(
+        boundary=boundary,
+        matched=matched,
+        scope_ok=scope_ok,
+        violations=violations,
+        lite_result=lite_result,
+        verdict=verdict,
+    )
+
+
 def arbitrate(
     data: dict[str, Any], *, ho_paths_path: str | None = None
 ) -> tuple[dict[str, Any], str]:
@@ -618,9 +676,6 @@ def arbitrate(
 
     戻り値: (provenance dict, 人間可読の理由サマリ)
     """
-    changed_files: list[str] = data["changed_files"]
-    allowed_paths: list[str] = data["allowed_paths"]
-    lite_input = data["lite"]
     class_value: str = data["class"]
     verdicts: dict[str, Any] = data["verdicts"]
     target_sha: str = data["target_sha"]
@@ -632,16 +687,19 @@ def arbitrate(
     reject_category: str | None = verdicts.get("reject_category")
     run: dict[str, Any] | None = data.get("run")
 
-    lite_result = lite_check(lite_input)
-
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
+
+    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
+    # ho_patterns が空（fail-closed）でも呼び出し可能（lite_result はその場合も
+    # 同一値。詳細は _evaluate_signals の docstring）。
+    signals = _evaluate_signals(data, ho_patterns)
 
     # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
     # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
     def _mk(**kw: Any) -> dict[str, Any]:
         return build_provenance(
-            lite_result=lite_result,
+            lite_result=signals.lite_result,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
@@ -665,29 +723,28 @@ def arbitrate(
         reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {searched_desc}"
         return provenance, reason
 
-    boundary, matched = boundary_check(changed_files, ho_patterns)
-
     # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
     # scope 検査（priority 1.5）より前で return するため scope_check は not_evaluated。
-    if boundary == "touches-HO":
+    if signals.boundary == "touches-HO":
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="not_evaluated",
         )
-        matched_desc = ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in matched)
+        matched_desc = ", ".join(
+            f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched
+        )
         reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
         return provenance, reason
 
     # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
-    scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
-    if not scope_ok:
+    if not signals.scope_ok:
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="scope_violation",
         )
-        violations_desc = ", ".join(violations)
+        violations_desc = ", ".join(signals.violations)
         reason = (
             f"priority 1.5: boundary=clean だが scope_violation"
             f"（allowed_paths 逸脱パス: {violations_desc}）"
@@ -696,10 +753,10 @@ def arbitrate(
 
     # ここに到達＝scope 検査を実際に通過（合格）。以降の全経路は in_scope を刻む。
     # priority 2: lite=false は human escalate。
-    if not lite_result:
+    if not signals.lite_result:
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
         )
         return provenance, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"
@@ -708,40 +765,40 @@ def arbitrate(
     if class_value == "merge":
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
         )
         return provenance, "priority 3: class=merge（Human-owned 固定）"
 
-    verdict = f"{model_a}-{model_b}"
-
     # priority 4: reject-reject / reject-approve は blocked。
-    if verdict in ("reject-reject", "reject-approve"):
+    if signals.verdict in ("reject-reject", "reject-approve"):
         provenance = _mk(
             decision=DECISION_BLOCKED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
         )
-        return provenance, f"priority 4: verdict={verdict}（A が設計妥当性で NG、または両者合意で NG）"
+        return provenance, f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）"
 
     # priority 6: approve-approve は auto-approve。
-    if verdict == "approve-approve":
+    if signals.verdict == "approve-approve":
         provenance = _mk(
             decision=DECISION_AUTO_APPROVED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
         )
         return provenance, "priority 6: verdict=approve-approve（合意）"
 
     # priority 5: approve-reject → severity 分類 → C/D 裁定。
     # (verdict は入力バリデーションで approve/reject の 2 値に限定済みのため、
-    #  ここに到達する場合は必ず approve-reject)
+    #  ここに到達する場合は必ず approve-reject。テーブル化しない理由は
+    #  TASK-0814 plan 参照 — severity 分類 + C/D 裁定の 2 段判定で分岐が
+    #  複雑なため個別処理のまま維持する）
     severity = classify_severity(reject_category)
 
     if severity in ("critical", "major"):
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
             severity=severity,
         )
@@ -755,7 +812,7 @@ def arbitrate(
     if model_c is None or model_d is None:
         provenance = _mk(
             decision=DECISION_HUMAN_ESCALATED,
-            boundary=boundary,
+            boundary=signals.boundary,
             scope_check="in_scope",
             severity=severity,
             model_c=model_c,
@@ -776,7 +833,7 @@ def arbitrate(
 
     provenance = _mk(
         decision=decision,
-        boundary=boundary,
+        boundary=signals.boundary,
         scope_check="in_scope",
         severity=severity,
         model_c=model_c,

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -711,82 +711,32 @@ def arbitrate(
             **kw,
         )
 
-    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。
-    # 各行は decision-table.md §3 の対応 priority 行 1 つに対応する
-    # (label, guard, decision, boundary_value, scope_check, reason_fn)。
-    # guard は「scope 検査を通過した以降は in_scope を刻む」という既存の
-    # 優先順位（コメント参照）をそのまま反映しており、上から順に最初に
-    # True になった行が採用される（元の if/return 連鎖と同一の短絡評価）。
+    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
+    # decision-table.md §3 の対応 priority 行 1 つに対応する (label, guard,
+    # decision, boundary_value, scope_check, reason_fn)。guard が True に
+    # なった最初の行が採用される（元の if/return 連鎖と同一の短絡評価）。
+    # scope 検査（priority 1.5）通過後の全行は in_scope を刻む（既存優先順位）。
     # priority 5（approve-reject の severity 分類 + C/D 裁定）は 2 段判定で
     # 分岐が複雑なため、無理にテーブルへ押し込まず本テーブルの後で個別処理
     # として残す（TASK-0814 plan の over-engineering 回避方針）。
+    def _matched_desc() -> str:
+        return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
+
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
-        (
-            "priority 0",
-            not ho_patterns,
-            DECISION_HUMAN_ESCALATED,
-            "unresolved",
-            "unresolved",
-            lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}",
-        ),
-        (
-            # scope 検査（priority 1.5）より前で return するため scope_check は
-            # not_evaluated。lite / class / verdict を問わず必ず human escalate 固定。
-            "priority 1",
-            signals.boundary == "touches-HO",
-            DECISION_HUMAN_ESCALATED,
-            signals.boundary,
-            "not_evaluated",
-            lambda: (
-                "priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: "
-                + ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
-            ),
-        ),
-        (
-            "priority 1.5",
-            not signals.scope_ok,
-            DECISION_HUMAN_ESCALATED,
-            signals.boundary,
-            "scope_violation",
-            lambda: (
-                "priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: "
-                + ", ".join(signals.violations)
-                + "）"
-            ),
-        ),
-        (
-            # ここに到達＝scope 検査を実際に通過（合格）。以降の全行は in_scope を刻む。
-            "priority 2",
-            not signals.lite_result,
-            DECISION_HUMAN_ESCALATED,
-            signals.boundary,
-            "in_scope",
-            lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）",
-        ),
-        (
-            "priority 3",
-            class_value == "merge",
-            DECISION_HUMAN_ESCALATED,
-            signals.boundary,
-            "in_scope",
-            lambda: "priority 3: class=merge（Human-owned 固定）",
-        ),
-        (
-            "priority 4",
-            signals.verdict in ("reject-reject", "reject-approve"),
-            DECISION_BLOCKED,
-            signals.boundary,
-            "in_scope",
-            lambda: f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）",
-        ),
-        (
-            "priority 6",
-            signals.verdict == "approve-approve",
-            DECISION_AUTO_APPROVED,
-            signals.boundary,
-            "in_scope",
-            lambda: "priority 6: verdict=approve-approve（合意）",
-        ),
+        ("priority 0", not ho_patterns, DECISION_HUMAN_ESCALATED, "unresolved", "unresolved",
+         lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"),
+        ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
+         lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
+        ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
+         lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
+        ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
+        ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         lambda: "priority 3: class=merge（Human-owned 固定）"),
+        ("priority 4", signals.verdict in ("reject-reject", "reject-approve"), DECISION_BLOCKED, signals.boundary, "in_scope",
+         lambda: f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）"),
+        ("priority 6", signals.verdict == "approve-approve", DECISION_AUTO_APPROVED, signals.boundary, "in_scope",
+         lambda: "priority 6: verdict=approve-approve（合意）"),
     ]
 
     for _label, guard, decision, boundary_value, scope_check, reason_fn in priority_table:

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -705,16 +705,15 @@ def arbitrate(
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
 
-    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
-    # ho_patterns が空（fail-closed）でも呼び出し可能（lite_result はその場合も
-    # 同一値。詳細は _evaluate_signals の docstring）。
-    signals = _evaluate_signals(data, ho_patterns)
-
     # 全裁定経路の provenance に ho-paths の出典・抽出件数を刻む（#809 監査可視化）。
     # boundary/scope/decision 等の可変フィールドは呼び出し側で個別に渡す。
-    def _mk(**kw: Any) -> dict[str, Any]:
+    # lite_result は fail-closed（priority 0）経路でも刻む必要があるため、
+    # signals 未算出の priority 0 経路では data["lite"] から直接評価する
+    # （lite_check は ho_patterns の解決可否と無関係な純関数のため、signals
+    # 経由でも直接でも同一値。gemini medium 反映の early-return 化に伴う）。
+    def _mk(lite_value: bool, **kw: Any) -> dict[str, Any]:
         return build_provenance(
-            lite_result=signals.lite_result,
+            lite_result=lite_value,
             class_value=class_value,
             target_sha=target_sha,
             model_a=model_a,
@@ -726,20 +725,39 @@ def arbitrate(
             **kw,
         )
 
-    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
+    # priority 0: ho-paths 未解決（fail-closed）は boundary=unresolved 固定で
+    # signals（boundary/scope）を一切使わないため、_evaluate_signals を呼ぶ前に
+    # early-return する（gemini medium 反映 / TASK-0814 R3+）。これにより
+    # 不要なパス正規化・boundary_check・check_allowed_paths を fail-closed 経路
+    # で実行しない（eager 評価の解消）。fail-open は絶対に行わない。
+    if not ho_patterns:
+        provenance = _mk(
+            lite_value=lite_check(data["lite"]),
+            decision=DECISION_HUMAN_ESCALATED,
+            boundary="unresolved",
+            scope_check="unresolved",
+        )
+        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"
+        return provenance, reason
+
+    # 判定前処理（boundary/scope/lite/verdict）を 1 箇所に集約（TASK-0814 R2）。
+    # priority 0（fail-closed）は上で early-return 済みのため、ここに到達する
+    # 時点で ho_patterns は非空。
+    signals = _evaluate_signals(data, ho_patterns)
+
+    # priority 1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。各行は
     # decision-table.md §3 の対応 priority 行 1 つに対応する (label, guard,
     # decision, boundary_value, scope_check, reason_fn)。guard が True に
     # なった最初の行が採用される（元の if/return 連鎖と同一の短絡評価）。
     # scope 検査（priority 1.5）通過後の全行は in_scope を刻む（既存優先順位）。
-    # priority 5（approve-reject の severity 分類 + C/D 裁定）は 2 段判定で
-    # 分岐が複雑なため、無理にテーブルへ押し込まず本テーブルの後で個別処理
-    # として残す（TASK-0814 plan の over-engineering 回避方針）。
+    # priority 0（fail-closed）は上で early-return 済み。priority 5
+    # （approve-reject の severity 分類 + C/D 裁定）は 2 段判定で分岐が複雑な
+    # ため、無理にテーブルへ押し込まず本テーブルの後で個別処理として残す
+    # （TASK-0814 plan の over-engineering 回避方針）。
     def _matched_desc() -> str:
         return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
 
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
-        ("priority 0", not ho_patterns, DECISION_HUMAN_ESCALATED, "unresolved", "unresolved",
-         lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}"),
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
         ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
@@ -756,7 +774,9 @@ def arbitrate(
 
     for _label, guard, decision, boundary_value, scope_check, reason_fn in priority_table:
         if guard:
-            provenance = _mk(decision=decision, boundary=boundary_value, scope_check=scope_check)
+            provenance = _mk(
+                lite_value=signals.lite_result, decision=decision, boundary=boundary_value, scope_check=scope_check
+            )
             return provenance, reason_fn()
 
     # priority 5: approve-reject → severity 分類 → C/D 裁定。
@@ -768,6 +788,7 @@ def arbitrate(
 
     if severity in ("critical", "major"):
         provenance = _mk(
+            lite_value=signals.lite_result,
             decision=DECISION_HUMAN_ESCALATED,
             boundary=signals.boundary,
             scope_check="in_scope",
@@ -782,6 +803,7 @@ def arbitrate(
     # C か D が欠落している場合は安全側で human escalate。
     if model_c is None or model_d is None:
         provenance = _mk(
+            lite_value=signals.lite_result,
             decision=DECISION_HUMAN_ESCALATED,
             boundary=signals.boundary,
             scope_check="in_scope",
@@ -803,6 +825,7 @@ def arbitrate(
         decision = DECISION_HUMAN_ESCALATED
 
     provenance = _mk(
+        lite_value=signals.lite_result,
         decision=decision,
         boundary=signals.boundary,
         scope_check="in_scope",

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -711,82 +711,88 @@ def arbitrate(
             **kw,
         )
 
-    # priority 0: ho-paths 未解決（fail-closed）。boundary 判定が実行不能なため
-    # 絶対条件として全件 human escalate とする。
-    if not ho_patterns:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary="unresolved",
-            scope_check="unresolved",
-        )
-        searched_desc = ", ".join(ho_searched)
-        reason = f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {searched_desc}"
-        return provenance, reason
+    # priority 0/1/1.5/2/3/4/6 のデータ駆動テーブル（TASK-0814 R1）。
+    # 各行は decision-table.md §3 の対応 priority 行 1 つに対応する
+    # (label, guard, decision, boundary_value, scope_check, reason_fn)。
+    # guard は「scope 検査を通過した以降は in_scope を刻む」という既存の
+    # 優先順位（コメント参照）をそのまま反映しており、上から順に最初に
+    # True になった行が採用される（元の if/return 連鎖と同一の短絡評価）。
+    # priority 5（approve-reject の severity 分類 + C/D 裁定）は 2 段判定で
+    # 分岐が複雑なため、無理にテーブルへ押し込まず本テーブルの後で個別処理
+    # として残す（TASK-0814 plan の over-engineering 回避方針）。
+    priority_table: list[tuple[str, bool, str, str, str, Any]] = [
+        (
+            "priority 0",
+            not ho_patterns,
+            DECISION_HUMAN_ESCALATED,
+            "unresolved",
+            "unresolved",
+            lambda: f"priority 0: ho-paths unresolved (fail-closed)。探索パス: {', '.join(ho_searched)}",
+        ),
+        (
+            # scope 検査（priority 1.5）より前で return するため scope_check は
+            # not_evaluated。lite / class / verdict を問わず必ず human escalate 固定。
+            "priority 1",
+            signals.boundary == "touches-HO",
+            DECISION_HUMAN_ESCALATED,
+            signals.boundary,
+            "not_evaluated",
+            lambda: (
+                "priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: "
+                + ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
+            ),
+        ),
+        (
+            "priority 1.5",
+            not signals.scope_ok,
+            DECISION_HUMAN_ESCALATED,
+            signals.boundary,
+            "scope_violation",
+            lambda: (
+                "priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: "
+                + ", ".join(signals.violations)
+                + "）"
+            ),
+        ),
+        (
+            # ここに到達＝scope 検査を実際に通過（合格）。以降の全行は in_scope を刻む。
+            "priority 2",
+            not signals.lite_result,
+            DECISION_HUMAN_ESCALATED,
+            signals.boundary,
+            "in_scope",
+            lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）",
+        ),
+        (
+            "priority 3",
+            class_value == "merge",
+            DECISION_HUMAN_ESCALATED,
+            signals.boundary,
+            "in_scope",
+            lambda: "priority 3: class=merge（Human-owned 固定）",
+        ),
+        (
+            "priority 4",
+            signals.verdict in ("reject-reject", "reject-approve"),
+            DECISION_BLOCKED,
+            signals.boundary,
+            "in_scope",
+            lambda: f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）",
+        ),
+        (
+            "priority 6",
+            signals.verdict == "approve-approve",
+            DECISION_AUTO_APPROVED,
+            signals.boundary,
+            "in_scope",
+            lambda: "priority 6: verdict=approve-approve（合意）",
+        ),
+    ]
 
-    # priority 1: touches-HO は lite / class / verdict を問わず必ず human escalate 固定。
-    # scope 検査（priority 1.5）より前で return するため scope_check は not_evaluated。
-    if signals.boundary == "touches-HO":
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=signals.boundary,
-            scope_check="not_evaluated",
-        )
-        matched_desc = ", ".join(
-            f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched
-        )
-        reason = f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {matched_desc}"
-        return provenance, reason
-
-    # priority 1.5: allowed_paths 逸脱（scope 違反）は human escalate。
-    if not signals.scope_ok:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=signals.boundary,
-            scope_check="scope_violation",
-        )
-        violations_desc = ", ".join(signals.violations)
-        reason = (
-            f"priority 1.5: boundary=clean だが scope_violation"
-            f"（allowed_paths 逸脱パス: {violations_desc}）"
-        )
-        return provenance, reason
-
-    # ここに到達＝scope 検査を実際に通過（合格）。以降の全経路は in_scope を刻む。
-    # priority 2: lite=false は human escalate。
-    if not signals.lite_result:
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=signals.boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"
-
-    # priority 3: class=merge は human escalate（merge=Human-owned 固定）。
-    if class_value == "merge":
-        provenance = _mk(
-            decision=DECISION_HUMAN_ESCALATED,
-            boundary=signals.boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 3: class=merge（Human-owned 固定）"
-
-    # priority 4: reject-reject / reject-approve は blocked。
-    if signals.verdict in ("reject-reject", "reject-approve"):
-        provenance = _mk(
-            decision=DECISION_BLOCKED,
-            boundary=signals.boundary,
-            scope_check="in_scope",
-        )
-        return provenance, f"priority 4: verdict={signals.verdict}（A が設計妥当性で NG、または両者合意で NG）"
-
-    # priority 6: approve-approve は auto-approve。
-    if signals.verdict == "approve-approve":
-        provenance = _mk(
-            decision=DECISION_AUTO_APPROVED,
-            boundary=signals.boundary,
-            scope_check="in_scope",
-        )
-        return provenance, "priority 6: verdict=approve-approve（合意）"
+    for _label, guard, decision, boundary_value, scope_check, reason_fn in priority_table:
+        if guard:
+            provenance = _mk(decision=decision, boundary=boundary_value, scope_check=scope_check)
+            return provenance, reason_fn()
 
     # priority 5: approve-reject → severity 分類 → C/D 裁定。
     # (verdict は入力バリデーションで approve/reject の 2 値に限定済みのため、

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -432,35 +432,50 @@ def _require(condition: bool, message: str) -> None:
         raise InputError(message)
 
 
+def _require_normalized_path_list(
+    value: Any, field: str, *, kind: str, require_non_empty: bool = False
+) -> None:
+    """changed_files / allowed_paths 共通の list 検証を集約する（TASK-0814 R3）。
+
+    手順は「(1) value が string のリストであること（require_non_empty=True
+    なら非空リスト・非空文字列要素も要求）→ (2) 各要素を
+    _safe_normalized_path で検証 → 不正なら _require で InputError」の
+    同型 2 回（changed_files / allowed_paths）を 1 関数に集約したもの。
+
+    `require_non_empty`（allowed_paths のみ True）: 空リスト・空文字列要素を
+    リスト構造検査の時点で拒否する（LoopSpec scope.allowed_paths 宣言は
+    非空必須のため）。changed_files（False）は空文字列要素の拒否を
+    _safe_normalized_path（空文字列は「空のパス」エラー）に委ねる —
+    元コードの挙動をそのまま踏襲する。
+    `kind`: エラーメッセージ中の名詞（changed_files="パス" /
+    allowed_paths="パターン"）。
+    """
+    if require_non_empty:
+        _require(
+            isinstance(value, list) and len(value) > 0 and all(isinstance(p, str) and p != "" for p in value),
+            f"{field} は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
+        )
+    else:
+        _require(
+            isinstance(value, list) and all(isinstance(p, str) for p in value),
+            f"{field} は string のリストである必要があります",
+        )
+    for path in value:
+        _norm, err = _safe_normalized_path(path)
+        _require(
+            err is None,
+            f"{field} に不正な{kind}があります（{err}。リポジトリ相対の正規{kind}のみ受理）: {path!r}",
+        )
+
+
 def validate_input(data: Any) -> dict[str, Any]:
     """入力 JSON の構造を検証し、明示的失敗（理由メッセージ付き）を返す。"""
     _require(isinstance(data, dict), "入力は JSON object である必要があります")
 
-    changed_files = data.get("changed_files")
-    _require(
-        isinstance(changed_files, list) and all(isinstance(p, str) for p in changed_files),
-        "changed_files は string のリストである必要があります",
+    _require_normalized_path_list(data.get("changed_files"), "changed_files", kind="パス")
+    _require_normalized_path_list(
+        data.get("allowed_paths"), "allowed_paths", kind="パターン", require_non_empty=True
     )
-    for path in changed_files:
-        _norm, err = _safe_normalized_path(path)
-        _require(
-            err is None,
-            f"changed_files に不正なパスがあります（{err}。リポジトリ相対の正規パスのみ受理）: {path!r}",
-        )
-
-    allowed_paths = data.get("allowed_paths")
-    _require(
-        isinstance(allowed_paths, list)
-        and len(allowed_paths) > 0
-        and all(isinstance(p, str) and p != "" for p in allowed_paths),
-        "allowed_paths は非空の string リストである必要があります（LoopSpec scope.allowed_paths 宣言を渡す）",
-    )
-    for path in allowed_paths:
-        _norm, err = _safe_normalized_path(path)
-        _require(
-            err is None,
-            f"allowed_paths に不正なパターンがあります（{err}。リポジトリ相対の正規パターンのみ受理）: {path!r}",
-        )
 
     lite = data.get("lite")
     _require(isinstance(lite, dict), "lite は object である必要があります")

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1384,5 +1384,501 @@ class MainExitCodeTests(unittest.TestCase):
         self.assertIn("入力エラー", stderr_value)
 
 
+
+
+class ArbitrateCharacterizationTests(unittest.TestCase):
+    """TASK-0814 R0: arbitrate() のリファクタリング（動作不変）に対する固定基準。
+
+    全 priority 経路（0 fail-closed / 1 touches-HO / 1.5 scope_violation /
+    2 lite=false / 3 class=merge / 4 verdict reject（reject-reject と
+    reject-approve の両方）/ 5 approve-reject（severity critical/major、
+    minor 側は C/D 裁定の 4 パターン + 欠落ケース）/ 6 approve-approve、
+    加えて run メタ付き（#780 Slice D 後半・additive）を網羅する。
+
+    各シナリオの (provenance dict, reason str) を **リファクタ前の現行コード
+    で実測して固定した値** と突き合わせる。`timestamp` は実行時刻依存のため
+    比較対象から除外し、`ho_paths_source` は cwd 依存の絶対パスのため
+    `_NORMALIZED_HO_SOURCE` プレースホルダに正規化してから比較する
+    （いずれも arbitrate() の priority 分岐ロジックとは無関係な環境依存
+    フィールドであり、正規化してもバイト一致検証の意味は損なわない）。
+
+    Python dict の等価性は JSON へ sort_keys=True でダンプした文字列の
+    等価性と同値（キー集合・値が完全一致すれば同一 JSON 文字列になる）
+    ため、本テストの assertEqual(dict, dict) が「record バイト一致」の
+    機械証明として機能する。
+
+    このテストが緑のまま Step 1〜3（_evaluate_signals 抽出 → priority
+    テーブル化 → _require_normalized_path_list 抽出）を完了できることが
+    「動作不変」の機械証明となる。
+    """
+
+    _NORMALIZED_HO_SOURCE = "<HO_PATHS_SOURCE>"
+
+    @classmethod
+    def _normalize(cls, provenance):
+        normalized = dict(provenance)
+        normalized.pop("timestamp", None)
+        if normalized.get("ho_paths_source") is not None:
+            normalized["ho_paths_source"] = cls._NORMALIZED_HO_SOURCE
+        return normalized
+
+    def _run(self, data, **kwargs):
+        provenance, reason = arbiter.arbitrate(data, **kwargs)
+        return self._normalize(provenance), reason
+
+    def _assert_json_roundtrip_stable(self, provenance):
+        """provenance を sort_keys=True JSON にダンプ→再ロードして元と一致
+        することを確認する（「バイト一致」の直接的な機械証明の補強）。"""
+        dumped = json.dumps(provenance, ensure_ascii=False, sort_keys=True)
+        self.assertEqual(json.loads(dumped), provenance)
+
+    def test_priority0_fail_closed(self):
+        data = _base_input()
+        provenance, reason = self._run(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "unresolved",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": None,
+                "ho_pattern_count": 0,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "unresolved",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 0: ho-paths unresolved (fail-closed)。探索パス: /nonexistent/ho-paths.md",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority1_touches_ho(self):
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            lite={"size_ok": False, "no_new_design": False, "follows_pattern": False, "reversible": False},
+            **{"class": "merge"},
+        )
+        data["verdicts"] = {
+            "model_a": "reject",
+            "model_b": "reject",
+            "reject_category": None,
+            "model_c": None,
+            "model_d": None,
+        }
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "touches-HO",
+                "class_check": "merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": False,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "not_evaluated",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "reject"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: bin/plangate (bin/plangate / HO-core)",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority1_5_scope_violation(self):
+        data = _base_input(changed_files=["docs/other/outside.md"], allowed_paths=["docs/workflows/ai-loop/**"])
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "scope_violation",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: docs/other/outside.md）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority2_lite_false(self):
+        data = _base_input(lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": False,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 2: boundary=clean だが lite=false（低リスク要件未充足）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority3_class_merge(self):
+        data = _base_input(**{"class": "merge"})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 3: class=merge（Human-owned 固定）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority4_reject_reject(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "reject"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 4: verdict=reject-reject（A が設計妥当性で NG、または両者合意で NG）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority4_reject_approve(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "reject", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 4: verdict=reject-approve（A が設計妥当性で NG、または両者合意で NG）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority6_approve_approve(self):
+        data = _base_input()
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 6: verdict=approve-approve（合意）")
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_severity_critical(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "security_break"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "reject_category": "security_break",
+                    "severity": "critical",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: verdict=approve-reject, severity=critical（reject_category='security_break'）→ human escalate 固定",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_severity_major(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "reject_category": "auth_change",
+                    "severity": "major",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: verdict=approve-reject, severity=major（reject_category='auth_change'）→ human escalate 固定",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_missing(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = None
+        data["verdicts"]["model_d"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_d": "approve",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor だが model_c/model_d のいずれかが欠落 → human escalate（安全側）",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_approve_approve(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "approve",
+                    "model_d": "approve",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=approve-approve → AUTO_APPROVED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_reject_reject(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "reject"
+        data["verdicts"]["model_d"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "BLOCKED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "reject",
+                    "model_d": "reject",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=reject-reject → BLOCKED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_priority5_cd_mixed(self):
+        data = _base_input()
+        data["verdicts"]["model_a"] = "approve"
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "reject"
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "HUMAN_ESCALATED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {
+                    "model_a": "approve",
+                    "model_b": "reject",
+                    "model_c": "approve",
+                    "model_d": "reject",
+                    "reject_category": "logic",
+                    "severity": "minor",
+                },
+            },
+        )
+        self.assertEqual(
+            reason,
+            "priority 5: severity=minor, C/D 裁定=approve-reject → HUMAN_ESCALATED",
+        )
+        self._assert_json_roundtrip_stable(provenance)
+
+    def test_with_run_meta_approve_approve(self):
+        data = _base_input(run={"run_id": "run-001", "round_index": 0, "task_id": "TASK-0814", "repair_action": None})
+        provenance, reason = self._run(data)
+        self.assertEqual(
+            provenance,
+            {
+                "boundary_check": "clean",
+                "class_check": "no-merge",
+                "decision": "AUTO_APPROVED",
+                "ho_paths_source": self._NORMALIZED_HO_SOURCE,
+                "ho_pattern_count": 18,
+                "issued_by": "arbiter-v0.1",
+                "lite_check": True,
+                "policy_ref": "auto-approve-lite-clean@v1",
+                "run": {
+                    "repair_action": None,
+                    "round_index": 0,
+                    "run_id": "run-001",
+                    "task_id": "TASK-0814",
+                },
+                "scope_check": "in_scope",
+                "target_sha": "abc1234",
+                "w_check": {"model_a": "approve", "model_b": "approve"},
+            },
+        )
+        self.assertEqual(reason, "priority 6: verdict=approve-approve（合意）")
+        self._assert_json_roundtrip_stable(provenance)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## 概要

#814。#809 で段階的に肥大した `arbiter.py` の `arbitrate`（priority 分岐の定型 3 行 × 7）を、**動作不変**でリファクタする。`growth-core:refactoring-guidance` スキルの検討結果に基づく純リファクタ（機能変更ゼロ・gate 挙動/不変条件/priority 順序を変えない）。

## 変更内容（3 段階・別コミット）

- **R-2**: 判定前処理（boundary_check / check_allowed_paths / lite_check / verdict 正規化）を `_evaluate_signals` に抽出
- **R-1**: priority 0/1/1.5/2/3/4/6 をデータ駆動テーブル + ループ化（decision-table.md の priority 表と対応）。**priority 5（approve-reject の C/D 裁定）は複雑なため個別処理として維持**（over-engineering 回避）
- **R-3**: validate_input の changed_files / allowed_paths 検証の重複を `_require_normalized_path_list` に抽出

**arbitrate: 185 → 140 行**（約 24% 削減）。

## 動作不変の証明（観測ベース）

- **characterization test 15 件**（全 priority 0〜6 + C/D 4 パターン + run メタ）を追加し、リファクタ各 Step で provenance record が**バイト一致**（timestamp / ho_paths_source のみ環境依存として正規化）
- **統合側の独立差分検証**: origin/main の arbiter と本 PR の arbiter に**同一入力バッテリー 259 ケース**（全 verdict 組合せ × lite × class × reject_category × C/D 提供有無 + 空 allowed_paths/changed_files/複数ファイルのエッジ）を流し、exit code と provenance が**全件バイト一致（0 mismatch）**。fail-closed 経路（ho-paths 未解決）の eager 評価化も影響なしを実測

## 検証

- `test_arbiter.py` 161 / scripts/ai-loop 全体 193 テスト GREEN（repo 正本 + plugin bundled 両方で自立 PASS）
- arbiter.py / test_arbiter.py とも plugin コピーと cmp IDENTICAL
- HO 9 カテゴリ・metrics.py・decision-table.md 非接触

## 設計判断

priority 5 をテーブル外に残したのは、severity 分類 → C/D 欠落チェック → 3 値分岐の 2 段判定が単純 tuple で表現しづらく、テーブル化のメリットより複雑化のデメリットが上回るため（スキルの over-engineering 回避方針）。

## 関連

Refs #814。後続: Slice B（plan 品質 hard gate・priority 1.7）はテーブル化により 1 エントリ追加で載る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)