### PR TITLE
docs: ai-loop run-023 監査資産の保全（run メタ付き record + skip-log 統合）

### DIFF
--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -114,3 +114,14 @@
 {"ts":"2026-07-12T05:16:52Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a82b530ec59286723/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T07:24:57Z","event":"EH-3_DOC_LIGHT_SKIP","target":"AGENT_LEARNINGS.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T07:46:00Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/Users/user/.claude/plans/deep-churning-wadler.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:20:05Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:20:18Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:20:31Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:21:22Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/agentic-six-stage-loop.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:21:46Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/decision-table.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:21:55Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a20e46d4651ab8279/docs/workflows/ai-loop/loop-safety-gates.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:32:09Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a0d7411d07f65fbd8/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:32:15Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a0d7411d07f65fbd8/docs/workflows/ai-loop/stop-rollback.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:50:38Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a5f4578a82af14f82/docs/ai/subagent-delegation/dispatch-template.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:50:52Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a5f4578a82af14f82/docs/ai/subagent-delegation/behavior-norms.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T08:52:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0833/ai-loop-runs/grader-output.md","acknowledged_by":null,"acknowledged_at":null}

--- a/docs/working/ai-loop-runs/20260712T085900Z-b42382d-run023.json
+++ b/docs/working/ai-loop-runs/20260712T085900Z-b42382d-run023.json
@@ -1,0 +1,26 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "gates": {
+    "breakdown": "pass",
+    "c1": "PASS"
+  },
+  "ho_paths_source": "docs/ai/ai-loop/ho-paths.md",
+  "ho_pattern_count": 18,
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v3",
+  "run": {
+    "round_index": 1,
+    "run_id": "run-023",
+    "task_id": "TASK-0833"
+  },
+  "scope_check": "in_scope",
+  "target_sha": "b42382d",
+  "timestamp": "2026-07-12T10:09:43Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}


### PR DESCRIPTION
## 概要

run-023（#833 / PR #834、HOTL 初のフルサイクル AUTO_APPROVED run）の残監査資産:

- `docs/working/ai-loop-runs/20260712T085900Z-b42382d-run023.json` — **run メタ（run_id/round_index/task_id）付き**裁定 record。metrics.py 集計対象（実測: run 数 1・first-pass rate 1/1・HOTL 健全性 escalate 30.8% / human intervention 34.6% の稼働を確認）
- `docs/working/_audit/skip-decision-log.jsonl` — ローカル/リモート append 分の union 統合（127 エントリ・JSONL 妥当性検証済み）

## run-023 で検出した摩擦（follow-up 候補）

1. `ai-loop-cycle` SKILL の入力例に `run` メタの記載がなく、初版 record が legacy 扱いになった
2. record 標準保存先（`docs/working/ai-loop-runs/`）への誘導が SKILL 側に弱い

🤖 Generated with [Claude Code](https://claude.com/claude-code)