### PR TITLE
feat: ai-loop discovery D-3 — candidate to Gate接続の道しるべ強化 (#818 / HOTL #822)

### DIFF
--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -31,6 +31,7 @@ discovery.py 自体はファイル入力を受けるだけで gh を直叩きし
 CLI:
     python3 scripts/ai-loop/discovery.py --issues <path.json>
         [--label ai-loop-auto] [--format md|json] [--ho-paths <path>]
+        [--emit-next-command]
 
 exit code:
     0 = 正常（候補あり/なし両方）
@@ -52,6 +53,20 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_LABEL = "ai-loop-auto"
+
+# recommended_next 構造化オブジェクト（TASK-0818 D-3）。discovery は execしない・
+# arbiterを呼ばない — human/orchestratorが既存 ai-loop-cycle を辿るための道しるべ。
+RECOMMENDED_NEXT_ACTION = "propose-to-ai-loop-cycle"
+RECOMMENDED_NEXT_ENTRY_POINT = "docs/workflows/ai-loop/execution-runbook.md"
+RECOMMENDED_NEXT_STEP = (
+    "human/orchestratorがissueを読み、通常のai-loop-cycle"
+    "（W check→arbiter裁定）をこのissueに対して開始する"
+)
+
+# 「discoveryはGateをbypassしない」旨の明示（サマリ md/json 共通）。
+NO_BYPASS_NOTICE = (
+    "次にGateを通すのはHuman/orchestratorの判断であり、discoveryはbypassしない。"
+)
 
 # HO（Hardening Override）示唆語 — docs/ai/ai-loop/ho-paths.md の代表パス断片 +
 # 承認境界を示す一般語。--ho-paths 指定時はここへ追加でパス断片を取り込む。
@@ -289,16 +304,31 @@ def evaluate_issue(
         "title": title_str,
         "candidate": True,
         "reasons": reasons,
-        "recommended_next": "propose-to-ai-loop-cycle",
+        "recommended_next": {
+            "action": RECOMMENDED_NEXT_ACTION,
+            "entry_point": RECOMMENDED_NEXT_ENTRY_POINT,
+            "next_step": RECOMMENDED_NEXT_STEP,
+        },
     }
+
+
+def _build_next_command(number: Any) -> str:
+    """人間がコピペ実行できる提案コマンド文字列を生成する（discovery自身は実行しない）。"""
+    return f"# candidate #{number}: 'ai-loop-cycle' skill を issue #{number} に対して開始してください"
 
 
 def run_discovery(
     issues: list[dict[str, Any]],
     label: str,
     ho_signals: tuple[str, ...],
+    emit_next_command: bool = False,
 ) -> dict[str, Any]:
-    """全 issue を評価し candidates/excluded/summary を構築する（read-only・純関数）。"""
+    """全 issue を評価し candidates/excluded/summary を構築する（read-only・純関数）。
+
+    emit_next_command=True の場合、各 candidate に人間がコピペ実行できる
+    提案コマンド文字列（next_command）を付加する。discovery 自身はこの
+    コマンドを一切実行しない（文字列生成のみ・subprocess呼び出し禁止）。
+    """
     candidates: list[dict[str, Any]] = []
     excluded: list[dict[str, Any]] = []
     no_label_count = 0
@@ -306,14 +336,15 @@ def run_discovery(
     for issue in issues:
         result = evaluate_issue(issue, label, ho_signals)
         if result["candidate"]:
-            candidates.append(
-                {
-                    "number": result["number"],
-                    "title": result["title"],
-                    "reasons": result["reasons"],
-                    "recommended_next": result["recommended_next"],
-                }
-            )
+            candidate: dict[str, Any] = {
+                "number": result["number"],
+                "title": result["title"],
+                "reasons": result["reasons"],
+                "recommended_next": result["recommended_next"],
+            }
+            if emit_next_command:
+                candidate["next_command"] = _build_next_command(result["number"])
+            candidates.append(candidate)
         else:
             excluded.append(
                 {
@@ -332,6 +363,7 @@ def run_discovery(
             "candidate_count": len(candidates),
             "excluded_count": len(excluded),
             "no_label_count": no_label_count,
+            "no_bypass_notice": NO_BYPASS_NOTICE,
         },
     }
 
@@ -351,6 +383,7 @@ def format_md(result: dict[str, Any]) -> str:
             n=summary["no_label_count"],
         )
     )
+    lines.append(f"- {summary['no_bypass_notice']}")
     lines.append("")
 
     lines.append("## Candidates")
@@ -365,10 +398,18 @@ def format_md(result: dict[str, Any]) -> str:
             reasons_str = ", ".join(
                 f"{k}={'OK' if v else 'NG'}" for k, v in cand["reasons"].items()
             )
+            next_action = cand["recommended_next"]["action"]
             lines.append(
                 f"| #{cand['number']} | {cand['title']} | "
-                f"{cand['recommended_next']} | {reasons_str} |"
+                f"{next_action} | {reasons_str} |"
             )
+        if any("next_command" in cand for cand in result["candidates"]):
+            lines.append("")
+            lines.append("### 提案コマンド（人間がコピペ実行・discoveryは実行しない）")
+            lines.append("")
+            for cand in result["candidates"]:
+                if "next_command" in cand:
+                    lines.append(cand["next_command"])
     lines.append("")
 
     lines.append("## Excluded（無言除外なし・全件理由付き）")
@@ -416,6 +457,15 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="ho-paths.md パス（HO シグナル拡充用・任意）",
     )
+    parser.add_argument(
+        "--emit-next-command",
+        action="store_true",
+        default=False,
+        help=(
+            "候補ごとに人間がコピペ実行できる提案コマンド文字列を出力に含める"
+            "（discovery自身は実行しない・read-only維持・既定false）"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -425,7 +475,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     ho_signals = _load_ho_signals(args.ho_paths)
-    result = run_discovery(issues, args.label, ho_signals)
+    result = run_discovery(
+        issues, args.label, ho_signals, emit_next_command=args.emit_next_command
+    )
 
     if args.format == "json":
         print(format_json(result))

--- a/scripts/ai-loop/test_discovery.py
+++ b/scripts/ai-loop/test_discovery.py
@@ -45,7 +45,17 @@ class TestEvaluateIssueCandidate(unittest.TestCase):
             issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
         )
         self.assertTrue(result["candidate"])
-        self.assertEqual(result["recommended_next"], "propose-to-ai-loop-cycle")
+        self.assertEqual(
+            result["recommended_next"],
+            {
+                "action": "propose-to-ai-loop-cycle",
+                "entry_point": "docs/workflows/ai-loop/execution-runbook.md",
+                "next_step": (
+                    "human/orchestratorがissueを読み、通常のai-loop-cycle"
+                    "（W check→arbiter裁定）をこのissueに対して開始する"
+                ),
+            },
+        )
         self.assertEqual(
             result["reasons"],
             {
@@ -54,6 +64,49 @@ class TestEvaluateIssueCandidate(unittest.TestCase):
                 "is_lite": True,
                 "deps_resolved": True,
             },
+        )
+
+
+class TestRecommendedNextStructured(unittest.TestCase):
+    def test_recommended_next_has_three_keys(self):
+        issue = _issue(
+            101,
+            title="小さな修正",
+            body="1ファイルの軽微な修正",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertEqual(
+            set(result["recommended_next"].keys()),
+            {"action", "entry_point", "next_step"},
+        )
+        self.assertEqual(
+            result["recommended_next"]["action"], "propose-to-ai-loop-cycle"
+        )
+        self.assertEqual(
+            result["recommended_next"]["entry_point"],
+            "docs/workflows/ai-loop/execution-runbook.md",
+        )
+
+    def test_run_discovery_candidates_carry_structured_recommended_next(self):
+        issues = [
+            _issue(
+                102,
+                title="小さな修正",
+                body="1ファイルの軽微な修正",
+                labels=["ai-loop-auto"],
+            )
+        ]
+        result = discovery.run_discovery(
+            issues, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        cand = result["candidates"][0]
+        self.assertIsInstance(cand["recommended_next"], dict)
+        self.assertEqual(
+            set(cand["recommended_next"].keys()),
+            {"action", "entry_point", "next_step"},
         )
 
 
@@ -425,6 +478,175 @@ class TestReadOnlyInvariant(unittest.TestCase):
             ["git", "status", "--porcelain"], cwd=REPO_ROOT, text=True
         )
         self.assertEqual(before, after)
+
+
+class TestEmitNextCommand(unittest.TestCase):
+    def test_emit_next_command_flag_includes_proposal_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            123,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "md",
+                    "--emit-next-command",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("#123", result.stdout)
+            self.assertIn("ai-loop-cycle", result.stdout)
+
+    def test_without_flag_no_proposal_command_string(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            124,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "md",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertNotIn("candidate #124", result.stdout)
+
+    def test_emit_next_command_json_format_includes_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            125,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "json",
+                    "--emit-next-command",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            cand = parsed["candidates"][0]
+            self.assertIn("next_command", cand)
+            self.assertIn("#125", cand["next_command"])
+
+    def test_emit_next_command_json_format_absent_without_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps(
+                    [
+                        _issue(
+                            126,
+                            title="小さな修正",
+                            body="1ファイルの軽微な修正",
+                            labels=["ai-loop-auto"],
+                        )
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--issues",
+                    str(issues_file),
+                    "--format",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            cand = parsed["candidates"][0]
+            self.assertNotIn("next_command", cand)
+
+
+class TestNoBypassSummaryLine(unittest.TestCase):
+    def test_md_summary_mentions_human_orchestrator_judgment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(200, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "md"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Human", result.stdout)
+            self.assertIn("bypass", result.stdout)
+
+    def test_json_summary_mentions_human_orchestrator_judgment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            issues_file = pathlib.Path(tmp) / "issues.json"
+            issues_file.write_text(
+                json.dumps([_issue(201, title="バグ修正", body="", labels=[])]),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--issues", str(issues_file), "--format", "json"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            parsed = json.loads(result.stdout)
+            self.assertIn("no_bypass_notice", parsed["summary"])
+            self.assertIn("Human", parsed["summary"]["no_bypass_notice"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
D-2（PR #824・マージ済み）に続き、discoveryのcandidateから既存ai-loop-cycle（W check→arbiter裁定）への接続を明確化する。

（#825のrebase版。#825はsquash-merge後のD-2ブランチから作成されmainとconflictしたためclose、本PRはorigin/main起点のクリーンな差分）

## 変更内容

1. `candidates[].recommended_next` を固定文字列から構造化オブジェクト（action/entry_point/next_step）に変更
2. `--emit-next-command`（既定false・任意フラグ）追加。指定時のみ各candidateにコピペ実行用の提案コマンド文字列を付加。discovery自身は生成のみで実行しない（subprocess呼び出しなし）
3. サマリに `no_bypass_notice`（次にGateを通すのはHuman/orchestratorの判断でありdiscoveryはbypassしない旨）を追加

## 安全境界（不変）

- read-only: git/gh/subprocess/exec を一切呼ばない（実行前後でgit status不変を独立検証済み）
- Gate非bypass: excludedにはnext_commandが付かない・discoveryは着手判断をしない
- 既存D-2の安全境界（opt-inラベル必須・HO非接触・lite・依存解決・無言除外禁止・AC-8安全側）は無変更

## 検証

- 37テスト（既存29+新規8）全PASS
- read-only独立検証: 実行前後でgit status --porcelain完全一致
- emit-next-commandフラグ未指定時の後方互換を確認（next_commandキーが出力に含まれない）
- excluded issueにnext_commandが付与されないことを確認（Gate非bypassの徹底）
- diff --stat が origin/main に対し discovery.py/test_discovery.py の2ファイルのみであることを確認（D-2は既にmainに含まれる）

Refs #818 / EPIC #822（HITL→HOTL変革）。

Out of scope（設計書どおり）: arbiter直接呼び出し・issue自動assign等の完全自動化は未実装（別途Human承認が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)