### PR TITLE
docs: 2026-07-12 git 操作事故 2 件の再発防止知見を追記

### DIFF
--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -78,12 +78,12 @@
 
 - [2026-07-12] checkout/restore でファイルを戻す前に「自分が作った変更か」を確認する
   - 事実: Human が適用済みの未コミット HO 変更（`apply-subagent-delegation-wiring.sh` による 4 ファイル追記）が作業ツリーに残る状態で、AI が該当 4 ファイルに対し `git checkout main -- <path>` を実行し Human 適用済み変更を上書き消失させた（Human にスクリプト再実行を依頼して復旧）
-  - 再利用条件: `git checkout -- path` / `git restore path` でファイルを既存 ref に戻す前に、対象ファイルの未コミット差分を `git diff path` で確認し、「自分が作った変更でない」場合は上書きしない（既存学び「名指し外 tracked 変更は破棄しない」の checkout -- path 形への拡張）
+  - 再利用条件: `git checkout [<branch>] -- path` / `git restore [--source <ref>] path` 等、ファイルを既存 ref の内容へ戻す操作の前に、対象ファイルの未コミット差分を `git diff path` で確認し、「自分が作った変更でない」場合は上書きしない（既存学び「名指し外 tracked 変更は破棄しない」の checkout -- path 形への拡張）
   - 根拠: 2026-07-12 セッション実害。既存 rule（`.claude/rules/responsibility-classes.md` HO 適用は Human-owned）と一貫
 
 - [2026-07-12] ブランチ作成失敗後の commit は current branch を必ず verify する
   - 事実: `set -e` 付き複合コマンド内で `git checkout -b <branch> origin/main` が untracked ファイル衝突で失敗した後、後続の `git add`/`git commit` が main 上で実行され main へ直接コミットが作られた（push 前に検知し branch 退避 + `reset --hard origin/main` で復旧）
-  - 再利用条件: ブランチ作成と commit を同一複合コマンドに含める場合、commit 直前に `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected>" ] || exit 1` を必ず挟む
+  - 再利用条件: ブランチ作成と後続の変更操作（`git add` / `git commit` 等）を同一複合コマンドに含める場合、最初の変更操作の直前に `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected>" ] || exit 1` を必ず挟む
   - 根拠: INC-2026-05-26-001 P-3（push 前 verify）の commit 前 verify への拡張。`.claude/rules/responsibility-classes.md` の Bash 連結コマンド error guard と一貫
 
 - [2026-06-16] Bash 作成 doc の EH-3 skip は merge 前に追認する

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -76,6 +76,16 @@
   - 再利用条件: マージ済 PR の後に追加修正が出たら、旧ブランチを使わず `git checkout -b fix/<topic> origin/main` で main 起点に切り直す。push 前に `sh scripts/check-branch-not-merged.sh` で「現ブランチが MERGED+remote削除済」を検知
   - 根拠: 既存学び[2026-05-16 PR後処理]の延長(マージ確定検証)。本セッションで guard script を新設
 
+- [2026-07-12] checkout/restore でファイルを戻す前に「自分が作った変更か」を確認する
+  - 事実: Human が適用済みの未コミット HO 変更（`apply-subagent-delegation-wiring.sh` による 4 ファイル追記）が作業ツリーに残る状態で、AI が該当 4 ファイルに対し `git checkout main -- <path>` を実行し Human 適用済み変更を上書き消失させた（Human にスクリプト再実行を依頼して復旧）
+  - 再利用条件: `git checkout -- path` / `git restore path` でファイルを既存 ref に戻す前に、対象ファイルの未コミット差分を `git diff path` で確認し、「自分が作った変更でない」場合は上書きしない（既存学び「名指し外 tracked 変更は破棄しない」の checkout -- path 形への拡張）
+  - 根拠: 2026-07-12 セッション実害。既存 rule（`.claude/rules/responsibility-classes.md` HO 適用は Human-owned）と一貫
+
+- [2026-07-12] ブランチ作成失敗後の commit は current branch を必ず verify する
+  - 事実: `set -e` 付き複合コマンド内で `git checkout -b <branch> origin/main` が untracked ファイル衝突で失敗した後、後続の `git add`/`git commit` が main 上で実行され main へ直接コミットが作られた（push 前に検知し branch 退避 + `reset --hard origin/main` で復旧）
+  - 再利用条件: ブランチ作成と commit を同一複合コマンドに含める場合、commit 直前に `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected>" ] || exit 1` を必ず挟む
+  - 根拠: INC-2026-05-26-001 P-3（push 前 verify）の commit 前 verify への拡張。`.claude/rules/responsibility-classes.md` の Bash 連結コマンド error guard と一貫
+
 - [2026-06-16] Bash 作成 doc の EH-3 skip は merge 前に追認する
   - 事実: #544 系 doc(rev.3 AEE / TASK-0130)を未追認の EH-3 skip エントリ付きでマージし main CI(`SKIP_REASON 追認`)が累積 RED(1→2)。main 赤は新規 PR 全てに波及
   - 再利用条件: Bash heredoc で discussions/ 等の doc を作り EH-3 skip を手動記録した場合、PR マージ前に `python3 scripts/batch-acknowledge-skip-decisions.py --apply --acknowledged-by <human>`(acknowledged_by は人間専任)で追認を済ませる。根治は #528 doc-light(skip 自体を出さない)


### PR DESCRIPTION
## Summary

- 本日 2026-07-12 のセッションで発生した AI git 操作ミス 2 件を `AGENT_LEARNINGS.md` に追記
- 事故1: Human 適用済み HO 変更（未コミット・4ファイル追記）を `git checkout main -- <path>` で上書き消失（Human 再実行で復旧）。教訓: checkout/restore 前に対象ファイルの未コミット差分が「自分が作ったものか」を `git diff` で確認する
- 事故2: `set -e` 複合コマンド内で `git checkout -b <branch> origin/main` が失敗した後、後続 commit が main 上で実行され main への直接コミットが発生（push 前検知・reset --hard で復旧）。教訓: ブランチ作成と commit を同一複合コマンドに含める場合、commit 直前に current branch を verify する

## Test plan

- [x] `npx markdownlint-cli2 AGENT_LEARNINGS.md` → 0 error(s)
- [x] 差分は `AGENT_LEARNINGS.md` のみ（`git diff main --stat` で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)