### PR TITLE
docs: EH-3 SKIP監査ログを保全（2026-07-12〜13セッション・6件）

### DIFF
--- a/docs/working/_audit/skip-decision-log.jsonl
+++ b/docs/working/_audit/skip-decision-log.jsonl
@@ -145,3 +145,9 @@
 {"ts":"2026-07-12T13:31:53Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T13:31:59Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
 {"ts":"2026-07-12T13:32:01Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0842/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-12T13:44:25Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/TASK-0811/pbi-input.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-13T00:03:34Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/discussions/2026-07-13-issue-851-framework-mapping.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-13T00:07:23Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/discussions/2026-07-13-issue-851-framework-mapping.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-13T00:07:39Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/discussions/2026-07-13-issue-851-framework-mapping.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-13T00:07:55Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/discussions/2026-07-13-issue-851-framework-mapping.md","acknowledged_by":null,"acknowledged_at":null}
+{"ts":"2026-07-13T00:08:14Z","event":"EH-3_DOC_LIGHT_SKIP","target":"docs/working/discussions/2026-07-13-issue-851-framework-mapping.md","acknowledged_by":null,"acknowledged_at":null}


### PR DESCRIPTION
## Summary
- TASK-0811 起草および #851 分析 doc 作成時の EH-3 DOC_LIGHT_SKIP 監査証跡を保全（#849 と同型）
- 追記のみ 6 件、削除なし、ローカル絶対パスなしを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)