### PR TITLE
docs: EH-3 SKIP監査ログを保全（2026-07-12セッション・5件）

### DIFF
--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -125,3 +125,8 @@
 {"ts":"2026-07-12T08:50:38Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a5f4578a82af14f82/docs/ai/subagent-delegation/dispatch-template.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T08:50:52Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a5f4578a82af14f82/docs/ai/subagent-delegation/behavior-norms.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T08:52:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0833/ai-loop-runs/grader-output.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:29:56Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a7adba0a7af6d1fd1/AGENT_LEARNINGS.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:30:22Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a7adba0a7af6d1fd1/AGENT_LEARNINGS.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:43:07Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/Users/user/Documents/GitHub/ai-second-brain/08 Agent Context/memory/plangate/project_session_2026_07_12_hotl_completion.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:43:34Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/Users/user/Documents/GitHub/ai-second-brain/08 Agent Context/memory/plangate/MEMORY.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:50:00Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/private/tmp/claude-502/-Users-user-Documents-GitHub-plangate/49ace254-47fd-43bf-84ea-46d7cfefcca0/scratchpad/issue749-drafts-v2.md","acknowledged_by":null,"acknowledged_at":null}

--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -127,6 +127,6 @@
 {"ts":"2026-07-12T08:52:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0833/ai-loop-runs/grader-output.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T10:29:56Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a7adba0a7af6d1fd1/AGENT_LEARNINGS.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T10:30:22Z","event":"EH-3_DOC_LIGHT_SKIP","target":".claude/worktrees/agent-a7adba0a7af6d1fd1/AGENT_LEARNINGS.md","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-07-12T10:43:07Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/Users/user/Documents/GitHub/ai-second-brain/08 Agent Context/memory/plangate/project_session_2026_07_12_hotl_completion.md","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-07-12T10:43:34Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/Users/user/Documents/GitHub/ai-second-brain/08 Agent Context/memory/plangate/MEMORY.md","acknowledged_by":null,"acknowledged_at":null}
-{"ts":"2026-07-12T10:50:00Z","event":"EH-3_DOC_LIGHT_SKIP","target":"/private/tmp/claude-502/-Users-user-Documents-GitHub-plangate/49ace254-47fd-43bf-84ea-46d7cfefcca0/scratchpad/issue749-drafts-v2.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:43:07Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<external:ai-second-brain>/08 Agent Context/memory/plangate/project_session_2026_07_12_hotl_completion.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:43:34Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<external:ai-second-brain>/08 Agent Context/memory/plangate/MEMORY.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T10:50:00Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<scratchpad>/issue749-drafts-v2.md","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
## Summary

- 2026-07-12 セッションで発生した `EH-3_DOC_LIGHT_SKIP` イベント 5 件を `docs/working/_audit/skip-decision-log.jsonl` に追記
- すべて正規経路（doc-light 判定によるスキップ）でのイベントで、ユーザー名指し承認済み
- 追認（acknowledged_by/acknowledged_at の記入）は Human 判断

## 対象イベント（5件）

- `.claude/worktrees/agent-a7adba0a7af6d1fd1/AGENT_LEARNINGS.md` ×2
- `ai-second-brain/.../project_session_2026_07_12_hotl_completion.md`
- `ai-second-brain/.../MEMORY.md`
- scratchpad `issue749-drafts-v2.md`

## Test plan

- [x] `git diff --cached --stat` で対象ファイル 1 件のみに変更が閉じていることを確認済み
- [x] append-only（既存行を変更していない）であることを diff で確認済み
- [ ] Human によるマージ判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)