### PR TITLE
feat: size_ok を changed_files 実数で機械検証 priority 1.9 + POLICY_REF @v3（#780 Slice C）

### DIFF
--- a/.agents/skills/ai-loop-cycle/SKILL.md
+++ b/.agents/skills/ai-loop-cycle/SKILL.md
@@ -32,7 +32,10 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   `scope.allowed_paths` 宣言** の 2 条件が前提。
 - **auto-approve 方針（Phase 1）**: lite 4 軸（`references/lite-criteria.md` §2）を
   申告制・AND・判定不能→false で満たせば、**実機能も `AUTO_APPROVED` 対象に含めてよい**
-  （docs 級限定ではない）。`size_ok` は当面申告制のまま。
+  （docs 級限定ではない）。`size_ok` は申告するが、arbiter が `changed_files` の
+  実ファイル数で機械検証する（`SIZE_OK_MAX_FILES`=2。実ファイル数が 2 を超えて
+  `size_ok=true` を申告すると priority 1.9 で human escalate。#780 Slice C）。
+  他 3 軸（`no_new_design`/`follows_pattern`/`reversible`）は引き続き申告制のまま。
 - **裁定記録・摩擦台帳の保存先は導入先プロジェクトで定義する**（本スキルは強制しない）。
   既定案として、導入先の作業ディレクトリ配下に run 単位の裁定 record 用サブディレクトリ
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
@@ -60,7 +63,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 
 `allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
 
-- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
+- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）。**申告するが、
+  arbiter が `changed_files` の実ファイル数で機械検証する**（`SIZE_OK_MAX_FILES`=2。
+  実ファイル数が 2 を超えて `size_ok=true` を申告すると priority 1.9 で human
+  escalate。#780 Slice C）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
 - `reversible`: 可逆か（`git revert` 一発等、機械的な巻き戻し手順があるか）

--- a/.claude/skills/ai-loop-cycle/SKILL.md
+++ b/.claude/skills/ai-loop-cycle/SKILL.md
@@ -42,7 +42,10 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
 lite 4 軸（[`lite-criteria.md`](../../../docs/workflows/ai-loop/lite-criteria.md) §2）を
 それぞれ根拠つきで宣言する。**いずれかの軸が判定不能なら false**（AC-8 安全側、虚偽宣言禁止）。
 
-- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
+- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）。**申告するが、
+  arbiter が `changed_files` の実ファイル数で機械検証する**（`SIZE_OK_MAX_FILES`=2。
+  実ファイル数が 2 を超えて `size_ok=true` を申告すると priority 1.9 で human
+  escalate。#780 Slice C）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
 - `reversible`: 可逆か（`git revert` 一発等、機械的な巻き戻し手順があるか）

--- a/.codex/skills/ai-loop-cycle/SKILL.md
+++ b/.codex/skills/ai-loop-cycle/SKILL.md
@@ -32,7 +32,10 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   `scope.allowed_paths` 宣言** の 2 条件が前提。
 - **auto-approve 方針（Phase 1）**: lite 4 軸（`references/lite-criteria.md` §2）を
   申告制・AND・判定不能→false で満たせば、**実機能も `AUTO_APPROVED` 対象に含めてよい**
-  （docs 級限定ではない）。`size_ok` は当面申告制のまま。
+  （docs 級限定ではない）。`size_ok` は申告するが、arbiter が `changed_files` の
+  実ファイル数で機械検証する（`SIZE_OK_MAX_FILES`=2。実ファイル数が 2 を超えて
+  `size_ok=true` を申告すると priority 1.9 で human escalate。#780 Slice C）。
+  他 3 軸（`no_new_design`/`follows_pattern`/`reversible`）は引き続き申告制のまま。
 - **裁定記録・摩擦台帳の保存先は導入先プロジェクトで定義する**（本スキルは強制しない）。
   既定案として、導入先の作業ディレクトリ配下に run 単位の裁定 record 用サブディレクトリ
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
@@ -60,7 +63,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 
 `allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
 
-- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
+- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）。**申告するが、
+  arbiter が `changed_files` の実ファイル数で機械検証する**（`SIZE_OK_MAX_FILES`=2。
+  実ファイル数が 2 を超えて `size_ok=true` を申告すると priority 1.9 で human
+  escalate。#780 Slice C）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
 - `reversible`: 可逆か（`git revert` 一発等、機械的な巻き戻し手順があるか）

--- a/docs/workflows/ai-loop/decision-table.md
+++ b/docs/workflows/ai-loop/decision-table.md
@@ -52,10 +52,10 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
-### priority 0 / 1.5 / 1.7（#809・#780 Slice B 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+### priority 0 / 1.5 / 1.7 / 1.9（#809・#780 Slice B・#780 Slice C 追加・機械実装のみで本表 1〜6 の番号体系は不変）
 
 上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
-3 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B）が実装する
+4 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B・#780 Slice C）が実装する
 **前置・割込みチェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
 
 | priority | 内容 | → 裁定 |
@@ -63,6 +63,7 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 | **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
 | **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
 | **1.7** | boundary=clean・scope 逸脱なし（priority 1.5 通過後）だが、`gates.c1 == "PASS"` かつ `gates.breakdown == "pass"`（両方とも厳密一致）を満たさない（plan 品質ゲート未充足） | **human escalate** |
+| **1.9** | priority 1.7 通過後、申告 `lite.size_ok == true`（bool）だが `changed_files` の実ファイル数が `SIZE_OK_MAX_FILES`（2）を超える（申告と blast-radius の不一致） | **human escalate** |
 
 - priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
   （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
@@ -70,7 +71,7 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 - priority 1.5 は priority 1（touches-HO）の**後**に評価する。
   `allowed_paths` に HO パスを宣言していても HO escalate は免れない
   （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
-- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 2（lite）の
+- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 1.9（size 機械検証）の
   **前**に評価する。`gates`（`{"c1": str, "breakdown": str}`）は任意入力フィールドで、
   欠落・null・非 dict・型不一致・値の表記違い（例: 小文字 `"pass"` 以外の
   `breakdown`、`"PASS"` 以外の `c1`）は**すべて安全側で未充足＝human escalate**
@@ -80,6 +81,14 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
   結果（`"PASS"` のみ通過）、`breakdown` は breakdown-gate スキルの粒度判定
   結果（`"pass"` のみ通過。`split-suggested` 等は未充足）を渡す想定
   （`.agents/skills/ai-loop-cycle/SKILL.md` Step 0/1 参照）
+- priority 1.9（#780 Slice C）は priority 1.7（plan-quality）の**後**・priority 2（lite）の
+  **前**に評価する。`lite.size_ok` は引き続き申告制（他 3 軸と同型の bool 申告）だが、
+  arbiter が `changed_files` の実ファイル数を機械算出し、`size_ok == true` の申告を
+  クロスチェックする。申告と実測が一致するケース（`size_ok=true` かつファイル数
+  ≤2、または `size_ok=false`）は**従来と同一の裁定を維持**する。**本チェックも
+  escalate 条件を追加するだけの安全側変更であり、以前 auto-approve/blocked
+  だった経路を auto-approve にする効果は一切持たない**（POLICY_REF を `@v2` →
+  `@v3` へ改版した理由）。
 
 ### 裁定ラベルと provenance 値の対応
 
@@ -123,7 +132,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v2（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v3（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -139,12 +148,17 @@ timestamp:          <ISO 8601>
 
 > **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
 > ho-paths 実行時解決の fail-closed 機械化）→ `@v2`（#780 Slice B: `gates`
-> 入力による plan 品質ゲート priority 1.7 の追加）。`@v0` 時点の PoC は
+> 入力による plan 品質ゲート priority 1.7 の追加）→ `@v3`（#780 Slice C:
+> `lite.size_ok` 申告を `changed_files` 実ファイル数（`SIZE_OK_MAX_FILES`=2）で
+> 機械検証する priority 1.9 の追加）。`@v0` 時点の PoC は
 > `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
 > ロジックが変わった本改版で policy バージョンを進めた。`@v2` は
 > auto-approve の新必要条件（`gates.c1 == "PASS"` かつ `gates.breakdown ==
 > "pass"`）を追加した改版であり、escalate 条件を追加するだけの安全側変更
 > （以前 auto-approve/blocked だった経路が新たに auto-approve になることはない）。
+> `@v3` も同型の安全側変更で、申告 `size_ok=true` かつ実ファイル数が閾値を
+> 超える（申告と blast-radius の不一致）ケースのみ escalate を追加する
+> （申告と実測が一致するケースは `@v2` までと同一裁定を維持）。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 

--- a/docs/workflows/ai-loop/lite-criteria.md
+++ b/docs/workflows/ai-loop/lite-criteria.md
@@ -23,10 +23,13 @@ issue [#782](https://github.com/s977043/plangate/issues/782) P1-2
 （「実機能は常に escalate に帰結し auto-approve が実質到達不能」）への応答は、
 Human 決定（issue [#807](https://github.com/s977043/plangate/issues/807)・
 2026-07-10）により **「docs 級限定の明文化」案から「lite 全域（本ドキュメント
-§2 の 4 軸を満たせば実機能も含む）」へ更新**された。`size_ok` の機械算出化
-（ファイル数閾値ではなく可逆性・パターン踏襲度を含む複合リスクスコア化。
-対応: issue [#780](https://github.com/s977043/plangate/issues/780) slice C）は
-当面の未実装事項として残り、申告制の保証を強化する unlock 位置づけである。
+§2 の 4 軸を満たせば実機能も含む）」へ更新**された。`size_ok` の機械検証化
+（issue [#780](https://github.com/s977043/plangate/issues/780) slice C で実装済み）は
+「ファイル数閾値（`SIZE_OK_MAX_FILES`=2）と `changed_files` 実数の突合」という
+最小形で実現された（当初想定した可逆性・パターン踏襲度を含む複合リスク
+スコア化は見送り、申告制の保証を強化する最小の unlock に留めた。§2 の
+「変更規模」欄・arbiter.py の `machine_size_check()` 参照）。他 3 軸
+（新規設計の有無・既存パターン踏襲・可逆性）は引き続き申告制のまま。
 AC-8 安全側（判定不能→false）・4 軸すべてを満たすことの要求は変更しない。
 
 ---
@@ -37,7 +40,7 @@ AC-8 安全側（判定不能→false）・4 軸すべてを満たすことの�
 
 | 軸 | lite=true 候補条件 | 継承元 |
 | ---- | -------------------- | -------- |
-| 変更規模 | `mode-classification.md` の light 相当以下（変更ファイル数 1〜2 目安） | `mode-classification.md` 定量基準 |
+| 変更規模 | `mode-classification.md` の light 相当以下（変更ファイル数 1〜2 目安）。**申告 `size_ok=true` は arbiter が `changed_files` 実数で機械検証する**（`SIZE_OK_MAX_FILES`=2 超過なら申告と実測の不一致として escalate。issue #780 slice C） | `mode-classification.md` 定量基準 |
 | 新規設計の有無 | なし（既存構造の枠内） | `mode-classification.md` lite_eligible 判定軸 |
 | 既存パターン踏襲 | あり（新規設計ゼロ・ミラー実装） | `mode-classification.md` lite_eligible 判定軸 |
 | **可逆性** | 変更が可逆である（巻き戻し手順が機械的に実行可能。例: `git revert` 一発、ファイル単位の差し戻しで完全復元できる） | 本ドキュメントで新規追加（PoC 固有） |
@@ -93,7 +96,9 @@ lite は「証明可能なときだけの例外」であり既定ではない。
 
 lite = true
 
-// 軸1: 変更規模
+// 軸1: 変更規模（申告 size_ok=true は arbiter.py が changed_files 実数で
+// SIZE_OK_MAX_FILES=2 と機械突合する。申告と実測が不一致なら priority 1.9
+// で human escalate — issue #780 slice C）
 if not (変更規模 <= light相当):
     lite = false
 

--- a/plugin/plangate/skills/ai-loop-cycle/SKILL.md
+++ b/plugin/plangate/skills/ai-loop-cycle/SKILL.md
@@ -32,7 +32,10 @@ description: "ai-loop-workflow の 1 サイクル（C-3' 裁定）を実行す�
   `scope.allowed_paths` 宣言** の 2 条件が前提。
 - **auto-approve 方針（Phase 1）**: lite 4 軸（`references/lite-criteria.md` §2）を
   申告制・AND・判定不能→false で満たせば、**実機能も `AUTO_APPROVED` 対象に含めてよい**
-  （docs 級限定ではない）。`size_ok` は当面申告制のまま。
+  （docs 級限定ではない）。`size_ok` は申告するが、arbiter が `changed_files` の
+  実ファイル数で機械検証する（`SIZE_OK_MAX_FILES`=2。実ファイル数が 2 を超えて
+  `size_ok=true` を申告すると priority 1.9 で human escalate。#780 Slice C）。
+  他 3 軸（`no_new_design`/`follows_pattern`/`reversible`）は引き続き申告制のまま。
 - **裁定記録・摩擦台帳の保存先は導入先プロジェクトで定義する**（本スキルは強制しない）。
   既定案として、導入先の作業ディレクトリ配下に run 単位の裁定 record 用サブディレクトリ
   （例: `<作業ディレクトリ>/ai-loop-runs/`）を設ける配置が参考になるが、導入先の
@@ -60,7 +63,10 @@ lite 4 軸（`references/lite-criteria.md` §2）をそれぞれ根拠つきで�
 
 `allowed_paths` は LoopSpec の `scope.allowed_paths` 宣言をそのまま渡す（#809）。
 
-- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）
+- `size_ok`: 変更規模が light 相当以下か（ファイル数 1〜2 目安）。**申告するが、
+  arbiter が `changed_files` の実ファイル数で機械検証する**（`SIZE_OK_MAX_FILES`=2。
+  実ファイル数が 2 を超えて `size_ok=true` を申告すると priority 1.9 で human
+  escalate。#780 Slice C）
 - `no_new_design`: 新規設計がないか（既存構造の枠内か）
 - `follows_pattern`: 既存パターンを踏襲しているか（ミラー実装か）
 - `reversible`: 可逆か（`git revert` 一発等、機械的な巻き戻し手順があるか）

--- a/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/decision-table.md
@@ -52,10 +52,10 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 > **boundary=touches-HO の場合、lite / class / verdict にかかわらず必ず human escalate 固定。**
 > これは W チェック結果・severity 分類・C/D 裁定のいずれをもスキップする絶対条件。
 
-### priority 0 / 1.5 / 1.7（#809・#780 Slice B 追加・機械実装のみで本表 1〜6 の番号体系は不変）
+### priority 0 / 1.5 / 1.7 / 1.9（#809・#780 Slice B・#780 Slice C 追加・機械実装のみで本表 1〜6 の番号体系は不変）
 
 上記 priority 1〜6 の番号体系（本リポジトリの正本表記）は変更しない。以下の
-3 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B）が実装する
+4 チェックは `scripts/ai-loop/arbiter.py`（#809・#780 Slice B・#780 Slice C）が実装する
 **前置・割込みチェック**であり、実装上は 1〜6 の評価より手前 / 間で評価される:
 
 | priority | 内容 | → 裁定 |
@@ -63,6 +63,7 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 | **0** | ho-paths.md が実行時解決できない、またはパース結果が 0 件（fail-closed）。boundary 判定そのものが実行不能なため、他のどの軸よりも先に評価する | **human escalate（固定・絶対条件）** |
 | **1.5** | boundary=clean（priority 1 通過後）だが、`changed_files` が `allowed_paths` のいずれの glob にも一致しない（scope 逸脱） | **human escalate** |
 | **1.7** | boundary=clean・scope 逸脱なし（priority 1.5 通過後）だが、`gates.c1 == "PASS"` かつ `gates.breakdown == "pass"`（両方とも厳密一致）を満たさない（plan 品質ゲート未充足） | **human escalate** |
+| **1.9** | priority 1.7 通過後、申告 `lite.size_ok == true`（bool）だが `changed_files` の実ファイル数が `SIZE_OK_MAX_FILES`（2）を超える（申告と blast-radius の不一致） | **human escalate** |
 
 - priority 0 は「boundary が touches-HO か clean か」を判定する前提条件
   （ho-paths 一覧そのもの）が欠落しているケースであり、fail-open
@@ -70,7 +71,7 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
 - priority 1.5 は priority 1（touches-HO）の**後**に評価する。
   `allowed_paths` に HO パスを宣言していても HO escalate は免れない
   （`design-philosophy.md` I-1 不変条件、LoopSpec 既存規定）
-- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 2（lite）の
+- priority 1.7（#780 Slice B）は priority 1.5（scope）の**後**・priority 1.9（size 機械検証）の
   **前**に評価する。`gates`（`{"c1": str, "breakdown": str}`）は任意入力フィールドで、
   欠落・null・非 dict・型不一致・値の表記違い（例: 小文字 `"pass"` 以外の
   `breakdown`、`"PASS"` 以外の `c1`）は**すべて安全側で未充足＝human escalate**
@@ -80,6 +81,14 @@ Arbiter L2 裁定層の判断ロジックを機械的に決定可能な形式で
   結果（`"PASS"` のみ通過）、`breakdown` は breakdown-gate スキルの粒度判定
   結果（`"pass"` のみ通過。`split-suggested` 等は未充足）を渡す想定
   （`.agents/skills/ai-loop-cycle/SKILL.md` Step 0/1 参照）
+- priority 1.9（#780 Slice C）は priority 1.7（plan-quality）の**後**・priority 2（lite）の
+  **前**に評価する。`lite.size_ok` は引き続き申告制（他 3 軸と同型の bool 申告）だが、
+  arbiter が `changed_files` の実ファイル数を機械算出し、`size_ok == true` の申告を
+  クロスチェックする。申告と実測が一致するケース（`size_ok=true` かつファイル数
+  ≤2、または `size_ok=false`）は**従来と同一の裁定を維持**する。**本チェックも
+  escalate 条件を追加するだけの安全側変更であり、以前 auto-approve/blocked
+  だった経路を auto-approve にする効果は一切持たない**（POLICY_REF を `@v2` →
+  `@v3` へ改版した理由）。
 
 ### 裁定ラベルと provenance 値の対応
 
@@ -123,7 +132,7 @@ auto-approve 時（priority 6 または C/D 合意）に刻印する最低限の
 ```text
 decision:           AUTO_APPROVED / HUMAN_ESCALATED / BLOCKED
 issued_by:          arbiter-v0.1（判断エンジン識別子）
-policy_ref:         auto-approve-lite-clean@v2（適用 policy 名 + バージョン）
+policy_ref:         auto-approve-lite-clean@v3（適用 policy 名 + バージョン）
 w_check:
   model_a: approve
   model_b: approve
@@ -139,12 +148,17 @@ timestamp:          <ISO 8601>
 
 > **policy_ref バージョン履歴**: `@v0` → `@v1`（#809: allowed_paths 必須化・
 > ho-paths 実行時解決の fail-closed 機械化）→ `@v2`（#780 Slice B: `gates`
-> 入力による plan 品質ゲート priority 1.7 の追加）。`@v0` 時点の PoC は
+> 入力による plan 品質ゲート priority 1.7 の追加）→ `@v3`（#780 Slice C:
+> `lite.size_ok` 申告を `changed_files` 実ファイル数（`SIZE_OK_MAX_FILES`=2）で
+> 機械検証する priority 1.9 の追加）。`@v0` 時点の PoC は
 > `HO_PATTERNS` ハードコード定数＋allowed_paths 未検証だったため、境界判定
 > ロジックが変わった本改版で policy バージョンを進めた。`@v2` は
 > auto-approve の新必要条件（`gates.c1 == "PASS"` かつ `gates.breakdown ==
 > "pass"`）を追加した改版であり、escalate 条件を追加するだけの安全側変更
 > （以前 auto-approve/blocked だった経路が新たに auto-approve になることはない）。
+> `@v3` も同型の安全側変更で、申告 `size_ok=true` かつ実ファイル数が閾値を
+> 超える（申告と blast-radius の不一致）ケースのみ escalate を追加する
+> （申告と実測が一致するケースは `@v2` までと同一裁定を維持）。
 
 ### C/D 裁定時の追加フィールド（severity=minor/low 時のみ）
 

--- a/plugin/plangate/skills/ai-loop-cycle/references/lite-criteria.md
+++ b/plugin/plangate/skills/ai-loop-cycle/references/lite-criteria.md
@@ -23,10 +23,13 @@ issue [#782](https://github.com/s977043/plangate/issues/782) P1-2
 （「実機能は常に escalate に帰結し auto-approve が実質到達不能」）への応答は、
 Human 決定（issue [#807](https://github.com/s977043/plangate/issues/807)・
 2026-07-10）により **「docs 級限定の明文化」案から「lite 全域（本ドキュメント
-§2 の 4 軸を満たせば実機能も含む）」へ更新**された。`size_ok` の機械算出化
-（ファイル数閾値ではなく可逆性・パターン踏襲度を含む複合リスクスコア化。
-対応: issue [#780](https://github.com/s977043/plangate/issues/780) slice C）は
-当面の未実装事項として残り、申告制の保証を強化する unlock 位置づけである。
+§2 の 4 軸を満たせば実機能も含む）」へ更新**された。`size_ok` の機械検証化
+（issue [#780](https://github.com/s977043/plangate/issues/780) slice C で実装済み）は
+「ファイル数閾値（`SIZE_OK_MAX_FILES`=2）と `changed_files` 実数の突合」という
+最小形で実現された（当初想定した可逆性・パターン踏襲度を含む複合リスク
+スコア化は見送り、申告制の保証を強化する最小の unlock に留めた。§2 の
+「変更規模」欄・arbiter.py の `machine_size_check()` 参照）。他 3 軸
+（新規設計の有無・既存パターン踏襲・可逆性）は引き続き申告制のまま。
 AC-8 安全側（判定不能→false）・4 軸すべてを満たすことの要求は変更しない。
 
 ---
@@ -37,7 +40,7 @@ AC-8 安全側（判定不能→false）・4 軸すべてを満たすことの�
 
 | 軸 | lite=true 候補条件 | 継承元 |
 | ---- | -------------------- | -------- |
-| 変更規模 | `mode-classification.md` の light 相当以下（変更ファイル数 1〜2 目安） | `mode-classification.md` 定量基準 |
+| 変更規模 | `mode-classification.md` の light 相当以下（変更ファイル数 1〜2 目安）。**申告 `size_ok=true` は arbiter が `changed_files` 実数で機械検証する**（`SIZE_OK_MAX_FILES`=2 超過なら申告と実測の不一致として escalate。issue #780 slice C） | `mode-classification.md` 定量基準 |
 | 新規設計の有無 | なし（既存構造の枠内） | `mode-classification.md` lite_eligible 判定軸 |
 | 既存パターン踏襲 | あり（新規設計ゼロ・ミラー実装） | `mode-classification.md` lite_eligible 判定軸 |
 | **可逆性** | 変更が可逆である（巻き戻し手順が機械的に実行可能。例: `git revert` 一発、ファイル単位の差し戻しで完全復元できる） | 本ドキュメントで新規追加（PoC 固有） |
@@ -93,7 +96,9 @@ lite は「証明可能なときだけの例外」であり既定ではない。
 
 lite = true
 
-// 軸1: 変更規模
+// 軸1: 変更規模（申告 size_ok=true は arbiter.py が changed_files 実数で
+// SIZE_OK_MAX_FILES=2 と機械突合する。申告と実測が不一致なら priority 1.9
+// で human escalate — issue #780 slice C）
 if not (変更規模 <= light相当):
     lite = false
 

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/arbiter.py
@@ -21,7 +21,9 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
       "changed_files": [str, ...],
       "allowed_paths": [str, ...],
       "lite": {
-        "size_ok": bool,
+        "size_ok": bool,                 #   申告値。arbiter が changed_files 実数で機械検証する
+                                          #   （#780 Slice C・SIZE_OK_MAX_FILES）。申告 true だが
+                                          #   実ファイル数が閾値超過なら priority 1.9 で escalate
         "no_new_design": bool,
         "follows_pattern": bool,
         "reversible": bool
@@ -68,6 +70,13 @@ provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が 
 **省略時は provenance に `run` キー自体を刻まない**（`"run": null` を出さない）ため、
 metrics.py は当該 record を legacy（run メタ未計装）に分類し invalid_run_meta へ
 誤計上しない。gate 挙動は変えないため POLICY_REF のバージョンは進めない。
+
+`lite.size_ok`（#780 Slice C 追加の機械検証）は従来どおり申告 bool だが、
+arbiter は `changed_files` の実ファイル数と `SIZE_OK_MAX_FILES` を比較し
+機械検証する。申告 `size_ok=true` かつ実ファイル数が閾値を超える場合のみ
+priority 1.9 で HUMAN_ESCALATED とする（申告と実測が一致するケース、および
+申告 `size_ok=false` のケースは既存裁定を維持する安全側変更）。POLICY_REF を
+`@v2` → `@v3` へ改版した理由（機械 size 検証の追加）。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -388,6 +397,42 @@ def lite_check(lite_input: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# size_ok 機械検証: priority 1.9（#780 Slice C・AC-8 安全側とは独立の追加検証）
+# ---------------------------------------------------------------------------
+# 出典: docs/workflows/ai-loop/plan-slice-c.md（TASK-0780 Slice C）・
+# docs/workflows/ai-loop/lite-criteria.md §2「変更規模」（ファイル数 1〜2 目安）。
+# `lite.size_ok` は引き続き申告制（他 3 軸と同じ AC-8 安全側は lite_check が担う）。
+# 本節は「申告 size_ok=true」を `changed_files` の実ファイル数で機械検証し、
+# 申告と実測が食い違う（実際は blast-radius が大きい）場合のみ escalate を
+# 追加する。**この変更は escalate 条件を追加するだけの安全側変更であり、
+# 以前 escalate だった経路を auto-approve にする効果は一切持たない**
+# （POLICY_REF を @v2 → @v3 へ改版した理由）。
+SIZE_OK_MAX_FILES = 2
+
+
+def _declared_size_ok(lite_input: Any) -> bool:
+    """`lite.size_ok` が厳密に bool 型の True で申告されているかを判定する。
+
+    lite_check の各軸判定と同型（bool は int のサブクラスのため
+    isinstance(value, bool) を先に確認する）。`lite_input` が dict でない・
+    `size_ok` キー欠落・None・非 bool・False はすべて false を返す
+    （申告=true と確定できる場合のみ true。機械検証チェックの前提入力）。
+    """
+    if not isinstance(lite_input, dict):
+        return False
+    value = lite_input.get("size_ok")
+    return isinstance(value, bool) and value is True
+
+
+def machine_size_check(changed_files: list[str]) -> bool:
+    """`changed_files` の実ファイル数が SIZE_OK_MAX_FILES 以下かを機械判定する。
+
+    出典: lite-criteria.md §2「変更規模」（ファイル数 1〜2 目安 = light 相当）。
+    """
+    return len(changed_files) <= SIZE_OK_MAX_FILES
+
+
+# ---------------------------------------------------------------------------
 # plan 品質ゲート判定: priority 1.7（#780 Slice B・AC-8 安全側）
 # ---------------------------------------------------------------------------
 # 出典: docs/workflows/ai-loop/decision-table.md §3 priority 1.7 /
@@ -453,7 +498,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v2"
+POLICY_REF = "auto-approve-lite-clean@v3"
 
 
 class InputError(ValueError):
@@ -673,8 +718,9 @@ class Signals:
     """arbitrate() の priority 分岐に先立つ判定前処理の結果（TASK-0814 R2）。
 
     _evaluate_signals() の戻り値。boundary_check / check_allowed_paths /
-    lite_check / verdict 正規化（model_a-model_b 文字列化）を 1 箇所に
-    集約し、arbitrate() は本 dataclass を見て priority 分岐のみを行う。
+    lite_check / size_ok 機械検証（#780 Slice C） / verdict 正規化
+    （model_a-model_b 文字列化）を 1 箇所に集約し、arbitrate() は本
+    dataclass を見て priority 分岐のみを行う。
     """
 
     boundary: str
@@ -683,6 +729,8 @@ class Signals:
     violations: list[str]
     lite_result: bool
     plan_quality_ok: bool
+    declared_size_ok: bool
+    machine_size_ok: bool
     verdict: str
 
 
@@ -712,6 +760,8 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     lite_result = lite_check(data["lite"])
     plan_quality_ok = plan_quality_check(data.get("gates"))
+    declared_size_ok = _declared_size_ok(data["lite"])
+    machine_size_ok = machine_size_check(changed_files)
     verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
 
     return Signals(
@@ -721,6 +771,8 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
         violations=violations,
         lite_result=lite_result,
         plan_quality_ok=plan_quality_ok,
+        declared_size_ok=declared_size_ok,
+        machine_size_ok=machine_size_ok,
         verdict=verdict,
     )
 
@@ -819,6 +871,15 @@ def arbitrate(
             return f"priority 1.7: plan-quality gate 未充足（gates が dict でない・型: {type(gates).__name__}）"
         return f"priority 1.7: plan-quality gate 未充足（c1={gates.get('c1')} breakdown={gates.get('breakdown')}）"
 
+    def _size_mismatch_reason() -> str:
+        # 出典: docs/workflows/ai-loop/plan-slice-c.md（#780 Slice C）。
+        # 申告 size_ok=true だが実ファイル数が SIZE_OK_MAX_FILES を超える
+        # （申告と blast-radius の不一致）ときのみ本行が採用される。
+        return (
+            f"priority 1.9: size_ok 申告=true だが実ファイル数 {len(data['changed_files'])} が"
+            f"閾値 {SIZE_OK_MAX_FILES} を超過（申告と blast-radius 不一致）"
+        )
+
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
@@ -826,6 +887,8 @@ def arbitrate(
          lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
         ("priority 1.7", not signals.plan_quality_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          _gates_reason),
+        ("priority 1.9", signals.declared_size_ok and not signals.machine_size_ok, DECISION_HUMAN_ESCALATED,
+         signals.boundary, "in_scope", _size_mismatch_reason),
         ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
         ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",

--- a/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
+++ b/plugin/plangate/skills/ai-loop-cycle/scripts/test_arbiter.py
@@ -479,6 +479,184 @@ class PlanQualityGatePriorityTests(unittest.TestCase):
         self.assertIn("型: NoneType", reason)
 
 
+class SizeOkMachineCheckTests(unittest.TestCase):
+    """#780 Slice C: priority 1.9（size_ok 機械検証）の裁定経路テスト。
+
+    中核原則: escalate 条件を追加するのみ。申告と実測が一致するケース
+    （size_ok=true かつ changed_files<=2、または size_ok=false）は
+    従来と同一裁定を維持し、申告 size_ok=true だが実ファイル数が
+    SIZE_OK_MAX_FILES（2）を超えるケースのみ HUMAN_ESCALATED に倒れる。
+    """
+
+    def test_size_ok_max_files_constant_is_two(self):
+        self.assertEqual(arbiter.SIZE_OK_MAX_FILES, 2)
+
+    def test_declared_true_one_file_reaches_auto_approve(self):
+        """申告 size_ok=true・changed_files=1 個 → 従来どおり AUTO_APPROVED。"""
+        data = _base_input(changed_files=["docs/workflows/ai-loop/decision-table.md"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_declared_true_two_files_boundary_reaches_auto_approve(self):
+        """申告 size_ok=true・changed_files=2 個（閾値ちょうど）→ 従来どおり AUTO_APPROVED。"""
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/decision-table.md", "docs/workflows/ai-loop/lite-criteria.md"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_declared_true_three_files_escalates(self):
+        """申告 size_ok=true・changed_files=3 個（閾値+1）→ HUMAN_ESCALATED
+        （申告と blast-radius の不一致・priority 1.9）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.9", reason)
+        self.assertIn("実ファイル数 3", reason)
+        self.assertIn("閾値 2", reason)
+
+    def test_declared_false_many_files_unchanged_reaches_priority2(self):
+        """申告 size_ok=false（実ファイル数に関わらず）→ 従来どおり priority 2 escalate
+        （priority 1.9 の対象外・変化なし）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_touches_ho_preempts_size_check(self):
+        """HO 優先: touches-HO + size_ok=true 申告 + ファイル数超過でも
+        boundary=touches-HO（priority 1）が先に確定する。"""
+        data = _base_input(
+            changed_files=["bin/plangate", "docs/a.md", "docs/b.md"],
+            allowed_paths=["**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_scope_violation_preempts_size_check(self):
+        """scope 優先: scope 逸脱 + size_ok=true 申告 + ファイル数超過でも
+        priority 1.5（scope）が priority 1.9 より先に確定する。"""
+        data = _base_input(
+            changed_files=["scripts/unrelated/a.py", "scripts/unrelated/b.py", "scripts/unrelated/c.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_plan_quality_preempts_size_check(self):
+        """plan-quality 優先: gates 不備 + size_ok=true 申告 + ファイル数超過でも
+        priority 1.7（plan-quality）が priority 1.9 より先に確定する。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            gates={"c1": "FAIL", "breakdown": "pass"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_size_check_preempts_lite_check(self):
+        """priority 1.9 優先: size 不一致 + 他 lite 軸 false（lite_result も false）
+        でも priority 1.9 が priority 2 より先に確定する
+        （size_ok=true 申告自体は他軸と独立に機械検証されるため）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": True, "no_new_design": False, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.9", reason)
+        self.assertNotIn("priority 2:", reason)
+
+    def test_size_ok_non_bool_declared_value_not_mismatch(self):
+        """AC-8 安全側と同型: size_ok が非 bool（例: 1）は「申告=true」と確定できない
+        ため priority 1.9 の対象にならない（lite_check 側で false 扱いとなり
+        priority 2 escalate に倒れる。安全側は「escalate しない」側に倒れない）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": 1, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+
+class DeclaredSizeOkUnitTests(unittest.TestCase):
+    """_declared_size_ok() / machine_size_check() 単体テスト。"""
+
+    def test_declared_true(self):
+        self.assertTrue(arbiter._declared_size_ok({"size_ok": True}))
+
+    def test_declared_false(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": False}))
+
+    def test_declared_missing_key(self):
+        self.assertFalse(arbiter._declared_size_ok({}))
+
+    def test_declared_none_value(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": None}))
+
+    def test_declared_non_bool_value(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": 1}))
+
+    def test_declared_not_a_dict(self):
+        self.assertFalse(arbiter._declared_size_ok("size_ok"))
+        self.assertFalse(arbiter._declared_size_ok(None))
+
+    def test_machine_size_check_one_file(self):
+        self.assertTrue(arbiter.machine_size_check(["a.md"]))
+
+    def test_machine_size_check_two_files_boundary(self):
+        self.assertTrue(arbiter.machine_size_check(["a.md", "b.md"]))
+
+    def test_machine_size_check_three_files_exceeds(self):
+        self.assertFalse(arbiter.machine_size_check(["a.md", "b.md", "c.md"]))
+
+    def test_machine_size_check_zero_files(self):
+        self.assertTrue(arbiter.machine_size_check([]))
+
+
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):
         data = _base_input()
@@ -621,7 +799,7 @@ class ProvenanceSchemaTests(unittest.TestCase):
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
         self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
@@ -820,15 +998,16 @@ class PolicyRefVersionTests(unittest.TestCase):
     """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。
 
     #780 Slice B で @v1 → @v2 へ再改版（gates 必須化・priority 1.7 追加）。
+    #780 Slice C で @v2 → @v3 へ再改版（size_ok 機械検証・priority 1.9 追加）。
     """
 
-    def test_tc11_policy_ref_is_v2(self):
-        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v2")
+    def test_tc11_policy_ref_is_v3(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v3")
 
-    def test_tc11_provenance_policy_ref_is_v2(self):
+    def test_tc11_provenance_policy_ref_is_v3(self):
         data = _base_input()
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class PathNormalizationSecurityTests(unittest.TestCase):
@@ -1394,10 +1573,10 @@ class RunMetaProvenanceTests(unittest.TestCase):
 
     def test_policy_ref_unchanged_when_run_present(self):
         """run は additive provenance であり policy 改版ではない（run 追加は据え置き。
-        現行ベースラインは #780 Slice B の gates 必須化で @v2 — run 起因の改版ではない）。"""
+        現行ベースラインは #780 Slice C の size_ok 機械検証で @v3 — run 起因の改版ではない）。"""
         data = _base_input(run=self.RUN_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class GatesProvenanceTests(unittest.TestCase):
@@ -1511,10 +1690,10 @@ class GatesProvenanceTests(unittest.TestCase):
 
     def test_policy_ref_unchanged_when_gates_present(self):
         """gates 刻印は additive provenance であり policy 改版ではない
-        （POLICY_REF は @v2 据え置き）。"""
+        （POLICY_REF は現行ベースライン @v3 据え置き。gates 追加自体が原因の改版ではない）。"""
         data = _base_input(gates=self.GATES_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
@@ -1761,7 +1940,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "unresolved",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1798,7 +1977,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "not_evaluated",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1824,7 +2003,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "scope_violation",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1850,7 +2029,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1873,7 +2052,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1898,7 +2077,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1926,7 +2105,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "approve"},
@@ -1952,7 +2131,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1978,7 +2157,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2012,7 +2191,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2048,7 +2227,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2085,7 +2264,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2123,7 +2302,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2161,7 +2340,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2194,7 +2373,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "run": {
                     "repair_action": None,
                     "round_index": 0,

--- a/scripts/ai-loop/arbiter.py
+++ b/scripts/ai-loop/arbiter.py
@@ -21,7 +21,9 @@ L1（呼び出し側）が別途取得し、その verdict を本モジュール
       "changed_files": [str, ...],
       "allowed_paths": [str, ...],
       "lite": {
-        "size_ok": bool,
+        "size_ok": bool,                 #   申告値。arbiter が changed_files 実数で機械検証する
+                                          #   （#780 Slice C・SIZE_OK_MAX_FILES）。申告 true だが
+                                          #   実ファイル数が閾値超過なら priority 1.9 で escalate
         "no_new_design": bool,
         "follows_pattern": bool,
         "reversible": bool
@@ -68,6 +70,13 @@ provenance にそのまま刻まれ、`scripts/ai-loop/metrics.py`（#812）が 
 **省略時は provenance に `run` キー自体を刻まない**（`"run": null` を出さない）ため、
 metrics.py は当該 record を legacy（run メタ未計装）に分類し invalid_run_meta へ
 誤計上しない。gate 挙動は変えないため POLICY_REF のバージョンは進めない。
+
+`lite.size_ok`（#780 Slice C 追加の機械検証）は従来どおり申告 bool だが、
+arbiter は `changed_files` の実ファイル数と `SIZE_OK_MAX_FILES` を比較し
+機械検証する。申告 `size_ok=true` かつ実ファイル数が閾値を超える場合のみ
+priority 1.9 で HUMAN_ESCALATED とする（申告と実測が一致するケース、および
+申告 `size_ok=false` のケースは既存裁定を維持する安全側変更）。POLICY_REF を
+`@v2` → `@v3` へ改版した理由（機械 size 検証の追加）。
 
 CLI:
     --input <file>      入力 JSON ファイル（省略時は stdin）
@@ -388,6 +397,42 @@ def lite_check(lite_input: Any) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# size_ok 機械検証: priority 1.9（#780 Slice C・AC-8 安全側とは独立の追加検証）
+# ---------------------------------------------------------------------------
+# 出典: docs/workflows/ai-loop/plan-slice-c.md（TASK-0780 Slice C）・
+# docs/workflows/ai-loop/lite-criteria.md §2「変更規模」（ファイル数 1〜2 目安）。
+# `lite.size_ok` は引き続き申告制（他 3 軸と同じ AC-8 安全側は lite_check が担う）。
+# 本節は「申告 size_ok=true」を `changed_files` の実ファイル数で機械検証し、
+# 申告と実測が食い違う（実際は blast-radius が大きい）場合のみ escalate を
+# 追加する。**この変更は escalate 条件を追加するだけの安全側変更であり、
+# 以前 escalate だった経路を auto-approve にする効果は一切持たない**
+# （POLICY_REF を @v2 → @v3 へ改版した理由）。
+SIZE_OK_MAX_FILES = 2
+
+
+def _declared_size_ok(lite_input: Any) -> bool:
+    """`lite.size_ok` が厳密に bool 型の True で申告されているかを判定する。
+
+    lite_check の各軸判定と同型（bool は int のサブクラスのため
+    isinstance(value, bool) を先に確認する）。`lite_input` が dict でない・
+    `size_ok` キー欠落・None・非 bool・False はすべて false を返す
+    （申告=true と確定できる場合のみ true。機械検証チェックの前提入力）。
+    """
+    if not isinstance(lite_input, dict):
+        return False
+    value = lite_input.get("size_ok")
+    return isinstance(value, bool) and value is True
+
+
+def machine_size_check(changed_files: list[str]) -> bool:
+    """`changed_files` の実ファイル数が SIZE_OK_MAX_FILES 以下かを機械判定する。
+
+    出典: lite-criteria.md §2「変更規模」（ファイル数 1〜2 目安 = light 相当）。
+    """
+    return len(changed_files) <= SIZE_OK_MAX_FILES
+
+
+# ---------------------------------------------------------------------------
 # plan 品質ゲート判定: priority 1.7（#780 Slice B・AC-8 安全側）
 # ---------------------------------------------------------------------------
 # 出典: docs/workflows/ai-loop/decision-table.md §3 priority 1.7 /
@@ -453,7 +498,7 @@ EXIT_CODES = {
 }
 
 ISSUED_BY = "arbiter-v0.1"
-POLICY_REF = "auto-approve-lite-clean@v2"
+POLICY_REF = "auto-approve-lite-clean@v3"
 
 
 class InputError(ValueError):
@@ -673,8 +718,9 @@ class Signals:
     """arbitrate() の priority 分岐に先立つ判定前処理の結果（TASK-0814 R2）。
 
     _evaluate_signals() の戻り値。boundary_check / check_allowed_paths /
-    lite_check / verdict 正規化（model_a-model_b 文字列化）を 1 箇所に
-    集約し、arbitrate() は本 dataclass を見て priority 分岐のみを行う。
+    lite_check / size_ok 機械検証（#780 Slice C） / verdict 正規化
+    （model_a-model_b 文字列化）を 1 箇所に集約し、arbitrate() は本
+    dataclass を見て priority 分岐のみを行う。
     """
 
     boundary: str
@@ -683,6 +729,8 @@ class Signals:
     violations: list[str]
     lite_result: bool
     plan_quality_ok: bool
+    declared_size_ok: bool
+    machine_size_ok: bool
     verdict: str
 
 
@@ -712,6 +760,8 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
     scope_ok, violations = check_allowed_paths(changed_files, allowed_paths)
     lite_result = lite_check(data["lite"])
     plan_quality_ok = plan_quality_check(data.get("gates"))
+    declared_size_ok = _declared_size_ok(data["lite"])
+    machine_size_ok = machine_size_check(changed_files)
     verdict = f"{verdicts['model_a']}-{verdicts['model_b']}"
 
     return Signals(
@@ -721,6 +771,8 @@ def _evaluate_signals(data: dict[str, Any], ho_patterns: list[tuple[str, str]]) 
         violations=violations,
         lite_result=lite_result,
         plan_quality_ok=plan_quality_ok,
+        declared_size_ok=declared_size_ok,
+        machine_size_ok=machine_size_ok,
         verdict=verdict,
     )
 
@@ -819,6 +871,15 @@ def arbitrate(
             return f"priority 1.7: plan-quality gate 未充足（gates が dict でない・型: {type(gates).__name__}）"
         return f"priority 1.7: plan-quality gate 未充足（c1={gates.get('c1')} breakdown={gates.get('breakdown')}）"
 
+    def _size_mismatch_reason() -> str:
+        # 出典: docs/workflows/ai-loop/plan-slice-c.md（#780 Slice C）。
+        # 申告 size_ok=true だが実ファイル数が SIZE_OK_MAX_FILES を超える
+        # （申告と blast-radius の不一致）ときのみ本行が採用される。
+        return (
+            f"priority 1.9: size_ok 申告=true だが実ファイル数 {len(data['changed_files'])} が"
+            f"閾値 {SIZE_OK_MAX_FILES} を超過（申告と blast-radius 不一致）"
+        )
+
     priority_table: list[tuple[str, bool, str, str, str, Any]] = [
         ("priority 1", signals.boundary == "touches-HO", DECISION_HUMAN_ESCALATED, signals.boundary, "not_evaluated",
          lambda: f"priority 1: boundary=touches-HO（絶対条件・固定）。一致パス: {_matched_desc()}"),
@@ -826,6 +887,8 @@ def arbitrate(
          lambda: f"priority 1.5: boundary=clean だが scope_violation（allowed_paths 逸脱パス: {', '.join(signals.violations)}）"),
         ("priority 1.7", not signals.plan_quality_ok, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          _gates_reason),
+        ("priority 1.9", signals.declared_size_ok and not signals.machine_size_ok, DECISION_HUMAN_ESCALATED,
+         signals.boundary, "in_scope", _size_mismatch_reason),
         ("priority 2", not signals.lite_result, DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",
          lambda: "priority 2: boundary=clean だが lite=false（低リスク要件未充足）"),
         ("priority 3", class_value == "merge", DECISION_HUMAN_ESCALATED, signals.boundary, "in_scope",

--- a/scripts/ai-loop/test_arbiter.py
+++ b/scripts/ai-loop/test_arbiter.py
@@ -479,6 +479,184 @@ class PlanQualityGatePriorityTests(unittest.TestCase):
         self.assertIn("型: NoneType", reason)
 
 
+class SizeOkMachineCheckTests(unittest.TestCase):
+    """#780 Slice C: priority 1.9（size_ok 機械検証）の裁定経路テスト。
+
+    中核原則: escalate 条件を追加するのみ。申告と実測が一致するケース
+    （size_ok=true かつ changed_files<=2、または size_ok=false）は
+    従来と同一裁定を維持し、申告 size_ok=true だが実ファイル数が
+    SIZE_OK_MAX_FILES（2）を超えるケースのみ HUMAN_ESCALATED に倒れる。
+    """
+
+    def test_size_ok_max_files_constant_is_two(self):
+        self.assertEqual(arbiter.SIZE_OK_MAX_FILES, 2)
+
+    def test_declared_true_one_file_reaches_auto_approve(self):
+        """申告 size_ok=true・changed_files=1 個 → 従来どおり AUTO_APPROVED。"""
+        data = _base_input(changed_files=["docs/workflows/ai-loop/decision-table.md"])
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_declared_true_two_files_boundary_reaches_auto_approve(self):
+        """申告 size_ok=true・changed_files=2 個（閾値ちょうど）→ 従来どおり AUTO_APPROVED。"""
+        data = _base_input(
+            changed_files=["docs/workflows/ai-loop/decision-table.md", "docs/workflows/ai-loop/lite-criteria.md"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "AUTO_APPROVED")
+        self.assertIn("priority 6", reason)
+
+    def test_declared_true_three_files_escalates(self):
+        """申告 size_ok=true・changed_files=3 個（閾値+1）→ HUMAN_ESCALATED
+        （申告と blast-radius の不一致・priority 1.9）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.9", reason)
+        self.assertIn("実ファイル数 3", reason)
+        self.assertIn("閾値 2", reason)
+
+    def test_declared_false_many_files_unchanged_reaches_priority2(self):
+        """申告 size_ok=false（実ファイル数に関わらず）→ 従来どおり priority 2 escalate
+        （priority 1.9 の対象外・変化なし）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": False, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_touches_ho_preempts_size_check(self):
+        """HO 優先: touches-HO + size_ok=true 申告 + ファイル数超過でも
+        boundary=touches-HO（priority 1）が先に確定する。"""
+        data = _base_input(
+            changed_files=["bin/plangate", "docs/a.md", "docs/b.md"],
+            allowed_paths=["**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["boundary_check"], "touches-HO")
+        self.assertIn("priority 1", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_scope_violation_preempts_size_check(self):
+        """scope 優先: scope 逸脱 + size_ok=true 申告 + ファイル数超過でも
+        priority 1.5（scope）が priority 1.9 より先に確定する。"""
+        data = _base_input(
+            changed_files=["scripts/unrelated/a.py", "scripts/unrelated/b.py", "scripts/unrelated/c.py"],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertEqual(provenance["scope_check"], "scope_violation")
+        self.assertIn("priority 1.5", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_plan_quality_preempts_size_check(self):
+        """plan-quality 優先: gates 不備 + size_ok=true 申告 + ファイル数超過でも
+        priority 1.7（plan-quality）が priority 1.9 より先に確定する。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            gates={"c1": "FAIL", "breakdown": "pass"},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.7", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+    def test_size_check_preempts_lite_check(self):
+        """priority 1.9 優先: size 不一致 + 他 lite 軸 false（lite_result も false）
+        でも priority 1.9 が priority 2 より先に確定する
+        （size_ok=true 申告自体は他軸と独立に機械検証されるため）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": True, "no_new_design": False, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 1.9", reason)
+        self.assertNotIn("priority 2:", reason)
+
+    def test_size_ok_non_bool_declared_value_not_mismatch(self):
+        """AC-8 安全側と同型: size_ok が非 bool（例: 1）は「申告=true」と確定できない
+        ため priority 1.9 の対象にならない（lite_check 側で false 扱いとなり
+        priority 2 escalate に倒れる。安全側は「escalate しない」側に倒れない）。"""
+        data = _base_input(
+            changed_files=[
+                "docs/workflows/ai-loop/decision-table.md",
+                "docs/workflows/ai-loop/lite-criteria.md",
+                "docs/workflows/ai-loop/flow-detect.md",
+            ],
+            allowed_paths=["docs/workflows/ai-loop/**"],
+            lite={"size_ok": 1, "no_new_design": True, "follows_pattern": True, "reversible": True},
+        )
+        provenance, reason = arbiter.arbitrate(data)
+        self.assertEqual(provenance["decision"], "HUMAN_ESCALATED")
+        self.assertIn("priority 2", reason)
+        self.assertNotIn("priority 1.9", reason)
+
+
+class DeclaredSizeOkUnitTests(unittest.TestCase):
+    """_declared_size_ok() / machine_size_check() 単体テスト。"""
+
+    def test_declared_true(self):
+        self.assertTrue(arbiter._declared_size_ok({"size_ok": True}))
+
+    def test_declared_false(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": False}))
+
+    def test_declared_missing_key(self):
+        self.assertFalse(arbiter._declared_size_ok({}))
+
+    def test_declared_none_value(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": None}))
+
+    def test_declared_non_bool_value(self):
+        self.assertFalse(arbiter._declared_size_ok({"size_ok": 1}))
+
+    def test_declared_not_a_dict(self):
+        self.assertFalse(arbiter._declared_size_ok("size_ok"))
+        self.assertFalse(arbiter._declared_size_ok(None))
+
+    def test_machine_size_check_one_file(self):
+        self.assertTrue(arbiter.machine_size_check(["a.md"]))
+
+    def test_machine_size_check_two_files_boundary(self):
+        self.assertTrue(arbiter.machine_size_check(["a.md", "b.md"]))
+
+    def test_machine_size_check_three_files_exceeds(self):
+        self.assertFalse(arbiter.machine_size_check(["a.md", "b.md", "c.md"]))
+
+    def test_machine_size_check_zero_files(self):
+        self.assertTrue(arbiter.machine_size_check([]))
+
+
 class SeverityEscalationTests(unittest.TestCase):
     def test_severity_critical_escalates(self):
         data = _base_input()
@@ -621,7 +799,7 @@ class ProvenanceSchemaTests(unittest.TestCase):
         ):
             self.assertIn(field, provenance)
         self.assertEqual(provenance["issued_by"], "arbiter-v0.1")
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
         self.assertEqual(provenance["scope_check"], "in_scope")
         self.assertEqual(provenance["w_check"]["model_a"], "approve")
         self.assertEqual(provenance["w_check"]["model_b"], "approve")
@@ -820,15 +998,16 @@ class PolicyRefVersionTests(unittest.TestCase):
     """TC-11: POLICY_REF が @v1 へ改版されていること（allowed_paths 必須化・fail-closed機械化）。
 
     #780 Slice B で @v1 → @v2 へ再改版（gates 必須化・priority 1.7 追加）。
+    #780 Slice C で @v2 → @v3 へ再改版（size_ok 機械検証・priority 1.9 追加）。
     """
 
-    def test_tc11_policy_ref_is_v2(self):
-        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v2")
+    def test_tc11_policy_ref_is_v3(self):
+        self.assertEqual(arbiter.POLICY_REF, "auto-approve-lite-clean@v3")
 
-    def test_tc11_provenance_policy_ref_is_v2(self):
+    def test_tc11_provenance_policy_ref_is_v3(self):
         data = _base_input()
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class PathNormalizationSecurityTests(unittest.TestCase):
@@ -1394,10 +1573,10 @@ class RunMetaProvenanceTests(unittest.TestCase):
 
     def test_policy_ref_unchanged_when_run_present(self):
         """run は additive provenance であり policy 改版ではない（run 追加は据え置き。
-        現行ベースラインは #780 Slice B の gates 必須化で @v2 — run 起因の改版ではない）。"""
+        現行ベースラインは #780 Slice C の size_ok 機械検証で @v3 — run 起因の改版ではない）。"""
         data = _base_input(run=self.RUN_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class GatesProvenanceTests(unittest.TestCase):
@@ -1511,10 +1690,10 @@ class GatesProvenanceTests(unittest.TestCase):
 
     def test_policy_ref_unchanged_when_gates_present(self):
         """gates 刻印は additive provenance であり policy 改版ではない
-        （POLICY_REF は @v2 据え置き）。"""
+        （POLICY_REF は現行ベースライン @v3 据え置き。gates 追加自体が原因の改版ではない）。"""
         data = _base_input(gates=self.GATES_META)
         provenance, _ = arbiter.arbitrate(data)
-        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v2")
+        self.assertEqual(provenance["policy_ref"], "auto-approve-lite-clean@v3")
 
 
 class ArbiterMetricsIntegrationTests(unittest.TestCase):
@@ -1761,7 +1940,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 0,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "unresolved",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1798,7 +1977,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "not_evaluated",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1824,7 +2003,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "scope_violation",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1850,7 +2029,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": False,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1873,7 +2052,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1898,7 +2077,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "reject"},
@@ -1926,7 +2105,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "reject", "model_b": "approve"},
@@ -1952,7 +2131,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {"model_a": "approve", "model_b": "approve"},
@@ -1978,7 +2157,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2012,7 +2191,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2048,7 +2227,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2085,7 +2264,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2123,7 +2302,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2161,7 +2340,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "scope_check": "in_scope",
                 "target_sha": "abc1234",
                 "w_check": {
@@ -2194,7 +2373,7 @@ class ArbitrateCharacterizationTests(unittest.TestCase):
                 "ho_pattern_count": 18,
                 "issued_by": "arbiter-v0.1",
                 "lite_check": True,
-                "policy_ref": "auto-approve-lite-clean@v2",
+                "policy_ref": "auto-approve-lite-clean@v3",
                 "run": {
                     "repair_action": None,
                     "round_index": 0,


### PR DESCRIPTION
## 概要

#780 Slice C。`lite.size_ok` の**自己申告**を、arbiter が `changed_files` の実ファイル数で**機械検証**する。ai-loop の核心「観測を信じる（自己申告に依存しない）」を size 軸で実現。#807/#817 の順序制約「導入先の実機能 auto-approve は size_ok 機械算出を前提とする」を満たす。

## 変更内容

- **priority 1.9（size 機械検証）**: `SIZE_OK_MAX_FILES = 2`。申告 `lite.size_ok == True`（厳密 bool）かつ `len(changed_files) > 2` → **HUMAN_ESCALATED**（申告と blast-radius の不一致を検出）。scope(1.5)/plan-quality(1.7) の後・lite(2) の前
- **申告 size_ok=false / 非 bool は従来どおり**（priority 2 lite=false escalate・変化なし）
- **他 lite 軸（no_new_design/follows_pattern/reversible）は申告制のまま**（size 軸のみ機械化・他は別 slice/V2）
- **POLICY_REF @v2 → @v3**（機械 size 検証が auto-approve 判定に加わる policy 改版）
- SKILL 4 配置・lite-criteria.md・decision-table.md に機械検証を明記

## 安全性の機械証明（三層独立検証・逆方向違反ゼロ）

**escalate 条件の追加のみ・以前 escalate/blocked → auto-approve の経路をゼロにする**:

| 検証 | 規模 | reverse_violations |
|---|---|---|
| maker | 138,240 通り | 0 |
| 統合側（独立差分） | size_ok×file数×verdict×class | **0**・size 起因で説明できない差分 0 |
| **opus 敵対レビュー** | **570,240 ケース** | **0**（全差分 278 件が escalate 方向のみ） |

境界検証（files=2→AUTO / files=3→escalate）・priority 順序（HO/scope/plan-quality が 1.9 に先行）・型（非 bool size_ok は 1.9 不発火→priority 2）・@v3 一貫性、すべて敵対レビューで HOLDS。

## 検証

- `test_arbiter.py` 217 テスト（+20）GREEN（repo 正本 + plugin bundled 両方で自立 PASS）
- arbiter.py / test_arbiter.py plugin コピーと cmp IDENTICAL・markdownlint 0・POLICY_REF @v3 全経路

## C-4 レビュー観点（gate 挙動変更のため）

ai-loop の gate セマンティクス変更（size 軸を機械検証）。安全側（誤申告の escalate 増）ですが、Human C-4 で「逆方向違反ゼロ」の妥当性をご確認ください。

## 関連

Refs #780。これで lite の size 軸が自己申告依存を脱し、導入先の実機能 auto-approve の順序制約が満たされる。follow-up: 他 3 lite 軸の機械化 / 行数ベース blast-radius。

🤖 Generated with [Claude Code](https://claude.com/claude-code)