### PR TITLE
feat: gates を provenance に刻む — plan-quality escalate の監査可能化（#780 follow-up）

### DIFF
--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -218,6 +218,7 @@ plan_quality_ok=false**（priority 1.7 で human escalate）に倒れる。
 | `run.round_index` | run 提供時のみ | int（bool 不可・必須）。**1 起点**（初回呼び出し=1、再試行ごとに +1）。`metrics.py` は round_index==1 を初回ラウンドの sentinel として first_pass を判定するため、0 起点にすると成功 run が恒久的に first_pass 分子から漏れる |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
 | `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
+| `gates` | 任意（#780 follow-up 追加・additive） | 呼び出し側入力の gates（priority 1.7 の plan-quality 判定に使う `{c1, breakdown}` 相当）を**生値のまま**刻む（dict でも非 dict でも判定せず記録のみ）。**省略時はキー自体を刻まない**（`null` も出力しない・`run` と同じ規約）。plan-quality gate で escalate した理由を provenance から監査・集計可能にする（Trust Ledger 強化）。判定ロジック（`plan_quality_check`）・`POLICY_REF` は変えない純粋な additive 拡張 |
 
 ### `target_sha` の計画時 vs 実装後の意味論（issue #782 P3）
 

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -177,10 +177,11 @@ run:
 ### 入力: gates（#780 Slice B 追加・additive・任意）
 
 呼び出し側入力の `gates`（省略可）は priority 1.7（plan 品質ゲート）の判定
-にのみ使う入力軸であり、`run` と異なり **provenance には echo されない**
-（判定結果は decision / reason にのみ反映される。PoC スコープでは gates 自体の
-生値を record に刻む必要性が薄いため見送り — 将来 Phase で必要になれば
-additive に追加検討）。
+に使う入力軸であり、判定結果は decision / reason に反映される。加えて
+**#780 follow-up（#819）以降は provenance にも生値のまま刻まれる**
+（省略時はキー省略・`run` と同じ additive 規約）。これにより plan-quality
+gate で escalate した理由を record から監査・集計できる。刻印の詳細仕様は
+§5 provenance フィールド表の `gates` 行を参照。
 
 ```text
 gates:

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -218,6 +218,7 @@ plan_quality_ok=false**（priority 1.7 で human escalate）に倒れる。
 | `run.round_index` | run 提供時のみ | int（bool 不可・必須）。**1 起点**（初回呼び出し=1、再試行ごとに +1）。`metrics.py` は round_index==1 を初回ラウンドの sentinel として first_pass を判定するため、0 起点にすると成功 run が恒久的に first_pass 分子から漏れる |
 | `run.task_id` | run 提供時のみ | string（対象 PBI 識別子） |
 | `run.repair_action` | run 提供時のみ・任意 | string（再試行時の修正内容の要約。初回 round には無いことが多い） |
+| `gates` | 任意（#780 follow-up 追加・additive） | 呼び出し側入力の gates（priority 1.7 の plan-quality 判定に使う `{c1, breakdown}` 相当）を**生値のまま**刻む（dict でも非 dict でも判定せず記録のみ）。**省略時はキー自体を刻まない**（`null` も出力しない・`run` と同じ規約）。plan-quality gate で escalate した理由を provenance から監査・集計可能にする（Trust Ledger 強化）。判定ロジック（`plan_quality_check`）・`POLICY_REF` は変えない純粋な additive 拡張 |
 
 ### `target_sha` の計画時 vs 実装後の意味論（issue #782 P3）
 

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -177,10 +177,11 @@ run:
 ### 入力: gates（#780 Slice B 追加・additive・任意）
 
 呼び出し側入力の `gates`（省略可）は priority 1.7（plan 品質ゲート）の判定
-にのみ使う入力軸であり、`run` と異なり **provenance には echo されない**
-（判定結果は decision / reason にのみ反映される。PoC スコープでは gates 自体の
-生値を record に刻む必要性が薄いため見送り — 将来 Phase で必要になれば
-additive に追加検討）。
+に使う入力軸であり、判定結果は decision / reason に反映される。加えて
+**#780 follow-up（#819）以降は provenance にも生値のまま刻まれる**
+（省略時はキー省略・`run` と同じ additive 規約）。これにより plan-quality
+gate で escalate した理由を record から監査・集計できる。刻印の詳細仕様は
+§5 provenance フィールド表の `gates` 行を参照。
 
 ```text
 gates:

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -591,6 +591,7 @@ def build_provenance(
     ho_paths_source: str | None = None,
     ho_pattern_count: int = 0,
     run: dict[str, Any] | None = None,
+    gates: Any = None,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
@@ -617,6 +618,15 @@ def build_provenance(
     ときのみ 4 サブフィールドを刻む。metrics.py が run 単位の集計（first-pass
     rate 等）に用いる。gate 挙動（POLICY_REF）は変えない純粋な additive
     provenance 拡張。
+
+    `gates`（#780 follow-up 追加・additive・任意）: 呼び出し側入力の
+    `gates`（priority 1.7 の plan-quality 判定に使われる `{c1, breakdown}` 相当）
+    を**生値のまま**刻む（dict でも非 dict でも判定せず診断用にそのまま記録）。
+    **gates が None（未指定）のときは `gates` キー自体を刻まない**（`run` と
+    同じ規約・`"gates": null` は出力しない）。これにより plan-quality gate で
+    escalate した理由（gates 不備の具体的な値）を provenance から監査・集計
+    できる（Trust Ledger 強化）。判定ロジック（plan_quality_check）・gate 挙動
+    （POLICY_REF）は変えない純粋な additive provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -647,6 +657,11 @@ def build_provenance(
     # 分類において、未計装を legacy に落とすため（#780 コーディネータ指摘）。
     if run is not None:
         provenance["run"] = run
+    # gates 未指定時は `gates` キー自体を省略する（`"gates": null` を出さない・
+    # run と同じ additive 規約）。plan-quality escalate（priority 1.7）の理由を
+    # record から監査できるようにする（#780 follow-up）。
+    if gates is not None:
+        provenance["gates"] = gates
     return provenance
 
 
@@ -737,6 +752,7 @@ def arbitrate(
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
     run: dict[str, Any] | None = data.get("run")
+    gates_meta: Any = data.get("gates")
 
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
@@ -758,6 +774,7 @@ def arbitrate(
             ho_paths_source=ho_source,
             ho_pattern_count=ho_pattern_count,
             run=run,
+            gates=gates_meta,
             **kw,
         )
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -1400,6 +1400,123 @@ class RunMetaProvenanceTests(unittest.TestCase):
         self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
+class GatesProvenanceTests(unittest.TestCase):
+    """#780 follow-up: provenance への gates 刻印（run と同じ additive パターンを厳密踏襲）。
+
+    build_provenance が入力の gates（priority 1.7 の plan-quality 判定に使う
+    {c1, breakdown}）を record に生値のまま刻む。省略時は run と同じく
+    `gates` キー自体を刻まない（`"gates": null` を出さない）。刻印は
+    plan-quality escalate の理由を監査・集計可能にする（Trust Ledger 強化）。
+    判定ロジック（plan_quality_check）・priority 順序・POLICY_REF は不変。
+    """
+
+    GATES_META = {"c1": "PASS", "breakdown": "pass"}
+
+    def test_gates_absent_omits_gates_key(self):
+        """gates フィールド自体が入力に無いとき、provenance に gates キー自体を
+        刻まない（run と同じ後方互換規約・`"gates": null` を出さない）。"""
+        data = _base_input()
+        del data["gates"]
+        validated = arbiter.validate_input(data)  # 入力エラーにならないことを確認
+        provenance, _ = arbiter.arbitrate(validated)
+        self.assertNotIn("gates", provenance)
+
+    def test_gates_non_dict_carries_raw_value(self):
+        """gates が dict でない（例: "oops"）場合も生値のまま刻む。判定は
+        plan_quality_check が担うため、刻印は診断用の生値でよい。"""
+        data = _base_input(gates="oops")
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["gates"], "oops")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+    def test_priority0_fail_closed_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_touches_ho_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, changed_files=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_5_scope_violation_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, changed_files=["out/of/scope.md"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_7_plan_quality_escalate_carries_failing_gates(self):
+        """priority 1.7（plan-quality escalate）でも gates（不備の生値）が
+        刻まれる。escalate 理由の監査可能化が本 follow-up の主眼。"""
+        bad_gates = {"c1": "FAIL", "breakdown": "pass"}
+        data = _base_input(gates=bad_gates)
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertEqual(provenance["gates"], bad_gates)
+
+    def test_priority2_lite_false_carries_gates(self):
+        data = _base_input(
+            gates=self.GATES_META,
+            lite={
+                "size_ok": False,
+                "no_new_design": True,
+                "follows_pattern": True,
+                "reversible": True,
+            },
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority3_merge_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, **{"class": "merge"})
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority4_blocked_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "BLOCKED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority5_human_escalated_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"  # severity=major
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority5_cd_auto_approved_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"  # severity=minor
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority6_auto_approved_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_policy_ref_unchanged_when_gates_present(self):
+        """gates 刻印は additive provenance であり policy 改版ではない
+        （POLICY_REF は @v2 据え置き）。"""
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+
+
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
     """#780 Slice D 後半の核心: arbiter が刻んだ run 付き record を実際に
     metrics.py（#812 消費側）へ渡し、first_pass 判定が正しく機能することを実証する。
@@ -1586,6 +1703,13 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
     minor 側は C/D 裁定の 4 パターン + 欠落ケース）/ 6 approve-approve、
     加えて run メタ付き（#780 Slice D 後半・additive）を網羅する。
 
+    全ケース共通で `_base_input()` の既定 gates（`{"c1": "PASS",
+    "breakdown": "pass"}`）が additive に刻まれる（#780 follow-up・
+    gates provenance 刻印）。gates 追加は `decision` / `reason` を一切
+    変えない purely additive な拡張であることを、本テストの固定値比較が
+    そのまま証明する（gates 追加前後で decision/reason は不変、
+    provenance に `gates` キーが増えるのみ）。
+
     各シナリオの (provenance dict, reason str) を **リファクタ前の現行コード
     で実測して固定した値** と突き合わせる。`timestamp` は実行時刻依存のため
     比較対象から除外し、`ho_paths_source` は cwd 依存の絶対パスのため
@@ -1632,6 +1756,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "unresolved",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": None,
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
@@ -1668,6 +1793,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "touches-HO",
                 "class_check": "merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1693,6 +1819,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1718,6 +1845,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1740,6 +1868,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1764,6 +1893,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1791,6 +1921,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1816,6 +1947,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1841,6 +1973,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1874,6 +2007,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1909,6 +2043,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1945,6 +2080,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1982,6 +2118,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -2019,6 +2156,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -2051,6 +2189,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -591,6 +591,7 @@ def build_provenance(
     ho_paths_source: str | None = None,
     ho_pattern_count: int = 0,
     run: dict[str, Any] | None = None,
+    gates: Any = None,
 ) -> dict[str, Any]:
     """decision-table.md §5 準拠の provenance JSON を構築する。
 
@@ -617,6 +618,15 @@ def build_provenance(
     ときのみ 4 サブフィールドを刻む。metrics.py が run 単位の集計（first-pass
     rate 等）に用いる。gate 挙動（POLICY_REF）は変えない純粋な additive
     provenance 拡張。
+
+    `gates`（#780 follow-up 追加・additive・任意）: 呼び出し側入力の
+    `gates`（priority 1.7 の plan-quality 判定に使われる `{c1, breakdown}` 相当）
+    を**生値のまま**刻む（dict でも非 dict でも判定せず診断用にそのまま記録）。
+    **gates が None（未指定）のときは `gates` キー自体を刻まない**（`run` と
+    同じ規約・`"gates": null` は出力しない）。これにより plan-quality gate で
+    escalate した理由（gates 不備の具体的な値）を provenance から監査・集計
+    できる（Trust Ledger 強化）。判定ロジック（plan_quality_check）・gate 挙動
+    （POLICY_REF）は変えない純粋な additive provenance 拡張。
     """
     w_check: dict[str, Any] = {"model_a": model_a, "model_b": model_b}
     if severity is not None:
@@ -647,6 +657,11 @@ def build_provenance(
     # 分類において、未計装を legacy に落とすため（#780 コーディネータ指摘）。
     if run is not None:
         provenance["run"] = run
+    # gates 未指定時は `gates` キー自体を省略する（`"gates": null` を出さない・
+    # run と同じ additive 規約）。plan-quality escalate（priority 1.7）の理由を
+    # record から監査できるようにする（#780 follow-up）。
+    if gates is not None:
+        provenance["gates"] = gates
     return provenance
 
 
@@ -737,6 +752,7 @@ def arbitrate(
     model_d: str | None = verdicts.get("model_d")
     reject_category: str | None = verdicts.get("reject_category")
     run: dict[str, Any] | None = data.get("run")
+    gates_meta: Any = data.get("gates")
 
     ho_patterns, ho_source, ho_searched = resolve_ho_patterns(ho_paths_path)
     ho_pattern_count = len(ho_patterns)
@@ -758,6 +774,7 @@ def arbitrate(
             ho_paths_source=ho_source,
             ho_pattern_count=ho_pattern_count,
             run=run,
+            gates=gates_meta,
             **kw,
         )
 

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -1400,6 +1400,123 @@ class RunMetaProvenanceTests(unittest.TestCase):
         self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
 
 
+class GatesProvenanceTests(unittest.TestCase):
+    """#780 follow-up: provenance への gates 刻印（run と同じ additive パターンを厳密踏襲）。
+
+    build_provenance が入力の gates（priority 1.7 の plan-quality 判定に使う
+    {c1, breakdown}）を record に生値のまま刻む。省略時は run と同じく
+    `gates` キー自体を刻まない（`"gates": null` を出さない）。刻印は
+    plan-quality escalate の理由を監査・集計可能にする（Trust Ledger 強化）。
+    判定ロジック（plan_quality_check）・priority 順序・POLICY_REF は不変。
+    """
+
+    GATES_META = {"c1": "PASS", "breakdown": "pass"}
+
+    def test_gates_absent_omits_gates_key(self):
+        """gates フィールド自体が入力に無いとき、provenance に gates キー自体を
+        刻まない（run と同じ後方互換規約・`"gates": null` を出さない）。"""
+        data = _base_input()
+        del data["gates"]
+        validated = arbiter.validate_input(data)  # 入力エラーにならないことを確認
+        provenance, _ = arbiter.arbitrate(validated)
+        self.assertNotIn("gates", provenance)
+
+    def test_gates_non_dict_carries_raw_value(self):
+        """gates が dict でない（例: "oops"）場合も生値のまま刻む。判定は
+        plan_quality_check が担うため、刻印は診断用の生値でよい。"""
+        data = _base_input(gates="oops")
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["gates"], "oops")
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+
+    def test_priority0_fail_closed_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data, ho_paths_path="/nonexistent/ho-paths.md")
+        self.assertEqual(provenance["boundary_check"], "unresolved")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_touches_ho_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, changed_files=["bin/plangate"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_5_scope_violation_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, changed_files=["out/of/scope.md"])
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority1_7_plan_quality_escalate_carries_failing_gates(self):
+        """priority 1.7（plan-quality escalate）でも gates（不備の生値）が
+        刻まれる。escalate 理由の監査可能化が本 follow-up の主眼。"""
+        bad_gates = {"c1": "FAIL", "breakdown": "pass"}
+        data = _base_input(gates=bad_gates)
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertEqual(provenance["gates"], bad_gates)
+
+    def test_priority2_lite_false_carries_gates(self):
+        data = _base_input(
+            gates=self.GATES_META,
+            lite={
+                "size_ok": False,
+                "no_new_design": True,
+                "follows_pattern": True,
+                "reversible": True,
+            },
+        )
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority3_merge_carries_gates(self):
+        data = _base_input(gates=self.GATES_META, **{"class": "merge"})
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority4_blocked_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_a"] = "reject"
+        data["verdicts"]["model_b"] = "reject"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "BLOCKED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority5_human_escalated_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "auth_change"  # severity=major
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority5_cd_auto_approved_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        data["verdicts"]["model_b"] = "reject"
+        data["verdicts"]["reject_category"] = "logic"  # severity=minor
+        data["verdicts"]["model_c"] = "approve"
+        data["verdicts"]["model_d"] = "approve"
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_priority6_auto_approved_carries_gates(self):
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertEqual(provenance["gates"], self.GATES_META)
+
+    def test_policy_ref_unchanged_when_gates_present(self):
+        """gates 刻印は additive provenance であり policy 改版ではない
+        （POLICY_REF は @v2 据え置き）。"""
+        data = _base_input(gates=self.GATES_META)
+        provenance, _ = arbiter.arbitrate(data)
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+
+
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
     """#780 Slice D 後半の核心: arbiter が刻んだ run 付き record を実際に
     metrics.py（#812 消費側）へ渡し、first_pass 判定が正しく機能することを実証する。
@@ -1586,6 +1703,13 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
     minor 側は C/D 裁定の 4 パターン + 欠落ケース）/ 6 approve-approve、
     加えて run メタ付き（#780 Slice D 後半・additive）を網羅する。
 
+    全ケース共通で `_base_input()` の既定 gates（`{"c1": "PASS",
+    "breakdown": "pass"}`）が additive に刻まれる（#780 follow-up・
+    gates provenance 刻印）。gates 追加は `decision` / `reason` を一切
+    変えない purely additive な拡張であることを、本テストの固定値比較が
+    そのまま証明する（gates 追加前後で decision/reason は不変、
+    provenance に `gates` キーが増えるのみ）。
+
     各シナリオの (provenance dict, reason str) を **リファクタ前の現行コード
     で実測して固定した値** と突き合わせる。`timestamp` は実行時刻依存のため
     比較対象から除外し、`ho_paths_source` は cwd 依存の絶対パスのため
@@ -1632,6 +1756,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "unresolved",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": None,
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
@@ -1668,6 +1793,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "touches-HO",
                 "class_check": "merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1693,6 +1819,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1718,6 +1845,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1740,6 +1868,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1764,6 +1893,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1791,6 +1921,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1816,6 +1947,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1841,6 +1973,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1874,6 +2007,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1909,6 +2043,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1945,6 +2080,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -1982,6 +2118,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "BLOCKED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -2019,6 +2156,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "HUMAN_ESCALATED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
@@ -2051,6 +2189,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "boundary_check": "clean",
                 "class_check": "no-merge",
                 "decision": "AUTO_APPROVED",
+                "gates": {"breakdown": "pass", "c1": "PASS"},
                 "ho_paths_source": self._NORMALIZED_HO_SOURCE,
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",


### PR DESCRIPTION
## 概要

#780 Slice B（#817）の follow-up。arbiter が plan-quality 判定（priority 1.7）に使う入力 `gates` を **decision record（provenance）に刻む**。これで「なぜ plan-quality で escalate したか」が record から追え、監査・集計が可能になる（Trust Ledger 強化）。

#817 時点では gates は判定に使うが record に刻まれていなかった（PR #817 本文で follow-up として明示）。

## 変更内容（純 additive）

- `build_provenance` に `gates` パラメータ追加。入力に gates がある場合のみ record に刻む（**省略時はキーを刻まない** = #815 の `run` と同一規約）
- 刻む値は入力の gates を**そのまま**（dict/非 dict とも生値・診断用）
- `arbitrate` の全裁定経路（0/1/1.5/1.7/2/3/4/5/6）が `_mk` を通るため 1 箇所の変更で全経路に刻印
- **POLICY_REF は @v2 据え置き**（additive provenance・gate 挙動不変。#815 の run が @v1 据え置きだったのと同じ理屈）
- decision-table.md §5 に gates フィールド追記

## 動作不変の証明（純 additive）

origin/main(#817) と本ブランチを差分比較:
- **decision_diff=0**（66 ケース: gates 完備/不備/非dict/省略 × 全 verdict × lite × class + HO/scope）— 裁定は完全不変
- **provenance の変化は gates キー追加のみ**（共通キーの値変化ゼロ・gates 以外の新キーゼロ）= 純粋 additive を機械証明
- maker 側も 36/36 scenario で decision/reason 文字列一致を確認

## 検証

- `test_arbiter.py` 197 テスト（+13 `GatesProvenanceTests`）GREEN（repo 正本 + plugin bundled 両方で自立 PASS）
- arbiter.py / test_arbiter.py plugin コピーと cmp IDENTICAL・markdownlint 0
- POLICY_REF @v2 不変・plan_quality_check ロジック不変・priority 順序不変

## 関連

Refs #780。これで plan-quality ゲート（#817）の判定入力が record に残り、metrics 側で plan-quality escalate の集計が可能になる素地ができた（消費側集計は別 follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)