### PR TITLE
feat: ai-loop discovery D-3 — candidate to Gate接続の道しるべ強化 (#818 / HOTL #822)

### DIFF
--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -31,6 +31,7 @@ discovery.py 自体はファイル入力を受けるだけで gh を直叩きし
 CLI:
     python3 scripts/ai-loop/discovery.py --issues <path.json>
         [--label ai-loop-auto] [--format md|json] [--ho-paths <path>]
+        [--emit-next-command]
 
 exit code:
     0 = 正常（候補あり/なし両方）
@@ -52,6 +53,20 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_LABEL = "ai-loop-auto"
+
+# recommended_next 構造化オブジェクト（TASK-0818 D-3）。discovery は execしない・
+# arbiterを呼ばない — human/orchestratorが既存 ai-loop-cycle を辿るための道しるべ。
+RECOMMENDED_NEXT_ACTION = "propose-to-ai-loop-cycle"
+RECOMMENDED_NEXT_ENTRY_POINT = "docs/workflows/ai-loop/execution-runbook.md"
+RECOMMENDED_NEXT_STEP = (
+    "human/orchestratorがissueを読み、通常のai-loop-cycle"
+    "（W check→arbiter裁定）をこのissueに対して開始する"
+)
+
+# 「discoveryはGateをbypassしない」旨の明示（サマリ md/json 共通）。
+NO_BYPASS_NOTICE = (
+    "次にGateを通すのはHuman/orchestratorの判断であり、discoveryはbypassしない。"
+)
 
 # HO（Hardening Override）示唆語 — docs/ai/ai-loop/ho-paths.md の代表パス断片 +
 # 承認境界を示す一般語。--ho-paths 指定時はここへ追加でパス断片を取り込む。
@@ -289,16 +304,31 @@ def evaluate_issue(
         "title": title_str,
         "candidate": True,
         "reasons": reasons,
-        "recommended_next": "propose-to-ai-loop-cycle",
+        "recommended_next": {
+            "action": RECOMMENDED_NEXT_ACTION,
+            "entry_point": RECOMMENDED_NEXT_ENTRY_POINT,
+            "next_step": RECOMMENDED_NEXT_STEP,
+        },
     }
+
+
+def _build_next_command(number: Any) -> str:
+    """人間がコピペ実行できる提案コマンド文字列を生成する（discovery自身は実行しない）。"""
+    return f"# candidate #{number}: 'ai-loop-cycle' skill を issue #{number} に対して開始してください"
 
 
 def run_discovery(
     issues: list[dict[str, Any]],
     label: str,
     ho_signals: tuple[str, ...],
+    emit_next_command: bool = False,
 ) -> dict[str, Any]:
-    """全 issue を評価し candidates/excluded/summary を構築する（read-only・純関数）。"""
+    """全 issue を評価し candidates/excluded/summary を構築する（read-only・純関数）。
+
+    emit_next_command=True の場合、各 candidate に人間がコピペ実行できる
+    提案コマンド文字列（next_command）を付加する。discovery 自身はこの
+    コマンドを一切実行しない（文字列生成のみ・subprocess呼び出し禁止）。
+    """
     candidates: list[dict[str, Any]] = []
     excluded: list[dict[str, Any]] = []
     no_label_count = 0
@@ -306,14 +336,15 @@ def run_discovery(
     for issue in issues:
         result = evaluate_issue(issue, label, ho_signals)
         if result["candidate"]:
-            candidates.append(
-                {
-                    "number": result["number"],
-                    "title": result["title"],
-                    "reasons": result["reasons"],
-                    "recommended_next": result["recommended_next"],
-                }
-            )
+            candidate: dict[str, Any] = {
+                "number": result["number"],
+                "title": result["title"],
+                "reasons": result["reasons"],
+                "recommended_next": result["recommended_next"],
+            }
+            if emit_next_command:
+                candidate["next_command"] = _build_next_command(result["number"])
+            candidates.append(candidate)
         else:
             excluded.append(
                 {
@@ -332,6 +363,7 @@ def run_discovery(
             "candidate_count": len(candidates),
             "excluded_count": len(excluded),
             "no_label_count": no_label_count,
+            "no_bypass_notice": NO_BYPASS_NOTICE,
         },
     }
 
@@ -351,6 +383,7 @@ def format_md(result: dict[str, Any]) -> str:
             n=summary["no_label_count"],
         )
     )
+    lines.append(f"- {summary['no_bypass_notice']}")
     lines.append("")
 
     lines.append("## Candidates")
@@ -365,10 +398,18 @@ def format_md(result: dict[str, Any]) -> str:
             reasons_str = ", ".join(
                 f"{k}={'OK' if v else 'NG'}" for k, v in cand["reasons"].items()
             )
+            next_action = cand["recommended_next"]["action"]
             lines.append(
                 f"| #{cand['number']} | {cand['title']} | "
-                f"{cand['recommended_next']} | {reasons_str} |"
+                f"{next_action} | {reasons_str} |"
             )
+        if any("next_command" in cand for cand in result["candidates"]):
+            lines.append("")
+            lines.append("### 提案コマンド（人間がコピペ実行・discoveryは実行しない）")
+            lines.append("")
+            for cand in result["candidates"]:
+                if "next_command" in cand:
+                    lines.append(cand["next_command"])
     lines.append("")
 
     lines.append("## Excluded（無言除外なし・全件理由付き）")
@@ -416,6 +457,15 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="ho-paths.md パス（HO シグナル拡充用・任意）",
     )
+    parser.add_argument(
+        "--emit-next-command",
+        action="store_true",
+        default=False,
+        help=(
+            "候補ごとに人間がコピペ実行できる提案コマンド文字列を出力に含める"
+            "（discovery自身は実行しない・read-only維持・既定false）"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -425,7 +475,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     ho_signals = _load_ho_signals(args.ho_paths)
-    result = run_discovery(issues, args.label, ho_signals)
+    result = run_discovery(
+        issues, args.label, ho_signals, emit_next_command=args.emit_next_command
+    )
 
     if args.format == "json":
         print(format_json(result))

--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -47,6 +47,7 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -72,6 +73,9 @@ DEFAULT_HO_SIGNALS: tuple[str, ...] = (
 )
 
 # 大規模語（lite 帯を外れるシグナル）。
+# 日本語語彙は既存を維持し、英語圏 issue がすり抜けないよう英語語彙を追加する
+# （false-positive 修正: Refactor entire auth module / large migration...
+# rewriting architecture 等が候補に混入していた実測に基づく）。
 LARGE_SCALE_SIGNALS: tuple[str, ...] = (
     "アーキ",
     "横断",
@@ -81,14 +85,62 @@ LARGE_SCALE_SIGNALS: tuple[str, ...] = (
     "破壊的変更",
     "全面書き換え",
     "大規模",
+    "refactor",
+    "rewrite",
+    "migration",
+    "migrate",
+    "architecture",
+    "architectural",
+    "cross-cutting",
+    "large-scale",
+    "overhaul",
+    "redesign",
 )
 
-# 未解決依存シグナル。
+# 未解決依存シグナル（直接一致で除外する固定フレーズ）。
+# 「waiting on #55 / #90 の完了を待って」等の言い回しがすり抜けていた実測に
+# 基づき追加（false-positive 修正）。
 DEPENDENCY_SIGNALS: tuple[str, ...] = (
     "blocked",
+    "block",
     "depends on #",
     "後続",
+    "waiting on",
+    "wait for",
+    "待って",
+    "待ち",
+    "保留",
+    "未完了",
+    "pending #",
 )
+
+# #数字 と共存する場合にのみ依存ありと判定する語幹（over-exclusion回避:
+# #数字単独では依存判定しない。DEPENDENCY_SIGNALS の固定フレーズより広い
+# 語幹をここに限定し、#数字との共起を条件とすることで誤検出を抑える）。
+DEPENDENCY_ISSUE_NUMBER_STEMS: tuple[str, ...] = (
+    "waiting",
+    "wait",
+    "depends",
+    "blocked",
+    "block",
+    "待",
+    "保留",
+    "後続",
+    "pending",
+)
+
+_ISSUE_NUMBER_RE = re.compile(r"#\d+")
+
+
+def _has_dependency_with_issue_number(text: str) -> bool:
+    """text 内に #数字 と依存語幹が共存する場合に True を返す。
+
+    #数字単独（依存語なし）は False のまま（over-exclusion回避 / AC-8 と対）。
+    """
+    if not _ISSUE_NUMBER_RE.search(text):
+        return False
+    return any(stem in text for stem in DEPENDENCY_ISSUE_NUMBER_STEMS)
+
 
 _HO_PATH_CELL_RE = re.compile(r"`([^`]+)`")
 
@@ -179,7 +231,10 @@ def evaluate_issue(
         if isinstance(entry, (str, dict))
     }
 
-    text = f"{title_str}\n{body_str}".lower()
+    # 全角文字（全角英字・全角記号等）を NFKC で正規化してから小文字化する。
+    # 正規化前は「ｓｃｒｉｐｔｓ／ｈｏｏｋｓ」等の全角表記が半角シグナルに
+    # マッチせず no_ho_risk=true の false-positive になっていた（fix 3, minor）。
+    text = unicodedata.normalize("NFKC", f"{title_str}\n{body_str}").lower()
 
     reasons: dict[str, bool] = {}
 
@@ -217,6 +272,8 @@ def evaluate_issue(
         }
 
     dep_hit = _contains_any(text, DEPENDENCY_SIGNALS)
+    if dep_hit is None and _has_dependency_with_issue_number(text):
+        dep_hit = "issue-number+dependency-word"
     reasons["deps_resolved"] = dep_hit is None
     if dep_hit is not None:
         return {

--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""discovery.py — ai-loop Triage discovery: read-only 候補提示 CLI（TASK-0818 D-2）。
+
+適用ドメイン: ai-loop-workflow（docs/workflows/ai-loop/ 配下）のみ。
+PlanGate 本番フロー（bin/plangate・scripts/hooks/）からは一切呼ばれない
+隔離 PoC スクリプト（arbiter.py / metrics.py と同じ位置付け）。
+
+目的: issue キューの中から「ai-loop で自動着手してよい低リスク候補」を
+**スコアリングして提示するだけ**の read-only ツール。着手・実行・issue 変更・
+git 操作は一切行わない。着手可否の最終判断は既存 Gate（arbiter）が別途行う
+— discovery は Gate を bypass しない（正本: docs/working/TASK-0818/design-d1.md）。
+
+入力: issue 配列 JSON ファイル（`gh issue list --json number,title,labels,body`
+相当。各要素 `{"number": int, "title": str, "labels": [str,...], "body": str}`）。
+discovery.py 自体はファイル入力を受けるだけで gh を直叩きしない
+（ネットワーク非依存・決定論・テスト可能）。
+
+スコアリング（opt-in ラベル必須。以下すべてを満たす issue のみ candidate）:
+- optin_label: issue.labels に --label 値（既定 ai-loop-auto）を含む
+- no_ho_risk: title+body が HO パス/語（.claude/rules・scripts/hooks・
+  schema・settings・承認境界 等）を示唆しない
+- is_lite: title+body に大規模語（アーキ・横断・リファクタ全体・移行・
+  breaking 等）が無い
+- deps_resolved: body に未解決依存の示唆（blocked・depends on #・後続 等）
+  が無い
+
+判定は安全側（AC-8）: 曖昧・判定不能な場合は「候補外」に倒す
+（false-positive で自動対象に誤って入れない）。無言除外は禁止し、excluded
+は全件理由付きで出力する。
+
+CLI:
+    python3 scripts/ai-loop/discovery.py --issues <path.json>
+        [--label ai-loop-auto] [--format md|json] [--ho-paths <path>]
+
+exit code:
+    0 = 正常（候補あり/なし両方）
+    1 = 入力エラー（--issues ファイル不在・JSON 破損等。stderr にメッセージ必須）
+
+禁止（read-only 保証）:
+    git 操作 / subprocess での gh 呼び出し / ファイル書き込み（出力は stdout
+    のみ）/ issue 変更 / Gate（arbiter）呼び出し・着手 は一切行わない。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LABEL = "ai-loop-auto"
+
+# HO（Hardening Override）示唆語 — docs/ai/ai-loop/ho-paths.md の代表パス断片 +
+# 承認境界を示す一般語。--ho-paths 指定時はここへ追加でパス断片を取り込む。
+DEFAULT_HO_SIGNALS: tuple[str, ...] = (
+    "scripts/hooks",
+    "bin/plangate",
+    ".claude/rules",
+    ".claude/settings",
+    ".claude/commands",
+    ".claude/agents",
+    "schemas/",
+    ".github/workflows",
+    "claude.md",
+    "agents.md",
+    "hook",
+    "schema",
+    "settings",
+    "承認境界",
+)
+
+# 大規模語（lite 帯を外れるシグナル）。
+LARGE_SCALE_SIGNALS: tuple[str, ...] = (
+    "アーキ",
+    "横断",
+    "リファクタ全体",
+    "移行",
+    "breaking",
+    "破壊的変更",
+    "全面書き換え",
+    "大規模",
+)
+
+# 未解決依存シグナル。
+DEPENDENCY_SIGNALS: tuple[str, ...] = (
+    "blocked",
+    "depends on #",
+    "後続",
+)
+
+_HO_PATH_CELL_RE = re.compile(r"`([^`]+)`")
+
+
+def _load_issues(path: Path) -> list[dict[str, Any]]:
+    """--issues ファイルを読み込み issue 配列を返す。
+
+    入力エラー（不在・JSON 破損・配列でない）は ValueError を送出する。
+    呼び出し側で exit 1 + stderr メッセージにマッピングする。
+    """
+    if not path.is_file():
+        raise ValueError(f"--issues file not found: {path}")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"--issues file unreadable: {path} ({exc})") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--issues file is not valid JSON: {path} ({exc})") from exc
+    if not isinstance(data, list):
+        raise ValueError(f"--issues file must contain a JSON array: {path}")
+    return data
+
+
+def _load_ho_signals(ho_paths_file: Path | None) -> tuple[str, ...]:
+    """ho-paths.md からパス断片を抽出し、既定シグナル語に追加する。
+
+    --ho-paths 未指定、またはファイルが読めない場合は既定シグナルのみを返す
+    （安全側: 追加シグナルが取れなくても既定の判定は維持する）。
+    """
+    if ho_paths_file is None:
+        return DEFAULT_HO_SIGNALS
+    if not ho_paths_file.is_file():
+        return DEFAULT_HO_SIGNALS
+    try:
+        text = ho_paths_file.read_text(encoding="utf-8")
+    except OSError:
+        return DEFAULT_HO_SIGNALS
+
+    fragments: list[str] = []
+    for cell in _HO_PATH_CELL_RE.findall(text):
+        # 「変更禁止」「approvals」等の非パスバッククォートも混ざるため、
+        # パスらしい断片（記号 / . を含む）だけを採用する。
+        stripped = cell.strip().strip("*")
+        if not stripped:
+            continue
+        if "/" not in stripped and "." not in stripped:
+            continue
+        fragments.append(stripped.lower())
+
+    combined = list(DEFAULT_HO_SIGNALS)
+    for frag in fragments:
+        if frag not in combined:
+            combined.append(frag)
+    return tuple(combined)
+
+
+def _contains_any(haystack: str, signals: tuple[str, ...]) -> str | None:
+    """haystack（小文字化済み）に signals のいずれかが含まれれば、その語を返す。"""
+    for signal in signals:
+        if signal and signal.lower() in haystack:
+            return signal
+    return None
+
+
+def evaluate_issue(
+    issue: dict[str, Any],
+    label: str,
+    ho_signals: tuple[str, ...],
+) -> dict[str, Any]:
+    """1 issue を評価し、判定結果（candidate/excluded と理由）を返す。
+
+    判定は安全側（AC-8）: number/title/body/labels の型が期待と異なる場合や
+    判定不能な場合は「候補外」に倒す。
+    """
+    number = issue.get("number")
+    title = issue.get("title")
+    body = issue.get("body")
+    labels = issue.get("labels")
+
+    title_str = title if isinstance(title, str) else ""
+    body_str = body if isinstance(body, str) else ""
+    label_list = labels if isinstance(labels, list) else []
+    label_names = {
+        (entry if isinstance(entry, str) else entry.get("name", ""))
+        for entry in label_list
+        if isinstance(entry, (str, dict))
+    }
+
+    text = f"{title_str}\n{body_str}".lower()
+
+    reasons: dict[str, bool] = {}
+
+    has_label = label in label_names
+    reasons["optin_label"] = has_label
+    if not has_label:
+        return {
+            "number": number,
+            "title": title_str,
+            "candidate": False,
+            "reason": "no-optin-label",
+            "reasons": reasons,
+        }
+
+    ho_hit = _contains_any(text, ho_signals)
+    reasons["no_ho_risk"] = ho_hit is None
+    if ho_hit is not None:
+        return {
+            "number": number,
+            "title": title_str,
+            "candidate": False,
+            "reason": "ho-risk",
+            "reasons": reasons,
+        }
+
+    scale_hit = _contains_any(text, LARGE_SCALE_SIGNALS)
+    reasons["is_lite"] = scale_hit is None
+    if scale_hit is not None:
+        return {
+            "number": number,
+            "title": title_str,
+            "candidate": False,
+            "reason": "not-lite",
+            "reasons": reasons,
+        }
+
+    dep_hit = _contains_any(text, DEPENDENCY_SIGNALS)
+    reasons["deps_resolved"] = dep_hit is None
+    if dep_hit is not None:
+        return {
+            "number": number,
+            "title": title_str,
+            "candidate": False,
+            "reason": "dependency",
+            "reasons": reasons,
+        }
+
+    return {
+        "number": number,
+        "title": title_str,
+        "candidate": True,
+        "reasons": reasons,
+        "recommended_next": "propose-to-ai-loop-cycle",
+    }
+
+
+def run_discovery(
+    issues: list[dict[str, Any]],
+    label: str,
+    ho_signals: tuple[str, ...],
+) -> dict[str, Any]:
+    """全 issue を評価し candidates/excluded/summary を構築する（read-only・純関数）。"""
+    candidates: list[dict[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    no_label_count = 0
+
+    for issue in issues:
+        result = evaluate_issue(issue, label, ho_signals)
+        if result["candidate"]:
+            candidates.append(
+                {
+                    "number": result["number"],
+                    "title": result["title"],
+                    "reasons": result["reasons"],
+                    "recommended_next": result["recommended_next"],
+                }
+            )
+        else:
+            excluded.append(
+                {
+                    "number": result["number"],
+                    "title": result["title"],
+                    "reason": result["reason"],
+                }
+            )
+            if result["reason"] == "no-optin-label":
+                no_label_count += 1
+
+    return {
+        "candidates": candidates,
+        "excluded": excluded,
+        "summary": {
+            "candidate_count": len(candidates),
+            "excluded_count": len(excluded),
+            "no_label_count": no_label_count,
+        },
+    }
+
+
+def format_json(result: dict[str, Any]) -> str:
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+def format_md(result: dict[str, Any]) -> str:
+    lines: list[str] = ["# ai-loop discovery 候補提示（read-only）", ""]
+
+    summary = result["summary"]
+    lines.append(
+        "- candidate: {c} / excluded: {e} / no-optin-label: {n}".format(
+            c=summary["candidate_count"],
+            e=summary["excluded_count"],
+            n=summary["no_label_count"],
+        )
+    )
+    lines.append("")
+
+    lines.append("## Candidates")
+    if not result["candidates"]:
+        lines.append("")
+        lines.append("候補なし。")
+    else:
+        lines.append("")
+        lines.append("| number | title | recommended_next | reasons |")
+        lines.append("|---|---|---|---|")
+        for cand in result["candidates"]:
+            reasons_str = ", ".join(
+                f"{k}={'OK' if v else 'NG'}" for k, v in cand["reasons"].items()
+            )
+            lines.append(
+                f"| #{cand['number']} | {cand['title']} | "
+                f"{cand['recommended_next']} | {reasons_str} |"
+            )
+    lines.append("")
+
+    lines.append("## Excluded（無言除外なし・全件理由付き）")
+    if not result["excluded"]:
+        lines.append("")
+        lines.append("除外なし。")
+    else:
+        lines.append("")
+        lines.append("| number | title | reason |")
+        lines.append("|---|---|---|")
+        for exc in result["excluded"]:
+            lines.append(f"| #{exc['number']} | {exc['title']} | {exc['reason']} |")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ai-loop Triage discovery — read-only 候補提示 CLI（TASK-0818 D-2）。"
+            "着手・実行・issue 変更・git 操作は一切行わない。"
+        )
+    )
+    parser.add_argument(
+        "--issues",
+        required=True,
+        type=Path,
+        help="issue 配列 JSON ファイル（gh issue list --json ... 相当）",
+    )
+    parser.add_argument(
+        "--label",
+        default=DEFAULT_LABEL,
+        help=f"opt-in ラベル（既定 {DEFAULT_LABEL}）",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("md", "json"),
+        default="md",
+        help="出力形式（既定 md）",
+    )
+    parser.add_argument(
+        "--ho-paths",
+        type=Path,
+        default=None,
+        help="ho-paths.md パス（HO シグナル拡充用・任意）",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        issues = _load_issues(args.issues)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    ho_signals = _load_ho_signals(args.ho_paths)
+    result = run_discovery(issues, args.label, ho_signals)
+
+    if args.format == "json":
+        print(format_json(result))
+    else:
+        print(format_md(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ai-loop/test_discovery.py
+++ b/scripts/ai-loop/test_discovery.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""test_discovery.py — discovery.py（TASK-0818 D-2）の unittest カバレッジ。
+
+実行: python3 scripts/ai-loop/test_discovery.py
+
+read-only 不変条件（git 操作・ファイル書き込みをしない）の検証も含む。
+外部依存なし（unittest 標準ライブラリのみ・metrics.py/arbiter.py と同じ位置付け）。
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import discovery  # noqa: E402
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = pathlib.Path(__file__).resolve().parent / "discovery.py"
+
+
+def _issue(number: int, title: str = "", body: str = "", labels=None) -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": labels if labels is not None else [],
+    }
+
+
+class TestEvaluateIssueCandidate(unittest.TestCase):
+    def test_optin_label_lite_no_ho_no_dependency_is_candidate(self):
+        issue = _issue(
+            1,
+            title="小さなタイポ修正",
+            body="README のタイポを1ファイルで修正する。",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertTrue(result["candidate"])
+        self.assertEqual(result["recommended_next"], "propose-to-ai-loop-cycle")
+        self.assertEqual(
+            result["reasons"],
+            {
+                "optin_label": True,
+                "no_ho_risk": True,
+                "is_lite": True,
+                "deps_resolved": True,
+            },
+        )
+
+
+class TestEvaluateIssueExcludedNoLabel(unittest.TestCase):
+    def test_missing_optin_label_is_excluded(self):
+        issue = _issue(2, title="バグ修正", body="小さな修正", labels=[])
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "no-optin-label")
+
+    def test_other_label_only_is_excluded(self):
+        issue = _issue(3, title="バグ修正", body="小さな修正", labels=["bug"])
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "no-optin-label")
+
+
+class TestEvaluateIssueExcludedHoRisk(unittest.TestCase):
+    def test_ho_path_fragment_in_body_is_excluded(self):
+        issue = _issue(
+            4,
+            title="hook 修正",
+            body="scripts/hooks 配下のロジックを変更する",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+    def test_schema_change_in_title_is_excluded(self):
+        issue = _issue(5, title="schema 変更を行う", body="", labels=["ai-loop-auto"])
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+
+class TestEvaluateIssueExcludedNotLite(unittest.TestCase):
+    def test_architecture_change_in_title_is_excluded(self):
+        issue = _issue(
+            6,
+            title="アーキテクチャ変更を実施する",
+            body="全体構造を見直す",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "not-lite")
+
+
+class TestEvaluateIssueExcludedDependency(unittest.TestCase):
+    def test_depends_on_open_issue_is_excluded(self):
+        issue = _issue(
+            7,
+            title="機能追加",
+            body="depends on #123 が解決するまで着手不可",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+    def test_blocked_word_is_excluded(self):
+        issue = _issue(8, title="機能追加", body="現在 blocked 状態", labels=["ai-loop-auto"])
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+
+class TestRunDiscoveryZeroCandidates(unittest.TestCase):
+    def test_zero_candidates_reports_summary_zero(self):
+        issues = [
+            _issue(9, title="バグ修正", body="", labels=[]),
+            _issue(10, title="アーキ変更", body="", labels=["ai-loop-auto"]),
+        ]
+        result = discovery.run_discovery(
+            issues, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertEqual(result["summary"]["candidate_count"], 0)
+        self.assertEqual(result["candidates"], [])
+
+
+class TestRunDiscoveryExcludedAllReasoned(unittest.TestCase):
+    def test_all_excluded_have_reason_field(self):
+        issues = [
+            _issue(11, title="バグ修正", body="", labels=[]),
+            _issue(12, title="hook 変更", body="scripts/hooks を触る", labels=["ai-loop-auto"]),
+            _issue(13, title="アーキ変更", body="", labels=["ai-loop-auto"]),
+            _issue(14, title="機能追加", body="depends on #1", labels=["ai-loop-auto"]),
+        ]
+        result = discovery.run_discovery(
+            issues, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertEqual(len(result["excluded"]), 4)
+        for exc in result["excluded"]:
+            self.assertTrue(exc["reason"])
+            self.assertIsInstance(exc["reason"], str)
+
+
+class TestRunDiscoverySafeSideAmbiguous(unittest.TestCase):
+    def test_non_string_title_body_does_not_crash_and_excludes(self):
+        issue = {"number": 15, "title": None, "body": None, "labels": ["ai-loop-auto"]}
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        # 型不正でも例外を投げず、候補判定は継続できる（安全側で判定）
+        self.assertEqual(result["number"], 15)
+
+
+class TestLoadHoSignals(unittest.TestCase):
+    def test_none_path_returns_default(self):
+        self.assertEqual(discovery._load_ho_signals(None), discovery.DEFAULT_HO_SIGNALS)
+
+    def test_missing_file_returns_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = pathlib.Path(tmp) / "does-not-exist.md"
+            self.assertEqual(
+                discovery._load_ho_signals(missing), discovery.DEFAULT_HO_SIGNALS
+            )
+
+    def test_valid_file_adds_fragments(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ho_file = pathlib.Path(tmp) / "ho-paths.md"
+            ho_file.write_text(
+                "| パス | 分類 |\n|---|---|\n| `custom/special-path` | HO-custom |\n",
+                encoding="utf-8",
+            )
+            signals = discovery._load_ho_signals(ho_file)
+            self.assertIn("custom/special-path", signals)
+            self.assertIn("scripts/hooks", signals)
+
+
+class TestCliInputErrors(unittest.TestCase):
+    def test_missing_issues_file_returns_exit_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = pathlib.Path(tmp) / "no-such-file.json"
+            exit_code = discovery.main(["--issues", str(missing)])
+            self.assertEqual(exit_code, 1)
+
+    def test_malformed_json_returns_exit_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "bad.json"
+            bad.write_text("{not valid json", encoding="utf-8")
+            exit_code = discovery.main(["--issues", str(bad)])
+            self.assertEqual(exit_code, 1)
+
+    def test_non_array_json_returns_exit_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = pathlib.Path(tmp) / "not-array.json"
+            bad.write_text(json.dumps({"foo": "bar"}), encoding="utf-8")
+            exit_code = discovery.main(["--issues", str(bad)])
+            self.assertEqual(exit_code, 1)
+
+
+class TestCliZeroCandidatesExitZero(unittest.TestCase):
+    def test_zero_candidates_input_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(20, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "md"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("候補なし", result.stdout)
+
+
+class TestOutputFormats(unittest.TestCase):
+    def test_json_format_is_parseable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            21,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            self.assertEqual(parsed["summary"]["candidate_count"], 1)
+            self.assertEqual(parsed["candidates"][0]["number"], 21)
+
+    def test_md_format_includes_excluded_section(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(22, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "md"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("## Excluded", result.stdout)
+            self.assertIn("no-optin-label", result.stdout)
+
+
+class TestReadOnlyInvariant(unittest.TestCase):
+    def test_running_discovery_leaves_git_status_clean(self):
+        before = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=REPO_ROOT, text=True
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            30,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        ),
+                        _issue(31, title="バグ修正", body="", labels=[]),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "json"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0)
+
+        after = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=REPO_ROOT, text=True
+        )
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ai-loop/test_discovery.py
+++ b/scripts/ai-loop/test_discovery.py
@@ -97,6 +97,22 @@ class TestEvaluateIssueExcludedHoRisk(unittest.TestCase):
         self.assertFalse(result["candidate"])
         self.assertEqual(result["reason"], "ho-risk")
 
+    def test_fullwidth_ho_signal_is_normalized_and_excluded(self):
+        # 全角英字 + 全角スラッシュで書かれた scripts/hooks 相当語。
+        # NFKC 正規化前は半角シグナルにマッチせず false-positive で candidate 化していた。
+        fullwidth_signal = "ｓｃｒｉｐｔｓ／ｈｏｏｋｓ"
+        issue = _issue(
+            107,
+            title="設定変更",
+            body=f"{fullwidth_signal} 配下を変更する",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
 
 class TestEvaluateIssueExcludedNotLite(unittest.TestCase):
     def test_architecture_change_in_title_is_excluded(self):
@@ -104,6 +120,32 @@ class TestEvaluateIssueExcludedNotLite(unittest.TestCase):
             6,
             title="アーキテクチャ変更を実施する",
             body="全体構造を見直す",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "not-lite")
+
+    def test_english_refactor_entire_module_is_excluded(self):
+        issue = _issue(
+            100,
+            title="Refactor entire auth module",
+            body="Clean up the whole authentication layer.",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "not-lite")
+
+    def test_english_large_migration_rewriting_architecture_is_excluded(self):
+        issue = _issue(
+            101,
+            title="Data store change",
+            body="This is a large migration effort rewriting architecture end to end.",
             labels=["ai-loop-auto"],
         )
         result = discovery.evaluate_issue(
@@ -134,6 +176,72 @@ class TestEvaluateIssueExcludedDependency(unittest.TestCase):
         )
         self.assertFalse(result["candidate"])
         self.assertEqual(result["reason"], "dependency")
+
+    def test_waiting_on_issue_number_is_excluded_dependency(self):
+        issue = _issue(
+            102,
+            title="機能追加",
+            body="waiting on #55 の完了を待って",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+    def test_matte_word_with_issue_number_is_excluded_dependency(self):
+        issue = _issue(
+            103,
+            title="機能追加",
+            body="#90 の完了を待って着手する",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+    def test_pending_hash_is_excluded_dependency(self):
+        issue = _issue(
+            104,
+            title="機能追加",
+            body="pending #77 の対応待ち",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+    def test_block_word_case_insensitive_is_excluded_dependency(self):
+        issue = _issue(
+            105,
+            title="機能追加",
+            body="BLOCK on other team's response",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "dependency")
+
+    def test_standalone_issue_number_without_dependency_word_is_not_excluded_as_dependency(self):
+        # over-exclusion回避: #数字単独（依存語なし）は dependency 理由で除外しない
+        issue = _issue(
+            106,
+            title="小さな修正",
+            body="Related to #42 but this is independent 1ファイルの軽微な修正",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertTrue(result["candidate"])
+        self.assertTrue(result["reasons"]["deps_resolved"])
 
 
 class TestRunDiscoveryZeroCandidates(unittest.TestCase):

--- a/scripts/ai-loop/test_discovery.py
+++ b/scripts/ai-loop/test_discovery.py
@@ -45,7 +45,17 @@ class TestEvaluateIssueCandidate(unittest.TestCase):
             issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
         )
         self.assertTrue(result["candidate"])
-        self.assertEqual(result["recommended_next"], "propose-to-ai-loop-cycle")
+        self.assertEqual(
+            result["recommended_next"],
+            {
+                "action": "propose-to-ai-loop-cycle",
+                "entry_point": "docs/workflows/ai-loop/execution-runbook.md",
+                "next_step": (
+                    "human/orchestratorがissueを読み、通常のai-loop-cycle"
+                    "（W check→arbiter裁定）をこのissueに対して開始する"
+                ),
+            },
+        )
         self.assertEqual(
             result["reasons"],
             {
@@ -54,6 +64,49 @@ class TestEvaluateIssueCandidate(unittest.TestCase):
                 "is_lite": True,
                 "deps_resolved": True,
             },
+        )
+
+
+class TestRecommendedNextStructured(unittest.TestCase):
+    def test_recommended_next_has_three_keys(self):
+        issue = _issue(
+            101,
+            title="小さな修正",
+            body="1ファイルの軽微な修正",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertEqual(
+            set(result["recommended_next"].keys()),
+            {"action", "entry_point", "next_step"},
+        )
+        self.assertEqual(
+            result["recommended_next"]["action"], "propose-to-ai-loop-cycle"
+        )
+        self.assertEqual(
+            result["recommended_next"]["entry_point"],
+            "docs/workflows/ai-loop/execution-runbook.md",
+        )
+
+    def test_run_discovery_candidates_carry_structured_recommended_next(self):
+        issues = [
+            _issue(
+                102,
+                title="小さな修正",
+                body="1ファイルの軽微な修正",
+                labels=["ai-loop-auto"],
+            )
+        ]
+        result = discovery.run_discovery(
+            issues, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        cand = result["candidates"][0]
+        self.assertIsInstance(cand["recommended_next"], dict)
+        self.assertEqual(
+            set(cand["recommended_next"].keys()),
+            {"action", "entry_point", "next_step"},
         )
 
 
@@ -425,6 +478,175 @@ class TestReadOnlyInvariant(unittest.TestCase):
             ["git", "status", "--porcelain"], cwd=REPO_ROOT, text=True
         )
         self.assertEqual(before, after)
+
+
+class TestEmitNextCommand(unittest.TestCase):
+    def test_emit_next_command_flag_includes_proposal_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            123,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "md",
+                    "--emit-next-command",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("#123", result.stdout)
+            self.assertIn("ai-loop-cycle", result.stdout)
+
+    def test_without_flag_no_proposal_command_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            124,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "md",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertNotIn("candidate #124", result.stdout)
+
+    def test_emit_next_command_json_format_includes_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            125,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "json",
+                    "--emit-next-command",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            cand = parsed["candidates"][0]
+            self.assertIn("next_command", cand)
+            self.assertIn("#125", cand["next_command"])
+
+    def test_emit_next_command_json_format_absent_without_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            126,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            cand = parsed["candidates"][0]
+            self.assertNotIn("next_command", cand)
+
+
+class TestNoBypassSummaryLine(unittest.TestCase):
+    def test_md_summary_mentions_human_orchestrator_judgment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(200, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "md"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Human", result.stdout)
+            self.assertIn("bypass", result.stdout)
+
+    def test_json_summary_mentions_human_orchestrator_judgment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(201, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            self.assertIn("no_bypass_notice", parsed["summary"])
+            self.assertIn("Human", parsed["summary"]["no_bypass_notice"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
D-2（PR #824・マージ済み）に続き、discoveryのcandidateから既存ai-loop-cycle（W check→arbiter裁定）への接続を明確化する。

## 変更内容

1. `candidates[].recommended_next` を固定文字列から構造化オブジェクト（action/entry_point/next_step）に変更
2. `--emit-next-command`（既定false・任意フラグ）追加。指定時のみ各candidateにコピペ実行用の提案コマンド文字列を付加。discovery自身は生成のみで実行しない（subprocess呼び出しなし）
3. サマリに `no_bypass_notice`（次にGateを通すのはHuman/orchestratorの判断でありdiscoveryはbypassしない旨）を追加

## 安全境界（不変）

- read-only: git/gh/subprocess/exec を一切呼ばない（実行前後でgit status不変を独立検証済み）
- Gate非bypass: excludedにはnext_commandが付かない・discoveryは着手判断をしない
- 既存D-2の安全境界（opt-inラベル必須・HO非接触・lite・依存解決・無言除外禁止・AC-8安全側）は無変更

## 検証

- 37テスト（既存29+新規8）全PASS
- read-only独立検証: 実行前後でgit status --porcelain完全一致
- emit-next-commandフラグ未指定時の後方互換を確認（next_commandキーが出力に含まれない）
- excluded issueにnext_commandが付与されないことを確認（Gate非bypassの徹底）

Refs #818 / EPIC #822（HITL→HOTL変革）。

Out of scope（設計書どおり）: arbiter直接呼び出し・issue自動assign等の完全自動化は未実装（別途Human承認が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)