### PR TITLE
feat: discovery A-1 の HO 事前判定強化 — HO-plugin 語彙追加（#839 / run-025）

### DIFF
--- a/docs/working/TASK-0839/ai-loop-runs/20260712T104906Z-65dd97a-run025.json
+++ b/docs/working/TASK-0839/ai-loop-runs/20260712T104906Z-65dd97a-run025.json
@@ -1,0 +1,26 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "gates": {
+    "breakdown": "pass",
+    "c1": "PASS"
+  },
+  "ho_paths_source": "docs/ai/ai-loop/ho-paths.md",
+  "ho_pattern_count": 18,
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v3",
+  "run": {
+    "round_index": 1,
+    "run_id": "run-025",
+    "task_id": "TASK-0839"
+  },
+  "scope_check": "in_scope",
+  "target_sha": "65dd97a",
+  "timestamp": "2026-07-12T10:49:06Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}

--- a/docs/working/TASK-0839/ai-loop-runs/grader-output.md
+++ b/docs/working/TASK-0839/ai-loop-runs/grader-output.md
@@ -1,0 +1,17 @@
+# rubric grader 出力（全文・run-025 / #839）
+
+- 対象: origin/main..feat/839-discovery-ho-token-match（maker commit 536bd19）
+- grader: maker 独立文脈サブエージェント（read-only + 独立テスト再実行で裏取り）
+
+```text
+verdict: pass
+failed_criteria: なし
+feedback: 追加は DEFAULT_HO_SIGNALS への除外方向の語彙 3 件とテスト 5 件のみで、受入基準 3 項目（#837 相当本文の ho-risk 除外・回帰なし・arbiter 不変）を実測で満たす。issue What の「パストークン抽出×突合」補助判定は未実装で「最小対応（語彙追加）」側のみの採用だが、受入基準はすべて充足しており fail-closed 方向のため減点しない。ブランチ名（ho-token-match）と実装内容（keyword 語彙追加）の乖離は後続 run への引き継ぎ時に留意。
+```
+
+## 証跡（基準ごと）
+1. 正確性・正本整合: ho-paths.md L42 `plugin/plangate/**` に対応。NFKC+lower 照合のためテスト断定（大文字 hit / カタカナ非 hit）は実装一致。独立実行 42 tests OK
+2. 要件適合: diff は宣言 2 ファイルのみ（discovery.py +10 / test_discovery.py +82）。AC1〜3 を実行確認（baseline 37 → 42・arbiter diff なし）
+3. 文体・構造踏襲: 既存 TestEvaluateIssueExcludedHoRisk と同一パターン・日本語コメント慣行整合
+4. 境界安全: 除外方向のみ・auto 通過拡大なし・偽陰性境界（カタカナ）をテストで明示文書化
+5. 重複定義回避: ho-paths 正本の参照+対応コメント。_load_ho_signals 動的取り込み機構は不変

--- a/docs/working/ai-loop-runs/20260712T103028Z-65dd97a-run024.json
+++ b/docs/working/ai-loop-runs/20260712T103028Z-65dd97a-run024.json
@@ -1,0 +1,27 @@
+{
+  "boundary_check": "touches-HO",
+  "class_check": "no-merge",
+  "decision": "HUMAN_ESCALATED",
+  "gates": {
+    "breakdown": "pass",
+    "c1": "PASS"
+  },
+  "ho_paths_source": "docs/ai/ai-loop/ho-paths.md",
+  "ho_pattern_count": 18,
+  "issued_by": "arbiter-v0.1",
+  "lite_check": false,
+  "policy_ref": "auto-approve-lite-clean@v3",
+  "run": {
+    "round_index": 1,
+    "run_id": "run-024",
+    "task_id": "TASK-0837"
+  },
+  "scope_check": "not_evaluated",
+  "target_sha": "65dd97a",
+  "timestamp": "2026-07-12T10:30:28Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "reject",
+    "reject_category": "logic"
+  }
+}

--- a/docs/working/ai-loop-runs/20260712T104906Z-65dd97a-run025.json
+++ b/docs/working/ai-loop-runs/20260712T104906Z-65dd97a-run025.json
@@ -1,0 +1,26 @@
+{
+  "boundary_check": "clean",
+  "class_check": "no-merge",
+  "decision": "AUTO_APPROVED",
+  "gates": {
+    "breakdown": "pass",
+    "c1": "PASS"
+  },
+  "ho_paths_source": "docs/ai/ai-loop/ho-paths.md",
+  "ho_pattern_count": 18,
+  "issued_by": "arbiter-v0.1",
+  "lite_check": true,
+  "policy_ref": "auto-approve-lite-clean@v3",
+  "run": {
+    "round_index": 1,
+    "run_id": "run-025",
+    "task_id": "TASK-0839"
+  },
+  "scope_check": "in_scope",
+  "target_sha": "65dd97a",
+  "timestamp": "2026-07-12T10:49:06Z",
+  "w_check": {
+    "model_a": "approve",
+    "model_b": "approve"
+  }
+}

--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -85,6 +85,16 @@ DEFAULT_HO_SIGNALS: tuple[str, ...] = (
     "schema",
     "settings",
     "承認境界",
+    # HO-plugin (ho-paths.md: `plugin/plangate/**`) 事前判定強化
+    # (#839 / run-024 乖離是正)。"plugin/" "plugin/plangate/" はパス断片、
+    # "plugin" は run-024 実測（#837）のように本文が「plugin 同梱」
+    # 「plugin bundled」等スラッシュ無しで言及するケースを拾うための広めの
+    # 語彙（fail-closed: 除外方向にのみ広げる。ASCII "plugin" のみを対象と
+    # し、カタカナ「プラグイン」等の表記ゆれは非対応 = 偽陰性は後段 arbiter
+    # に委ねる）。
+    "plugin/",
+    "plugin/plangate/",
+    "plugin",
 )
 
 # 大規模語（lite 帯を外れるシグナル）。

--- a/scripts/ai-loop/discovery.py
+++ b/scripts/ai-loop/discovery.py
@@ -86,14 +86,14 @@ DEFAULT_HO_SIGNALS: tuple[str, ...] = (
     "settings",
     "承認境界",
     # HO-plugin (ho-paths.md: `plugin/plangate/**`) 事前判定強化
-    # (#839 / run-024 乖離是正)。"plugin/" "plugin/plangate/" はパス断片、
-    # "plugin" は run-024 実測（#837）のように本文が「plugin 同梱」
-    # 「plugin bundled」等スラッシュ無しで言及するケースを拾うための広めの
-    # 語彙（fail-closed: 除外方向にのみ広げる。ASCII "plugin" のみを対象と
-    # し、カタカナ「プラグイン」等の表記ゆれは非対応 = 偽陰性は後段 arbiter
-    # に委ねる）。
-    "plugin/",
-    "plugin/plangate/",
+    # (#839 / run-024 乖離是正)。_contains_any は substring 判定のため、
+    # "plugin" 1 語のみで "plugin/" "plugin/plangate/" 等のパス断片を
+    # すべて包含する（gemini medium 指摘反映・#841。冗長な複数語登録を
+    # 廃し "plugin" に集約）。run-024 実測（#837）のように本文が
+    # 「plugin 同梱」「plugin bundled」等スラッシュ無しで言及するケース
+    # も同じ 1 語で拾う（fail-closed: 除外方向にのみ広げる。ASCII
+    # "plugin" のみを対象とし、カタカナ「プラグイン」等の表記ゆれは
+    # 非対応 = 偽陰性は後段 arbiter に委ねる）。
     "plugin",
 )
 

--- a/scripts/ai-loop/test_discovery.py
+++ b/scripts/ai-loop/test_discovery.py
@@ -167,6 +167,88 @@ class TestEvaluateIssueExcludedHoRisk(unittest.TestCase):
         self.assertEqual(result["reason"], "ho-risk")
 
 
+class TestEvaluateIssueExcludedHoPluginToken(unittest.TestCase):
+    """#839: HO-plugin（plugin/plangate/**）語彙の事前判定（run-024 乖離是正）。
+
+    fail-closed 原則: 追加は除外方向のみ。突合不能（表記ゆれ等）は従来どおり
+    通過させ後段 arbiter に委ねる（偽陰性の境界も明示的にテストする）。
+    """
+
+    def test_837_like_body_without_slash_is_excluded_ho_risk(self):
+        # run-024 実測: #837 本文は「plugin 同梱側」「plugin bundled SKILL.md」
+        # とスラッシュ無しで言及し、旧語彙では no_ho_risk を通過していた。
+        issue = _issue(
+            837,
+            title="docs: ai-loop-cycle SKILL の run メタ記載と record 保存先誘導を改善",
+            body=(
+                "SKILL.md（plugin 同梱側の正本配置に従う）の入力 JSON 例に "
+                "run メタを追加する。plugin bundled SKILL.md も対象。"
+            ),
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+    def test_backtick_plugin_path_literal_is_excluded_ho_risk(self):
+        issue = _issue(
+            838,
+            title="docs 更新",
+            body="対象は `plugin/plangate/skills/ai-loop-cycle/SKILL.md` のみ。",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+    def test_bare_plugin_path_literal_is_excluded_ho_risk(self):
+        issue = _issue(
+            839,
+            title="docs 更新",
+            body="対象は plugin/plangate/skills/ai-loop-cycle/SKILL.md のみ。",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+    def test_uppercase_plugin_mention_is_excluded_ho_risk(self):
+        # evaluate_issue は NFKC 正規化 + 小文字化するため大文字表記も拾う。
+        issue = _issue(
+            840,
+            title="Update Plugin bundled docs",
+            body="Sync the PLUGIN/PLANGATE bundled resources description.",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertFalse(result["candidate"])
+        self.assertEqual(result["reason"], "ho-risk")
+
+    def test_katakana_plugin_only_is_not_excluded_false_negative_boundary(self):
+        # 偽陰性の境界を文書化: カタカナ「プラグイン」のみ（ASCII plugin 無し）
+        # は除外しない = 従来どおり通過させ後段 arbiter に委ねる（fail-closed:
+        # discovery を Gate の代替にしない。除外方向にだけ語彙を追加する）。
+        issue = _issue(
+            841,
+            title="ドキュメントの誤字修正",
+            body="プラグインの説明文の誤字を 1 箇所直す。",
+            labels=["ai-loop-auto"],
+        )
+        result = discovery.evaluate_issue(
+            issue, "ai-loop-auto", discovery.DEFAULT_HO_SIGNALS
+        )
+        self.assertTrue(result["candidate"])
+        self.assertTrue(result["reasons"]["no_ho_risk"])
+
+
 class TestEvaluateIssueExcludedNotLite(unittest.TestCase):
     def test_architecture_change_in_title_is_excluded(self):
         issue = _issue(


### PR DESCRIPTION
## 概要

Closes #839

run-024 で顕在化した triage/Gate 乖離（#837 が `no_ho_risk=OK` 判定 → arbiter で touches-HO escalate）の是正。`DEFAULT_HO_SIGNALS` に `plugin/` `plugin/plangate/` `plugin` を追加し、#837 相当の本文（slash なしの「plugin 同梱」等）を discovery 段で `ho-risk` 除外できるようにする。

## ai-loop run-025（フルサイクル成果物）

| 段階 | 結果 |
|---|---|
| W チェック（Model A/B 独立） | approve-approve |
| Gate（arbiter C-3'） | **AUTO_APPROVED**（priority 6・record 同梱） |
| Worker（maker・TDD） | red 4 → green 42/42・#837 実地確認（reason=ho-risk） |
| Verifier（grader 独立） | **pass**（5 基準・独立テスト再実行で裏取り） |

## 実装アプローチの開示

issue What の「本文パストークン抽出 × ho-paths glob 突合」の汎用機構ではなく、**語彙追加の最小対応**を採用（受入基準 3 項目はすべて充足・fail-closed 方向のみ・YAGNI）。汎用トークン突合が必要になった場合は別 issue で。カタカナ「プラグイン」のみの言及は意図的に非対応（偽陰性境界としてテストで文書化・後段 arbiter が最終判定する二重構造は不変）。

## テスト

- test_discovery.py: 37 → 42（全 green・TDD red 確認済み）
- 全体: 303 tests、回帰ゼロ（test_metrics の既存失敗 1 件は無関係・PR #749 系で修復予定）

## 監査資産

`docs/working/TASK-0839/ai-loop-runs/`（run-025 record + grader 全文）+ `docs/working/ai-loop-runs/`（run-024/025 record）を同梱。

書き込みは EH-3 正規経路（`PLANGATE_SKIP_REASON` + ユーザー名指し承認 2026-07-12・skip-log 監査記録あり）。merge は Human-owned。

🤖 Generated with [Claude Code](https://claude.com/claude-code)