### PR TITLE
docs: 派遣プロンプト定型に EH-3 SKIP_REASON 正規経路を明示 + 迂回禁止（#833）

### DIFF
--- a/docs/ai/subagent-delegation/behavior-norms.md
+++ b/docs/ai/subagent-delegation/behavior-norms.md
@@ -98,6 +98,7 @@ issue #714 のフル版に含める「優先順位: CLAUDE.md / rules / 派遣�
 2. CLAUDE.md・`.claude/rules/*.md` はいずれも [`docs/ai/project-rules.md`](../project-rules.md) §G の参照先一覧に連なるドキュメント群であり、両者は通常矛盾しない。矛盾が生じた場合（想定外の記述不整合）はサブエージェント側で断定判断せず、要判断事項（P0）として差し戻す
 3. 「派遣プロンプト制約」（[dispatch-template.md](./dispatch-template.md) 要素6）は当該タスク限定の追加制約であり、CLAUDE.md・rules が定める禁止事項を緩和する方向には作用しない（追加のみ許可、緩和不可）
 4. SSOT（派遣プロンプト要素3で示す最初に読む資料）は最後尾に位置づける。SSOT の記述が古い・現状と乖離している場合は実測結果を優先し、その旨を報告する
+5. EH-3（`scripts/hooks/check-plan-hash.sh` の Edit ゲート）にブロックされた場合、Bash 経由の直接書き込みでのゲート迂回は禁止事項として緩和されない。正規経路（`PLANGATE_SKIP_REASON` を設定して再実行し、`docs/working/_audit/skip-decision-log.jsonl` に記録させる）に従う（[dispatch-template.md](./dispatch-template.md) 要素6参照）
 
 ## 4. 使い分け基準
 

--- a/docs/ai/subagent-delegation/behavior-norms.md
+++ b/docs/ai/subagent-delegation/behavior-norms.md
@@ -98,7 +98,7 @@ issue #714 のフル版に含める「優先順位: CLAUDE.md / rules / 派遣�
 2. CLAUDE.md・`.claude/rules/*.md` はいずれも [`docs/ai/project-rules.md`](../project-rules.md) §G の参照先一覧に連なるドキュメント群であり、両者は通常矛盾しない。矛盾が生じた場合（想定外の記述不整合）はサブエージェント側で断定判断せず、要判断事項（P0）として差し戻す
 3. 「派遣プロンプト制約」（[dispatch-template.md](./dispatch-template.md) 要素6）は当該タスク限定の追加制約であり、CLAUDE.md・rules が定める禁止事項を緩和する方向には作用しない（追加のみ許可、緩和不可）
 4. SSOT（派遣プロンプト要素3で示す最初に読む資料）は最後尾に位置づける。SSOT の記述が古い・現状と乖離している場合は実測結果を優先し、その旨を報告する
-5. EH-3（`scripts/hooks/check-plan-hash.sh` の Edit ゲート）にブロックされた場合、Bash 経由の直接書き込みでのゲート迂回は禁止事項として緩和されない。正規経路（`PLANGATE_SKIP_REASON` を設定して再実行し、`docs/working/_audit/skip-decision-log.jsonl` に記録させる）に従う（[dispatch-template.md](./dispatch-template.md) 要素6参照）
+5. EH-3（`scripts/hooks/check-plan-hash.sh` の Edit ゲート）にブロックされた場合、Bash 経由の直接書き込みでのゲート迂回は禁止事項として緩和されない。正規経路（`PLANGATE_SKIP_REASON` を設定して再実行し、`docs/working/_audit/skip-decision-log.jsonl` に記録させる）に従う（[dispatch-template.md](./dispatch-template.md#要素6-制約) 要素6参照）
 
 ## 4. 使い分け基準
 

--- a/docs/ai/subagent-delegation/dispatch-template.md
+++ b/docs/ai/subagent-delegation/dispatch-template.md
@@ -78,6 +78,7 @@
 | 触ってはいけないファイル・ディレクトリ・repo | 「`.claude/rules/*.md` / `.claude/settings*.json` 等の HO パスは Write/Edit 禁止（作成のみ許可、適用は人間）」 |
 | 稼働中プロセス停止禁止                       | 「他セッションが起動しているプロセス・サーバーを `kill` しない」                                               |
 | 削除・外部投稿・破壊的操作                   | 「`git push` / PR 作成 / issue 起票 / ファイル削除は事前承認なしに行わない」                                   |
+| EH-3（`check-plan-hash.sh`）にブロックされた場合 | 「Edit ゲートに拒否されたら `PLANGATE_SKIP_REASON` を設定して再実行する正規経路を使う（`docs/working/_audit/skip-decision-log.jsonl` に記録される）。Bash 経由の直接書き込みでゲートを迂回しない」 |
 | ソフト上限                                   | 「Nステップ（目安 15）または概算 Mトークン相当で一旦中断し、進捗を報告する」                                   |
 
 ### 要素7: 出力形式

--- a/docs/working/TASK-0833/ai-loop-runs/20260712T084943Z-b42382d.json
+++ b/docs/working/TASK-0833/ai-loop-runs/20260712T084943Z-b42382d.json
@@ -1,0 +1,21 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "gates": {
+    "breakdown": "pass",
+    "c1": "PASS"
+  },
+  "ho_paths_source": "docs/ai/ai-loop/ho-paths.md",
+  "ho_pattern_count": 18,
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v3",
+  "scope_check": "in_scope",
+  "target_sha": "b42382d",
+  "timestamp": "2026-07-12T08:49:43Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}

--- a/docs/working/TASK-0833/ai-loop-runs/grader-output.md
+++ b/docs/working/TASK-0833/ai-loop-runs/grader-output.md
@@ -1,0 +1,19 @@
+# rubric grader 出力（全文・run 記録 / #833）
+
+- 対象: `git diff origin/main origin/docs/833-eh3-skip-reason-dispatch`（maker SHA 407386c）
+- grader: maker 独立文脈の sonnet サブエージェント（read-only）
+- 裁定 record: 同ディレクトリの arbiter record（AUTO_APPROVED / priority 6）と対
+
+```text
+verdict: pass
+failed_criteria: なし
+feedback: 差分は issue #833 の受入基準2項目を過不足なく満たし、PLANGATE_SKIP_REASON / docs/working/_audit/skip-decision-log.jsonl の実装一致、既存文書の表・番号リスト形式踏襲、境界緩和なしを確認した。TASK-0833 ai-loop 裁定レコードも変更対象宣言内。
+```
+
+## 証跡ブロック（基準ごと）
+
+1. 正確性・正本整合: `scripts/hooks/check-plan-hash.sh` L281 `PLANGATE_SKIP_REASON`、L167/188/289 `$WORKING_DIR/_audit/skip-decision-log.jsonl` と、追記文中の変数名・パスが完全一致。`dispatch-template.md` 内リンクはファイル自身の相互参照として妥当。
+2. 要件適合: (1) dispatch-template.md 要素6の表に EH-3 遭遇時の正規手順行を追加、(2) 同行末尾「Bash 経由の直接書き込みでゲートを迂回しない」で禁止事項を明記。behavior-norms.md にも同旨5項目目を追加し二重に補強。宣言外ファイル変更なし。
+3. 文体・構造踏襲: dispatch-template.md は既存の表形式の行追加のみ、behavior-norms.md は既存の番号付き箇条書き（1〜4）に5番目を追加する形式で、見出し階層・文体を逸脱していない。
+4. 境界安全: 追記内容は迂回禁止を強化する方向であり、承認境界・HO境界・停止規則を緩める記述は含まれない。既存「緩和不可」原則とも整合。
+5. 重複定義回避: SKIP_REASON の運用手順自体を再定義せず、check-plan-hash.sh の既存実装・ログ出力先を参照する形に留まる。両ファイル間も相互リンク参照で重複定義なし。


### PR DESCRIPTION
## 概要

Closes #833

サブエージェント委託プロンプト定型に、EH-3（check-plan-hash.sh の Edit ゲート）遭遇時の正規経路（`PLANGATE_SKIP_REASON` → skip-decision-log.jsonl 監査記録）を明記し、Bash 直接書き込みによるゲート迂回を禁止事項化する。2026-07-12 セッションで迂回実例 3 件（誠実自己申告）が発生した再発防止。

## ai-loop HOTL 実走 run（本 PR はフルサイクルの成果物）

| 段階 | 結果 |
|---|---|
| Triage（discovery D-2/D-3） | candidate 判定(optin/no_ho_risk/is_lite/deps 全 OK) |
| W チェック（Model A/B 独立） | approve-approve |
| Gate（arbiter C-3'） | **AUTO_APPROVED**（priority 6・boundary=clean・scope=in_scope・gates c1/breakdown pass） |
| Worker（maker） | SKIP_REASON 仕様を実測（check-plan-hash.sh L277-296）した正確な文面で追記 |
| Verifier（rubric grader・独立） | **pass**（5 基準すべて証跡付き） |

裁定 record（provenance 刻印）と grader 全文は `docs/working/TASK-0833/ai-loop-runs/` に同梱。

## 変更

- `docs/ai/subagent-delegation/dispatch-template.md` — 要素6 制約表に EH-3 正規経路の行を追加
- `docs/ai/subagent-delegation/behavior-norms.md` — §3 に迂回禁止（緩和不可）を追加
- `docs/working/TASK-0833/` — ai-loop 裁定 record + grader 出力（監査資産）

merge は Human-owned（NO MERGE BY AI）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)