### PR TITLE
feat: ai-loop plan 品質ゲート priority 1.7 — C-1/breakdown を auto-approve 必要条件に（#780 Slice B）

### DIFF
--- a/.agents/skills/ai-loop-cycle/SKILL.md
+++ b/.agents/skills/ai-loop-cycle/SKILL.md
@@ -22,6 +22,7 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 - **C-1 PASS・C-2 完了済み**であること（`references/execution-runbook.md` §2 前提）。
   本サイクルは C-3' ゲートの位置づけであり、C-1/C-2 未完了の変更には使わない。
+  この C-1 の実施結果（`PASS`）を Step 1 の入力 `gates.c1` にそのまま渡す（#780 Slice B）。
 - 対象は **lite 帯候補の変更**（`references/lite-criteria.md` §2 の 4 軸を満たしうる変更）。
   high-risk / critical 相当や boundary=touches-HO が明らかな変更には使わない
   （使っても flow フェーズで即 human escalate になる）。
@@ -36,6 +37,16 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   既定案として、導入先の作業ディレクトリ配下に run 単位の裁定 record 用サブディレクトリ
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
   ディレクトリ規約を優先すること。
+
+## Step 0: breakdown-gate による粒度判定（#780 Slice B）
+
+`breakdown-gate` スキル（同梱・または導入先の等価スキル）でタスク粒度を
+判定する（理想 / 許容 / 分割必須の 3 段階）。判定結果を `gates.breakdown`
+へ変換する:
+
+- 理想 / 許容 → `"pass"`
+- 分割必須 → `"pass"` 以外の値（例 `"split-suggested"`）。arbiter は priority 1.7
+  で human escalate する（分割してから再度サイクルへ）
 
 ## Step 1: 入力の組み立て
 
@@ -56,6 +67,14 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
+
+`gates`（任意・#780 Slice B）は plan 品質ゲート（priority 1.7）の入力。**Step 0**
+（breakdown-gate 判定）の verdict を `gates.breakdown` に（`理想`/`許容` → `"pass"`、
+`分割必須` → それ以外の値。`"pass"` 以外はすべて未充足扱い）、**Step 1 の前提**
+（C-1 実施結果）を `gates.c1` に（`"PASS"` のみ通過）設定する。**gates 省略も
+入力エラーにはならないが、priority 1.7 で human escalate に倒れる**（後方互換・
+安全側。以前の auto-approve 経路を壊さないためには gates を両方
+`"PASS"`/`"pass"` で渡す必要がある）。
 
 `run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
@@ -80,6 +99,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_d": null
   },
   "target_sha": "abc1234",
+  "gates": {
+    "c1": "PASS",
+    "breakdown": "pass"
+  },
   "run": {
     "run_id": "run-022",
     "round_index": 1,

--- a/.claude/skills/ai-loop-cycle/SKILL.md
+++ b/.claude/skills/ai-loop-cycle/SKILL.md
@@ -14,6 +14,7 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 - **C-1 PASS・C-2 完了済み**であること（[`execution-runbook.md`](../../../docs/workflows/ai-loop/execution-runbook.md) §2 前提）。
   本サイクルは C-3' ゲートの位置づけであり、C-1/C-2 未完了の変更には使わない。
+  この C-1 の実施結果（`PASS`）を Step 1 の入力 `gates.c1` にそのまま渡す（#780 Slice B）。
 - 対象は **lite 帯候補の変更**（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.md) §2 の
   4 軸を満たしうる変更）。high-risk / critical 相当や boundary=touches-HO が明らかな変更には使わない
   （使っても flow フェーズで即 human escalate になる）。
@@ -21,6 +22,15 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   （`bin/plangate`・`scripts/hooks/`）からは呼ばれない隔離 PoC である。②導入先リポジトリ = ho-paths
   を導入先で確定し LoopSpec `scope.allowed_paths` を宣言していれば適用可（導入先の本番承認フロー
   からは呼ばれない点は不変）。
+
+## Step 0: breakdown-gate による粒度判定（#780 Slice B）
+
+[`breakdown-gate`](../breakdown-gate/SKILL.md) スキルでタスク粒度を判定する
+（理想 / 許容 / 分割必須の 3 段階）。判定結果を `gates.breakdown` へ変換する:
+
+- 理想 / 許容 → `"pass"`
+- 分割必須 → `"pass"` 以外の値（例 `"split-suggested"`）。arbiter は priority 1.7
+  で human escalate する（分割してから再度サイクルへ）
 
 ## Step 1: 入力の組み立て
 
@@ -40,6 +50,15 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。`allowed_paths` は LoopSpec の `scope.allowed_paths`
 宣言をそのまま渡す（#809）。
+
+`gates`（任意・#780 Slice B）は plan 品質ゲート（priority 1.7）の入力。**Step 0**
+（breakdown-gate スキルで粒度判定）の verdict を `gates.breakdown` に
+（`理想`/`許容` → `"pass"`、`分割必須` → それ以外の値、例 `"split-suggested"`。
+`"pass"` 以外はすべて未充足扱い）、**Step 1**（C-1 実施結果）を `gates.c1` に
+（`"PASS"` のみ通過。`FAIL`/未実施はそれ以外の値）設定する。**gates 自体を
+省略した場合も入力エラーにはならないが、priority 1.7 で human escalate に
+倒れる**（後方互換・安全側。以前の auto-approve 経路を壊さないためには
+gates を両方 `"PASS"`/`"pass"` で渡す必要がある）。
 
 `run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
@@ -64,6 +83,10 @@ lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.
     "model_d": null
   },
   "target_sha": "abc1234",
+  "gates": {
+    "c1": "PASS",
+    "breakdown": "pass"
+  },
   "run": {
     "run_id": "run-022",
     "round_index": 1,

--- a/.codex/skills/ai-loop-cycle/SKILL.md
+++ b/.codex/skills/ai-loop-cycle/SKILL.md
@@ -5,20 +5,6 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 # ai-loop-cycle
 
-> **配置に関する注記（#809）**: 本 `.codex/skills/ai-loop-cycle/` 配置は
-> bundled resources（`references/`・`scripts/`）を**同梱していない**（本文中の
-> 記述は `.agents/skills/ai-loop-cycle/SKILL.md` と共通のテキストであり、
-> bundled 配置を前提とした文言を含むが、実体の `references/`・`scripts/`
-> ディレクトリはここには存在しない）。判定ロジック・provenance スキーマの
-> 実装は repo 正本 [`scripts/ai-loop/arbiter.py`](../../../scripts/ai-loop/arbiter.py)、
-> 手順・分岐表の正本は [`docs/workflows/ai-loop/`](../../../docs/workflows/ai-loop/)
-> を参照すること。`.agents/` → `.codex/` の同期は
-> `scripts/install-plangate-skills-to-codex.sh` によるが、3 配置
-> （`.agents/` / `.codex/` / `plugin/plangate/`）の SKILL.md 内容同一性を
-> 機械的に強制するテストは現状存在しない（手動同期依存）。
-
-<!-- 以下は .agents/skills/ai-loop-cycle/SKILL.md と共通のテキスト（bundled 配置前提の文言を含む） -->
-
 > 本スキルは **bundled resources**（`references/`・`scripts/`）で自己完結する。
 > スキルディレクトリ直下の `references/<name>.md` と `scripts/arbiter.py` を同梱し、
 > 導入先が独自の正本（`docs/workflows/ai-loop/` 等）を別途保持している場合は
@@ -36,6 +22,7 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 - **C-1 PASS・C-2 完了済み**であること（`references/execution-runbook.md` §2 前提）。
   本サイクルは C-3' ゲートの位置づけであり、C-1/C-2 未完了の変更には使わない。
+  この C-1 の実施結果（`PASS`）を Step 1 の入力 `gates.c1` にそのまま渡す（#780 Slice B）。
 - 対象は **lite 帯候補の変更**（`references/lite-criteria.md` §2 の 4 軸を満たしうる変更）。
   high-risk / critical 相当や boundary=touches-HO が明らかな変更には使わない
   （使っても flow フェーズで即 human escalate になる）。
@@ -51,6 +38,16 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
   ディレクトリ規約を優先すること。
 
+## Step 0: breakdown-gate による粒度判定（#780 Slice B）
+
+`breakdown-gate` スキル（同梱・または導入先の等価スキル）でタスク粒度を
+判定する（理想 / 許容 / 分割必須の 3 段階）。判定結果を `gates.breakdown`
+へ変換する:
+
+- 理想 / 許容 → `"pass"`
+- 分割必須 → `"pass"` 以外の値（例 `"split-suggested"`）。arbiter は priority 1.7
+  で human escalate する（分割してから再度サイクルへ）
+
 ## Step 1: 入力の組み立て
 
 `changed_files` を決定する:
@@ -61,6 +58,8 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで宣言する。**いずれかの軸が
 判定不能なら false**（AC-8 安全側、虚偽宣言禁止）。
 
+`allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
+
 - `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
@@ -69,6 +68,14 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
 
+`gates`（任意・#780 Slice B）は plan 品質ゲート（priority 1.7）の入力。**Step 0**
+（breakdown-gate 判定）の verdict を `gates.breakdown` に（`理想`/`許容` → `"pass"`、
+`分割必須` → それ以外の値。`"pass"` 以外はすべて未充足扱い）、**Step 1 の前提**
+（C-1 実施結果）を `gates.c1` に（`"PASS"` のみ通過）設定する。**gates 省略も
+入力エラーにはならないが、priority 1.7 で human escalate に倒れる**（後方互換・
+安全側。以前の auto-approve 経路を壊さないためには gates を両方
+`"PASS"`/`"pass"` で渡す必要がある）。
+
 `run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
 入力 JSON の例:
@@ -76,6 +83,7 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 ```json
 {
   "changed_files": ["docs/example.md"],
+  "allowed_paths": ["docs/example.md"],
   "lite": {
     "size_ok": true,
     "no_new_design": true,
@@ -91,6 +99,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_d": null
   },
   "target_sha": "abc1234",
+  "gates": {
+    "c1": "PASS",
+    "breakdown": "pass"
+  },
   "run": {
     "run_id": "run-022",
     "round_index": 1,

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -52,16 +52,17 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
-### priority 0 / 1.5（#809 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+### priority 0 / 1.5 / 1.7（#809・#780 Slice B 追加・機械実装のみで本表 1〜6 の番号体系は不変）
 
 上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
-2 チェックは `scripts/ai-loop/arbiter.py`（#809）が実装する**前置・割込み
-チェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
+3 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B）が実装する
+**前置・割込みチェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
 
 | priority | 内容 | → 裁定 |
 | ---------- | ------ | -------- |
 | **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
 | **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
+| **1.7** | boundary=clean・scope 逸脱なし（priority 1.5 通過後）だが、`gates.c1 == "PASS"` かつ `gates.breakdown == "pass"`（両方とも厳密一致）を満たさない（plan 品質ゲート未充足） | **human escalate** |
 
 - priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
   （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
@@ -69,6 +70,16 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 - priority 1.5 は priority 1（touches-HO）の**後**に評価する。
   `allowed_paths` に HO パスを宣言していても HO escalate は免れない
   （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
+- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 2（lite）の
+  **前**に評価する。`gates`（`{"c1": str, "breakdown": str}`）は任意入力フィールドで、
+  欠落・null・非 dict・型不一致・値の表記違い（例: 小文字 `"pass"` 以外の
+  `breakdown`、`"PASS"` 以外の `c1`）は**すべて安全側で未充足＝human escalate**
+  に倒れる。**本チェックは escalate 条件を追加するだけの安全側変更であり、
+  以前 escalate/blocked だった経路を auto-approve にする効果は一切持たない**
+  （POLICY_REF を `@v1` → `@v2` へ改版した理由）。`c1` は C-1 セルフレビューの
+  結果（`"PASS"` のみ通過）、`breakdown` は breakdown-gate スキルの粒度判定
+  結果（`"pass"` のみ通過。`split-suggested` 等は未充足）を渡す想定
+  （`.agents/skills/ai-loop-cycle/SKILL.md` Step 0/1 参照）
 
 ### 裁定ラベルと provenance 値の対応
 
@@ -112,7 +123,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v1（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v2（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -127,9 +138,13 @@ timestamp:          <ISO 8601>
 ```
 
 > **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
-> ho-paths 実行時解決の fail-closed 機械化）。`@v0` 時点の PoC は
+> ho-paths 実行時解決の fail-closed 機械化）→ `@v2`（#780 Slice B: `gates`
+> 入力による plan 品質ゲート priority 1.7 の追加）。`@v0` 時点の PoC は
 > `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
-> ロジックが変わった本改版で policy バージョンを進めた。
+> ロジックが変わった本改版で policy バージョンを進めた。`@v2` は
+> auto-approve の新必要条件（`gates.c1 == "PASS"` かつ `gates.breakdown ==
+> "pass"`）を追加した改版であり、escalate 条件を追加するだけの安全側変更
+> （以前 auto-approve/blocked だった経路が新たに auto-approve になることはない）。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 
@@ -156,7 +171,25 @@ run:
 
 `run` は `scripts/ai-loop/metrics.py`（#812）が run 単位の集計（first-pass rate 等）に
 用いる消費契約。gate 挙動（POLICY_REF）は変えない純粋な additive provenance 拡張であり、
-本追加による policy バージョン改版は行わない（`auto-approve-lite-clean@v1` 据え置き）。
+本追加による policy バージョン改版は行わない（run 追加自体は据え置き。現行ベースラインは
+`@v2` — #780 Slice B の `gates` 必須化によるもので、run 起因の改版ではない）。
+
+### 入力: gates（#780 Slice B 追加・additive・任意）
+
+呼び出し側入力の `gates`（省略可）は priority 1.7（plan 品質ゲート）の判定
+にのみ使う入力軸であり、`run` と異なり **provenance には echo されない**
+（判定結果は decision / reason にのみ反映される。PoC スコープでは gates 自体の
+生値を record に刻む必要性が薄いため見送り — 将来 Phase で必要になれば
+additive に追加検討）。
+
+```text
+gates:
+  c1:        PASS（C-1 セルフレビューの結果。"PASS" 以外はすべて未充足扱い）
+  breakdown: pass（breakdown-gate スキルの粒度判定結果。"pass" 以外はすべて未充足扱い）
+```
+
+`gates` 省略・null・非 dict・キー欠落・値の表記違いは**すべて安全側で
+plan_quality_ok=false**（priority 1.7 で human escalate）に倒れる。
 
 ### フィールド定義
 

--- a/plugin/plangate/skills/ai-loop-cycle/SKILL.md
+++ b/plugin/plangate/skills/ai-loop-cycle/SKILL.md
@@ -22,6 +22,7 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 
 - **C-1 PASS・C-2 完了済み**であること（`references/execution-runbook.md` §2 前提）。
   本サイクルは C-3' ゲートの位置づけであり、C-1/C-2 未完了の変更には使わない。
+  この C-1 の実施結果（`PASS`）を Step 1 の入力 `gates.c1` にそのまま渡す（#780 Slice B）。
 - 対象は **lite 帯候補の変更**（`references/lite-criteria.md` §2 の 4 軸を満たしうる変更）。
   high-risk / critical 相当や boundary=touches-HO が明らかな変更には使わない
   （使っても flow フェーズで即 human escalate になる）。
@@ -36,6 +37,16 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   既定案として、導入先の作業ディレクトリ配下に run 単位の裁定 record 用サブディレクトリ
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
   ディレクトリ規約を優先すること。
+
+## Step 0: breakdown-gate による粒度判定（#780 Slice B）
+
+`breakdown-gate` スキル（同梱・または導入先の等価スキル）でタスク粒度を
+判定する（理想 / 許容 / 分割必須の 3 段階）。判定結果を `gates.breakdown`
+へ変換する:
+
+- 理想 / 許容 → `"pass"`
+- 分割必須 → `"pass"` 以外の値（例 `"split-suggested"`）。arbiter は priority 1.7
+  で human escalate する（分割してから再度サイクルへ）
 
 ## Step 1: 入力の組み立て
 
@@ -56,6 +67,14 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 
 `class` は `merge` を含む変更なら `"merge"`（即 human escalate）、含まなければ `"no-merge"`。
 `target_sha` は対象コミットの SHA。
+
+`gates`（任意・#780 Slice B）は plan 品質ゲート（priority 1.7）の入力。**Step 0**
+（breakdown-gate 判定）の verdict を `gates.breakdown` に（`理想`/`許容` → `"pass"`、
+`分割必須` → それ以外の値。`"pass"` 以外はすべて未充足扱い）、**Step 1 の前提**
+（C-1 実施結果）を `gates.c1` に（`"PASS"` のみ通過）設定する。**gates 省略も
+入力エラーにはならないが、priority 1.7 で human escalate に倒れる**（後方互換・
+安全側。以前の auto-approve 経路を壊さないためには gates を両方
+`"PASS"`/`"pass"` で渡す必要がある）。
 
 `run`（任意）は `run_id`（`run-NNN` 連番）・`round_index`（**初回呼び出し=1**、再試行ごとに +1。1 起点。metrics は round_index==1 を初回 sentinel に first_pass 判定するため 0 起点不可）・`task_id`（対象 PBI）を刻む。省略可だが、省略すると metrics 集計対象外（legacy）になる。
 
@@ -80,6 +99,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
     "model_d": null
   },
   "target_sha": "abc1234",
+  "gates": {
+    "c1": "PASS",
+    "breakdown": "pass"
+  },
   "run": {
     "run_id": "run-022",
     "round_index": 1,

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -52,16 +52,17 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
-### priority 0 / 1.5（#809 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+### priority 0 / 1.5 / 1.7（#809・#780 Slice B 追加・機械実装のみで本表 1〜6 の番号体系は不変）
 
 上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
-2 チェックは `scripts/ai-loop/arbiter.py`（#809）が実装する**前置・割込み
-チェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
+3 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B）が実装する
+**前置・割込みチェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
 
 | priority | 内容 | → 裁定 |
 | ---------- | ------ | -------- |
 | **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
 | **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
+| **1.7** | boundary=clean・scope 逸脱なし（priority 1.5 通過後）だが、`gates.c1 == "PASS"` かつ `gates.breakdown == "pass"`（両方とも厳密一致）を満たさない（plan 品質ゲート未充足） | **human escalate** |
 
 - priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
   （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
@@ -69,6 +70,16 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 - priority 1.5 は priority 1（touches-HO）の**後**に評価する。
   `allowed_paths` に HO パスを宣言していても HO escalate は免れない
   （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
+- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 2（lite）の
+  **前**に評価する。`gates`（`{"c1": str, "breakdown": str}`）は任意入力フィールドで、
+  欠落・null・非 dict・型不一致・値の表記違い（例: 小文字 `"pass"` 以外の
+  `breakdown`、`"PASS"` 以外の `c1`）は**すべて安全側で未充足＝human escalate**
+  に倒れる。**本チェックは escalate 条件を追加するだけの安全側変更であり、
+  以前 escalate/blocked だった経路を auto-approve にする効果は一切持たない**
+  （POLICY_REF を `@v1` → `@v2` へ改版した理由）。`c1` は C-1 セルフレビューの
+  結果（`"PASS"` のみ通過）、`breakdown` は breakdown-gate スキルの粒度判定
+  結果（`"pass"` のみ通過。`split-suggested` 等は未充足）を渡す想定
+  （`.agents/skills/ai-loop-cycle/SKILL.md` Step 0/1 参照）
 
 ### 裁定ラベルと provenance 値の対応
 
@@ -112,7 +123,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v1（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v2（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -127,9 +138,13 @@ timestamp:          <ISO 8601>
 ```
 
 > **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
-> ho-paths 実行時解決の fail-closed 機械化）。`@v0` 時点の PoC は
+> ho-paths 実行時解決の fail-closed 機械化）→ `@v2`（#780 Slice B: `gates`
+> 入力による plan 品質ゲート priority 1.7 の追加）。`@v0` 時点の PoC は
 > `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
-> ロジックが変わった本改版で policy バージョンを進めた。
+> ロジックが変わった本改版で policy バージョンを進めた。`@v2` は
+> auto-approve の新必要条件（`gates.c1 == "PASS"` かつ `gates.breakdown ==
+> "pass"`）を追加した改版であり、escalate 条件を追加するだけの安全側変更
+> （以前 auto-approve/blocked だった経路が新たに auto-approve になることはない）。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 
@@ -156,7 +171,25 @@ run:
 
 `run` は `scripts/ai-loop/metrics.py`（#812）が run 単位の集計（first-pass rate 等）に
 用いる消費契約。gate 挙動（POLICY_REF）は変えない純粋な additive provenance 拡張であり、
-本追加による policy バージョン改版は行わない（`auto-approve-lite-clean@v1` 据え置き）。
+本追加による policy バージョン改版は行わない（run 追加自体は据え置き。現行ベースラインは
+`@v2` — #780 Slice B の `gates` 必須化によるもので、run 起因の改版ではない）。
+
+### 入力: gates（#780 Slice B 追加・additive・任意）
+
+呼び出し側入力の `gates`（省略可）は priority 1.7（plan 品質ゲート）の判定
+にのみ使う入力軸であり、`run` と異なり **provenance には echo されない**
+（判定結果は decision / reason にのみ反映される。PoC スコープでは gates 自体の
+生値を record に刻む必要性が薄いため見送り — 将来 Phase で必要になれば
+additive に追加検討）。
+
+```text
+gates:
+  c1:        PASS（C-1 セルフレビューの結果。"PASS" 以外はすべて未充足扱い）
+  breakdown: pass（breakdown-gate スキルの粒度判定結果。"pass" 以外はすべて未充足扱い）
+```
+
+`gates` 省略・null・非 dict・キー欠落・値の表記違いは**すべて安全側で
+plan_quality_ok=false**（priority 1.7 で human escalate）に倒れる。
 
 ### フィールド定義
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -795,9 +795,12 @@ def arbitrate(
 
     def _gates_reason() -> str:
         gates = data.get("gates")
-        c1_value = gates.get("c1") if isinstance(gates, dict) else None
-        breakdown_value = gates.get("breakdown") if isinstance(gates, dict) else None
-        return f"priority 1.7: plan-quality gate 未充足（c1={c1_value} breakdown={breakdown_value}）"
+        # 理由メッセージのみ型を判別（decision・判定ロジックは不変）。gates が
+        # dict でない（str/list/int 等）場合は「キー未指定（c1=None）」と区別
+        # できるよう型不正を明示する（gemini medium 反映・#780 Slice B）。
+        if not isinstance(gates, dict):
+            return f"priority 1.7: plan-quality gate 未充足（gates が dict でない・型: {type(gates).__name__}）"
+        return f"priority 1.7: plan-quality gate 未充足（c1={gates.get('c1')} breakdown={gates.get('breakdown')}）"
 
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -35,6 +35,10 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "model_d": "approve" | "reject" | null
       },
       "target_sha": str,
+      "gates": {                         # 任意（#780 Slice B 追加・additive）
+        "c1": str,                       #   "PASS" 厳密一致のみ plan-quality を満たす
+        "breakdown": str                 #   "pass" 厳密一致のみ plan-quality を満たす
+      } | 省略可,                        # 省略・null・非 dict・値不一致はすべて priority 1.7 escalate（安全側）
       "run": {                          # 任意（#780 Slice D 後半 追加・additive）
         "run_id": str,                  #   非空 string（run 単位の連番識別子）
         "round_index": int,             #   bool 不可・必須（run 提供時）
@@ -49,6 +53,14 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
 allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
 I-1 不変条件）。
+
+`gates`（#780 Slice B 追加）は任意フィールド。`gates.c1 == "PASS"` かつ
+`gates.breakdown == "pass"`（両方とも厳密一致）のときのみ plan-quality gate
+を満たしたとみなす（priority 1.7）。欠落・null・非 dict・型不一致・値の
+表記違いはすべて安全側で未充足（human escalate）に倒れる。**この変更は
+escalate 条件を追加するだけの安全側変更であり、以前 escalate だった経路を
+auto-approve にする効果は一切持たない**（POLICY_REF を @v1 → @v2 へ改版した
+理由）。
 
 `run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
 provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
@@ -376,6 +388,27 @@ def lite_check(lite_input: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# plan 品質ゲート判定: priority 1.7（#780 Slice B・AC-8 安全側）
+# ---------------------------------------------------------------------------
+# 出典: docs/workflows/ai-loop/decision-table.md §3 priority 1.7 /
+# `.agents/skills/ai-loop-cycle/SKILL.md` Step 0（breakdown-gate）・Step 1（C-1）。
+# 任意フィールド `gates`（{"c1": str, "breakdown": str}）を厳密一致で判定する。
+# **この関数は escalate 条件を追加するだけの安全側変更**であり、以前 escalate
+# だった経路を auto-approve に倒す効果を一切持たない（gates 欠落・null・
+# 異表記・非 str はすべて false＝escalate 側に倒れる）。
+def plan_quality_check(gates: Any) -> bool:
+    """gates.c1 == "PASS" かつ gates.breakdown == "pass"（両方とも厳密一致）のときのみ true。
+
+    `gates` 自体が dict でない（欠落・null・非 dict）場合も false。
+    値が str でない場合は `==` 比較が自然に False になるため追加の型検査は不要
+    （例: 123 == "PASS" は False）。
+    """
+    if not isinstance(gates, dict):
+        return False
+    return gates.get("c1") == "PASS" and gates.get("breakdown") == "pass"
+
+
+# ---------------------------------------------------------------------------
 # severity 分類（priority 5 時のみ使用）
 # ---------------------------------------------------------------------------
 # 出典: docs/workflows/ai-loop/flow-detect.md §3.2.1 カテゴリマッピング表。
@@ -420,7 +453,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v1"
+POLICY_REF = "auto-approve-lite-clean@v2"
 
 
 class InputError(ValueError):
@@ -634,6 +667,7 @@ class Signals:
     scope_ok: bool
     violations: list[str]
     lite_result: bool
+    plan_quality_ok: bool
     verdict: str
 
 
@@ -662,6 +696,7 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
     boundary, matched = boundary_check(changed_files, ho_patterns)
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     lite_result = lite_check(data["lite"])
+    plan_quality_ok = plan_quality_check(data.get("gates"))
     verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
 
     return Signals(
@@ -670,6 +705,7 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
         scope_ok=scope_ok,
         violations=violations,
         lite_result=lite_result,
+        plan_quality_ok=plan_quality_ok,
         verdict=verdict,
     )
 
@@ -757,11 +793,19 @@ def arbitrate(
     def _matched_desc() -> str:
         return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
 
+    def _gates_reason() -> str:
+        gates = data.get("gates")
+        c1_value = gates.get("c1") if isinstance(gates, dict) else None
+        breakdown_value = gates.get("breakdown") if isinstance(gates, dict) else None
+        return f"priority 1.7: plan-quality gate 未充足（c1={c1_value} breakdown={breakdown_value}）"
+
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
         ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
          lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
+        ("priority 1.7", not signals.plan_quality_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         _gates_reason),
         ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
         ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -46,6 +46,11 @@ def _base_input(**overrides):
             "model_d": None,
         },
         "target_sha": "abc1234",
+        # #780 Slice B: priority 1.7（plan-quality gate）を既定で満たしておく。
+        # これにより priority 2 以降の裁定を検証する既存 characterization test
+        # 群は、gates 未対応時代の裁定と同一の結果を維持する（gates 完備は
+        # escalate を追加しないための前提条件・後方互換のための既定値）。
+        "gates": {"c1": "PASS", "breakdown": "pass"},
     }
     data.update(overrides)
     return data
@@ -292,6 +297,144 @@ class DecisionTablePriorityTests(unittest.TestCase):
         self.assertIn("priority 6", reason)
 
 
+class PlanQualityCheckUnitTests(unittest.TestCase):
+    """plan_quality_check() 単体テスト（AC-8 安全側: 欠落・null・型不一致は false）。"""
+
+    def test_both_pass_is_true(self):
+        self.assertTrue(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "pass"}))
+
+    def test_c1_fail_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "FAIL", "breakdown": "pass"}))
+
+    def test_breakdown_split_suggested_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "split-suggested"}))
+
+    def test_gates_missing_key_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS"}))
+        self.assertFalse(arbiter.plan_quality_check({"breakdown": "pass"}))
+        self.assertFalse(arbiter.plan_quality_check({}))
+
+    def test_gates_none_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check(None))
+
+    def test_gates_non_dict_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check("PASS"))
+        self.assertFalse(arbiter.plan_quality_check(["PASS", "pass"]))
+
+    def test_c1_non_string_is_false(self):
+        """AC-8 安全側: 非 str（例: 123）は false。"""
+        self.assertFalse(arbiter.plan_quality_check({"c1": 123, "breakdown": "pass"}))
+
+    def test_breakdown_none_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": None}))
+
+    def test_case_sensitive_mismatch_is_false(self):
+        """厳密一致: "pass"（小文字）・"PASS"（大文字）以外の表記ゆれは false。"""
+        self.assertFalse(arbiter.plan_quality_check({"c1": "pass", "breakdown": "pass"}))
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "PASS"}))
+
+
+class PlanQualityGatePriorityTests(unittest.TestCase):
+    """#780 Slice B: priority 1.7（plan-quality gate）の裁定経路テスト。
+
+    中核原則: escalate 条件を追加するのみ。以前 auto-approve だったケースは
+    gates 完備時のみ auto-approve を維持し、gates 不備は escalate に倒れる。
+    """
+
+    def test_gates_complete_reaches_auto_approve(self):
+        """gates 完備 + 他 auto-approve 条件 → AUTO_APPROVED（#816 と同一裁定）。"""
+        data = _base_input(gates={"c1": "PASS", "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_gates_c1_fail_escalates(self):
+        data = _base_input(gates={"c1": "FAIL", "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertIn("plan-quality", reason)
+
+    def test_gates_breakdown_split_suggested_escalates(self):
+        data = _base_input(gates={"c1": "PASS", "breakdown": "split-suggested"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_missing_field_escalates_exit2_not_exit1(self):
+        """gates フィールド自体が無い入力は exit 1（入力エラー）ではなく
+        exit 2（HUMAN_ESCALATED）になる（後方互換の要）。"""
+        data = _base_input()
+        del data["gates"]
+        validated = arbiter.validate_input(data)  # 入力エラーにならないことを確認
+        provenance, reason = arbiter.arbitrate(validated)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertEqual(arbiter.EXIT_CODES[provenance["decision"]], 2)
+
+    def test_gates_null_escalates(self):
+        data = _base_input(gates=None)
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_c1_null_escalates(self):
+        data = _base_input(gates={"c1": None, "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_c1_non_string_escalates(self):
+        data = _base_input(gates={"c1": 123, "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_touches_ho_preempts_plan_quality_gate(self):
+        """HO 優先: touches-HO + gates.c1=FAIL でも boundary=touches-HO が先に確定する
+        （priority 1 が priority 1.7 より先。c1 の値で上書きされない）。"""
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            allowed_paths=["bin/plangate"],
+            gates={"c1": "FAIL", "breakdown": "split-suggested"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.7", reason)
+
+    def test_scope_violation_preempts_plan_quality_gate(self):
+        """scope 優先: scope 逸脱 + gates 完備でも priority 1.5（scope）が
+        priority 1.7 より先に確定する。"""
+        data = _base_input(
+            changed_files=["scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            gates={"c1": "PASS", "breakdown": "pass"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertNotIn("priority 1.7", reason)
+
+    def test_gates_ok_but_lite_false_reaches_priority2(self):
+        """gates 完備で priority 1.7 を通過した後、priority 2（lite=false）へ進む。"""
+        data = _base_input(
+            gates={"c1": "PASS", "breakdown": "pass"},
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+
+    def test_gates_reason_includes_values(self):
+        data = _base_input(gates={"c1": "FAIL", "breakdown": "not-pass"})
+        _provenance, reason = arbiter.arbitrate(data)
+        self.assertIn("c1=FAIL", reason)
+        self.assertIn("breakdown=not-pass", reason)
+
+
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):
         data = _base_input()
@@ -434,7 +577,7 @@ class ProvenanceSchemaTests(unittest.TestCase):
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
         self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
@@ -630,15 +773,18 @@ class AllowedPathsScopeTests(unittest.TestCase):
 
 
 class PolicyRefVersionTests(unittest.TestCase):
-    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。"""
+    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。
 
-    def test_tc11_policy_ref_is_v1(self):
-        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v1")
+    #780 Slice B で @v1 → @v2 へ再改版（gates 必須化・priority 1.7 追加）。
+    """
 
-    def test_tc11_provenance_policy_ref_is_v1(self):
+    def test_tc11_policy_ref_is_v2(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v2")
+
+    def test_tc11_provenance_policy_ref_is_v2(self):
         data = _base_input()
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
 class PathNormalizationSecurityTests(unittest.TestCase):
@@ -1203,10 +1349,11 @@ class RunMetaProvenanceTests(unittest.TestCase):
         self.assertEqual(provenance["run"], self.RUN_META)
 
     def test_policy_ref_unchanged_when_run_present(self):
-        """run は additive provenance であり policy 改版ではない（@v1 据え置き）。"""
+        """run は additive provenance であり policy 改版ではない（run 追加は据え置き。
+        現行ベースラインは #780 Slice B の gates 必須化で @v2 — run 起因の改版ではない）。"""
         data = _base_input(run=self.RUN_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
@@ -1445,7 +1592,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "unresolved",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1481,7 +1628,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "not_evaluated",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1506,7 +1653,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "scope_violation",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1531,7 +1678,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1553,7 +1700,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1577,7 +1724,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1604,7 +1751,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "approve"},
@@ -1629,7 +1776,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1654,7 +1801,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1687,7 +1834,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1722,7 +1869,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1758,7 +1905,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1795,7 +1942,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1832,7 +1979,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1864,7 +2011,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "run": {
                     "repair_action": None,
                     "round_index": 0,

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -434,6 +434,50 @@ class PlanQualityGatePriorityTests(unittest.TestCase):
         self.assertIn("c1=FAIL", reason)
         self.assertIn("breakdown=not-pass", reason)
 
+    def test_gates_non_dict_reason_indicates_type_error(self):
+        """gemini medium: gates が dict 以外（str/list/int）のとき、理由が
+        「gates が dict でない・型: <型名>」を明示し、「キー未指定（c1=None）」と
+        区別できる（decision は不変・escalate のまま）。"""
+        for bad_gates, type_name in [
+            ("not-a-dict", "str"),
+            (["c1", "pass"], "list"),
+            (123, "int"),
+        ]:
+            with self.subTest(gates=bad_gates):
+                data = _base_input(gates=bad_gates)
+                provenance, reason = arbiter.arbitrate(data)
+                self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+                self.assertIn("priority 1.7", reason)
+                self.assertIn("gates が dict でない", reason)
+                self.assertIn(f"型: {type_name}", reason)
+                # 非 dict では c1=None 表記を出さない（型不正と混同させない）
+                self.assertNotIn("c1=None", reason)
+
+    def test_gates_dict_missing_keys_reason_uses_key_values(self):
+        """回帰: gates が dict のままキー不備（例: 空 dict・部分 dict）は従来どおり
+        c1=<値> breakdown=<値> の理由（型不正メッセージにはしない）。coordinator
+        仕様の「gates=dict で c1/breakdown 不備 → 従来どおりの理由」に対応。"""
+        for partial in [{}, {"c1": "FAIL"}, {"breakdown": "split-suggested"}]:
+            with self.subTest(gates=partial):
+                data = _base_input(gates=partial)
+                _provenance, reason = arbiter.arbitrate(data)
+                self.assertIn("priority 1.7", reason)
+                self.assertIn(f"c1={partial.get('c1')}", reason)
+                self.assertIn(f"breakdown={partial.get('breakdown')}", reason)
+                self.assertNotIn("dict でない", reason)
+
+    def test_gates_absent_reason_indicates_type_error(self):
+        """gates キー自体が欠落（data.get→None）も非 dict 扱いで型明示。
+        「gates 未提供」を「dict でない・型: NoneType」として c1=None 混同を避ける
+        （decision は escalate のまま不変）。"""
+        data = _base_input()
+        del data["gates"]
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertIn("gates が dict でない", reason)
+        self.assertIn("型: NoneType", reason)
+
 
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -795,9 +795,12 @@ def arbitrate(
 
     def _gates_reason() -> str:
         gates = data.get("gates")
-        c1_value = gates.get("c1") if isinstance(gates, dict) else None
-        breakdown_value = gates.get("breakdown") if isinstance(gates, dict) else None
-        return f"priority 1.7: plan-quality gate 未充足（c1={c1_value} breakdown={breakdown_value}）"
+        # 理由メッセージのみ型を判別（decision・判定ロジックは不変）。gates が
+        # dict でない（str/list/int 等）場合は「キー未指定（c1=None）」と区別
+        # できるよう型不正を明示する（gemini medium 反映・#780 Slice B）。
+        if not isinstance(gates, dict):
+            return f"priority 1.7: plan-quality gate 未充足（gates が dict でない・型: {type(gates).__name__}）"
+        return f"priority 1.7: plan-quality gate 未充足（c1={gates.get('c1')} breakdown={gates.get('breakdown')}）"
 
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -35,6 +35,10 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
         "model_d": "approve" | "reject" | null
       },
       "target_sha": str,
+      "gates": {                         # 任意（#780 Slice B 追加・additive）
+        "c1": str,                       #   "PASS" 厳密一致のみ plan-quality を満たす
+        "breakdown": str                 #   "pass" 厳密一致のみ plan-quality を満たす
+      } | 省略可,                        # 省略・null・非 dict・値不一致はすべて priority 1.7 escalate（安全側）
       "run": {                          # 任意（#780 Slice D 後半 追加・additive）
         "run_id": str,                  #   非空 string（run 単位の連番識別子）
         "round_index": int,             #   bool 不可・必須（run 提供時）
@@ -49,6 +53,14 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
 する（#809）。ただし HO 接触判定（boundary=touches-HO）が常に先に評価され、
 allowed_paths に HO パスを含めても HO escalate は免れない（design-philosophy
 I-1 不変条件）。
+
+`gates`（#780 Slice B 追加）は任意フィールド。`gates.c1 == "PASS"` かつ
+`gates.breakdown == "pass"`（両方とも厳密一致）のときのみ plan-quality gate
+を満たしたとみなす（priority 1.7）。欠落・null・非 dict・型不一致・値の
+表記違いはすべて安全側で未充足（human escalate）に倒れる。**この変更は
+escalate 条件を追加するだけの安全側変更であり、以前 escalate だった経路を
+auto-approve にする効果は一切持たない**（POLICY_REF を @v1 → @v2 へ改版した
+理由）。
 
 `run`（#780 Slice D 後半 追加）は任意フィールド。指定すると全裁定経路の
 provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が run 単位の
@@ -376,6 +388,27 @@ def lite_check(lite_input: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# plan 品質ゲート判定: priority 1.7（#780 Slice B・AC-8 安全側）
+# ---------------------------------------------------------------------------
+# 出典: docs/workflows/ai-loop/decision-table.md §3 priority 1.7 /
+# `.agents/skills/ai-loop-cycle/SKILL.md` Step 0（breakdown-gate）・Step 1（C-1）。
+# 任意フィールド `gates`（{"c1": str, "breakdown": str}）を厳密一致で判定する。
+# **この関数は escalate 条件を追加するだけの安全側変更**であり、以前 escalate
+# だった経路を auto-approve に倒す効果を一切持たない（gates 欠落・null・
+# 異表記・非 str はすべて false＝escalate 側に倒れる）。
+def plan_quality_check(gates: Any) -> bool:
+    """gates.c1 == "PASS" かつ gates.breakdown == "pass"（両方とも厳密一致）のときのみ true。
+
+    `gates` 自体が dict でない（欠落・null・非 dict）場合も false。
+    値が str でない場合は `==` 比較が自然に False になるため追加の型検査は不要
+    （例: 123 == "PASS" は False）。
+    """
+    if not isinstance(gates, dict):
+        return False
+    return gates.get("c1") == "PASS" and gates.get("breakdown") == "pass"
+
+
+# ---------------------------------------------------------------------------
 # severity 分類（priority 5 時のみ使用）
 # ---------------------------------------------------------------------------
 # 出典: docs/workflows/ai-loop/flow-detect.md §3.2.1 カテゴリマッピング表。
@@ -420,7 +453,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v1"
+POLICY_REF = "auto-approve-lite-clean@v2"
 
 
 class InputError(ValueError):
@@ -634,6 +667,7 @@ class Signals:
     scope_ok: bool
     violations: list[str]
     lite_result: bool
+    plan_quality_ok: bool
     verdict: str
 
 
@@ -662,6 +696,7 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
     boundary, matched = boundary_check(changed_files, ho_patterns)
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     lite_result = lite_check(data["lite"])
+    plan_quality_ok = plan_quality_check(data.get("gates"))
     verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
 
     return Signals(
@@ -670,6 +705,7 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
         scope_ok=scope_ok,
         violations=violations,
         lite_result=lite_result,
+        plan_quality_ok=plan_quality_ok,
         verdict=verdict,
     )
 
@@ -757,11 +793,19 @@ def arbitrate(
     def _matched_desc() -> str:
         return ", ".join(f"{m['path']} ({m['pattern']} / {m['classification']})" for m in signals.matched)
 
+    def _gates_reason() -> str:
+        gates = data.get("gates")
+        c1_value = gates.get("c1") if isinstance(gates, dict) else None
+        breakdown_value = gates.get("breakdown") if isinstance(gates, dict) else None
+        return f"priority 1.7: plan-quality gate 未充足（c1={c1_value} breakdown={breakdown_value}）"
+
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
         ("priority 1.5", not signals.scope_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "scope_violation",
          lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
+        ("priority 1.7", not signals.plan_quality_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
+         _gates_reason),
         ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
         ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -46,6 +46,11 @@ def _base_input(**overrides):
             "model_d": None,
         },
         "target_sha": "abc1234",
+        # #780 Slice B: priority 1.7（plan-quality gate）を既定で満たしておく。
+        # これにより priority 2 以降の裁定を検証する既存 characterization test
+        # 群は、gates 未対応時代の裁定と同一の結果を維持する（gates 完備は
+        # escalate を追加しないための前提条件・後方互換のための既定値）。
+        "gates": {"c1": "PASS", "breakdown": "pass"},
     }
     data.update(overrides)
     return data
@@ -292,6 +297,144 @@ class DecisionTablePriorityTests(unittest.TestCase):
         self.assertIn("priority 6", reason)
 
 
+class PlanQualityCheckUnitTests(unittest.TestCase):
+    """plan_quality_check() 単体テスト（AC-8 安全側: 欠落・null・型不一致は false）。"""
+
+    def test_both_pass_is_true(self):
+        self.assertTrue(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "pass"}))
+
+    def test_c1_fail_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "FAIL", "breakdown": "pass"}))
+
+    def test_breakdown_split_suggested_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "split-suggested"}))
+
+    def test_gates_missing_key_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS"}))
+        self.assertFalse(arbiter.plan_quality_check({"breakdown": "pass"}))
+        self.assertFalse(arbiter.plan_quality_check({}))
+
+    def test_gates_none_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check(None))
+
+    def test_gates_non_dict_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check("PASS"))
+        self.assertFalse(arbiter.plan_quality_check(["PASS", "pass"]))
+
+    def test_c1_non_string_is_false(self):
+        """AC-8 安全側: 非 str（例: 123）は false。"""
+        self.assertFalse(arbiter.plan_quality_check({"c1": 123, "breakdown": "pass"}))
+
+    def test_breakdown_none_is_false(self):
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": None}))
+
+    def test_case_sensitive_mismatch_is_false(self):
+        """厳密一致: "pass"（小文字）・"PASS"（大文字）以外の表記ゆれは false。"""
+        self.assertFalse(arbiter.plan_quality_check({"c1": "pass", "breakdown": "pass"}))
+        self.assertFalse(arbiter.plan_quality_check({"c1": "PASS", "breakdown": "PASS"}))
+
+
+class PlanQualityGatePriorityTests(unittest.TestCase):
+    """#780 Slice B: priority 1.7（plan-quality gate）の裁定経路テスト。
+
+    中核原則: escalate 条件を追加するのみ。以前 auto-approve だったケースは
+    gates 完備時のみ auto-approve を維持し、gates 不備は escalate に倒れる。
+    """
+
+    def test_gates_complete_reaches_auto_approve(self):
+        """gates 完備 + 他 auto-approve 条件 → AUTO_APPROVED（#816 と同一裁定）。"""
+        data = _base_input(gates={"c1": "PASS", "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_gates_c1_fail_escalates(self):
+        data = _base_input(gates={"c1": "FAIL", "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertIn("plan-quality", reason)
+
+    def test_gates_breakdown_split_suggested_escalates(self):
+        data = _base_input(gates={"c1": "PASS", "breakdown": "split-suggested"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_missing_field_escalates_exit2_not_exit1(self):
+        """gates フィールド自体が無い入力は exit 1（入力エラー）ではなく
+        exit 2（HUMAN_ESCALATED）になる（後方互換の要）。"""
+        data = _base_input()
+        del data["gates"]
+        validated = arbiter.validate_input(data)  # 入力エラーにならないことを確認
+        provenance, reason = arbiter.arbitrate(validated)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertEqual(arbiter.EXIT_CODES[provenance["decision"]], 2)
+
+    def test_gates_null_escalates(self):
+        data = _base_input(gates=None)
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_c1_null_escalates(self):
+        data = _base_input(gates={"c1": None, "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_gates_c1_non_string_escalates(self):
+        data = _base_input(gates={"c1": 123, "breakdown": "pass"})
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+
+    def test_touches_ho_preempts_plan_quality_gate(self):
+        """HO 優先: touches-HO + gates.c1=FAIL でも boundary=touches-HO が先に確定する
+        （priority 1 が priority 1.7 より先。c1 の値で上書きされない）。"""
+        data = _base_input(
+            changed_files=["bin/plangate"],
+            allowed_paths=["bin/plangate"],
+            gates={"c1": "FAIL", "breakdown": "split-suggested"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.7", reason)
+
+    def test_scope_violation_preempts_plan_quality_gate(self):
+        """scope 優先: scope 逸脱 + gates 完備でも priority 1.5（scope）が
+        priority 1.7 より先に確定する。"""
+        data = _base_input(
+            changed_files=["scripts/unrelated/tool.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            gates={"c1": "PASS", "breakdown": "pass"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertNotIn("priority 1.7", reason)
+
+    def test_gates_ok_but_lite_false_reaches_priority2(self):
+        """gates 完備で priority 1.7 を通過した後、priority 2（lite=false）へ進む。"""
+        data = _base_input(
+            gates={"c1": "PASS", "breakdown": "pass"},
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+
+    def test_gates_reason_includes_values(self):
+        data = _base_input(gates={"c1": "FAIL", "breakdown": "not-pass"})
+        _provenance, reason = arbiter.arbitrate(data)
+        self.assertIn("c1=FAIL", reason)
+        self.assertIn("breakdown=not-pass", reason)
+
+
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):
         data = _base_input()
@@ -434,7 +577,7 @@ class ProvenanceSchemaTests(unittest.TestCase):
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
         self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
@@ -630,15 +773,18 @@ class AllowedPathsScopeTests(unittest.TestCase):
 
 
 class PolicyRefVersionTests(unittest.TestCase):
-    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。"""
+    """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。
 
-    def test_tc11_policy_ref_is_v1(self):
-        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v1")
+    #780 Slice B で @v1 → @v2 へ再改版（gates 必須化・priority 1.7 追加）。
+    """
 
-    def test_tc11_provenance_policy_ref_is_v1(self):
+    def test_tc11_policy_ref_is_v2(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v2")
+
+    def test_tc11_provenance_policy_ref_is_v2(self):
         data = _base_input()
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
 class PathNormalizationSecurityTests(unittest.TestCase):
@@ -1203,10 +1349,11 @@ class RunMetaProvenanceTests(unittest.TestCase):
         self.assertEqual(provenance["run"], self.RUN_META)
 
     def test_policy_ref_unchanged_when_run_present(self):
-        """run は additive provenance であり policy 改版ではない（@v1 据え置き）。"""
+        """run は additive provenance であり policy 改版ではない（run 追加は据え置き。
+        現行ベースラインは #780 Slice B の gates 必須化で @v2 — run 起因の改版ではない）。"""
         data = _base_input(run=self.RUN_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v1")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
@@ -1445,7 +1592,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "unresolved",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1481,7 +1628,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "not_evaluated",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1506,7 +1653,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "scope_violation",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1531,7 +1678,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1553,7 +1700,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1577,7 +1724,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1604,7 +1751,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "approve"},
@@ -1629,7 +1776,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1654,7 +1801,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1687,7 +1834,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1722,7 +1869,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1758,7 +1905,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1795,7 +1942,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1832,7 +1979,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -1864,7 +2011,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v1",
+                "policy_ref": "auto-approve-lite-clean@v2",
                 "run": {
                     "repair_action": None,
                     "round_index": 0,

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -434,6 +434,50 @@ class PlanQualityGatePriorityTests(unittest.TestCase):
         self.assertIn("c1=FAIL", reason)
         self.assertIn("breakdown=not-pass", reason)
 
+    def test_gates_non_dict_reason_indicates_type_error(self):
+        """gemini medium: gates が dict 以外（str/list/int）のとき、理由が
+        「gates が dict でない・型: <型名>」を明示し、「キー未指定（c1=None）」と
+        区別できる（decision は不変・escalate のまま）。"""
+        for bad_gates, type_name in [
+            ("not-a-dict", "str"),
+            (["c1", "pass"], "list"),
+            (123, "int"),
+        ]:
+            with self.subTest(gates=bad_gates):
+                data = _base_input(gates=bad_gates)
+                provenance, reason = arbiter.arbitrate(data)
+                self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+                self.assertIn("priority 1.7", reason)
+                self.assertIn("gates が dict でない", reason)
+                self.assertIn(f"型: {type_name}", reason)
+                # 非 dict では c1=None 表記を出さない（型不正と混同させない）
+                self.assertNotIn("c1=None", reason)
+
+    def test_gates_dict_missing_keys_reason_uses_key_values(self):
+        """回帰: gates が dict のままキー不備（例: 空 dict・部分 dict）は従来どおり
+        c1=<値> breakdown=<値> の理由（型不正メッセージにはしない）。coordinator
+        仕様の「gates=dict で c1/breakdown 不備 → 従来どおりの理由」に対応。"""
+        for partial in [{}, {"c1": "FAIL"}, {"breakdown": "split-suggested"}]:
+            with self.subTest(gates=partial):
+                data = _base_input(gates=partial)
+                _provenance, reason = arbiter.arbitrate(data)
+                self.assertIn("priority 1.7", reason)
+                self.assertIn(f"c1={partial.get('c1')}", reason)
+                self.assertIn(f"breakdown={partial.get('breakdown')}", reason)
+                self.assertNotIn("dict でない", reason)
+
+    def test_gates_absent_reason_indicates_type_error(self):
+        """gates キー自体が欠落（data.get→None）も非 dict 扱いで型明示。
+        「gates 未提供」を「dict でない・型: NoneType」として c1=None 混同を避ける
+        （decision は escalate のまま不変）。"""
+        data = _base_input()
+        del data["gates"]
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertIn("gates が dict でない", reason)
+        self.assertIn("型: NoneType", reason)
+
 
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):


### PR DESCRIPTION
## 概要

#780 Slice B。ai-loop arbiter に **priority 1.7（plan 品質ゲート）** を追加し、外部評価（2026-07-11）が指摘した空白を埋める:
- **Verifier「C-1 が loop 内で必須化されていない」** → `gates.c1 == "PASS"` を auto-approve の必要条件に
- **Conductor「着手前分解が空白」** → breakdown-gate を Step 0 で接続（`gates.breakdown == "pass"` / split-suggested → escalate）

## 変更内容

- **`gates: {c1, breakdown}`**（任意フィールド）: `c1=="PASS" かつ breakdown=="pass"`（厳密一致）を満たさなければ priority 1.7 で **HUMAN_ESCALATED**
- **後方互換・安全側**: gates 欠落・null・異表記・型不正は **exit 1 にせず escalate**（未証明＝人間へ、AC-8 と一貫）。既存呼び出しは壊れず escalate に落ちる
- **priority 順序**: 1.7 は scope(1.5) の後・lite(2) の前。**HO(1)/scope(1.5) が 1.7 に先行**（touches-HO は plan-quality で上書きしない）
- **POLICY_REF @v1 → @v2**（auto-approve の必要条件が増える policy 改版・Human-owned 手続き）
- SKILL 4 配置に Step 0（breakdown-gate）/ Step 1（C-1→gates.c1）を明記・decision-table.md に priority 1.7 追記

## 安全性の機械証明（三層独立検証）

**この変更は「escalate 条件の追加」のみで、以前 escalate/blocked だったものを auto-approve にする経路を一切作らない**ことを 3 者が独立に確認:

| 検証 | gates 完備 | gates 不備 |
|---|---|---|
| maker | main と 0 mismatch（13 シナリオ） | 50 変化・全 escalate 方向・逆方向 0 |
| 統合側（独立差分） | 0 mismatch（50 ケース） | 21 変化・reverse_violations=0 |
| opus 敵対レビュー | 完全一致 | **39,168 combo（AUTO 到達 612 件）で逆方向違反 0** |

厳密一致検証（" PASS "/"Pass"/int/bool/list/null 全て False）・priority 順序（HO/scope 先行）も敵対レビューで HOLDS。

## 検証

- `test_arbiter.py` 181 テスト（+20）GREEN（repo 正本 + plugin bundled 両方で自立 PASS）
- arbiter.py / test_arbiter.py plugin コピーと cmp IDENTICAL・markdownlint 0
- POLICY_REF 全経路で @v2・@v1 残存 0

## C-4 レビュー観点（gate 挙動変更のため）

これは ai-loop の gate セマンティクス変更です（auto-approve 条件を厳格化）。安全側（escalate 増）ですが、Human C-4 で「逆方向違反ゼロ」の妥当性をご確認ください。

## 関連

Refs #780。これで ai-loop は「着手前に C-1(plan 品質) と breakdown(粒度) を機械ゲート通過した変更のみ auto-approve」する形に。follow-up: gates を provenance に刻む（現状 PoC スコープで非刻印）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)