### PR TITLE
chore: サブエージェント委譲プロトコルの HO 参照導線を配線（#715/#710）

### DIFF
--- a/.claude/rules/orchestrator-mode.md
+++ b/.claude/rules/orchestrator-mode.md
@@ -22,6 +22,7 @@
 | [`hybrid-architecture.md`](./hybrid-architecture.md) | Rule 1〜5 を継承。本ルールは Rule 5（最終成果物は handoff に集約）を親 PBI 層に拡張 |
 | [`working-context.md`](./working-context.md) | `docs/working/TASK-XXXX/` 構造を子 PBI 層で再利用、親 PBI 層は `docs/working/PBI-XXX/` を別途使用 |
 | [`review-principles.md`](./review-principles.md) | レビュー判定フレームを親 / 子両方に適用 |
+| [`docs/ai/subagent-delegation/README.md`](../../docs/ai/subagent-delegation/README.md) | サブエージェント派遣プロンプトの契約層（委譲判断基準 / OUTCOME 契約 / 行動規範）を追加する。本ルールの Gate 不変条件（AS-1〜5 / `ChildExecAllowed` / `ParentDone`）とは直交し、変更しない |
 
 ## 不変条件 1: ChildExecAllowed
 

--- a/.claude/rules/responsibility-classes.md
+++ b/.claude/rules/responsibility-classes.md
@@ -130,6 +130,7 @@ INC-2026-05-26-001 では `git checkout` 失敗のエラーメッセージを AI
 | [`docs/ai/settings-wiring-contract.md`](../../docs/ai/settings-wiring-contract.md) 責務分離表 | CI-owned（reference）/ AI-owned（doctor 実体検証）/ Human-owned（適用）の具体適用例 |
 | TASK-0077 AC-4（TASK-0071 との責務境界）| 本正本がその上位集約。Lite/降格は Human-owned 承認境界に従属 |
 | [本正本 「対外公開アーティファクト publish 責務分界」節](#対外公開アーティファクト-publish-責務分界) | tag/release publish は AI が draft/コマンド提示まで、実行は Human-owned（または計画段階で明示承認を取得した AI 実行）。issue #296 で正本化 |
+| [`docs/ai/subagent-delegation/README.md`](../../docs/ai/subagent-delegation/README.md)（サブエージェント委譲プロトコル） | AI-owned（派遣プロンプト作成・完了結果の最低限受け入れ確認）+ Human-owned（P0 要判断事項の承認・破壊的操作の承認） |
 
 ## 位置づけ
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - 役割分担: `docs/ai/tool-roles.md`
 - 作業コンテキストプロトコル（Progressive Disclosure）: `.claude/rules/working-context.md`
 - ワークフロー: `docs/ai-driven-development.md` / Orchestrator: `docs/orchestrator-mode.md`
+- サブエージェント委譲プロトコル: `docs/ai/subagent-delegation/README.md`（派遣プロンプト必須8要素 / OUTCOME契約 / 行動規範。既存の C-3/C-4 ゲートおよび orchestrator-mode の Gate 不変条件は変更しない）
 
 ## 出力
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - 運用ルール: `.claude/rules/`（hybrid-architecture / orchestrator-mode 含む）
 - 共有スキル: `.agents/skills/`（Codex CLI と共用）
 - ワークフロー詳細: [`docs/ai-driven-development.md`](docs/ai-driven-development.md) / Orchestrator: [`docs/orchestrator-mode.md`](docs/orchestrator-mode.md)
+- サブエージェント委譲プロトコル: [`docs/ai/subagent-delegation/README.md`](docs/ai/subagent-delegation/README.md)（派遣プロンプト必須8要素 / OUTCOME契約 / 行動規範 / PlanGateフロー接続。既存の C-3/C-4 ゲートおよび orchestrator-mode の Gate 不変条件は変更しない）
 
 ## v8.16.0 ai-loop 実運用（dogfooding）・Plugin 同梱配布（最新リリース機能）
 


### PR DESCRIPTION
## 概要

Closes #715
Refs #710（本 PR マージ後、親 issue もクローズ可能）

`scripts/apply-subagent-delegation-wiring.sh` を **Human が実行**（2026-07-12・HO 対象のため AI 実行禁止に従い dry-run 検証 → Human 適用 → AI がコミット/PR 準備の分担）。

## 変更（各 1 行の参照追加のみ・Gate 不変条件は不変）

| ファイル | 追記内容 |
|---|---|
| `.claude/rules/orchestrator-mode.md` | 既存ルールとの関係表に subagent-delegation 参照（AS-1〜5 とは直交・変更しないと明記） |
| `.claude/rules/responsibility-classes.md` | 既存ルール対応表に委譲プロトコルの責務分界（AI-owned: 派遣プロンプト作成・受け入れ確認 / Human-owned: P0 承認・破壊的操作承認） |
| `CLAUDE.md` | 参照導線（discoverability） |
| `AGENTS.md` | 参照導線（Codex parity） |

## 検証

- dry-run 差分と適用差分の一致を確認
- markdownlint: 本差分起因のエラーなし（CLAUDE.md の MD033 2 件は既存の `<language>`/`<law>` タグ由来・main でも既存）
- `bin/plangate doctor`: PASS (all checks passed)

これにより #715 の残条件「HO 対象 4 ファイルへの参照導線」が充足。マージ後、#715 → #710 の順でクローズ可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)