### PR TITLE
docs: EH-3 SKIP監査ログを保全（2026-07-12セッション・6件）

### DIFF
--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -139,3 +139,9 @@
 {"ts":"2026-07-12T12:59:25Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<external:ai-second-brain>/08 Agent Context/memory/plangate/feedback_w_split_organizer_factcheck.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T12:59:46Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<external:ai-second-brain>/08 Agent Context/memory/plangate/reference_plugin_install_source.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T12:59:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"<external:ai-second-brain>/08 Agent Context/memory/plangate/MEMORY.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:21:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0810/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:30:05Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:31:49Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:31:53Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:31:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:32:01Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
## Summary
- 本セッションの pbi-input 作成時に発火した EH-3 DOC_LIGHT_SKIP の監査証跡保全（#846 と同型）
- `docs/working/_audit/skip-decision-log.jsonl` に 2026-07-12T13:21〜13:32 の EH-3_DOC_LIGHT_SKIP 6件を追記
- target はすべてリポジトリ相対パス（docs/working/TASK-0810|0842/pbi-input.md）のため redact 不要

## Test plan
- [x] `git diff --stat` で追記のみ（+6行）を確認
- [x] 対象1ファイルのみのステージングを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)